### PR TITLE
drop extraneous check=True from e2e tests

### DIFF
--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -128,7 +128,6 @@ def setup_network(h: harness.Harness, instance_id: str):
         ],
         max_retries=3,
         delay_between_retries=1,
-        check=True,
     )
 
     retry_until_condition(
@@ -149,7 +148,6 @@ def setup_network(h: harness.Harness, instance_id: str):
         ],
         max_retries=3,
         delay_between_retries=1,
-        check=True,
     )
 
 

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -73,7 +73,6 @@ def test_network(h: harness.Harness, tmp_path: Path):
     p = h.exec(
         instance_id,
         ["k8s", "kubectl", "apply", "-f", "-"],
-        check=True,
         input=Path(manifest).read_bytes(),
     )
 
@@ -93,7 +92,6 @@ def test_network(h: harness.Harness, tmp_path: Path):
         ],
         max_retries=3,
         delay_between_retries=1,
-        check=True,
     )
 
     p = h.exec(

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -38,7 +38,6 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         instance_id,
         ["k8s", "enable", "storage"],
         capture_output=True,
-        check=True,
     )
     assert "enabled" in out.stderr.decode()
 
@@ -69,14 +68,12 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         ],
         max_retries=3,
         delay_between_retries=1,
-        check=True,
     )
 
     manifest = MANIFESTS_DIR / "storage-test.yaml"
     h.exec(
         instance_id,
         ["k8s", "kubectl", "apply", "-f", "-"],
-        check=True,
         input=Path(manifest).read_bytes(),
     )
 
@@ -106,7 +103,6 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         ],
         max_retries=3,
         delay_between_retries=1,
-        check=True,
     )
 
     LOG.info("Waiting for storage to get provisioned...")
@@ -144,7 +140,6 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         ],
         max_retries=3,
         delay_between_retries=1,
-        check=True,
     )
 
     util.retry_until_condition(
@@ -154,6 +149,5 @@ def test_storage(h: harness.Harness, tmp_path: Path):
         condition=lambda p: "LOREM IPSUM" in p.stdout.decode(),
         max_retries=5,
         delay_between_retries=10,
-        check=True,
     )
     LOG.info("Data can be read between pods.")


### PR DESCRIPTION
### Summary

`check=True` is set by default on `util.run` at https://github.com/canonical/k8s-snap/blob/main/tests/e2e/tests/e2e_util/util.py#L18

Cleanup the code a bit, in hope that future tests do not clutter by imitating the existing ones.