### PR TITLE
Add retry to testing harness

### DIFF
--- a/tests/e2e/tests/e2e_util/harness/lxd.py
+++ b/tests/e2e/tests/e2e_util/harness/lxd.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from e2e_util import config
 from e2e_util.harness import Harness, HarnessError
-from e2e_util.util import run
+from e2e_util.util import run, run_with_retry
 
 LOG = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class LXDHarness(Harness):
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:
-            run(
+            run_with_retry(
                 [
                     "lxc",
                     "launch",


### PR DESCRIPTION
Some commands in the testing harness fail sometimes e.g. pulling LXD images because of network problems.
This commit adds a `run_with_retry` method to avoid this kind of flakyness in the CI and applies it to the LXD launch command (where we have seen these network problem already).