### PR TITLE
Cleanup snap interface connections

### DIFF
--- a/k8s/connect-interfaces.sh
+++ b/k8s/connect-interfaces.sh
@@ -1,33 +1,32 @@
 #!/usr/bin/env bash
 
-set -u
+set -ue
 
 if [ "$EUID" -ne 0 ]
 then echo "Please run this script as root."
   exit 1
 fi
 
-for i in account-control \
-         docker-privileged \
-         kubernetes-support \
-         k8s-journald \
-         k8s-kubelet \
-         k8s-kubeproxy \
-         network \
-         network-bind \
-         network-control \
-         network-observe \
-         firewall-control \
-         process-control \
-         kernel-module-observe \
-         mount-observe \
-         hardware-observe \
-         system-observe \
-         home \
-         opengl \
-         home-read-all \
-         login-session-observe \
-         log-observe
-do
-  snap connect k8s:$i
+declare -a INTERFACES=(
+  docker-privileged
+  kubernetes-support
+  network
+  network-bind
+  network-control
+  network-observe
+  firewall-control
+  process-control
+  kernel-module-observe
+  mount-observe
+  hardware-observe
+  system-observe
+  home
+  opengl
+  home-read-all
+  login-session-observe
+  log-observe
+)
+
+for if in "${INTERFACES[@]}"; do
+  bash -x -c "snap connect 'k8s:${if}'"
 done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -192,7 +192,6 @@ apps:
   k8s:
     command: k8s/wrappers/commands/k8s
     plugs:
-      - account-control
       - firewall-control
       - home-read-all
       - home


### PR DESCRIPTION
### Summary

- remove unused account-control interface (we do not edit group memberships)
- tidy up connect-interfaces.sh script
- do not attempt to connect removed `k8s-*` interfaces