### PR TITLE
Support loopback devices on LXD profile

### DIFF
--- a/tests/e2e/lxd-profile.yaml
+++ b/tests/e2e/lxd-profile.yaml
@@ -26,3 +26,333 @@ devices:
     path: /proc/sys/net/netfilter/nf_conntrack_max
     source: /proc/sys/net/netfilter/nf_conntrack_max
     type: disk
+  dev-loop-control:
+    major: "10"
+    minor: "237"
+    path: /dev/loop-control
+    type: unix-char
+  dev-loop0:
+    major: "7"
+    minor: "0"
+    path: /dev/loop0
+    type: unix-block
+  dev-loop1:
+    major: "7"
+    minor: "1"
+    path: /dev/loop1
+    type: unix-block
+  dev-loop2:
+    major: "7"
+    minor: "2"
+    path: /dev/loop2
+    type: unix-block
+  dev-loop3:
+    major: "7"
+    minor: "3"
+    path: /dev/loop3
+    type: unix-block
+  dev-loop4:
+    major: "7"
+    minor: "4"
+    path: /dev/loop4
+    type: unix-block
+  dev-loop5:
+    major: "7"
+    minor: "5"
+    path: /dev/loop5
+    type: unix-block
+  dev-loop6:
+    major: "7"
+    minor: "6"
+    path: /dev/loop6
+    type: unix-block
+  dev-loop7:
+    major: "7"
+    minor: "7"
+    path: /dev/loop7
+    type: unix-block
+  dev-loop8:
+    major: "7"
+    minor: "8"
+    path: /dev/loop8
+    type: unix-block
+  dev-loop9:
+    major: "7"
+    minor: "9"
+    path: /dev/loop9
+    type: unix-block
+  dev-loop10:
+    major: "7"
+    minor: "10"
+    path: /dev/loop10
+    type: unix-block
+  dev-loop11:
+    major: "7"
+    minor: "11"
+    path: /dev/loop11
+    type: unix-block
+  dev-loop12:
+    major: "7"
+    minor: "12"
+    path: /dev/loop12
+    type: unix-block
+  dev-loop13:
+    major: "7"
+    minor: "13"
+    path: /dev/loop13
+    type: unix-block
+  dev-loop14:
+    major: "7"
+    minor: "14"
+    path: /dev/loop14
+    type: unix-block
+  dev-loop15:
+    major: "7"
+    minor: "15"
+    path: /dev/loop15
+    type: unix-block
+  dev-loop16:
+    major: "7"
+    minor: "16"
+    path: /dev/loop16
+    type: unix-block
+  dev-loop17:
+    major: "7"
+    minor: "17"
+    path: /dev/loop17
+    type: unix-block
+  dev-loop18:
+    major: "7"
+    minor: "18"
+    path: /dev/loop18
+    type: unix-block
+  dev-loop19:
+    major: "7"
+    minor: "19"
+    path: /dev/loop19
+    type: unix-block
+  dev-loop20:
+    major: "7"
+    minor: "20"
+    path: /dev/loop20
+    type: unix-block
+  dev-loop21:
+    major: "7"
+    minor: "21"
+    path: /dev/loop21
+    type: unix-block
+  dev-loop22:
+    major: "7"
+    minor: "22"
+    path: /dev/loop22
+    type: unix-block
+  dev-loop23:
+    major: "7"
+    minor: "23"
+    path: /dev/loop23
+    type: unix-block
+  dev-loop24:
+    major: "7"
+    minor: "24"
+    path: /dev/loop24
+    type: unix-block
+  dev-loop25:
+    major: "7"
+    minor: "25"
+    path: /dev/loop25
+    type: unix-block
+  dev-loop26:
+    major: "7"
+    minor: "26"
+    path: /dev/loop26
+    type: unix-block
+  dev-loop27:
+    major: "7"
+    minor: "27"
+    path: /dev/loop27
+    type: unix-block
+  dev-loop28:
+    major: "7"
+    minor: "28"
+    path: /dev/loop28
+    type: unix-block
+  dev-loop29:
+    major: "7"
+    minor: "29"
+    path: /dev/loop29
+    type: unix-block
+  dev-loop30:
+    major: "7"
+    minor: "30"
+    path: /dev/loop30
+    type: unix-block
+  dev-loop31:
+    major: "7"
+    minor: "31"
+    path: /dev/loop31
+    type: unix-block
+  dev-loop32:
+    major: "7"
+    minor: "32"
+    path: /dev/loop32
+    type: unix-block
+  dev-loop33:
+    major: "7"
+    minor: "33"
+    path: /dev/loop33
+    type: unix-block
+  dev-loop34:
+    major: "7"
+    minor: "34"
+    path: /dev/loop34
+    type: unix-block
+  dev-loop35:
+    major: "7"
+    minor: "35"
+    path: /dev/loop35
+    type: unix-block
+  dev-loop36:
+    major: "7"
+    minor: "36"
+    path: /dev/loop36
+    type: unix-block
+  dev-loop37:
+    major: "7"
+    minor: "37"
+    path: /dev/loop37
+    type: unix-block
+  dev-loop38:
+    major: "7"
+    minor: "38"
+    path: /dev/loop38
+    type: unix-block
+  dev-loop39:
+    major: "7"
+    minor: "39"
+    path: /dev/loop39
+    type: unix-block
+  dev-loop40:
+    major: "7"
+    minor: "40"
+    path: /dev/loop40
+    type: unix-block
+  dev-loop41:
+    major: "7"
+    minor: "41"
+    path: /dev/loop41
+    type: unix-block
+  dev-loop42:
+    major: "7"
+    minor: "42"
+    path: /dev/loop42
+    type: unix-block
+  dev-loop43:
+    major: "7"
+    minor: "43"
+    path: /dev/loop43
+    type: unix-block
+  dev-loop44:
+    major: "7"
+    minor: "44"
+    path: /dev/loop44
+    type: unix-block
+  dev-loop45:
+    major: "7"
+    minor: "45"
+    path: /dev/loop45
+    type: unix-block
+  dev-loop46:
+    major: "7"
+    minor: "46"
+    path: /dev/loop46
+    type: unix-block
+  dev-loop47:
+    major: "7"
+    minor: "47"
+    path: /dev/loop47
+    type: unix-block
+  dev-loop48:
+    major: "7"
+    minor: "48"
+    path: /dev/loop48
+    type: unix-block
+  dev-loop49:
+    major: "7"
+    minor: "49"
+    path: /dev/loop49
+    type: unix-block
+  dev-loop50:
+    major: "7"
+    minor: "50"
+    path: /dev/loop50
+    type: unix-block
+  dev-loop51:
+    major: "7"
+    minor: "51"
+    path: /dev/loop51
+    type: unix-block
+  dev-loop52:
+    major: "7"
+    minor: "52"
+    path: /dev/loop52
+    type: unix-block
+  dev-loop53:
+    major: "7"
+    minor: "53"
+    path: /dev/loop53
+    type: unix-block
+  dev-loop54:
+    major: "7"
+    minor: "54"
+    path: /dev/loop54
+    type: unix-block
+  dev-loop55:
+    major: "7"
+    minor: "55"
+    path: /dev/loop55
+    type: unix-block
+  dev-loop56:
+    major: "7"
+    minor: "56"
+    path: /dev/loop56
+    type: unix-block
+  dev-loop57:
+    major: "7"
+    minor: "57"
+    path: /dev/loop57
+    type: unix-block
+  dev-loop58:
+    major: "7"
+    minor: "58"
+    path: /dev/loop58
+    type: unix-block
+  dev-loop59:
+    major: "7"
+    minor: "59"
+    path: /dev/loop59
+    type: unix-block
+  dev-loop60:
+    major: "7"
+    minor: "60"
+    path: /dev/loop60
+    type: unix-block
+  dev-loop61:
+    major: "7"
+    minor: "61"
+    path: /dev/loop61
+    type: unix-block
+  dev-loop62:
+    major: "7"
+    minor: "62"
+    path: /dev/loop62
+    type: unix-block
+  dev-loop63:
+    major: "7"
+    minor: "63"
+    path: /dev/loop63
+    type: unix-block
+  dev-loop64:
+    major: "7"
+    minor: "64"
+    path: /dev/loop64
+    type: unix-block


### PR DESCRIPTION
### Summary

Update the LXD profile to allow containers to mount loopback devices.

Note that adding these devices on the profile does not clutter the host or the container with extra loop devices. It only ensures that they can be used as needed.

### Test

```bash
# start a container with this profile
lxc launch ubuntu:22.04 -p default -p k8s-e2e test-container
lxc shell test-container

# create a loopback device based on a sparse file on disk
truncate -s 1G a.img
losetup -fP a.img
```