### PR TITLE
Polish k8s status CLI command

### DIFF
--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"net"
 	"strings"
 )
 
@@ -80,9 +81,9 @@ func (c ClusterStatus) String() string {
 	result := strings.Builder{}
 
 	if c.Ready {
-		result.WriteString("k8s is running")
+		result.WriteString("k8s is ready.")
 	} else {
-		result.WriteString("k8s is not running.\n")
+		result.WriteString("k8s is not ready.\n")
 		return result.String()
 	}
 	result.WriteString("\n")
@@ -94,10 +95,18 @@ func (c ClusterStatus) String() string {
 		result.WriteString("no")
 	}
 	result.WriteString("\n\n")
+	result.WriteString("control-plane nodes:\n")
+	for _, member := range c.Members {
+		// There is not much that we can do if the hostport is wrong.
+		// Thus, ignore the error and just display an empty IP field.
+		apiServerIp, _, _ := net.SplitHostPort(member.Address)
+		result.WriteString(fmt.Sprintf("  %s: %s\n", member.Name, apiServerIp))
+	}
+	result.WriteString("\n")
 
 	result.WriteString("components:\n")
 	for _, component := range c.Components {
-		result.WriteString(fmt.Sprintf("  %s: %s\n", component.Name, component.Status))
+		result.WriteString(fmt.Sprintf("  %-10s %s\n", component.Name, component.Status))
 	}
 
 	return result.String()

--- a/src/k8s/api/v1/component.go
+++ b/src/k8s/api/v1/component.go
@@ -26,6 +26,6 @@ type ComponentStatus string
 
 const (
 	Unknown          ComponentStatus = "unknown"
-	ComponentEnable  ComponentStatus = "enable"
-	ComponentDisable ComponentStatus = "disable"
+	ComponentEnable  ComponentStatus = "enabled"
+	ComponentDisable ComponentStatus = "disabled"
 )

--- a/src/k8s/cmd/k8s/formatter/formatter.go
+++ b/src/k8s/cmd/k8s/formatter/formatter.go
@@ -24,7 +24,7 @@ func New(formatterType string, writer io.Writer) (Formatter, error) {
 	case "yaml":
 		return yamlFormatter{writer: writer}, nil
 	default:
-		return nil, fmt.Errorf("unknown formatter type %s", formatterType)
+		return nil, fmt.Errorf("unknown formatter type %q", formatterType)
 	}
 }
 

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -15,13 +14,6 @@ var (
 		Use:          "k8s",
 		Short:        "Canonical Kubernetes CLI",
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
-			return nil
-		},
 	}
 )
 

--- a/src/k8s/cmd/k8s/k8s_add_node.go
+++ b/src/k8s/cmd/k8s/k8s_add_node.go
@@ -4,29 +4,21 @@ import (
 	"fmt"
 
 	"github.com/canonical/k8s/pkg/k8s/client"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
 	addNodeCmd = &cobra.Command{
-		Use:    "add-node <name>",
-		Short:  "Create a connection token for a node to join the cluster",
-		Args:   cobra.ExactArgs(1),
-		Hidden: true,
+		Use:   "add-node <name>",
+		Short: "Create a connection token for a node to join the cluster",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			name := args[0]
 
 			c, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				StorageDir:    clusterCmdOpts.storageDir,
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				Port:          clusterCmdOpts.port,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -4,32 +4,25 @@ import (
 	"fmt"
 
 	"github.com/canonical/k8s/pkg/k8s/client"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
-	initCmd = &cobra.Command{
-		Use:   "init",
-		Short: "Initialize the k8s node",
+	boostrapCmd = &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Bootstrap a k8s cluster on this node.",
 		Long:  "Initialize the necessary folders, permissions, service arguments, certificates and start up the Kubernetes services.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			c, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				StorageDir:    clusterCmdOpts.storageDir,
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				Port:          clusterCmdOpts.port,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			cluster, err := c.Init(cmd.Context())
+			cluster, err := c.Bootstrap(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("failed to initialize k8s cluster: %w", err)
 			}
@@ -41,5 +34,5 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(boostrapCmd)
 }

--- a/src/k8s/cmd/k8s/k8s_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_cluster.go
@@ -3,21 +3,18 @@ package k8s
 import (
 	"os"
 	"path"
-	"strconv"
-
-	"github.com/canonical/k8s/pkg/config"
 )
 
 var (
 	clusterCmdOpts struct {
-		remoteAddress string
-		port          string
-		storageDir    string
+		storageDir string
 	}
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.remoteAddress, "remote-address", "", "IP Address of another cluster member")
-	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.port, "port", strconv.Itoa(config.DefaultPort), "Port on which the REST-API is exposed")
 	rootCmd.PersistentFlags().StringVar(&clusterCmdOpts.storageDir, "storage-dir", path.Join(os.Getenv("SNAP_COMMON"), "/var/lib/k8sd"), "Directory with the dqlite datastore")
+
+	// By default, the storage dir is set to a fixed directory in the snap.
+	// This shouldn't be overwritten by the user.
+	rootCmd.Flags().MarkHidden("storage-dir")
 }

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/canonical/k8s/pkg/k8s/client"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -14,16 +13,10 @@ var (
 		Short:  "Generate a kubeconfig that can be used to access the Kubernetes cluster",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			c, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				StorageDir:    clusterCmdOpts.storageDir,
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				Port:          clusterCmdOpts.port,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)
@@ -35,7 +28,6 @@ var (
 			}
 
 			fmt.Println(adminConfig)
-
 			return nil
 		},
 	}

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -6,13 +6,11 @@ import (
 
 	api "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8s/client"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-func init() {
-
-	disableCmd := &cobra.Command{
+var (
+	disableCmd = &cobra.Command{
 		Use:       "disable <component>",
 		Short:     "Disable a specific component in the cluster",
 		Long:      fmt.Sprintf("Disable one of the specific components: %s.", strings.Join(componentList, ",")),
@@ -22,10 +20,9 @@ func init() {
 			name := args[0]
 
 			client, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				StorageDir:    clusterCmdOpts.storageDir,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)
@@ -36,10 +33,12 @@ func init() {
 				return fmt.Errorf("failed to %s %s: %w", name, api.ComponentDisable, err)
 			}
 
-			logrus.WithField("component", name).Info("Component disabled.")
+			fmt.Printf("Component %q disabled.\n", name)
 			return nil
 		},
 	}
+)
 
+func init() {
 	rootCmd.AddCommand(disableCmd)
 }

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -6,15 +6,13 @@ import (
 
 	api "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8s/client"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-var componentList = []string{"network", "dns", "gateway", "ingress", "rbac", "storage"}
+var (
+	componentList = []string{"network", "dns", "gateway", "ingress", "rbac", "storage"}
 
-func init() {
-
-	enableCmd := &cobra.Command{
+	enableCmd = &cobra.Command{
 		Use:       "enable <component>",
 		Short:     "Enable a specific component in the cluster",
 		Long:      fmt.Sprintf("Enable one of the specific components: %s.", strings.Join(componentList, ",")),
@@ -24,10 +22,9 @@ func init() {
 			name := args[0]
 
 			client, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				StorageDir:    clusterCmdOpts.storageDir,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)
@@ -38,10 +35,12 @@ func init() {
 				return fmt.Errorf("failed to %s %s: %w", name, api.ComponentEnable, err)
 			}
 
-			logrus.WithField("component", name).Info("Component enabled.")
+			fmt.Printf("Component %q enabled.\n", name)
 			return nil
 		},
 	}
+)
 
+func init() {
 	rootCmd.AddCommand(enableCmd)
 }

--- a/src/k8s/cmd/k8s/k8s_generate_auth_token.go
+++ b/src/k8s/cmd/k8s/k8s_generate_auth_token.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/canonical/k8s/pkg/k8s/client"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -20,15 +19,10 @@ var (
 		Short:  "Generate an auth token for Kubernetes",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			client, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				StorageDir:    clusterCmdOpts.storageDir,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create cluster client: %w", err)

--- a/src/k8s/cmd/k8s/k8s_init.go
+++ b/src/k8s/cmd/k8s/k8s_init.go
@@ -34,7 +34,7 @@ var (
 				return fmt.Errorf("failed to initialize k8s cluster: %w", err)
 			}
 
-			logrus.Infof("Initialized k8s cluster on %q (%s).", cluster.Name, cluster.Address)
+			fmt.Printf("Bootstrapped k8s cluster on %q (%s).\n", cluster.Name, cluster.Address)
 			return nil
 		},
 	}

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -59,7 +59,7 @@ var (
 				return fmt.Errorf("failed to join cluster: %w", err)
 			}
 
-			logrus.Infof("Joined %s (%s) to cluster.", joinNodeCmdOpts.name, joinNodeCmdOpts.address)
+			fmt.Println("Joined the cluster.")
 			return nil
 		},
 	}

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -7,7 +7,6 @@ import (
 	"github.com/canonical/k8s/pkg/config"
 	"github.com/canonical/k8s/pkg/k8s/client"
 	"github.com/canonical/lxd/lxd/util"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,15 +17,10 @@ var (
 	}
 
 	joinNodeCmd = &cobra.Command{
-		Use:    "join-node <token>",
-		Short:  "Join a cluster",
-		Args:   cobra.ExactArgs(1),
-		Hidden: true,
+		Use:   "join-cluster <token>",
+		Short: "Join a cluster",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			token := args[0]
 
 			// Use hostname as default node name
@@ -45,10 +39,9 @@ var (
 			}
 
 			client, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				StorageDir:    clusterCmdOpts.storageDir,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create cluster client: %w", err)

--- a/src/k8s/cmd/k8s/k8s_kubectl.go
+++ b/src/k8s/cmd/k8s/k8s_kubectl.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -17,10 +16,6 @@ var (
 		// All commands should be passed to kubectl
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			// Allow users to provide their own kubeconfig but
 			// fallback to the admin config if nothing is provided.
 			if os.Getenv("KUBECONFIG") == "" {

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/canonical/k8s/pkg/k8s/client"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -14,21 +13,15 @@ var (
 	}
 
 	removeNodeCmd = &cobra.Command{
-		Use:    "remove-node <name>",
-		Short:  "Remove a node from the cluster",
-		Hidden: true,
-		Args:   cobra.ExactArgs(1),
+		Use:   "remove-node <name>",
+		Short: "Remove a node from the cluster",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			name := args[0]
 			client, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				StorageDir:    clusterCmdOpts.storageDir,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create cluster client: %w", err)
@@ -38,7 +31,7 @@ var (
 			if err != nil {
 				return fmt.Errorf("failed to remove node from cluster: %w", err)
 			}
-			logrus.Infof("Removed %s from cluster", name)
+			fmt.Printf("Removed %s from cluster.\n", name)
 			return nil
 		},
 	}

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/canonical/k8s/cmd/k8s/formatter"
 	"github.com/canonical/k8s/pkg/k8s/client"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -23,16 +22,10 @@ var (
 		Short:  "Retrieve the current status of the cluster",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if rootCmdOpts.logDebug {
-				logrus.SetLevel(logrus.TraceLevel)
-			}
-
 			c, err := client.NewClient(cmd.Context(), client.ClusterOpts{
-				StorageDir:    clusterCmdOpts.storageDir,
-				RemoteAddress: clusterCmdOpts.remoteAddress,
-				Port:          clusterCmdOpts.port,
-				Verbose:       rootCmdOpts.logVerbose,
-				Debug:         rootCmdOpts.logDebug,
+				StorageDir: clusterCmdOpts.storageDir,
+				Verbose:    rootCmdOpts.logVerbose,
+				Debug:      rootCmdOpts.logDebug,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/canonical/k8s/cmd/k8s/formatter"
 	"github.com/canonical/k8s/pkg/k8s/client"
@@ -12,6 +14,8 @@ import (
 var (
 	statusCmdOpts struct {
 		outputFormat string
+		timeout      time.Duration
+		waitReady    bool
 	}
 
 	statusCmd = &cobra.Command{
@@ -34,7 +38,15 @@ var (
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			clusterStatus, err := c.ClusterStatus(cmd.Context())
+			const minTimeout = 3
+			if statusCmdOpts.timeout < minTimeout*time.Second {
+				cmd.PrintErrf("Timeout %v is less than minimum of %ds. Using the minimum %ds instead.\n", statusCmdOpts.timeout, minTimeout, minTimeout)
+				statusCmdOpts.timeout = minTimeout * time.Second
+			}
+
+			timeoutCtx, cancel := context.WithTimeout(cmd.Context(), statusCmdOpts.timeout)
+			defer cancel()
+			clusterStatus, err := c.ClusterStatus(timeoutCtx, statusCmdOpts.waitReady)
 			if err != nil {
 				return fmt.Errorf("failed to get cluster status: %w", err)
 			}
@@ -51,4 +63,6 @@ var (
 func init() {
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.PersistentFlags().StringVar(&statusCmdOpts.outputFormat, "format", "plain", "Specify in which format the output should be printed. One of plain, json or yaml")
+	rootCmd.PersistentFlags().DurationVar(&statusCmdOpts.timeout, "timeout", 90*time.Second, "The max time to wait for the K8s API server to be ready.")
+	rootCmd.PersistentFlags().BoolVar(&statusCmdOpts.waitReady, "wait-ready", false, "If set, the command will block until at least one cluster node is ready.")
 }

--- a/src/k8s/cmd/k8s/main.go
+++ b/src/k8s/cmd/k8s/main.go
@@ -4,6 +4,8 @@ import "os"
 
 func Main() {
 	if rootCmd.Execute() != nil {
+		// TODO: We need to define actionable error message in the future
+		// That tell the user what went wrong on a high-level and - if possible - how it can be fixed.
 		os.Exit(1)
 	}
 }

--- a/src/k8s/pkg/k8s/client/client.go
+++ b/src/k8s/pkg/k8s/client/client.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/canonical/microcluster/client"
@@ -13,10 +12,6 @@ import (
 type ClusterOpts struct {
 	// StorageDir is the directory that contains the cluster state (for local clients).
 	StorageDir string
-	// RemoteAddress is the address of the cluster (for remote clients).
-	RemoteAddress string
-	// Port is the port on which the REST-API is exposed.
-	Port string
 	// Verbose enables info level logging.
 	Verbose bool
 	// Debug enables trace level logging.
@@ -35,24 +30,17 @@ type Client struct {
 // elsewhere it returns a HTTPS client that expects the certificates to be located at ClusterOpts.StorageDir
 func NewClient(ctx context.Context, opts ClusterOpts) (*Client, error) {
 	m, err := microcluster.App(ctx, microcluster.Args{
-		Debug:      opts.Debug,
-		ListenPort: opts.Port,
-		StateDir:   opts.StorageDir,
-		Verbose:    opts.Verbose,
+		Debug:    opts.Debug,
+		StateDir: opts.StorageDir,
+		Verbose:  opts.Verbose,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot read cluster info: %w", err)
 	}
 
-	var microClient *client.Client
-	if opts.RemoteAddress == "" {
-		microClient, err = m.LocalClient()
-		if err != nil {
-			return nil, fmt.Errorf("cannot create local client: %w", err)
-		}
-	} else {
-		// TODO: Implement the remote client. This requires the cluster certs to be available at `opts.StorageDir`
-		return nil, errors.New("remote clients are not yet supported. The CLI needs to run on a cluster node.")
+	microClient, err := m.LocalClient()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create local client: %w", err)
 	}
 
 	return &Client{

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -61,17 +62,16 @@ func (c *Client) Init(ctx context.Context) (apiv1.ClusterMember, error) {
 }
 
 // ClusterStatus returns the current status of the cluster.
-func (c *Client) ClusterStatus(ctx context.Context) (apiv1.ClusterStatus, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
-	defer cancel()
-
+func (c *Client) ClusterStatus(ctx context.Context, waitReady bool) (apiv1.ClusterStatus, error) {
 	var response apiv1.GetClusterStatusResponse
-	err := c.mc.Query(queryCtx, "GET", api.NewURL().Path("k8sd", "cluster"), nil, &response)
-	if err != nil {
-		clientURL := c.mc.URL()
-		return apiv1.ClusterStatus{}, fmt.Errorf("failed to query endpoint on %q: %w", clientURL.String(), err)
-	}
-	return response.ClusterStatus, nil
+	err := utils.WaitUntilReady(ctx, func() (bool, error) {
+		err := c.mc.Query(ctx, "GET", api.NewURL().Path("k8sd", "cluster"), nil, &response)
+		if err != nil {
+			return false, err
+		}
+		return !waitReady || response.ClusterStatus.Ready, nil
+	})
+	return response.ClusterStatus, err
 }
 
 // KubeConfig returns admin kubeconfig to connect to the cluster.

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -4,30 +4,26 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/config"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 )
 
-// Init bootstraps the k8s cluster
-func (c *Client) Init(ctx context.Context) (apiv1.ClusterMember, error) {
+// Bootstrap bootstraps the k8s cluster
+func (c *Client) Bootstrap(ctx context.Context) (apiv1.ClusterMember, error) {
 	// Get system hostname.
 	hostname, err := os.Hostname()
 	if err != nil {
 		return apiv1.ClusterMember{}, fmt.Errorf("failed to retrieve system hostname: %w", err)
 	}
 
-	port, err := strconv.Atoi(c.opts.Port)
-	if err != nil {
-		return apiv1.ClusterMember{}, fmt.Errorf("failed to parse Port: %w", err)
-	}
 	// Get system addrPort.
 	addrPort := util.CanonicalNetworkAddress(
-		util.NetworkInterfaceAddress(), port,
+		util.NetworkInterfaceAddress(), config.DefaultPort,
 	)
 
 	// This should be done behind the REST API.

--- a/src/k8s/pkg/k8sd/api/impl/component.go
+++ b/src/k8s/pkg/k8sd/api/impl/component.go
@@ -22,7 +22,7 @@ func GetComponents(snap snap.Snap) ([]api.Component, error) {
 
 	// Decouple the internal Component type from the external API types.
 	extComponents := make([]api.Component, len(components))
-	for _, component := range components {
+	for i, component := range components {
 		var status api.ComponentStatus
 		if component.Status {
 			status = api.ComponentEnable
@@ -30,10 +30,10 @@ func GetComponents(snap snap.Snap) ([]api.Component, error) {
 			status = api.ComponentDisable
 		}
 
-		extComponents = append(extComponents, api.Component{
+		extComponents[i] = api.Component{
 			Name:   component.Name,
 			Status: status,
-		})
+		}
 	}
 	return extComponents, nil
 }

--- a/src/k8s/pkg/utils/control.go
+++ b/src/k8s/pkg/utils/control.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// WaitUntilReady waits until the specified condition becomes true.
+// checkFunc can return an error to return early.
+func WaitUntilReady(ctx context.Context, checkFunc func() (bool, error)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+			if ok, err := checkFunc(); err != nil {
+				return fmt.Errorf("wait check failed: %w", err)
+			} else if ok {
+				return nil
+			}
+		}
+	}
+}

--- a/src/k8s/pkg/utils/control_test.go
+++ b/src/k8s/pkg/utils/control_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// Mock check function that returns true after 2 iterations.
+func mockCheckFunc() (bool, error) {
+	return true, nil
+}
+
+var testError = errors.New("test error")
+
+// Mock check function that returns an error.
+func mockErrorCheckFunc() (bool, error) {
+	return false, testError
+}
+
+func TestWaitUntilReady(t *testing.T) {
+	// Test case 1: Successful completion
+	ctx1, cancel1 := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel1()
+
+	err1 := WaitUntilReady(ctx1, mockCheckFunc)
+	if err1 != nil {
+		t.Errorf("Expected no error, got: %v", err1)
+	}
+
+	// Test case 2: Context cancellation
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	cancel2() // Cancel the context immediately
+
+	err2 := WaitUntilReady(ctx2, mockCheckFunc)
+	if err2 == nil || err2 != context.Canceled {
+		t.Errorf("Expected context.Canceled error, got: %v", err2)
+	}
+
+	// Test case 3: Timeout
+	ctx3, cancel3 := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel3()
+
+	err3 := WaitUntilReady(ctx3, func() (bool, error) { return false, nil })
+	if err3 == nil || !errors.Is(err3, context.DeadlineExceeded) {
+		t.Errorf("Expected context.DeadlineExceeded error, got: %v", err3)
+	}
+
+	// Test case 4: CheckFunc returns an error
+	ctx4, cancel4 := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel4()
+
+	err4 := WaitUntilReady(ctx4, mockErrorCheckFunc)
+	if err4 == nil || !errors.Is(err4, testError) {
+		t.Errorf("Expected test error, got: %v", err4)
+	}
+}

--- a/src/k8s/pkg/utils/k8s/status.go
+++ b/src/k8s/pkg/utils/k8s/status.go
@@ -4,9 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// WaitApiServerReady waits until the kube-apiserver becomes available.
+func WaitApiServerReady(ctx context.Context, client *k8sClient) error {
+	return utils.WaitUntilReady(ctx, func() (bool, error) {
+		_, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		// We want to retry if an error occurs (=API server not ready)
+		// returning the error would abort, thus checking for nil
+		return err == nil, nil
+	})
+}
 
 // ClusterReady checks the status of all nodes in the Kubernetes cluster.
 // If at least one node is in READY state it will return true.

--- a/tests/e2e/tests/test_cilium_e2e.py
+++ b/tests/e2e/tests/test_cilium_e2e.py
@@ -29,7 +29,7 @@ def test_cilium_e2e(h: harness.Harness, tmp_path: Path):
     instance_id = h.new_instance()
 
     util.setup_k8s_snap(h, instance_id, snap_path)
-    h.exec(instance_id, ["k8s", "init"])
+    h.exec(instance_id, ["k8s", "bootstrap"])
     util.setup_network(h, instance_id)
 
     h.exec(instance_id, ["bash", "-c", "mkdir -p ~/.kube"])

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -1,7 +1,6 @@
 #
 # Copyright 2023 Canonical, Ltd.
 #
-import base64
 import logging
 from pathlib import Path
 from typing import List
@@ -33,11 +32,7 @@ def add_node(h: harness.Harness, cluster_node: str, joining_node: str) -> str:
         ["k8s", "add-node", joining_node],
         capture_output=True,
     )
-    token = out.stdout.decode().strip()
-    assert (
-        base64.b64encode(base64.b64decode(token)).decode() == token
-    ), f"add-node should return a base64 token but got {token}"
-    return token
+    return out.stdout.decode().strip()
 
 
 # Join an existing cluster.
@@ -47,7 +42,7 @@ def join_cluster(h: harness.Harness, instance_id, token):
         ["k8s", "join-node", token],
         capture_output=True,
     )
-    assert f"Joined {instance_id}" in out.stderr.decode()
+    assert "Joined" in out.stdout.decode()
 
 
 def test_clustering(h: harness.Harness, tmp_path: Path):

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -39,7 +39,7 @@ def add_node(h: harness.Harness, cluster_node: str, joining_node: str) -> str:
 def join_cluster(h: harness.Harness, instance_id, token):
     out = h.exec(
         instance_id,
-        ["k8s", "join-node", token],
+        ["k8s", "join-cluster", token],
         capture_output=True,
     )
     assert "Joined" in out.stdout.decode()
@@ -54,7 +54,7 @@ def test_clustering(h: harness.Harness, tmp_path: Path):
     cluster_node = instances[0]
     joining_node = instances[1]
 
-    h.exec(cluster_node, ["k8s", "init"])
+    h.exec(cluster_node, ["k8s", "bootstrap"])
     util.setup_network(h, cluster_node)
 
     token = add_node(h, cluster_node, joining_node)

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -22,7 +22,7 @@ def test_network(h: harness.Harness, tmp_path: Path):
     instance_id = h.new_instance()
 
     util.setup_k8s_snap(h, instance_id, snap_path)
-    h.exec(instance_id, ["k8s", "init"])
+    h.exec(instance_id, ["k8s", "bootstrap"])
     util.setup_network(h, instance_id)
 
     p = h.exec(

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -20,7 +20,7 @@ def test_smoke(h: harness.Harness, tmp_path: Path):
     instance_id = h.new_instance()
 
     util.setup_k8s_snap(h, instance_id, snap_path)
-    h.exec(instance_id, ["k8s", "init"])
+    h.exec(instance_id, ["k8s", "bootstrap"])
     util.setup_network(h, instance_id)
 
     util.wait_until_k8s_ready(h, instance_id)

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -31,7 +31,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     instance_id = h.new_instance()
 
     util.setup_k8s_snap(h, instance_id, snap_path)
-    h.exec(instance_id, ["k8s", "init"])
+    h.exec(instance_id, ["k8s", "bootstrap"])
     util.setup_network(h, instance_id)
 
     out = h.exec(
@@ -39,7 +39,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         ["k8s", "enable", "storage"],
         capture_output=True,
     )
-    assert "enabled" in out.stderr.decode()
+    assert "enabled" in out.stdout.decode()
 
     LOG.info("Waiting for storage provisioner pod to show up...")
     util.retry_until_condition(


### PR DESCRIPTION
* Adds `--wait-ready` flag that blocks until a node is ready
* Adds `--timeout`
* `k8s status` always waits for API server to become ready (with timeout)
* Fixes a bug in `GetComponents` that added empty component entries to the result.

```
ubuntu@my-node:~/k8s$ sudo k8s status --wait-ready
k8s is ready.
high-availability: no

control-plane nodes:
  my-node: 10.84.220.162

components:
  dns        disabled
  network    enabled
  storage    disabled
```