### PR TITLE
Format cluster status CLI output

### DIFF
--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -1,5 +1,10 @@
 package v1
 
+import (
+	"fmt"
+	"strings"
+)
+
 // GetClusterStatusRequest is used to request the current status of the cluster.
 type GetClusterStatusRequest struct{}
 
@@ -69,4 +74,31 @@ func (c ClusterStatus) HaClusterFormed() bool {
 		}
 	}
 	return voters > 2
+}
+
+func (c ClusterStatus) String() string {
+	result := strings.Builder{}
+
+	if c.Ready {
+		result.WriteString("k8s is running")
+	} else {
+		result.WriteString("k8s is not running.\n")
+		return result.String()
+	}
+	result.WriteString("\n")
+
+	result.WriteString("high-availability: ")
+	if c.HaClusterFormed() {
+		result.WriteString("yes")
+	} else {
+		result.WriteString("no")
+	}
+	result.WriteString("\n\n")
+
+	result.WriteString("components:\n")
+	for _, component := range c.Components {
+		result.WriteString(fmt.Sprintf("  %s: %s\n", component.Name, component.Status))
+	}
+
+	return result.String()
 }

--- a/src/k8s/cmd/k8s/formatter/formatter.go
+++ b/src/k8s/cmd/k8s/formatter/formatter.go
@@ -1,0 +1,54 @@
+package formatter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Formatter interface {
+	// Print formattes the output.
+	Print(any) error
+}
+
+// New creates a new formatter based on passed type
+// Can be "plain", "json", "yaml".
+func New(formatterType string, writer io.Writer) (Formatter, error) {
+	switch formatterType {
+	case "plain":
+		return plainFormatter{writer: writer}, nil
+	case "json":
+		return jsonFormatter{writer: writer}, nil
+	case "yaml":
+		return yamlFormatter{writer: writer}, nil
+	default:
+		return nil, fmt.Errorf("unknown formatter type %s", formatterType)
+	}
+}
+
+type plainFormatter struct {
+	writer io.Writer
+}
+
+func (p plainFormatter) Print(data any) error {
+	_, err := fmt.Fprint(p.writer, data)
+	return err
+}
+
+type jsonFormatter struct {
+	writer io.Writer
+}
+
+func (j jsonFormatter) Print(data any) error {
+	return json.NewEncoder(j.writer).Encode(data)
+}
+
+type yamlFormatter struct {
+	writer io.Writer
+}
+
+func (y yamlFormatter) Print(data any) error {
+	return yaml.NewEncoder(y.writer).Encode(data)
+}


### PR DESCRIPTION
Adds flags to specify in which format the CLI output should be displayed.

Current output (the `:` seem to be a bug in the components endpoint that I address in a follow-up PR)
```
ubuntu@init:~/k8s$ sudo k8s status
k8s is running
high-availability: no

components:
  : 
  : 
  : 
  dns: disable
  storage: disable
  network: enable
```