### PR TITLE
Add k8s-dqlite clustering support

### DIFF
--- a/k8s/args/k8s-dqlite
+++ b/k8s/args/k8s-dqlite
@@ -1,2 +1,2 @@
---storage-dir=/var/lib/k8s-dqlite
---listen=unix:///var/lib/k8s-dqlite/k8s-dqlite.sock
+--storage-dir=${SNAP_COMMON}/var/lib/k8s-dqlite 
+--listen=unix://${SNAP_COMMON}/var/lib/k8s-dqlite/k8s-dqlite.sock

--- a/k8s/args/kube-apiserver
+++ b/k8s/args/kube-apiserver
@@ -8,7 +8,7 @@
 --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
 --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key
 --secure-port=6443
---etcd-servers="unix:///var/lib/k8s-dqlite/k8s-dqlite.sock"
+--etcd-servers="unix://${SNAP_COMMON}/var/lib/k8s-dqlite/k8s-dqlite.sock"
 --allow-privileged=true
 --service-account-issuer='https://kubernetes.default.svc'
 --service-account-signing-key-file=/etc/kubernetes/pki/serviceaccount.key

--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -8,6 +8,12 @@ type GetClusterStatusResponse struct {
 	ClusterStatus ClusterStatus `json:"status"`
 }
 
+// InitClusterRequest is used to initialize a k8s cluster.
+type InitClusterRequest struct{}
+
+// InitClusterResponse is the response for "POST 1.0/k8sd/cluster".
+type InitClusterResponse struct{}
+
 // ClusterMember holds information about a node in the k8s cluster.
 type ClusterMember struct {
 	Name        string `json:"name"`

--- a/src/k8s/cmd/k8s/k8s_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_cluster.go
@@ -17,6 +17,6 @@ var (
 func init() {
 	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.remoteAddress, "remote-address", "", "IP Address of another cluster member")
 	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.port, "port", strconv.Itoa(client.DefaultPort), "Port on which the REST-API is exposed")
-	// TODO: Use snap interface instead of hardcoded string
+	// TODO(bschimke): Use common path from snap when k8s CLI is enabled
 	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.storageDir, "storage-dir", "/var/snap/k8s/common/var/lib/k8sd", "Directory with the dqlite datastore")
 }

--- a/src/k8s/cmd/k8s/k8s_init.go
+++ b/src/k8s/cmd/k8s/k8s_init.go
@@ -2,10 +2,10 @@ package k8s
 
 import (
 	"fmt"
-	"os/exec"
 
 	"github.com/canonical/k8s/pkg/k8s/client"
 	"github.com/canonical/k8s/pkg/k8s/setup"
+	"github.com/canonical/k8s/pkg/snap"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -61,14 +61,12 @@ var (
 				return fmt.Errorf("failed to initialize kube-apiserver: %w", err)
 			}
 
-			err = setup.InitPermissions()
+			err = setup.InitPermissions(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("failed to setup permissions: %w", err)
 			}
 
-			startCmd := exec.Command("snapctl", "start", "k8s")
-
-			_, err = startCmd.Output()
+			err = snap.StartService(cmd.Context(), "k8s")
 			if err != nil {
 				return fmt.Errorf("failed to start services: %w", err)
 			}

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -3,8 +3,8 @@ package component
 import (
 	"fmt"
 	"os"
-	"path"
 
+	"github.com/canonical/k8s/pkg/snap"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"helm.sh/helm/v3/pkg/action"
@@ -52,7 +52,7 @@ func logAdapter(format string, v ...any) {
 func NewManager() (*helmClient, error) {
 	viper.SetConfigName("components")
 	viper.SetConfigType("yaml")
-	viper.AddConfigPath(path.Join(os.Getenv("SNAP"), "k8s", "components"))
+	viper.AddConfigPath(snap.Path("k8s/components"))
 	err := viper.ReadInConfig()
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (h *helmClient) Enable(name string) error {
 		return nil
 	}
 
-	chart, err := loader.Load(path.Join(os.Getenv("SNAP"), "k8s", "components", "charts", component.Chart))
+	chart, err := loader.Load(snap.Path("k8s/components/charts", component.Chart))
 	if err != nil {
 		return fmt.Errorf("failed to load component manifest: %w", err)
 	}
@@ -189,7 +189,7 @@ func (h *helmClient) Refresh(name string) error {
 	upgrade.Namespace = component.Namespace
 	upgrade.ReuseValues = true
 
-	chart, err := loader.Load(path.Join(os.Getenv("SNAP"), component.Chart))
+	chart, err := loader.Load(snap.Path(component.Chart))
 	if err != nil {
 		return fmt.Errorf("failed to load component manifest: %w", err)
 	}

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -12,7 +12,8 @@ import (
 
 // JoinNode calls "POST 1.0/k8sd/cluster/<node>"
 func (c *Client) JoinNode(ctx context.Context, name string, address string, token string) error {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	// Joining a node takes some time since services need to be restarted.
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*180)
 	defer cancel()
 
 	// TODO: This is super ugly but we first need to "initialize" the database with this join command before we can

--- a/src/k8s/pkg/k8s/setup/containerd.go
+++ b/src/k8s/pkg/k8s/setup/containerd.go
@@ -2,20 +2,20 @@ package setup
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/k8s/utils"
+	"github.com/canonical/k8s/pkg/snap"
 )
 
 // InitContainerd handles the setup of containerd.
 //   - Copies required files and binaries needed by Containerd to the correct paths.
 func InitContainerd() error {
-	err := utils.CopyFile(filepath.Join(utils.SNAP, "k8s/config/containerd/config.toml"), "/etc/containerd/config.toml")
+	err := utils.CopyFile(snap.Path("k8s/config/containerd/config.toml"), "/etc/containerd/config.toml")
 	if err != nil {
 		return fmt.Errorf("failed to copy containerd config: %w", err)
 	}
 
-	err = utils.CopyDirectory(filepath.Join(utils.SNAP, "opt/cni/bin/"), "/opt/cni/bin")
+	err = utils.CopyDirectory(snap.Path("opt/cni/bin/"), "/opt/cni/bin")
 	if err != nil {
 		return fmt.Errorf("failed to copy cni/bin: %w", err)
 	}

--- a/src/k8s/pkg/k8s/setup/folders.go
+++ b/src/k8s/pkg/k8s/setup/folders.go
@@ -3,15 +3,14 @@ package setup
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/k8s/certutils"
-	"github.com/canonical/k8s/pkg/k8s/utils"
+	"github.com/canonical/k8s/pkg/snap"
 )
 
 // InitFolders creates the necessary folders for service arguments and certificates.
 func InitFolders() error {
-	argsDir := filepath.Join(utils.SNAP_DATA, "args")
+	argsDir := snap.Path("args")
 	err := os.MkdirAll(argsDir, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("failed to create arguments directory: %w", err)

--- a/src/k8s/pkg/k8s/setup/k8sd.go
+++ b/src/k8s/pkg/k8s/setup/k8sd.go
@@ -3,18 +3,15 @@ package setup
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8s/client"
+	"github.com/canonical/k8s/pkg/snap"
 )
 
 // InitK8sd handles the setup of K8sd.
 func InitK8sd(ctx context.Context, clusterOpts client.ClusterOpts) (*client.Client, error) {
-	startCmd := exec.Command("snapctl", "start", "k8s.k8sd")
-	var err error
-
-	_, err = startCmd.Output()
+	err := snap.StartService(ctx, "k8sd")
 	if err != nil {
 		return nil, fmt.Errorf("failed to start services: %w", err)
 	}

--- a/src/k8s/pkg/k8s/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8s/setup/kube_apiserver.go
@@ -2,10 +2,10 @@ package setup
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/k8s/client"
 	"github.com/canonical/k8s/pkg/k8s/utils"
+	"github.com/canonical/k8s/pkg/snap"
 )
 
 // InitKubeApiserver handles the setup of kube-apiserver.
@@ -16,7 +16,7 @@ func InitKubeApiserver() error {
 		return fmt.Errorf("failed to get default ip: %w", err)
 	}
 
-	utils.TemplateAndSave(filepath.Join(utils.SNAP, "k8s/config/apiserver-token-hook.tmpl"),
+	utils.TemplateAndSave(snap.Path("k8s/config/apiserver-token-hook.tmpl"),
 		struct {
 			WebhookIp   string
 			WebhookPort int

--- a/src/k8s/pkg/k8s/setup/permissions.go
+++ b/src/k8s/pkg/k8s/setup/permissions.go
@@ -1,26 +1,24 @@
 package setup
 
 import (
+	"context"
 	"fmt"
-	"os/exec"
-	"path/filepath"
 
-	"github.com/canonical/k8s/pkg/k8s/utils"
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils"
 )
 
 // InitPermissions makes sure(sets up) the permissions of paths utilized by the snap are correct.
-func InitPermissions() error {
+func InitPermissions(ctx context.Context) error {
 	// Shelling out since go doesn't support symbolic mode definitions.
-	chmcmd := exec.Command(
+	err := utils.RunCommand(ctx,
 		"chmod", "go-rxw", "-R",
-		filepath.Join(utils.SNAP_DATA, "args"),
-		filepath.Join(utils.SNAP_COMMON, "opt"),
-		filepath.Join(utils.SNAP_COMMON, "etc"),
-		filepath.Join(utils.SNAP_COMMON, "var/lib"),
-		filepath.Join(utils.SNAP_COMMON, "var/log"),
+		snap.DataPath("args"),
+		snap.CommonPath("opt"),
+		snap.CommonPath("etc"),
+		snap.CommonPath("var/lib"),
+		snap.CommonPath("var/log"),
 	)
-
-	_, err := chmcmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to change folder permissions: %w", err)
 	}

--- a/src/k8s/pkg/k8s/setup/serviceargs.go
+++ b/src/k8s/pkg/k8s/setup/serviceargs.go
@@ -2,16 +2,16 @@ package setup
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/k8s/utils"
+	"github.com/canonical/k8s/pkg/snap"
 )
 
 // InitServiceArgs handles the setup of services arguments.
 //   - For each service, copies the default arguments files from the snap under $SNAP_DATA/args
 func InitServiceArgs() error {
 	for _, service := range []string{"containerd", "k8sd", "k8s-dqlite", "kube-apiserver", "kube-controller-manager", "kube-proxy", "kube-scheduler", "kubelet"} {
-		err := utils.CopyFile(filepath.Join(utils.SNAP, "k8s/args", service), filepath.Join(utils.SNAP_DATA, "args", service))
+		err := utils.CopyFile(snap.Path("k8s/args", service), snap.DataPath("args", service))
 		if err != nil {
 			return fmt.Errorf("failed to copy %s args: %w", service, err)
 		}

--- a/src/k8s/pkg/k8s/utils/file.go
+++ b/src/k8s/pkg/k8s/utils/file.go
@@ -9,13 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"syscall"
-)
 
-// TODO (KU-167): Replace this with a proper snap helper/interface
-var (
-	SNAP_DATA   = os.Getenv("SNAP_DATA")
-	SNAP_COMMON = os.Getenv("SNAP_COMMON")
-	SNAP        = os.Getenv("SNAP")
+	"github.com/canonical/k8s/pkg/snap"
 )
 
 // TemplateAndSave compiles a template with the data and saves it to the given target path.
@@ -60,7 +55,7 @@ func ChmodRecursive(name string, mode fs.FileMode) error {
 func GetServiceArgument(service string, argument string) (string, error) {
 	re := regexp.MustCompile(fmt.Sprintf("%s=(.+)", argument))
 
-	b, err := os.ReadFile(filepath.Join(SNAP_DATA, "args", service)) // just pass the file name
+	b, err := os.ReadFile(snap.DataPath("args", service)) // just pass the file name
 	if err != nil {
 		return "", fmt.Errorf("failed to read args file: %w", err)
 	}

--- a/src/k8s/pkg/k8s/utils/kubeconfig.go
+++ b/src/k8s/pkg/k8s/utils/kubeconfig.go
@@ -3,15 +3,13 @@ package utils
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
+
+	"github.com/canonical/k8s/pkg/snap"
 )
 
 // GenerateX509Kubeconfig creates a kubeconfig file with the given x509 certificate and key data.
 func GenerateX509Kubeconfig(keyPem, certPem, caCertPem []byte, path string) error {
-	SNAP := os.Getenv("SNAP")
-
 	val, err := GetServiceArgument("kube-apiserver", "--secure-port")
 	if err != nil {
 		return fmt.Errorf("failed while getting apiserver port: %w", err)
@@ -22,7 +20,7 @@ func GenerateX509Kubeconfig(keyPem, certPem, caCertPem []byte, path string) erro
 		return fmt.Errorf("apiserver port is not an integer: %w", err)
 	}
 
-	return TemplateAndSave(filepath.Join(SNAP, "k8s/config/kubeconfig-with-x509.tmpl"),
+	return TemplateAndSave(snap.Path("k8s/config/kubeconfig-with-x509.tmpl"),
 		struct {
 			CaData        string
 			ApiServerIp   string
@@ -42,8 +40,6 @@ func GenerateX509Kubeconfig(keyPem, certPem, caCertPem []byte, path string) erro
 
 // GenerateKubeconfig creates a kubeconfig file with the given token and CA data.
 func GenerateKubeconfig(token string, caCertPem []byte, path string) error {
-	SNAP := os.Getenv("SNAP")
-
 	val, err := GetServiceArgument("kube-apiserver", "--secure-port")
 	if err != nil {
 		return fmt.Errorf("failed while getting apiserver port: %w", err)
@@ -54,7 +50,7 @@ func GenerateKubeconfig(token string, caCertPem []byte, path string) error {
 		return fmt.Errorf("apiserver port is not an integer: %w", err)
 	}
 
-	return TemplateAndSave(filepath.Join(SNAP, "k8s/config/kubeconfig-with-token.tmpl"),
+	return TemplateAndSave(snap.Path("k8s/config/kubeconfig-with-token.tmpl"),
 		struct {
 			CaData        string
 			ApiServerIp   string

--- a/src/k8s/pkg/k8sd/api/cluster.go
+++ b/src/k8s/pkg/k8sd/api/cluster.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
@@ -13,6 +14,7 @@ import (
 var k8sdCluster = rest.Endpoint{
 	Path: "k8sd/cluster",
 	Get:  rest.EndpointAction{Handler: clusterGet, AllowUntrusted: false},
+	Post: rest.EndpointAction{Handler: clusterPost, AllowUntrusted: false},
 }
 
 func clusterGet(s *state.State, r *http.Request) response.Response {
@@ -26,4 +28,14 @@ func clusterGet(s *state.State, r *http.Request) response.Response {
 	}
 
 	return response.SyncResponse(true, &result)
+}
+
+func clusterPost(s *state.State, r *http.Request) response.Response {
+	// The `k8s init` command will be move here eventually - right now this only writes the k8s-dqlite
+	// certificate to the cluster so that k8s-dqlite joining works.
+	err := utils.WriteK8sDqliteCertInfoToK8sd(r.Context(), s)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("failed to write k8s-dqlite cert to k8sd: %w", err))
+	}
+	return response.SyncResponse(true, &apiv1.InitClusterResponse{})
 }

--- a/src/k8s/pkg/k8sd/api/utils/k8s-dqlite.go
+++ b/src/k8s/pkg/k8sd/api/utils/k8s-dqlite.go
@@ -1,0 +1,232 @@
+package utils
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/microcluster/rest/types"
+	"github.com/canonical/microcluster/state"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	// TODO(bschimke): Do not use global state here.
+	clusterDir       = snap.CommonPath("var/lib/k8s-dqlite")
+	clusterBackupDir = snap.CommonPath("var/lib/k8s-dqlite-backup")
+)
+
+// WriteK8sDqliteCertInfoToK8sd gets local cert and key and stores them in the k8sd database.
+func WriteK8sDqliteCertInfoToK8sd(ctx context.Context, state *state.State) error {
+	// Read cert and key from local
+	cert, err := os.ReadFile(path.Join(clusterDir, "cluster.crt"))
+	if err != nil {
+		return fmt.Errorf("failed to read cluster.cert from %s: %w", clusterDir, err)
+	}
+	key, err := os.ReadFile(path.Join(clusterDir, "cluster.key"))
+	if err != nil {
+		return fmt.Errorf("failed to read cluster.key from %s: %w", clusterDir, err)
+	}
+
+	logrus.WithField("cert_length", len(string(cert))).WithField("key_length", len(string(key))).Debug("Writing k8s-dqlite cert and key to database")
+	if err := state.Database.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		err = database.CreateCertificate(ctx, tx, "k8s-dqlite", string(cert), string(key))
+		if err != nil {
+			return fmt.Errorf("failed to write k8s-dqlite certs and key to database: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to perform k8s-dqlite certificate transaction write request: %w", err)
+	}
+	return nil
+}
+
+// UpdateK8sDqlite joins the k8s-dqlite databases by performing the following steps:
+//
+//	Stop apiserver and k8s-dqlite
+//	Backup existing k8s-cluster
+//	Retrieve k8s-dqlite certificates from cluster node (k8sd is already joined at this point so we can access the certificates)
+//	Store new certificates in k8s-dqlite cluster directory
+//	Get current address and port from backup `info.yaml`
+//	Get voters from join token (TODO: implement new token that encodes k8sd token and voter info into one token)
+//	for now - just use the voter IPs from the k8sd token and assume the default k8s-dqlite port
+//	write k8s-dqlite init file
+//	restart services and wait to join
+func UpdateK8sDqlite(ctx context.Context, state *state.State, voters []string, host string) error {
+	logrus.Debug("Stop kube-apiserver")
+	if err := snap.StopService(ctx, "kube-apiserver"); err != nil {
+		return fmt.Errorf("failed to stop apiserver: %w", err)
+	}
+
+	logrus.Debug("Stop k8s-dqlite")
+	if err := snap.StopService(ctx, "k8s-dqlite"); err != nil {
+		return fmt.Errorf("failed to stop k8s-dqlite: %w", err)
+	}
+
+	logrus.Debug("Clean backupdir")
+	if err := os.RemoveAll(clusterBackupDir); err != nil {
+		return fmt.Errorf("failed to remove directory: %w", err)
+	}
+
+	logrus.Debugf("Rename %s to %s", clusterDir, clusterBackupDir)
+	if err := os.Rename(clusterDir, clusterBackupDir); err != nil {
+		return fmt.Errorf("failed to move directory: %w", err)
+	}
+
+	logrus.Debug("Create new cluster dir")
+	if err := os.Mkdir(clusterDir, os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	logrus.Debug("Update cluster certificates")
+	if err := updateClusterCertificate(ctx, state); err != nil {
+		return fmt.Errorf("failed to update k8s-dqlite cluster certificate: %w", err)
+	}
+
+	logrus.Debug("Update cluster info file")
+	if err := createClusterInitFile(voters, host); err != nil {
+		return fmt.Errorf("failed to update cluster info.yaml file: %w", err)
+	}
+
+	logrus.Debug("Start k8s-dqlite service")
+	if err := snap.StartService(ctx, "k8s-dqlite"); err != nil {
+		return fmt.Errorf("failed to stop k8s-dqlite: %w", err)
+	}
+
+	logrus.Debug("Wait for node to join")
+	if err := waitForNodeJoin(ctx, host); err != nil {
+		return fmt.Errorf("failed to wait for k8s-dqlite cluster to join: %w", err)
+	}
+
+	logrus.Debug("Start kube-apiserver")
+	if err := snap.StartService(ctx, "kube-apiserver"); err != nil {
+		return fmt.Errorf("failed to stop apiserver: %w", err)
+	}
+
+	return nil
+}
+
+// updateClusterCertificate read the k8s-dqlite certificate & key from the k8sd database and write it
+// to the joining node k8s-dqlite directory.
+func updateClusterCertificate(ctx context.Context, state *state.State) error {
+	// Get the certificates from the k8sd cluster
+	var cert, key string
+	var err error
+	if err := state.Database.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		cert, key, err = database.GetCertificateAndKey(ctx, tx, "k8s-dqlite")
+		if err != nil {
+			return fmt.Errorf("failed to get k8s-dqlite certs and key from database: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to perform k8s-dqlite certificate transaction request: %w", err)
+	}
+
+	logrus.WithField("cert", cert).Debug("Write k8s-dqlite certificate")
+	// Write them to the k8s-dqlite cluster directory
+	if err := os.WriteFile(path.Join(clusterDir, "cluster.crt"), []byte(cert), 0644); err != nil {
+		return fmt.Errorf("failed to write cluster.cert to %s: %w", clusterDir, err)
+	}
+	logrus.WithField("key", key).Debug("Write k8s-dqlite cert key")
+	if err := os.WriteFile(path.Join(clusterDir, "cluster.key"), []byte(key), 0644); err != nil {
+		return fmt.Errorf("failed to write cluster.key to %s: %w", clusterDir, err)
+	}
+	return nil
+}
+
+// clusterInit represents the yaml file structure of the dqlite `init.yaml` file.
+type clusterInit struct {
+	ID      string   `yaml:"ID,omitempty"`
+	Address string   `yaml:"Address,omitempty"`
+	Role    int      `yaml:"Role,omitempty"`
+	Cluster []string `yaml:"Cluster,omitempty"`
+}
+
+// createClusterInitFile writes the `init.yaml` file to the k8s-dqlite directory.
+// it contains the informations to join an existing cluster (e.g. members addresses)
+// and is picked up by k8s-dqlite on startup.
+func createClusterInitFile(voters []string, host string) error {
+	// Get the dqlite port from the already existing deployment
+	port := 2380
+	infoFileData, err := os.ReadFile(filepath.Join(clusterBackupDir, "info.yaml"))
+	if err != nil {
+		return fmt.Errorf("failed to %s: %w", filepath.Join(clusterBackupDir, "info.yaml"), err)
+	}
+
+	info := clusterInit{}
+	err = yaml.Unmarshal(infoFileData, &info)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal the info.yaml from the cluster backup: %w", err)
+	}
+
+	addr, err := types.ParseAddrPort(info.Address)
+	if err == nil {
+		port = int(addr.Port())
+	}
+
+	// Assumes that all cluster members use the same port for k8s-dqlite
+	// TODO: do not reuse voter information from the k8sd token but encode the real k8s-dqlite
+	// member data into a new token (see `UpdateDqlite` above for more).
+	v := []string{}
+	addrPorts, err := types.ParseAddrPorts(voters)
+	if err != nil {
+		return fmt.Errorf("failed to parse voter addresses: %w", err)
+	}
+	for _, a := range addrPorts {
+		v = append(v, fmt.Sprintf("%s:%d", a.Addr(), port))
+	}
+
+	initData := clusterInit{
+		Cluster: v,
+		Address: fmt.Sprintf("%s:%d", host, port),
+	}
+
+	marshaled, err := yaml.Marshal(&initData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cluster init data: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(clusterDir, "init.yaml"), []byte(marshaled), 0644); err != nil {
+		return fmt.Errorf("failed to write init.yaml to %s: %w", clusterDir, err)
+	}
+	return nil
+}
+
+func waitForNodeJoin(ctx context.Context, host string) error {
+	ch := make(chan struct{}, 1)
+	go func() {
+		for {
+			cmd := exec.Command(
+				snap.Path("bin/dqlite"),
+				"-s", fmt.Sprintf("file://%s/cluster.yaml", clusterDir),
+				"-c", fmt.Sprintf("%s/cluster.crt", clusterDir),
+				"-k", fmt.Sprintf("%s/cluster.key", clusterDir),
+				"-f", "json", "k8s", ".cluster",
+			)
+
+			out, err := cmd.CombinedOutput()
+			if err == nil && strings.Contains(string(out), host) {
+				break
+			}
+		}
+		ch <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Minute):
+		return fmt.Errorf("Node did not finish joining the cluster within time.")
+	case <-ch:
+		return nil
+	}
+}

--- a/src/k8s/pkg/k8sd/api/utils/token.go
+++ b/src/k8s/pkg/k8sd/api/utils/token.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// K8sdToken is the token that is used to cluster k8sd and
+// contains base64 encoded cluster information
+type K8sdToken struct {
+	Token         string   `json:"token"`
+	NodeName      string   `json:"name"`
+	Secret        string   `json:"secret"`
+	Fingerprint   string   `json:"fingerprint"`
+	JoinAddresses []string `json:"join_addresses"`
+}
+
+// K8sdTokenFromBase64Token creates a K8sdToken instance
+// from a microcluster base64 token.
+func K8sdTokenFromBase64Token(token64 string) (K8sdToken, error) {
+	tokenData, err := base64.StdEncoding.DecodeString(token64)
+	if err != nil {
+		return K8sdToken{}, fmt.Errorf("failed to decode k8sd token %s: %w", tokenData, err)
+	}
+
+	token := K8sdToken{}
+	err = json.Unmarshal(tokenData, &token)
+	if err != nil {
+		return K8sdToken{}, fmt.Errorf("failed to unmarshal k8sd token: %w", err)
+	}
+	token.Token = token64
+	return token, nil
+}

--- a/src/k8s/pkg/k8sd/database/certificates.go
+++ b/src/k8s/pkg/k8sd/database/certificates.go
@@ -1,0 +1,59 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"fmt"
+
+	"github.com/canonical/microcluster/cluster"
+)
+
+var (
+	certificatesStmts = map[string]int{
+		"insert-certificate": mustPrepareStatement("certificates", "insert-certificate.sql"),
+		"select-by-name":     mustPrepareStatement("certificates", "select-by-name.sql"),
+	}
+)
+
+// CreateCertificate inserts a new certificate entry.
+// TODO: convert this to Upsert if necessary.
+func CreateCertificate(ctx context.Context, tx *sql.Tx, name string, certificate string, key string) error {
+	if name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+	if certificate == "" {
+		return fmt.Errorf("certificate cannot be empty")
+	}
+	if key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+	insertTxStmt, err := cluster.Stmt(tx, certificatesStmts["insert-certificate"])
+	if err != nil {
+		return fmt.Errorf("failed to prepare insert statement: %w", err)
+	}
+	if _, err := insertTxStmt.ExecContext(ctx, name, key, certificate); err != nil {
+		return fmt.Errorf("insert certificate query failed: %w", err)
+	}
+
+	return nil
+}
+
+// GetCertificateAndKey retrieves the certificate and key for the given name.
+func GetCertificateAndKey(ctx context.Context, tx *sql.Tx, name string) (cert string, key string, err error) {
+	if name == "" {
+		return "", "", fmt.Errorf("name cannot be empty")
+	}
+	txStmt, err := cluster.Stmt(tx, certificatesStmts["select-by-name"])
+	if err != nil {
+		return "", "", fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	if err := txStmt.QueryRowContext(ctx, name).Scan(&cert, &key); err != nil {
+		if err == sql.ErrNoRows {
+			return "", "", fmt.Errorf("no cert for name=%s: %w", name, err)
+		}
+		return "", "", fmt.Errorf("failed to get certificate: %w", err)
+	}
+
+	return cert, key, nil
+}

--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -14,6 +14,7 @@ import (
 var (
 	SchemaExtensions = map[int]schema.Update{
 		1: schemaApplyMigration("kubernetes-auth-tokens", "000-create.sql"),
+		2: schemaApplyMigration("certificates", "000-create.sql"),
 	}
 
 	//go:embed sql/migrations

--- a/src/k8s/pkg/k8sd/database/sql/migrations/certificates/000-create.sql
+++ b/src/k8s/pkg/k8sd/database/sql/migrations/certificates/000-create.sql
@@ -1,0 +1,6 @@
+CREATE TABLE certificates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name TEXT NOT NULL,
+    certificate TEXT NOT NULL,
+    key TEXT NOT NULL
+)

--- a/src/k8s/pkg/k8sd/database/sql/queries/certificates/insert-certificate.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/certificates/insert-certificate.sql
@@ -1,0 +1,4 @@
+INSERT INTO 
+    certificates(name, certificate, key)
+VALUES 
+    ( ?, ?, ? )

--- a/src/k8s/pkg/k8sd/database/sql/queries/certificates/select-by-name.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/certificates/select-by-name.sql
@@ -1,0 +1,6 @@
+SELECT
+    key, certificate
+FROM
+    certificates AS c
+WHERE
+    ( c.name = ? )

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -1,0 +1,41 @@
+package snap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/utils"
+)
+
+func Path(parts ...string) string {
+	return filepath.Join(append([]string{os.Getenv("SNAP")}, parts...)...)
+}
+
+func DataPath(parts ...string) string {
+	return filepath.Join(append([]string{os.Getenv("SNAP_DATA")}, parts...)...)
+}
+func CommonPath(parts ...string) string {
+	return filepath.Join(append([]string{os.Getenv("SNAP_COMMON")}, parts...)...)
+}
+
+// StartService starts a k8s service. The name can be either prefixed or not.
+func StartService(ctx context.Context, name string) error {
+	return utils.RunCommand(ctx, "snapctl", "start", serviceName(name))
+}
+
+// StopService stops a k8s service. The name can be either prefixed or not.
+func StopService(ctx context.Context, name string) error {
+	return utils.RunCommand(ctx, "snapctl", "stop", serviceName(name))
+}
+
+// serviceName infers the name of the snapctl daemon from the service name.
+// if the serviceName is the snap name `k8s` (=referes to all services) it will return it as is.
+func serviceName(serviceName string) string {
+	if strings.HasPrefix(serviceName, "k8s.") || serviceName == "k8s" {
+		return serviceName
+	}
+	return fmt.Sprintf("k8s.%s", serviceName)
+}

--- a/src/k8s/pkg/utils/utils.go
+++ b/src/k8s/pkg/utils/utils.go
@@ -1,6 +1,11 @@
 package utils
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
 
 // sanitiseMap converts a map with interface{} keys to a map with string keys.
 // This is useful for preparing data for use with the Helm client, which requires
@@ -17,4 +22,20 @@ func SanitiseMap(m map[interface{}]interface{}) map[string]interface{} {
 		}
 	}
 	return result
+}
+
+// runCommand executes a command with a given context.
+// runCommand returns nil if the command completes successfully and the exit code is 0.
+func RunCommand(ctx context.Context, command ...string) error {
+	var args []string
+	if len(command) > 1 {
+		args = command[1:]
+	}
+	cmd := exec.CommandContext(ctx, command[0], args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("command %v failed with exit code %d: %w", command, cmd.ProcessState.ExitCode(), err)
+	}
+	return nil
 }


### PR DESCRIPTION
This PR integrates the clustering of k8s-dqlite into the REST-API.
For that, the k8s-dqlite certificate will be written into k8sd when
initializing k8s. When a new node joins the cluster it will first join
k8sd and then use the certificate and key from the database to join the
k8s-dqlite cluster.