### PR TITLE
Add remove-node command to k8s CLI

### DIFF
--- a/src/k8s/cmd/k8s/k8s_join_node.go
+++ b/src/k8s/cmd/k8s/k8s_join_node.go
@@ -54,7 +54,7 @@ var (
 
 			err = client.JoinCluster(cmd.Context(), joinNodeCmdOpts.name, joinNodeCmdOpts.address, token)
 			if err != nil {
-				return fmt.Errorf("failed to join cluser: %w", err)
+				return fmt.Errorf("failed to join cluster: %w", err)
 			}
 
 			return nil

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -1,0 +1,50 @@
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8s/cluster"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	removeNodeCmdOpts struct {
+		force bool
+	}
+
+	removeNodeCmd = &cobra.Command{
+		Use:   "remove-node <name>",
+		Short: "Remove a node from the cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if rootCmdOpts.logDebug {
+				logrus.SetLevel(logrus.TraceLevel)
+			}
+
+			name := args[0]
+			client, err := cluster.NewClient(cmd.Context(), cluster.ClusterOpts{
+				RemoteAddress: clusterCmdOpts.remoteAddress,
+				StorageDir:    clusterCmdOpts.storageDir,
+				Verbose:       rootCmdOpts.logVerbose,
+				Debug:         rootCmdOpts.logDebug,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create cluster client: %w", err)
+			}
+
+			err = client.RemoveNode(cmd.Context(), name, removeNodeCmdOpts.force)
+			if err != nil {
+				return fmt.Errorf("failed to remove node from cluster: %w", err)
+			}
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	removeNodeCmd.Flags().BoolVar(&removeNodeCmdOpts.force, "force", false, "Forcibly remove the cluster member")
+
+	rootCmd.AddCommand(removeNodeCmd)
+}

--- a/src/k8s/pkg/k8s/cluster/cluster.go
+++ b/src/k8s/pkg/k8s/cluster/cluster.go
@@ -142,6 +142,19 @@ func (c *Client) JoinCluster(ctx context.Context, name string, address string, t
 	return c.app.JoinCluster(name, address, token, time.Second*30)
 }
 
+// RemoveNode removes a node by name from the cluster
+func (c *Client) RemoveNode(ctx context.Context, name string, force bool) error {
+	microClient, err := c.microClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get client: %w", err)
+	}
+	err = microClient.DeleteClusterMember(ctx, name, force)
+	if err != nil {
+		return fmt.Errorf("failed to delete cluster member %s: %w", name, err)
+	}
+	return nil
+}
+
 // ClusterMember holds information about a server in a cluster.
 // This is a wrapper around the internal microcluster ClusterMember type.
 type ClusterMember struct {


### PR DESCRIPTION
A node can removed by name with the command:

`k8s remove-node <node-name> (--force)`