### PR TITLE
Wait for k8sd to become up in CLI

### DIFF
--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -16,6 +16,11 @@ func (c *Client) JoinNode(ctx context.Context, name string, address string, toke
 		return fmt.Errorf("failed to join k8sd cluster: %w", err)
 	}
 
+	err = c.m.Ready(30)
+	if err != nil {
+		return fmt.Errorf("cluster did not come up in time: %w", err)
+	}
+
 	// Joining a node takes some time since services need to be restarted.
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*180)
 	defer cancel()


### PR DESCRIPTION
The check for this in `k8s init` was already added in (#45). This PR also adds it to the `join-node` workflow.