### PR TITLE
chore: improve error handling on CLI

### DIFF
--- a/src/k8s/cmd/k8s-dqlite/main.go
+++ b/src/k8s/cmd/k8s-dqlite/main.go
@@ -1,14 +1,9 @@
 package k8s_dqlite
 
-import (
-	"os"
-
-	"github.com/sirupsen/logrus"
-)
+import "os"
 
 func Main() {
-	if err := rootCmd.Execute(); err != nil {
-		logrus.WithError(err).Print("k8s-dqlite command failed")
+	if rootCmd.Execute() != nil {
 		os.Exit(1)
 	}
 }

--- a/src/k8s/cmd/k8s/main.go
+++ b/src/k8s/cmd/k8s/main.go
@@ -1,14 +1,9 @@
 package k8s
 
-import (
-	"os"
-
-	"github.com/sirupsen/logrus"
-)
+import "os"
 
 func Main() {
-	if err := rootCmd.Execute(); err != nil {
-		logrus.WithError(err).Print("k8s command failed")
+	if rootCmd.Execute() != nil {
 		os.Exit(1)
 	}
 }

--- a/src/k8s/cmd/k8sd/main.go
+++ b/src/k8s/cmd/k8sd/main.go
@@ -1,14 +1,9 @@
 package k8sd
 
-import (
-	"os"
-
-	"github.com/sirupsen/logrus"
-)
+import "os"
 
 func Main() {
-	if err := rootCmd.Execute(); err != nil {
-		logrus.WithError(err).Print("k8sd command failed")
+	if rootCmd.Execute() != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### Summary

Do not print duplicate error messages in case of CLI errors:

#### Before:

```
$ k8sd init 
Error: unknown command "init" for "k8sd"
Run 'k8sd --help' for usage.
INFO[0000] k8sd command failed                           error="unknown command \"init\" for \"k8sd\""
```

#### After:

```
$ k8sd init
Error: unknown command "init" for "k8sd"
Run 'k8sd --help' for usage.
```