### PR TITLE
Use a `tmpfs` for containerd's runtime state

### DIFF
--- a/k8s/args/containerd
+++ b/k8s/args/containerd
@@ -1,3 +1,3 @@
 --config /etc/containerd/config.toml
 --address ${SNAP_COMMON}/run/containerd.sock
---state ${SNAP_COMMON}/run/containerd
+--state /var/lib/run/containerd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -337,6 +337,9 @@ layout:
     bind: $SNAP_COMMON/var/log/pods
   /var/log/containers:
     bind: $SNAP_COMMON/var/log/containers
+  # Containerd runtime state (note: snapd does not allow "/run/containerd")
+  /var/lib/run/containerd:
+    type: tmpfs
   # CNI
   /var/lib/cni:
     bind: $SNAP_COMMON/var/lib/cni


### PR DESCRIPTION
### Summary

Containerd expects a `/run/containerd` of type `tmpfs` to store its runtime state. This should be a `tmpfs` filesystem, not a normal directory, as it confuses the machine across reboots.

Note that we use `/var/lib/run/containerd` instead of `/run/containerd`, because `/run/containerd` [is not allowed by snapd](https://forum.snapcraft.io/#layout-reference-2)