### PR TITLE
Use `k8s kubectl` in e2e tests

### DIFF
--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -105,17 +105,7 @@ def setup_network(h: harness.Harness, instance_id: str):
     retry_until_condition(
         h,
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "get",
-            "po",
-            "-n",
-            "kube-system",
-            "-o",
-            "json",
-        ],
+        ["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"],
         condition=lambda p: "cilium" in p.stdout.decode(),
     )
     LOG.info("Cilium pods showed up.")
@@ -124,9 +114,8 @@ def setup_network(h: harness.Harness, instance_id: str):
         h,
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
@@ -146,9 +135,8 @@ def setup_network(h: harness.Harness, instance_id: str):
         h,
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
@@ -184,15 +172,7 @@ def wait_until_k8s_ready(h: harness.Harness, instance_id):
     result = retry_until_condition(
         h,
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "get",
-            "node",
-            hostname,
-            "--no-headers",
-        ],
+        ["k8s", "kubectl", "get", "node", hostname, "--no-headers"],
         condition=lambda p: "Ready" in p.stdout.decode(),
     )
     LOG.info("Kubelet registered successfully!")

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -28,11 +28,10 @@ def test_network(h: harness.Harness, tmp_path: Path):
     p = h.exec(
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "get",
-            "po",
+            "pod",
             "-n",
             "kube-system",
             "-l",
@@ -51,9 +50,8 @@ def test_network(h: harness.Harness, tmp_path: Path):
     p = h.exec(
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "exec",
             "-it",
             cilium_pod["metadata"]["name"],
@@ -74,14 +72,7 @@ def test_network(h: harness.Harness, tmp_path: Path):
     manifest = MANIFESTS_DIR / "nginx-pod.yaml"
     p = h.exec(
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "apply",
-            "-f",
-            "-",
-        ],
+        ["k8s", "kubectl", "apply", "-f", "-"],
         check=True,
         input=Path(manifest).read_bytes(),
     )
@@ -90,9 +81,8 @@ def test_network(h: harness.Harness, tmp_path: Path):
         h,
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
@@ -109,9 +99,8 @@ def test_network(h: harness.Harness, tmp_path: Path):
     p = h.exec(
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "exec",
             "-it",
             cilium_pod["metadata"]["name"],

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -46,17 +46,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     util.retry_until_condition(
         h,
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "get",
-            "po",
-            "-n",
-            "kube-system",
-            "-o",
-            "json",
-        ],
+        ["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"],
         condition=lambda p: "ck-storage" in p.stdout.decode(),
     )
     LOG.info("Storage provisioner pod showed up.")
@@ -65,9 +55,8 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         h,
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
@@ -86,14 +75,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     manifest = MANIFESTS_DIR / "storage-test.yaml"
     h.exec(
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "apply",
-            "-f",
-            "-",
-        ],
+        ["k8s", "kubectl", "apply", "-f", "-"],
         check=True,
         input=Path(manifest).read_bytes(),
     )
@@ -102,15 +84,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     util.retry_until_condition(
         h,
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "get",
-            "po",
-            "-o",
-            "json",
-        ],
+        ["k8s", "kubectl", "get", "pod", "-o", "json"],
         condition=lambda p: "storage-writer-pod" in p.stdout.decode(),
         delay_between_retries=10,
     )
@@ -120,9 +94,8 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         h,
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
@@ -140,15 +113,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     util.retry_until_condition(
         h,
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "get",
-            "pvc",
-            "-o",
-            "json",
-        ],
+        ["k8s", "kubectl", "get", "pvc", "-o", "json"],
         condition=check_pvc_bound,
     )
     LOG.info("Storage got provisioned and pvc is bound.")
@@ -157,15 +122,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     util.retry_until_condition(
         h,
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "get",
-            "po",
-            "-o",
-            "json",
-        ],
+        ["k8s", "kubectl", "get", "pod", "-o", "json"],
         condition=lambda p: "storage-reader-pod" in p.stdout.decode(),
         delay_between_retries=10,
     )
@@ -175,9 +132,8 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         h,
         instance_id,
         [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
+            "k8s",
+            "kubectl",
             "wait",
             "--for=condition=ready",
             "pod",
@@ -194,13 +150,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     util.retry_until_condition(
         h,
         instance_id,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "logs",
-            "storage-reader-pod",
-        ],
+        ["k8s", "kubectl", "logs", "storage-reader-pod"],
         condition=lambda p: "LOREM IPSUM" in p.stdout.decode(),
         max_retries=5,
         delay_between_retries=10,


### PR DESCRIPTION
### Summary

After #56, use the `k8s kubectl` command in e2e tests