### PR TITLE
Add node joining to k8s clustering CLI

### DIFF
--- a/k8s/args/k8sd
+++ b/k8s/args/k8sd
@@ -1,2 +1,2 @@
---port=6444
+--port=6400
 --storage-dir=/var/lib/k8sd

--- a/k8s/args/k8sd
+++ b/k8s/args/k8sd
@@ -1,0 +1,2 @@
+--port=6444
+--storage-dir=/var/lib/k8sd

--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -195,6 +195,14 @@ k8s::init::k8s_dqlite() {
   cp "$SNAP/k8s/args/k8s-dqlite" "$SNAP_DATA/args/k8s-dqlite"
 }
 
+# Initialize a single-node k8sd cluster
+k8s::init::k8sd() {
+  k8s::common::setup_env
+
+  mkdir -p "$SNAP_DATA/args"
+  cp "$SNAP/k8s/args/k8sd" "$SNAP_DATA/args/k8sd"
+}
+
 # Initialize containerd for the local node
 k8s::init::containerd() {
   k8s::common::setup_env
@@ -319,6 +327,7 @@ k8s::init::permissions() {
 k8s::init() {
   k8s::init::containerd
   k8s::init::k8s_dqlite
+  k8s::init::k8sd
   k8s::init::ca
   k8s::init::pki
   k8s::init::kubernetes

--- a/k8s/wrappers/services/k8sd
+++ b/k8s/wrappers/services/k8sd
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+. "$SNAP/k8s/lib.sh"
+
+# required to open unix-socket in the snap
+export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
+
+k8s::common::execute_service k8sd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -228,6 +228,13 @@ apps:
     daemon: simple
     plugs:
       - network-bind
+  k8sd:
+    command: k8s/wrappers/services/k8sd
+    install-mode: disable
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
   kubelet:
     install-mode: disable
     command: k8s/wrappers/services/kubelet
@@ -337,6 +344,8 @@ layout:
     bind: $SNAP_COMMON/var/lib/containerd
   /var/lib/k8s-dqlite:
     bind: $SNAP_COMMON/var/lib/k8s-dqlite
+  /var/lib/k8sd:
+    bind: $SNAP_COMMON/var/lib/k8sd
   # Logs and temporary files
   /var/log/pods:
     bind: $SNAP_COMMON/var/log/pods

--- a/src/k8s/cmd/k8s/k8s_add_node.go
+++ b/src/k8s/cmd/k8s/k8s_add_node.go
@@ -9,36 +9,38 @@ import (
 )
 
 var (
-	bootstrapClusterCmd = &cobra.Command{
-		Use:   "bootstrap-cluster",
-		Short: "Create new cluster",
+	addNodeCmd = &cobra.Command{
+		Use:   "add-node <name>",
+		Short: "Create a connection token for a node to join the cluster",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if rootCmdOpts.logDebug {
 				logrus.SetLevel(logrus.TraceLevel)
 			}
 
+			name := args[0]
+
 			client, err := cluster.NewClient(cmd.Context(), cluster.ClusterOpts{
 				RemoteAddress: clusterCmdOpts.remoteAddress,
-				Debug:         rootCmdOpts.logDebug,
-				Port:          clusterCmdOpts.port,
 				StorageDir:    clusterCmdOpts.storageDir,
 				Verbose:       rootCmdOpts.logVerbose,
+				Debug:         rootCmdOpts.logDebug,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to create client: %w", err)
+				return fmt.Errorf("failed to create cluster client: %w", err)
 			}
 
-			cluster, err := client.Bootstrap(cmd.Context())
+			token, err := client.GetToken(cmd.Context(), name)
 			if err != nil {
-				return fmt.Errorf("failed to bootstrap cluster: %w", err)
+				return fmt.Errorf("failed to retrieve token: %w", err)
 			}
 
-			logrus.Infof("Cluster with member %s on %s created.", cluster.Name, cluster.Address)
-			return err
+			fmt.Println(token)
+			return nil
 		},
 	}
 )
 
 func init() {
-	rootCmd.AddCommand(bootstrapClusterCmd)
+	rootCmd.AddCommand(addNodeCmd)
 }

--- a/src/k8s/cmd/k8s/k8s_bootstrap_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap_cluster.go
@@ -18,10 +18,11 @@ var (
 			}
 
 			cluster, err := cluster.Bootstrap(cmd.Context(), cluster.ClusterOpts{
-				Address:  clusterCmdOpts.address,
-				StateDir: clusterCmdOpts.stateDir,
-				Verbose:  rootCmdOpts.logVerbose,
-				Debug:    rootCmdOpts.logDebug,
+				Address:    clusterCmdOpts.address,
+				Debug:      rootCmdOpts.logDebug,
+				Port:       clusterCmdOpts.port,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to bootstrap cluster: %w", err)

--- a/src/k8s/cmd/k8s/k8s_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_cluster.go
@@ -1,15 +1,21 @@
 package k8s
 
+import (
+	"strconv"
+
+	"github.com/canonical/k8s/pkg/k8s/cluster"
+)
+
 var (
 	clusterCmdOpts struct {
-		address    string
-		port       string
-		storageDir string
+		remoteAddress string
+		port          string
+		storageDir    string
 	}
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.address, "address", "", "IP Address of the cluster - required if not running on k8s node")
-	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.port, "port", "6444", "Port on which the REST-API is exposed")
+	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.remoteAddress, "remote-address", "", "IP Address of another cluster member")
+	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.port, "port", strconv.Itoa(cluster.DefaultPort), "Port on which the REST-API is exposed")
 	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.storageDir, "storage-dir", "", "Directory with the dqlite datastore")
 }

--- a/src/k8s/cmd/k8s/k8s_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_cluster.go
@@ -2,12 +2,14 @@ package k8s
 
 var (
 	clusterCmdOpts struct {
-		address  string
-		stateDir string
+		address    string
+		port       string
+		storageDir string
 	}
 )
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.address, "address", "", "IP Address of the cluster - required if not running on k8s node")
-	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.stateDir, "state-dir", "", "Path to state store of local k8sd instance.")
+	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.port, "port", "6444", "Port on which the REST-API is exposed")
+	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.storageDir, "storage-dir", "", "Directory with the dqlite datastore")
 }

--- a/src/k8s/cmd/k8s/k8s_join_node.go
+++ b/src/k8s/cmd/k8s/k8s_join_node.go
@@ -1,0 +1,70 @@
+package k8s
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/canonical/k8s/pkg/k8s/cluster"
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	joinNodeCmdOpts struct {
+		name    string
+		address string
+	}
+
+	joinNodeCmd = &cobra.Command{
+		Use:   "join-node <name>",
+		Short: "Join a cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if rootCmdOpts.logDebug {
+				logrus.SetLevel(logrus.TraceLevel)
+			}
+
+			token := args[0]
+
+			// Use hostname as default node name
+			if joinNodeCmdOpts.name == "" {
+				hostname, err := os.Hostname()
+				if err != nil {
+					return fmt.Errorf("--name is not set and failed to get hostname: %w", err)
+				}
+				joinNodeCmdOpts.name = hostname
+			}
+
+			if joinNodeCmdOpts.address == "" {
+				joinNodeCmdOpts.address = util.CanonicalNetworkAddress(
+					util.NetworkInterfaceAddress(), cluster.DefaultPort,
+				)
+			}
+
+			client, err := cluster.NewClient(cmd.Context(), cluster.ClusterOpts{
+				RemoteAddress: clusterCmdOpts.remoteAddress,
+				StorageDir:    clusterCmdOpts.storageDir,
+				Verbose:       rootCmdOpts.logVerbose,
+				Debug:         rootCmdOpts.logDebug,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create cluster client: %w", err)
+			}
+
+			err = client.JoinCluster(cmd.Context(), joinNodeCmdOpts.name, joinNodeCmdOpts.address, token)
+			if err != nil {
+				return fmt.Errorf("failed to join cluser: %w", err)
+			}
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	joinNodeCmd.Flags().StringVar(&joinNodeCmdOpts.name, "name", "", "The name of the joining node. defaults to hostname")
+	joinNodeCmd.Flags().StringVar(&joinNodeCmdOpts.address, "address", "", "The address (IP:Port) on which the nodes REST API should be available")
+
+	rootCmd.AddCommand(joinNodeCmd)
+}

--- a/src/k8s/cmd/k8s/k8s_list_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_list_cluster.go
@@ -24,10 +24,10 @@ var (
 			}
 
 			client, err := cluster.NewClient(cmd.Context(), cluster.ClusterOpts{
-				Address:  clusterCmdOpts.address,
-				StateDir: clusterCmdOpts.stateDir,
-				Verbose:  rootCmdOpts.logVerbose,
-				Debug:    rootCmdOpts.logDebug,
+				Address:    clusterCmdOpts.address,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create cluster client: %w", err)

--- a/src/k8s/cmd/k8s/k8s_list_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_list_cluster.go
@@ -15,6 +15,7 @@ var (
 	listClusterCmdOpts struct {
 		format string
 	}
+
 	listClusterCmd = &cobra.Command{
 		Use:   "list-cluster",
 		Short: "List servers in the cluster",
@@ -24,10 +25,10 @@ var (
 			}
 
 			client, err := cluster.NewClient(cmd.Context(), cluster.ClusterOpts{
-				Address:    clusterCmdOpts.address,
-				StorageDir: clusterCmdOpts.storageDir,
-				Verbose:    rootCmdOpts.logVerbose,
-				Debug:      rootCmdOpts.logDebug,
+				RemoteAddress: clusterCmdOpts.remoteAddress,
+				StorageDir:    clusterCmdOpts.storageDir,
+				Verbose:       rootCmdOpts.logVerbose,
+				Debug:         rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create cluster client: %w", err)

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -3,7 +3,9 @@ package k8sd
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/canonical/k8s/pkg/k8s/cluster"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
 )
@@ -48,7 +50,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logDebug, "debug", "d", false, "Show all debug messages")
 	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
 
-	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.port, "port", "6444", "Port on which the REST-API is exposed")
+	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.port, "port", strconv.Itoa(cluster.DefaultPort), "Port on which the REST-API is exposed")
 
 	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.storageDir, "storage-dir", "", "directory with the dqlite datastore")
 }

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -13,7 +13,8 @@ var (
 		version    bool
 		logDebug   bool
 		logVerbose bool
-		stateDir   string
+		storageDir string
+		port       string
 	}
 
 	rootCmd = &cobra.Command{
@@ -23,9 +24,10 @@ var (
 			m, err := microcluster.App(
 				context.Background(),
 				microcluster.Args{
-					StateDir: rootCmdOpts.stateDir,
-					Verbose:  rootCmdOpts.logVerbose,
-					Debug:    rootCmdOpts.logDebug,
+					ListenPort: rootCmdOpts.port,
+					StateDir:   rootCmdOpts.storageDir,
+					Verbose:    rootCmdOpts.logVerbose,
+					Debug:      rootCmdOpts.logDebug,
 				},
 			)
 			if err != nil {
@@ -46,5 +48,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logDebug, "debug", "d", false, "Show all debug messages")
 	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
 
-	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Path to store state information")
+	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.port, "port", "6444", "Port on which the REST-API is exposed")
+
+	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.storageDir, "storage-dir", "", "directory with the dqlite datastore")
 }

--- a/src/k8s/pkg/k8s/cluster/cluster.go
+++ b/src/k8s/pkg/k8s/cluster/cluster.go
@@ -15,40 +15,11 @@ import (
 	"github.com/canonical/microcluster/microcluster"
 )
 
-// Bootstrap sets up new cluster and returns the information about the daemon.
-func Bootstrap(ctx context.Context, opts ClusterOpts) (ClusterMember, error) {
-	m, err := microcluster.App(ctx, microcluster.Args{
-		Debug:      opts.Debug,
-		ListenPort: opts.Port,
-		StateDir:   opts.StorageDir,
-		Verbose:    opts.Verbose,
-	})
-	if err != nil {
-		return ClusterMember{}, fmt.Errorf("failed to configure cluster: %w", err)
-	}
-
-	// Get system hostname.
-	hostname, err := os.Hostname()
-	if err != nil {
-		return ClusterMember{}, fmt.Errorf("failed to retrieve system hostname: %w", err)
-	}
-
-	port, err := strconv.Atoi(opts.Port)
-	if err != nil {
-		return ClusterMember{}, fmt.Errorf("failed to parse Port: %w", err)
-	}
-	// Get system address.
-	address := util.CanonicalNetworkAddress(
-		util.NetworkInterfaceAddress(), port,
-	)
-
-	member := ClusterMember{
-		Name:    hostname,
-		Address: address,
-	}
-	err = m.NewCluster(hostname, address, time.Second*30)
-	return member, err
-}
+const (
+	// DefaultPort is the port under which
+	// the REST API is exposed by default.
+	DefaultPort = 6400
+)
 
 // NewClient returns a client to interact with the cluster.
 // It will return:
@@ -74,32 +45,68 @@ func NewClient(ctx context.Context, opts ClusterOpts) (*Client, error) {
 		return nil, fmt.Errorf("cannot read cluster info: %w", err)
 	}
 
+	return &Client{
+		opts: opts,
+		app:  m,
+	}, nil
+}
+
+// Client is a wrapper around the MicroCluster client
+type Client struct {
+	opts ClusterOpts
+	app  *microcluster.MicroCluster
+}
+
+func (c *Client) microClient(ctx context.Context) (*client.Client, error) {
 	var microClient *client.Client
-	if opts.Address != "" {
-		microClient, err = m.RemoteClient(opts.Address)
+	var err error
+	if c.opts.RemoteAddress != "" {
+		microClient, err = c.app.RemoteClient(c.opts.RemoteAddress)
 	} else {
-		microClient, err = m.LocalClient()
+		microClient, err = c.app.LocalClient()
 	}
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
-	return &Client{
-		microClient: microClient,
-	}, nil
+	return microClient, nil
 }
 
-// Client is a wrapper around the MicroCluster client
-type Client struct {
-	microClient *client.Client
+// Bootstrap sets up new cluster and returns the information about the daemon.
+func (c *Client) Bootstrap(ctx context.Context) (ClusterMember, error) {
+	// Get system hostname.
+	hostname, err := os.Hostname()
+	if err != nil {
+		return ClusterMember{}, fmt.Errorf("failed to retrieve system hostname: %w", err)
+	}
+
+	port, err := strconv.Atoi(c.opts.Port)
+	if err != nil {
+		return ClusterMember{}, fmt.Errorf("failed to parse Port: %w", err)
+	}
+	// Get system address.
+	address := util.CanonicalNetworkAddress(
+		util.NetworkInterfaceAddress(), port,
+	)
+
+	member := ClusterMember{
+		Name:    hostname,
+		Address: address,
+	}
+	err = c.app.NewCluster(hostname, address, time.Second*30)
+	return member, err
 }
 
 // GetMembers returns information about all members of the cluster.
 func (c *Client) GetMembers(ctx context.Context) ([]ClusterMember, error) {
-	clusterMembers, err := c.microClient.GetClusterMembers(context.Background())
+	microClient, err := c.microClient(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
+	clusterMembers, err := microClient.GetClusterMembers(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster members: %w", err)
 	}
 
 	members := make([]ClusterMember, len(clusterMembers))
@@ -121,6 +128,20 @@ func (c *Client) GetMembers(ctx context.Context) ([]ClusterMember, error) {
 	return members, nil
 }
 
+// GetToken returns a token for a node to use to join the cluster.
+func (c *Client) GetToken(ctx context.Context, name string) (string, error) {
+	microClient, err := c.microClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get client: %w", err)
+	}
+	return microClient.RequestToken(ctx, name)
+}
+
+// JoinCluster joins a node to an existing cluster (token is supplied by existing cluster member)
+func (c *Client) JoinCluster(ctx context.Context, name string, address string, token string) error {
+	return c.app.JoinCluster(name, address, token, time.Second*30)
+}
+
 // ClusterMember holds information about a server in a cluster.
 // This is a wrapper around the internal microcluster ClusterMember type.
 type ClusterMember struct {
@@ -135,8 +156,8 @@ type ClusterMember struct {
 type ClusterOpts struct {
 	// StorageDir is the directory that contains the cluster state (for local clients).
 	StorageDir string
-	// Address is the address of the cluster (for remote clients).
-	Address string
+	// RemoteAddress is the address of the cluster (for remote clients).
+	RemoteAddress string
 	// Port is the port on which the REST-API is exposed.
 	Port string
 	// Verbose enables info level logging.
@@ -148,9 +169,9 @@ type ClusterOpts struct {
 // isValid verifies that a valid IP address is set (for remote)
 // and that the state dir exists.
 func (c ClusterOpts) isValid() error {
-	if c.Address != "" {
-		if net.ParseIP(c.Address) == nil {
-			return fmt.Errorf("%s is not a valid IP address", c.Address)
+	if c.RemoteAddress != "" {
+		if net.ParseIP(c.RemoteAddress) == nil {
+			return fmt.Errorf("%s is not a valid IP address", c.RemoteAddress)
 		}
 		return nil
 	}

--- a/src/k8s/pkg/k8s/cluster/cluster.go
+++ b/src/k8s/pkg/k8s/cluster/cluster.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/canonical/lxd/lxd/util"
@@ -17,9 +18,10 @@ import (
 // Bootstrap sets up new cluster and returns the information about the daemon.
 func Bootstrap(ctx context.Context, opts ClusterOpts) (ClusterMember, error) {
 	m, err := microcluster.App(ctx, microcluster.Args{
-		StateDir: opts.StateDir,
-		Verbose:  opts.Verbose,
-		Debug:    opts.Debug,
+		Debug:      opts.Debug,
+		ListenPort: opts.Port,
+		StateDir:   opts.StorageDir,
+		Verbose:    opts.Verbose,
 	})
 	if err != nil {
 		return ClusterMember{}, fmt.Errorf("failed to configure cluster: %w", err)
@@ -31,9 +33,13 @@ func Bootstrap(ctx context.Context, opts ClusterOpts) (ClusterMember, error) {
 		return ClusterMember{}, fmt.Errorf("failed to retrieve system hostname: %w", err)
 	}
 
+	port, err := strconv.Atoi(opts.Port)
+	if err != nil {
+		return ClusterMember{}, fmt.Errorf("failed to parse Port: %w", err)
+	}
 	// Get system address.
 	address := util.CanonicalNetworkAddress(
-		util.NetworkInterfaceAddress(), 6443,
+		util.NetworkInterfaceAddress(), port,
 	)
 
 	member := ClusterMember{
@@ -59,9 +65,10 @@ func NewClient(ctx context.Context, opts ClusterOpts) (*Client, error) {
 	}
 
 	m, err := microcluster.App(ctx, microcluster.Args{
-		StateDir: opts.StateDir,
-		Verbose:  opts.Verbose,
-		Debug:    opts.Debug,
+		Debug:      opts.Debug,
+		ListenPort: opts.Port,
+		StateDir:   opts.StorageDir,
+		Verbose:    opts.Verbose,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot read cluster info: %w", err)
@@ -126,11 +133,12 @@ type ClusterMember struct {
 
 // ClusterOpts contains options for cluster queries.
 type ClusterOpts struct {
-	// StateDir is the cluster state directory (for local clients).
-	// TODO(bschimke): We can set the snaps default directory here once we snapped the CLI
-	StateDir string
-	// Address is the cluster address for remote clients.
+	// StorageDir is the directory that contains the cluster state (for local clients).
+	StorageDir string
+	// Address is the address of the cluster (for remote clients).
 	Address string
+	// Port is the port on which the REST-API is exposed.
+	Port string
 	// Verbose enables info level logging.
 	Verbose bool
 	// Debug enables trace level logging.
@@ -147,11 +155,11 @@ func (c ClusterOpts) isValid() error {
 		return nil
 	}
 
-	if c.StateDir != "" {
-		if _, err := os.Stat(c.StateDir); os.IsNotExist(err) {
-			return fmt.Errorf("%s does not exist", c.StateDir)
+	if c.StorageDir != "" {
+		if _, err := os.Stat(c.StorageDir); os.IsNotExist(err) {
+			return fmt.Errorf("%s does not exist", c.StorageDir)
 		}
-		_, err := net.Dial("unix", filepath.Join(c.StateDir, "control.socket"))
+		_, err := net.Dial("unix", filepath.Join(c.StorageDir, "control.socket"))
 		if err != nil {
 			return fmt.Errorf("cannot connect to local cluster - is it running?")
 		}


### PR DESCRIPTION
Introduces the following CLI commands:
 * `add-node <name>`: generates a connection token for <name>
 * `join-node <token>`: join a cluster with the token (to be executed on the <name> node)

The workflow now looks like this:
1. On the cluster node: 
```
$ k8s add-node <hostname of joining node or arbitrary name>
<token>
```
2. On the joining node:
```
k8s join-node <token>
```

The `--name` flag for `k8s join-node <token>` defaults to the hostname of the joining node.


This was tested locally with the binaries (k8s CLI is not integrated in the snap yet)