### PR TITLE
Use uuid instead of time for test harness instance_id

### DIFF
--- a/tests/e2e/tests/e2e_util/harness/lxd.py
+++ b/tests/e2e/tests/e2e_util/harness/lxd.py
@@ -2,9 +2,9 @@
 # Copyright 2023 Canonical, Ltd.
 #
 import logging
+import os
 import shlex
 import subprocess
-import time
 from pathlib import Path
 
 from e2e_util import config
@@ -57,8 +57,7 @@ class LXDHarness(Harness):
         )
 
     def new_instance(self) -> str:
-        # TODO(neoaggelos): make this unique
-        instance_id = f"k8s-e2e-{int(time.time())}-{self.next_id()}"
+        instance_id = f"k8s-e2e-{os.urandom(3).hex()}-{self.next_id()}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:

--- a/tests/e2e/tests/e2e_util/harness/multipass.py
+++ b/tests/e2e/tests/e2e_util/harness/multipass.py
@@ -2,9 +2,9 @@
 # Copyright 2023 Canonical, Ltd.
 #
 import logging
+import os
 import shlex
 import subprocess
-import time
 from pathlib import Path
 
 from e2e_util import config
@@ -35,8 +35,7 @@ class MultipassHarness(Harness):
         LOG.debug("Configured Multipass substrate (image %s)", self.image)
 
     def new_instance(self) -> str:
-        # TODO(neoaggelos): make this unique
-        instance_id = f"k8s-e2e-{int(time.time())}-{self.next_id()}"
+        instance_id = f"k8s-e2e-{os.urandom(3).hex()}-{self.next_id()}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:


### PR DESCRIPTION
Sometimes a name collision occurred in the Github CI when creating multiple lxd instances.
Using uuid hopefully fixes this. 

Example: https://github.com/canonical/k8s-snap/actions/runs/7125853720/job/19403294870?pr=22