### PR TITLE
Ensure XDG_RUNTIME_DIR exists, needed for kubectl exec

### DIFF
--- a/k8s/wrappers/services/containerd
+++ b/k8s/wrappers/services/containerd
@@ -2,6 +2,11 @@
 
 . "$SNAP/k8s/lib.sh"
 
+k8s::common::setup_env
+
+# Ensure XDG_RUNTIME_DIR exists, needed by runc for 'kubectl exec' to work
+mkdir -p "${XDG_RUNTIME_DIR}"
+
 # Apply the containerd profile
 apparmor_parser -r "$SNAP/k8s/profiles/containerd"
 


### PR DESCRIPTION
### Summary

Fixes the following issue:

```bash
$ kubectl run --image nginx nginx
$ kubectl exec -it nginx -- bash
error: Internal error occurred: error executing command in container: failed to exec in container: failed to start exec "bdb0772d894c4b8e2603833b6b642042f060321976dcd7547b1b1d46597bc398": failed to create runc console socket: stat /run/user/0/snap.k8s: no such file or directory: unknown
$ journalctl -f
Nov 21 17:44:13 ts-1 k8s.containerd[3624]: E1121 17:44:13.338375    3624 exec.go:87] error executing command in container: failed to exec in container: failed to start exec "bdb0772d894c4b8e2603833b6b642042f060321976dcd7547b1b1d46597bc398": failed to create runc console socket: stat /run/user/0/snap.k8s: no such file or directory: unknown
```