### PR TITLE
Adding the network enablement support

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,6 +51,7 @@ jobs:
         run: pip install tox
       - name: Install lxd
         run: |
+          sudo snap refresh lxd --channel 5.19/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'

--- a/k8s/network-requirements.sh
+++ b/k8s/network-requirements.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [ "$EUID" -ne 0 ]
+then echo "Please run this script as root."
+  exit 1
+fi
+
+# Require cgroup2 to be mounted
+cgroup_hostroot="$(mount -t cgroup2 | head -1 | cut -d' ' -f3)"
+if [ -z "$cgroup_hostroot" ]; then
+  echo "cgroup2 mount not found, fail"
+  exit 1
+fi
+
+# Require bpf to be mounted
+# TODO: Move into init after https://bugs.launchpad.net/snapd/+bug/2048506
+bpf_root="$(mount -t bpf | head -1 | cut -d' ' -f3)"
+if [ -z "$bpf_root" ]; then
+  if ! mount -t bpf -o rw,nosuid,nodev,noexec,relatime,mode=700 bpf /sys/fs/bpf; then
+    echo "/sys/fs/bpf not found and couldn't auto mount, failing..."
+    exit 1
+  fi
+fi
+
+# TODO: Move into init after https://bugs.launchpad.net/snapd/+bug/2048507
+# Cilium expects rp_filter=0 which is set to rp_filter=1 by defaut by systemd(Ubuntu 22.04>)
+# Check https://github.com/cilium/cilium/issues/20125 for more.
+sudo sed -i -e '/net.ipv4.conf.*.rp_filter/d' $(sudo grep -ril '\.rp_filter' /etc/sysctl.d/ /usr/lib/sysctl.d/)
+sudo sysctl -a | grep '\.rp_filter' | awk '{print $1" = 0"}' | sudo tee -a /etc/sysctl.d/1000-cilium.conf
+sudo sysctl --system
+
+# TODO: Remove after https://bugs.launchpad.net/snapd/+bug/2047798
+sudo sed -i -e 's/\/run\/netns\/ r/\/run\/netns\/ rk/g' /var/lib/snapd/apparmor/profiles/snap.k8s.containerd
+sudo sed -i -e 's/userns,/userns rwk,/g' /var/lib/snapd/apparmor/profiles/snap.k8s.containerd # Tempfix
+sudo apparmor_parser -r /var/lib/snapd/apparmor/profiles/snap.k8s.containerd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -236,9 +236,12 @@ apps:
     command: k8s/wrappers/services/k8sd
     install-mode: enable
     daemon: simple
+    # FIXME: we keep 'kubernetes-support' because 'mount-observe' is not sufficient for some reason, investigate
     plugs:
       - network
       - network-bind
+      - mount-observe
+      - kubernetes-support
   kubelet:
     install-mode: disable
     command: k8s/wrappers/services/kubelet

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/mattn/go-sqlite3 v1.14.18
+	github.com/moby/sys/mountinfo v0.6.2
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -104,7 +104,16 @@ func (h *helmClient) Enable(name string) error {
 		return fmt.Errorf("failed to load component manifest: %w", err)
 	}
 
-	_, err = install.Run(chart, nil)
+	var values map[string]any = nil
+	valuesHook, ok := valuesHooks[name]
+	if ok {
+		values, err = valuesHook()
+		if err != nil {
+			return fmt.Errorf("could not generate config for component '%s': %w", name, err)
+		}
+	}
+
+	_, err = install.Run(chart, values)
 	if err != nil {
 		return fmt.Errorf("failed to enable component '%s': %w", name, err)
 	}

--- a/src/k8s/pkg/component/hook.go
+++ b/src/k8s/pkg/component/hook.go
@@ -1,0 +1,93 @@
+package component
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/utils"
+)
+
+type valuesHook func() (map[string]any, error)
+
+var valuesHooks = map[string]valuesHook{
+	"network": networkValues,
+}
+
+func networkValues() (map[string]any, error) {
+	bpfMnt, err := utils.GetMountPath("bpf")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bpf mount path: %w", err)
+	}
+
+	cgrMnt, err := utils.GetMountPath("cgroup2")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cgroup2 mount path: %w", err)
+	}
+
+	// TODO: the cluster cidr should be configurable through a common interface
+	clusterCIDRStr, err := utils.GetServiceArgument("kube-proxy", "--cluster-cidr")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster cidrs from kube-proxy arguments: %w", err)
+	}
+
+	clusterCIDRs := strings.Split(clusterCIDRStr, ",")
+	if v := len(clusterCIDRs); v != 1 && v != 2 {
+		return nil, fmt.Errorf("invalid kube-proxy --cluster-cidr value: %v", clusterCIDRs)
+	}
+
+	var (
+		ipv4CIDR string
+		ipv6CIDR string
+	)
+	for _, cidr := range clusterCIDRs {
+		_, parsed, err := net.ParseCIDR(cidr)
+		switch {
+		case err != nil:
+			return nil, fmt.Errorf("failed to parse cidr: %w", err)
+		case parsed.IP.To4() != nil:
+			ipv4CIDR = cidr
+		default:
+			ipv6CIDR = cidr
+		}
+	}
+
+	values := map[string]any{
+		"cni": map[string]any{
+			"confPath": "/etc/cni/net.d",
+			"binPath":  "/opt/cni/bin",
+		},
+		"daemon": map[string]any{
+			"runPath": utils.SnapCommonPath("var", "run", "cilium"),
+		},
+		"operator": map[string]any{
+			"replicas": 1,
+		},
+		"ipam": map[string]any{
+			"operator": map[string]any{
+				"clusterPoolIPv4PodCIDRList": ipv4CIDR,
+				"clusterPoolIPv6PodCIDRList": ipv6CIDR,
+			},
+		},
+		"nodePort": map[string]any{
+			"enabled": true,
+		},
+		"bpf": map[string]any{
+			"autoMount": map[string]any{
+				"enabled": false,
+			},
+			"root": bpfMnt,
+		},
+		"cgroup": map[string]any{
+			"autoMount": map[string]any{
+				"enabled": false,
+			},
+			"hostRoot": cgrMnt,
+		},
+		"l2announcements": map[string]any{
+			"enabled": true,
+		},
+	}
+
+	return values, nil
+}

--- a/src/k8s/pkg/utils/file.go
+++ b/src/k8s/pkg/utils/file.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"syscall"
+
+	"github.com/moby/sys/mountinfo"
 )
 
 func SnapPath(parts ...string) string {
@@ -182,4 +184,17 @@ func CopySymLink(source, dest string) error {
 		return fmt.Errorf("could not read symlink: %w", err)
 	}
 	return os.Symlink(link, dest)
+}
+
+// GetMountPath returns the first mountpath for a given filesystem type.
+func GetMountPath(fsType string) (string, error) {
+	mounts, err := mountinfo.GetMounts(mountinfo.FSTypeFilter(fsType))
+	if err != nil {
+		return "", fmt.Errorf("failed to find the mount info for %s: %w", fsType, err)
+	}
+	if len(mounts) == 0 {
+		return "", fmt.Errorf("could not find any %s filesystem mount", fsType)
+	}
+
+	return mounts[0].Mountpoint, nil
 }

--- a/tests/e2e/lxd-profile.yaml
+++ b/tests/e2e/lxd-profile.yaml
@@ -10,7 +10,19 @@ config:
   security.nesting: "true"
   security.privileged: "true"
 devices:
-  dev_kmsg:
+  aadisable:
+    path: /sys/module/nf_conntrack/parameters/hashsize
+    source: /sys/module/nf_conntrack/parameters/hashsize
+    type: disk
+  aadisable2:
     path: /dev/kmsg
     source: /dev/kmsg
     type: unix-char
+  aadisable3:
+    path: /sys/fs/bpf
+    source: /sys/fs/bpf
+    type: disk
+  aadisable4:
+    path: /proc/sys/net/netfilter/nf_conntrack_max
+    source: /proc/sys/net/netfilter/nf_conntrack_max
+    type: disk

--- a/tests/e2e/templates/nginx-pod.yaml
+++ b/tests/e2e/templates/nginx-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+  namespace: default
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+  restartPolicy: Always

--- a/tests/e2e/tests/e2e_util/config.py
+++ b/tests/e2e/tests/e2e_util/config.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 DIR = Path(__file__).absolute().parent
 
+MANIFESTS_DIR = DIR / ".." / ".." / "templates"
+
 # SNAP is the absolute path to the snap against which we run the e2e tests.
 SNAP = os.getenv("TEST_SNAP")
 

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -1,0 +1,131 @@
+#
+# Copyright 2023 Canonical, Ltd.
+#
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from e2e_util import config, harness, util
+from e2e_util.config import MANIFESTS_DIR
+
+LOG = logging.getLogger(__name__)
+
+
+def test_network(h: harness.Harness, tmp_path: Path):
+    if not config.SNAP:
+        pytest.fail("Set TEST_SNAP to the path where the snap is")
+
+    snap_path = (tmp_path / "k8s.snap").as_posix()
+
+    LOG.info("Create instance")
+    instance_id = h.new_instance()
+
+    util.setup_k8s_snap(h, instance_id, snap_path)
+    h.exec(instance_id, ["k8s", "init"])
+    util.setup_network(h, instance_id)
+
+    p = h.exec(
+        instance_id,
+        [
+            "/snap/k8s/current/bin/kubectl",
+            "--kubeconfig",
+            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "get",
+            "po",
+            "-n",
+            "kube-system",
+            "-l",
+            "k8s-app=cilium",
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+    )
+
+    out = json.loads(p.stdout.decode())
+    assert len(out["items"]) > 0
+
+    cilium_pod = out["items"][0]
+
+    p = h.exec(
+        instance_id,
+        [
+            "/snap/k8s/current/bin/kubectl",
+            "--kubeconfig",
+            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "exec",
+            "-it",
+            cilium_pod["metadata"]["name"],
+            "-n",
+            "kube-system",
+            "-c",
+            "cilium-agent",
+            "--",
+            "cilium",
+            "status",
+            "--brief",
+        ],
+        capture_output=True,
+    )
+
+    assert p.stdout.decode().strip() == "OK"
+
+    manifest = MANIFESTS_DIR / "nginx-pod.yaml"
+    p = h.exec(
+        instance_id,
+        [
+            "/snap/k8s/current/bin/kubectl",
+            "--kubeconfig",
+            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "apply",
+            "-f",
+            "-",
+        ],
+        check=True,
+        input=Path(manifest).read_bytes(),
+    )
+
+    util.retry_until_condition(
+        h,
+        instance_id,
+        [
+            "/snap/k8s/current/bin/kubectl",
+            "--kubeconfig",
+            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-l",
+            "app=nginx",
+            "--timeout",
+            "180s",
+        ],
+        max_retries=3,
+        delay_between_retries=1,
+        check=True,
+    )
+
+    p = h.exec(
+        instance_id,
+        [
+            "/snap/k8s/current/bin/kubectl",
+            "--kubeconfig",
+            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "exec",
+            "-it",
+            cilium_pod["metadata"]["name"],
+            "-n",
+            "kube-system",
+            "-c",
+            "cilium-agent",
+            "--",
+            "cilium",
+            "endpoint",
+            "list",
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+    )
+    assert "nginx" in p.stdout.decode().strip()

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -21,6 +21,6 @@ def test_smoke(h: harness.Harness, tmp_path: Path):
 
     util.setup_k8s_snap(h, instance_id, snap_path)
     h.exec(instance_id, ["k8s", "init"])
+    util.setup_network(h, instance_id)
 
-    # TODO(bschimke): The node will not report ready as the CNI is not yet implemented in the k8s snap.
-    #                 Validate ready state with the `wait_until_k8s_ready` method once this is done.
+    util.wait_until_k8s_ready(h, instance_id)


### PR DESCRIPTION
To get the CNI working:
```bash
sudo snap install ./k8s.snap --dangerous
sudo /snap/k8s/current/k8s/connect-interfaces.sh
sudo /snap/k8s/current/k8s/network-requirements.sh
sudo k8s init
sudo k8s enable network 
```

Having `kubernetes-support` interface on `k8sd` is not ideal, however we can not check existing paths without it. Although `mount-observe` feels like it should be enough.

Passing in dynamic values to deployment mechanism is also up for discussion. 