### PR TITLE
Add integration test for clustering

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,11 +33,11 @@ jobs:
           path: k8s.snap
 
   test-e2e:
-    name: Test ${{ matrix.runner }}
+    name: Test ${{ matrix.os }}
     strategy:
       matrix:
-        runner: [ubuntu-20.04, ubuntu-22.04]
-    runs-on: "${{ matrix.runner }}"
+        os: ["ubuntu:20.04", "ubuntu:22.04"]
+    runs-on: ubuntu-20.04
     needs: build
 
     steps:
@@ -49,6 +49,11 @@ jobs:
           python-version: '3.8'
       - name: Install tox
         run: pip install tox
+      - name: Install lxd
+        run: |
+          sudo lxd init --auto
+          sudo usermod --append --groups lxd $USER
+          sg lxd -c 'lxc version'
       - name: Download snap
         uses: actions/download-artifact@v3.0.2
         with:
@@ -57,4 +62,6 @@ jobs:
       - name: Run end to end tests
         run: |
           export TEST_SNAP="$PWD/build/k8s.snap"
-          cd tests/e2e && tox -e e2e
+          export TEST_SUBSTRATE=lxd
+          export TEST_LXD_IMAGE=${{ matrix.os }}
+          cd tests/e2e && sg lxd -c 'tox -e e2e'

--- a/k8s/wrappers/services/k8sd
+++ b/k8s/wrappers/services/k8sd
@@ -3,6 +3,6 @@
 . "$SNAP/k8s/lib.sh"
 
 # required to open unix-socket in the snap
-export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
+export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.k8sd"
 
 k8s::common::execute_service k8sd

--- a/src/k8s/cmd/k8s/k8s_join_node.go
+++ b/src/k8s/cmd/k8s/k8s_join_node.go
@@ -17,7 +17,7 @@ var (
 	}
 
 	joinNodeCmd = &cobra.Command{
-		Use:   "join-node <name>",
+		Use:   "join-node <token>",
 		Short: "Join a cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -57,6 +57,7 @@ var (
 				return fmt.Errorf("failed to join cluster: %w", err)
 			}
 
+			logrus.Infof("Joined %s (%s) to cluster.", joinNodeCmdOpts.name, joinNodeCmdOpts.address)
 			return nil
 		},
 	}

--- a/src/k8s/pkg/k8s/cluster/cluster.go
+++ b/src/k8s/pkg/k8s/cluster/cluster.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -128,7 +127,7 @@ func (c *Client) GetMembers(ctx context.Context) ([]ClusterMember, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)
 	}
-	clusterMembers, err := microClient.GetClusterMembers(context.Background())
+	clusterMembers, err := microClient.GetClusterMembers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster members: %w", err)
 	}
@@ -192,10 +191,6 @@ func (c ClusterOpts) isValid() error {
 	if c.StorageDir != "" {
 		if _, err := os.Stat(c.StorageDir); os.IsNotExist(err) {
 			return fmt.Errorf("%s does not exist", c.StorageDir)
-		}
-		_, err := net.Dial("unix", filepath.Join(c.StorageDir, "control.socket"))
-		if err != nil {
-			return fmt.Errorf("cannot connect to local cluster - is it running?")
 		}
 		return nil
 	}

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -4,6 +4,11 @@
 import logging
 import shlex
 import subprocess
+import time
+from pathlib import Path
+
+import pytest
+from e2e_util import config, harness
 
 LOG = logging.getLogger(__name__)
 
@@ -14,3 +19,49 @@ def run(command: list, **kwargs) -> subprocess.CompletedProcess:
 
     LOG.debug("Execute command %s (kwargs=%s)", shlex.join(command), kwargs)
     return subprocess.run(command, **kwargs)
+
+
+# Installs and setups the k8s snap on the given instance.
+# If wait_ready is set, it is validated that the K8s node is in Ready state.
+def setup_k8s_snap(
+    h: harness.Harness, instance_id: str, snap_path: Path, wait_ready: bool = True
+):
+    LOG.info("Install snap")
+    h.send_file(instance_id, config.SNAP, snap_path)
+    h.exec(instance_id, ["snap", "install", snap_path, "--dangerous"])
+
+    LOG.info("Initialize Kubernetes")
+    h.exec(instance_id, ["/snap/k8s/current/k8s/init.sh"])
+    h.exec(instance_id, ["k8s", "init"])
+
+    LOG.info("Start Kubernetes")
+    h.exec(instance_id, ["k8s", "start"])
+
+    if not wait_ready:
+        return
+
+    hostname = (
+        h.exec(instance_id, ["hostname"], capture_output=True).stdout.decode().strip()
+    )
+    success = False
+    for attempt in range(30):
+        try:
+            LOG.info("(attempt %d) Waiting for Kubelet to register", attempt)
+            p = h.exec(
+                instance_id,
+                ["k8s", "kubectl", "get", "node", hostname, "--no-headers"],
+                capture_output=True,
+            )
+
+            if "NotReady" in p.stdout.decode():
+                continue
+
+            success = True
+            LOG.info("Kubelet registered successfully!")
+            LOG.info("%s", p.stdout.decode())
+            break
+        except subprocess.CalledProcessError:
+            time.sleep(5)
+
+    if not success:
+        pytest.fail("Kubelet node did not register")

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -1,0 +1,85 @@
+#
+# Copyright 2023 Canonical, Ltd.
+#
+import base64
+import logging
+from pathlib import Path
+from typing import List
+
+import pytest
+from e2e_util import config, harness, util
+
+LOG = logging.getLogger(__name__)
+# TODO(bschimke): Remove when snap supports CLI alias
+K8S_BINARY_PATH = "/snap/k8s/current/bin/k8s"
+# TODO(KU-142): Remove when CLI uses snap env variables
+K8S_CLI_CONFIG = [
+    "--storage-dir",
+    "/var/snap/k8s/common/var/lib/k8sd",
+    "--port",
+    "6400",
+]
+
+
+# Create <num_instances> instances and setup the k8s snap in each.
+def setup_k8s_instances(
+    h: harness.Harness, snap_path: str, num_instances: int, wait_ready: bool = True
+) -> List[str]:
+    instances = []
+
+    for _ in range(num_instances):
+        instance_id = h.new_instance()
+        instances.append(instance_id)
+        util.setup_k8s_snap(h, instance_id, snap_path, wait_ready=wait_ready)
+
+    return instances
+
+
+# Bootstrap microcluster on this instance
+def bootstrap_cluster(h: harness.Harness, instance_id: str):
+    out = h.exec(
+        instance_id,
+        [K8S_BINARY_PATH, "bootstrap-cluster", *K8S_CLI_CONFIG],
+        capture_output=True,
+    )
+    assert "created" in out.stderr.decode()
+
+
+# Create a token to join a node to an existing cluster
+def add_node(h: harness.Harness, cluster_node: str, joining_node: str) -> str:
+    out = h.exec(
+        cluster_node,
+        [K8S_BINARY_PATH, "add-node", *K8S_CLI_CONFIG, joining_node],
+        capture_output=True,
+    )
+    token = out.stdout.decode().strip()
+    assert (
+        base64.b64encode(base64.b64decode(token)).decode() == token
+    ), f"add-node should return a base64 token but got {token}"
+    return token
+
+
+# Join an existing cluster.
+def join_cluster(h: harness.Harness, instance_id, token):
+    out = h.exec(
+        instance_id,
+        [K8S_BINARY_PATH, "join-node", *K8S_CLI_CONFIG, token],
+        capture_output=True,
+    )
+    LOG.info(out.stdout.decode())
+    LOG.info(out.stderr.decode())
+    assert f"Joined {instance_id}" in out.stderr.decode()
+
+
+def test_clustering(h: harness.Harness, tmp_path: Path):
+    if not config.SNAP:
+        pytest.fail("Set TEST_SNAP to the path where the snap is")
+
+    snap_path = (tmp_path / "k8s.snap").as_posix()
+    instances = setup_k8s_instances(h, snap_path, num_instances=2, wait_ready=False)
+    cluster_node = instances[0]
+    joining_node = instances[1]
+
+    bootstrap_cluster(h, cluster_node)
+    token = add_node(h, cluster_node, joining_node)
+    join_cluster(h, joining_node, token)


### PR DESCRIPTION
Adds an integration test for the clustering CLI. That verifies that a cluster can be bootstrapped, tokens can be generated and a node can join an existing cluster.
Included some minor fixed to make the test pass.

## Changes

* Add integration test
* Refactored testing setup code into reusable util functions
* Removed check if unix-socket is enabled (this is not required, e.g. when joining a node and will eventually be validated in the microcluster code anyways)
* Minor drive-by fixes  