### PR TITLE
Add k8s client and ClusterReady check

### DIFF
--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -45,17 +45,19 @@ type ExtraServiceArgs map[string]map[string]string
 
 // ClusterMember holds information about a node in the k8s cluster.
 type ClusterMember struct {
-	Name        string `json:"name"`
-	Address     string `json:"address"`
-	Role        string `json:"role"`
-	Fingerprint string `json:"fingerprint"`
-	Status      string `json:"status"`
+	Name        string `mapstructure:"name,omitempty"`
+	Address     string `mapstructure:"address,omitempty"`
+	Role        string `mapstructure:"role,omitempty"`
+	Fingerprint string `mapstructure:"fingerprint,omitempty"`
+	Status      string `mapstructure:"status,omitempty"`
 }
 
 // ClusterStatus holds information about the cluster, e.g. its current members
 type ClusterStatus struct {
-	Members    []ClusterMember `json:"members"`
-	Components []Component     `json:"components"`
+	// Ready is true if at least one node in the cluster is in READY state.
+	Ready      bool            `mapstructure:"ready,omitempty"`
+	Members    []ClusterMember `mapstructure:"members,omitempty"`
+	Components []Component     `mapstructure:"components,omitempty"`
 }
 
 // HaClusterFormed returns true if the cluster is in high-availability mode (more than two voter nodes).

--- a/src/k8s/pkg/k8sd/api/impl/k8sd.go
+++ b/src/k8s/pkg/k8sd/api/impl/k8sd.go
@@ -7,6 +7,7 @@ import (
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/microcluster/state"
@@ -26,7 +27,18 @@ func GetClusterStatus(ctx context.Context, s *state.State) (apiv1.ClusterStatus,
 		return apiv1.ClusterStatus{}, fmt.Errorf("failed to get cluster components: %w", err)
 	}
 
+	k8sClient, err := k8s.NewClient()
+	if err != nil {
+		return apiv1.ClusterStatus{}, fmt.Errorf("failed to create k8s client: %w", err)
+	}
+
+	ready, err := k8s.ClusterReady(ctx, k8sClient)
+	if err != nil {
+		return apiv1.ClusterStatus{}, fmt.Errorf("failed to get cluster components: %w", err)
+	}
+
 	return apiv1.ClusterStatus{
+		Ready:      ready,
 		Members:    members,
 		Components: components,
 	}, nil

--- a/src/k8s/pkg/utils/k8s/client.go
+++ b/src/k8s/pkg/utils/k8s/client.go
@@ -1,0 +1,35 @@
+package k8s
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// k8sClient is a wrapper around the k8s clientset
+type k8sClient struct {
+	kubernetes.Interface
+}
+
+// NewClient creates a client to the k8s cluster.
+//
+// TODO:
+// There is no way for the user to overwrite this kubeconfig.
+// We might need to add this functionality similar to `k8s kubectl`.
+// However, simply querying the KUBECONFIG env will not work for remote clients.
+func NewClient() (*k8sClient, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", "/etc/kubernetes/admin.conf")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s clientset: %w", err)
+	}
+
+	return &k8sClient{
+		clientset,
+	}, nil
+}

--- a/src/k8s/pkg/utils/k8s/status.go
+++ b/src/k8s/pkg/utils/k8s/status.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ClusterReady checks the status of all nodes in the Kubernetes cluster.
+// If at least one node is in READY state it will return true.
+func ClusterReady(ctx context.Context, client *k8sClient) (bool, error) {
+	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get cluster nodes: %v", err)
+	}
+
+	for _, node := range nodes.Items {
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == "Ready" {
+				if condition.Status == v1.ConditionTrue {
+					// At least one node is ready.
+					// That's enough for the cluster to operate.
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/src/k8s/pkg/utils/k8s/status_test.go
+++ b/src/k8s/pkg/utils/k8s/status_test.go
@@ -1,0 +1,100 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestClusterReady(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodes         []runtime.Object
+		expectedReady bool
+	}{
+		{
+			name: "all nodes not ready",
+			nodes: []runtime.Object{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeReady, Status: v1.ConditionFalse},
+						},
+					},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeReady, Status: v1.ConditionFalse},
+						},
+					},
+				},
+			},
+			expectedReady: false,
+		},
+		{
+			name: "some nodes not ready",
+			nodes: []runtime.Object{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeReady, Status: v1.ConditionTrue},
+						},
+					},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeReady, Status: v1.ConditionFalse},
+						},
+					},
+				},
+			},
+			expectedReady: true,
+		},
+		{
+			name: "all nodes ready",
+			nodes: []runtime.Object{
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeReady, Status: v1.ConditionTrue},
+						},
+					},
+				},
+				&v1.Node{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{Type: v1.NodeReady, Status: v1.ConditionTrue},
+						},
+					},
+				},
+			},
+			expectedReady: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			clientset := fake.NewSimpleClientset(tt.nodes...)
+			k8sClient := &k8sClient{Interface: clientset}
+
+			ready, err := ClusterReady(context.Background(), k8sClient)
+
+			g.Expect(err).To(BeNil())
+			g.Expect(ready).To(Equal(tt.expectedReady))
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces a client to query the k8s cluster. 
It wraps the official go-k8s client library and introduces `ClusterReady` in the k8s Status.
