### PR TITLE
Run cilium end-to-end connectivity tests

### DIFF
--- a/src/k8s/cmd/k8s/k8s_helm.go
+++ b/src/k8s/cmd/k8s/k8s_helm.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	helmCmd = &cobra.Command{
+		Use:                "helm",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Allow users to provide their own kubeconfig but
+			// fallback to the admin config if nothing is provided.
+			if os.Getenv("KUBECONFIG") == "" {
+				os.Setenv("KUBECONFIG", "/etc/kubernetes/admin.conf")
+			}
+			path, err := exec.LookPath("helm")
+			if err != nil {
+				return fmt.Errorf("helm not found")
+			}
+
+			command := append(
+				[]string{"helm"},
+				args...,
+			)
+			// completly replace the executable with helm
+			// as we want to be as close as possible to a "real"
+			// helm invocation.
+			return syscall.Exec(path, command, os.Environ())
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(helmCmd)
+}

--- a/tests/e2e/tests/test_cilium_e2e.py
+++ b/tests/e2e/tests/test_cilium_e2e.py
@@ -1,0 +1,119 @@
+#
+# Copyright 2023 Canonical, Ltd.
+#
+import logging
+import platform
+from pathlib import Path
+
+import pytest
+from e2e_util import config, harness, util
+
+LOG = logging.getLogger(__name__)
+
+ARCH = platform.machine()
+CILIUM_CLI_ARCH_MAP = {"aarch64": "arm64", "x86_64": "amd64"}
+CILIUM_CLI_VERSION = "v0.15.19"
+CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CILIUM_CLI_VERSION}/cilium-linux-{CILIUM_CLI_ARCH_MAP.get(ARCH)}.tar.gz"  # noqa
+
+
+@pytest.mark.skipif(
+    ARCH not in CILIUM_CLI_ARCH_MAP, reason=f"Platform {ARCH} not supported"
+)
+def test_cilium_e2e(h: harness.Harness, tmp_path: Path):
+    if not config.SNAP:
+        pytest.fail("Set TEST_SNAP to the path where the snap is")
+
+    snap_path = (tmp_path / "k8s.snap").as_posix()
+
+    LOG.info("Create instance")
+    instance_id = h.new_instance()
+
+    util.setup_k8s_snap(h, instance_id, snap_path)
+    h.exec(instance_id, ["k8s", "init"])
+    util.setup_network(h, instance_id)
+
+    h.exec(instance_id, ["bash", "-c", "mkdir -p ~/.kube"])
+    h.exec(instance_id, ["bash", "-c", "k8s config > ~/.kube/config"])
+
+    # TODO(neoaggelos): this is temporary until "k8s enable dns" is ready
+    h.exec(
+        instance_id,
+        [
+            "k8s",
+            "helm",
+            "install",
+            "coredns",
+            "coredns",
+            "-n",
+            "kube-system",
+            "--repo",
+            "https://coredns.github.io/helm",
+            "--set",
+            "service.clusterIP=10.152.183.10",
+        ],
+    )
+    h.exec(
+        instance_id,
+        [
+            "bash",
+            "-c",
+            "echo --cluster-dns=10.152.183.10 >> /var/snap/k8s/current/args/kubelet",
+        ],
+    )
+    h.exec(
+        instance_id,
+        [
+            "bash",
+            "-c",
+            "echo --cluster-domain=cluster.local >> /var/snap/k8s/current/args/kubelet",
+        ],
+    )
+    h.exec(instance_id, ["snap", "restart", "k8s.kubelet"])
+
+    # Download cilium-cli
+    h.exec(instance_id, ["curl", "-L", CILIUM_CLI_TAR_GZ, "-o", "cilium.tar.gz"])
+    h.exec(instance_id, ["tar", "xvzf", "cilium.tar.gz"])
+    h.exec(instance_id, ["./cilium", "version", "--client"])
+
+    # TODO(neoaggelos): replace with "k8s status --wait-ready"
+    util.retry_until_condition(
+        h,
+        instance_id,
+        [
+            "k8s",
+            "kubectl",
+            "exec",
+            "-it",
+            "ds/cilium",
+            "-n",
+            "kube-system",
+            "-c",
+            "cilium-agent",
+            "--",
+            "cilium",
+            "status",
+            "--brief",
+        ],
+        condition=lambda p: p.stdout.decode().strip() == "OK",
+    )
+
+    # Run cilium e2e tests
+    e2e_args = []
+    if config.SUBSTRATE == "lxd":
+        # NOTE(neoaggelos): disable "no-unexpected-packet-drops" on LXD as it fails:
+        # [=] Test [no-unexpected-packet-drops] [1/61]
+        #   [-] Scenario [no-unexpected-packet-drops/no-unexpected-packet-drops]
+        #       Found unexpected packet drops:
+        # {
+        #   "labels": {
+        #     "direction": "INGRESS",
+        #     "reason": "VLAN traffic disallowed by VLAN filter"
+        #   },
+        #   "name": "cilium_drop_count_total",
+        #   "value": 4
+        # }
+        e2e_args.extend(["--test", "!no-unexpected-packet-drops"])
+
+    h.exec(instance_id, ["./cilium", "connectivity", "test", *e2e_args])
+
+    h.cleanup()

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -67,15 +67,4 @@ def test_clustering(h: harness.Harness, tmp_path: Path):
 
     util.wait_until_k8s_ready(h, instances)
 
-    h.exec(
-        cluster_node,
-        [
-            "/snap/k8s/current/bin/kubectl",
-            "--kubeconfig",
-            "/var/snap/k8s/common/etc/kubernetes/admin.conf",
-            "get",
-            "nodes",
-            "--no-headers",
-        ],
-        capture_output=True,
-    )
+    h.cleanup()

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -116,3 +116,5 @@ def test_network(h: harness.Harness, tmp_path: Path):
         capture_output=True,
     )
     assert "nginx" in p.stdout.decode().strip()
+
+    h.cleanup()

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -24,3 +24,5 @@ def test_smoke(h: harness.Harness, tmp_path: Path):
     util.setup_network(h, instance_id)
 
     util.wait_until_k8s_ready(h, instance_id)
+
+    h.cleanup()

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -151,3 +151,5 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         delay_between_retries=10,
     )
     LOG.info("Data can be read between pods.")
+
+    h.cleanup()


### PR DESCRIPTION
### Summary

Adds the Cilium end-to-end connectivity tests. These require the cilium CLI to be downloaded and run.

There is one test that fails on LXD, see the inline note in the test.