### PR TITLE
Add k8s config REST endpoint and CLI command

### DIFF
--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -14,6 +14,14 @@ type InitClusterRequest struct{}
 // InitClusterResponse is the response for "POST 1.0/k8sd/cluster".
 type InitClusterResponse struct{}
 
+// GetKubeConfigRequest is used to ask for the admin kubeconfig
+type GetKubeConfigRequest struct{}
+
+// GetKubeConfigResponse is the response for "GET 1.0/k8sd/cluster/config".
+type GetKubeConfigResponse struct {
+	KubeConfig string `json:"kube_config"`
+}
+
 // ClusterMember holds information about a node in the k8s cluster.
 type ClusterMember struct {
 	Name        string `json:"name"`

--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -19,7 +19,7 @@ type GetKubeConfigRequest struct{}
 
 // GetKubeConfigResponse is the response for "GET 1.0/k8sd/cluster/config".
 type GetKubeConfigResponse struct {
-	KubeConfig string `json:"kube_config"`
+	KubeConfig string `json:"kubeconfig"`
 }
 
 // ClusterMember holds information about a node in the k8s cluster.

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -11,7 +11,7 @@ import (
 var (
 	configCmd = &cobra.Command{
 		Use:    "config",
-		Short:  "Prints the admin config to connect to the cluster",
+		Short:  "Generate a kubeconfig that can be used to access the Kubernetes cluster",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if rootCmdOpts.logDebug {

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -1,0 +1,46 @@
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8s/client"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	configCmd = &cobra.Command{
+		Use:    "config",
+		Short:  "Prints the admin config to connect to the cluster",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if rootCmdOpts.logDebug {
+				logrus.SetLevel(logrus.TraceLevel)
+			}
+
+			c, err := client.NewClient(cmd.Context(), client.ClusterOpts{
+				StorageDir:    clusterCmdOpts.storageDir,
+				RemoteAddress: clusterCmdOpts.remoteAddress,
+				Port:          clusterCmdOpts.port,
+				Verbose:       rootCmdOpts.logVerbose,
+				Debug:         rootCmdOpts.logDebug,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create client: %w", err)
+			}
+
+			adminConfig, err := c.KubeConfig(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("failed to get admin config: %w", err)
+			}
+
+			fmt.Println(adminConfig)
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -73,3 +73,17 @@ func (c *Client) ClusterStatus(ctx context.Context) (apiv1.ClusterStatus, error)
 	}
 	return response.ClusterStatus, nil
 }
+
+// KubeConfig returns admin kubeconfig to connect to the cluster.
+func (c *Client) KubeConfig(ctx context.Context) (string, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	var response apiv1.GetKubeConfigResponse
+	err := c.mc.Query(queryCtx, "GET", api.NewURL().Path("k8sd", "config"), nil, &response)
+	if err != nil {
+		clientURL := c.mc.URL()
+		return "", fmt.Errorf("failed to query endpoint on %q: %w", clientURL.String(), err)
+	}
+	return response.KubeConfig, nil
+}

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -80,7 +80,7 @@ func (c *Client) KubeConfig(ctx context.Context) (string, error) {
 	defer cancel()
 
 	var response apiv1.GetKubeConfigResponse
-	err := c.mc.Query(queryCtx, "GET", api.NewURL().Path("k8sd", "config"), nil, &response)
+	err := c.mc.Query(queryCtx, "GET", api.NewURL().Path("k8sd", "kubeconfig"), nil, &response)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return "", fmt.Errorf("failed to query endpoint on %q: %w", clientURL.String(), err)

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -12,11 +12,13 @@ import (
 )
 
 var k8sdClusterConfig = rest.Endpoint{
-	Path: "k8sd/config",
+	Path: "k8sd/kubeconfig",
 	Get:  rest.EndpointAction{Handler: clusterConfigGet, AllowUntrusted: false},
 }
 
 func clusterConfigGet(s *state.State, r *http.Request) response.Response {
+	// TODO: Render a new kubeconfig instead of reading the existing one
+	//       when the config can be altered via request parameters.
 	config, err := os.ReadFile("/etc/kubernetes/admin.conf")
 	if err != nil {
 		return response.SmartError(fmt.Errorf("failed to read admin kubeconfig: %w", err))

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+)
+
+var k8sdClusterConfig = rest.Endpoint{
+	Path: "k8sd/config",
+	Get:  rest.EndpointAction{Handler: clusterConfigGet, AllowUntrusted: false},
+}
+
+func clusterConfigGet(s *state.State, r *http.Request) response.Response {
+	config, err := os.ReadFile("/etc/kubernetes/admin.conf")
+	if err != nil {
+		return response.SmartError(fmt.Errorf("failed to read admin kubeconfig: %w", err))
+	}
+
+	result := apiv1.GetKubeConfigResponse{
+		KubeConfig: string(config),
+	}
+	return response.SyncResponse(true, &result)
+}

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -8,6 +8,7 @@ import (
 var Endpoints = []rest.Endpoint{
 	k8sdCluster,
 	k8sdClusterNode,
+	k8sdClusterConfig,
 	k8sdComponents,
 	k8sdComponentsName,
 	k8sdToken,


### PR DESCRIPTION
Provides an endpoint to retrieve an admin kubeconfig, e.g. for the charm. 
Note that this PR provides an initial implementation of the endpoint. As discussed, we might need argument overwrites (e.g. server address) in the future. For that, the `GetKubeConfigRequest` object can easily be extended later as needed.

The CLI is hidden and only a convenience for internal dev and test work (the same output can be obtained with `kubectl config view --raw`).