### PR TITLE
Added ingress support

### DIFF
--- a/k8s/components/components.yaml
+++ b/k8s/components/components.yaml
@@ -10,3 +10,5 @@ storage:
   release: "ck-storage"
   chart: "hostpath-provisioner-0.1.0.tgz"
   namespace: "kube-system"
+ingress:
+  parent: "network"

--- a/k8s/connect-interfaces.sh
+++ b/k8s/connect-interfaces.sh
@@ -17,6 +17,7 @@ declare -a INTERFACES=(
   firewall-control
   process-control
   kernel-module-observe
+  cilium-module-load
   mount-observe
   hardware-observe
   system-observe

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -221,6 +221,7 @@ apps:
       - network-control
       - mount-observe
       - kubernetes-support
+      - cilium-module-load
       - opengl
       - cifs-mount
       - fuse-support
@@ -388,6 +389,18 @@ plugs:
   docker-unprivileged:
     interface: docker-support
     privileged-containers: false
+  # Cilium Ingress requires and loads iptable_raw and xt_socket modules
+  # If these modules are not loaded, ingress responses return 503 Service Unavailable
+  # since datapath L7 redirection does not work correctly.
+  # https://github.com/cilium/cilium/blob/1ab043d546e52fb2428300e6c6ea35fa3bd7c711/install/kubernetes/cilium/values.yaml#L792-L796
+  # https://github.com/cilium/cilium/issues/25021#issuecomment-1699969830
+  cilium-module-load:
+    interface: kernel-module-load
+    modules:
+    - name: iptable_raw
+      load: "on-boot"
+    - name: xt_socket
+      load: "on-boot"
 
 hooks:
   remove:

--- a/src/k8s/api/v1/component.go
+++ b/src/k8s/api/v1/component.go
@@ -31,6 +31,18 @@ type UpdateStorageComponentRequest struct {
 	Status ComponentStatus `json:"status"`
 }
 
+// UpdateIngressComponentRequest is used to update the Ingress component state.
+type UpdateIngressComponentRequest struct {
+	Status ComponentStatus        `json:"status"`
+	Config IngressComponentConfig `json:"config,omitempty"`
+}
+
+// IngressComponentConfig holds the configuration values for the Ingress component.
+type IngressComponentConfig struct {
+	DefaultTLSSecret    string `json:"defaultTLSSecret,omitempty"`
+	EnableProxyProtocol bool   `json:"enableProxyProtocol,omitempty"`
+}
+
 // UpdateDNSComponentResponse is the response for "PUT 1.0/k8sd/components/dns".
 type UpdateDNSComponentResponse struct{}
 
@@ -39,6 +51,9 @@ type UpdateNetworkComponentResponse struct{}
 
 // UpdateStorageComponentResponse is the response for "PUT 1.0/k8sd/components/storage".
 type UpdateStorageComponentResponse struct{}
+
+// UpdateIngressComponentResponse is the response for "PUT 1.0/k8sd/components/ingress".
+type UpdateIngressComponentResponse struct{}
 
 // Component holds information about a k8s component.
 type Component struct {

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -24,4 +24,5 @@ func init() {
 	enableCmd.AddCommand(enableDNSCmd)
 	enableCmd.AddCommand(enableNetworkCmd)
 	enableCmd.AddCommand(enableStorageCmd)
+	enableCmd.AddCommand(enableIngressCmd)
 }

--- a/src/k8s/cmd/k8s/k8s_enable_ingress.go
+++ b/src/k8s/cmd/k8s/k8s_enable_ingress.go
@@ -8,13 +8,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var enableIngressCmdConfig struct {
+var enableIngressCmdOpts struct {
 	DefaultTLSSecret    string
 	EnableProxyProtocol bool
 }
 var enableIngressCmd = &cobra.Command{
 	Use:   "ingress",
-	Short: "Enable the Ingress component in the cluster.",
+	Short: "Enable the Ingress component in the cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, err := client.NewClient(cmd.Context(), client.ClusterOpts{
 			StateDir: clusterCmdOpts.stateDir,
@@ -28,8 +28,8 @@ var enableIngressCmd = &cobra.Command{
 		request := api.UpdateIngressComponentRequest{
 			Status: api.ComponentEnable,
 			Config: api.IngressComponentConfig{
-				DefaultTLSSecret:    enableIngressCmdConfig.DefaultTLSSecret,
-				EnableProxyProtocol: enableIngressCmdConfig.EnableProxyProtocol,
+				DefaultTLSSecret:    enableIngressCmdOpts.DefaultTLSSecret,
+				EnableProxyProtocol: enableIngressCmdOpts.EnableProxyProtocol,
 			},
 		}
 
@@ -44,6 +44,6 @@ var enableIngressCmd = &cobra.Command{
 }
 
 func init() {
-	enableIngressCmd.Flags().StringVar(&enableIngressCmdConfig.DefaultTLSSecret, "default-tls-secret", "", "Name of the TLS Secret in the kube-system namespace that will be used as the default Ingress certificate")
-	enableIngressCmd.Flags().BoolVar(&enableIngressCmdConfig.EnableProxyProtocol, "enable-proxy-protocol", false, "If set, proxy protocol will be enabled for the Ingress")
+	enableIngressCmd.Flags().StringVar(&enableIngressCmdOpts.DefaultTLSSecret, "default-tls-secret", "", "Name of the TLS Secret in the kube-system namespace that will be used as the default Ingress certificate")
+	enableIngressCmd.Flags().BoolVar(&enableIngressCmdOpts.EnableProxyProtocol, "enable-proxy-protocol", false, "If set, proxy protocol will be enabled for the Ingress")
 }

--- a/src/k8s/cmd/k8s/k8s_enable_ingress.go
+++ b/src/k8s/cmd/k8s/k8s_enable_ingress.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	"fmt"
+
+	api "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/k8s/client"
+	"github.com/spf13/cobra"
+)
+
+var enableIngressCmdConfig struct {
+	DefaultTLSSecret    string
+	EnableProxyProtocol bool
+}
+var enableIngressCmd = &cobra.Command{
+	Use:   "ingress",
+	Short: "Enable the Ingress component in the cluster.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := client.NewClient(cmd.Context(), client.ClusterOpts{
+			StateDir: clusterCmdOpts.stateDir,
+			Verbose:  rootCmdOpts.logVerbose,
+			Debug:    rootCmdOpts.logDebug,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create client: %w", err)
+		}
+
+		request := api.UpdateIngressComponentRequest{
+			Status: api.ComponentEnable,
+			Config: api.IngressComponentConfig{
+				DefaultTLSSecret:    enableIngressCmdConfig.DefaultTLSSecret,
+				EnableProxyProtocol: enableIngressCmdConfig.EnableProxyProtocol,
+			},
+		}
+
+		err = client.UpdateIngressComponent(cmd.Context(), request)
+		if err != nil {
+			return fmt.Errorf("failed to enable Ingress component: %w", err)
+		}
+
+		cmd.Println("Component 'Ingress' enabled")
+		return nil
+	},
+}
+
+func init() {
+	enableIngressCmd.Flags().StringVar(&enableIngressCmdConfig.DefaultTLSSecret, "default-tls-secret", "", "Name of the TLS Secret in the kube-system namespace that will be used as the default Ingress certificate")
+	enableIngressCmd.Flags().BoolVar(&enableIngressCmdConfig.EnableProxyProtocol, "enable-proxy-protocol", false, "If set, proxy protocol will be enabled for the Ingress")
+}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -1,0 +1,74 @@
+package component
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/k8s"
+)
+
+func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyProtocol bool) error {
+	manager, err := NewManager(s)
+	if err != nil {
+		return fmt.Errorf("failed to get component manager: %w", err)
+	}
+
+	values := map[string]any{
+		"ingressController": map[string]any{
+			"enabled":                true,
+			"loadbalancerMode":       "shared",
+			"defaultSecretNamespace": "kube-system",
+			"defaultTLSSecret":       defaultTLSSecret,
+			"enableProxyProtocol":    enableProxyProtocol,
+		},
+	}
+
+	err = manager.Refresh("network", values)
+	if err != nil {
+		return fmt.Errorf("failed to enable ingress component: %w", err)
+	}
+
+	client, err := k8s.NewClient()
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = k8s.RestartDeployment(ctx, client, "cilium-operator", "kube-system")
+	if err != nil {
+		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
+	}
+
+	err = k8s.RestartDaemonset(ctx, client, "cilium", "kube-system")
+	if err != nil {
+		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
+	}
+
+	return nil
+}
+
+func DisableIngressComponent(s snap.Snap) error {
+	manager, err := NewManager(s)
+	if err != nil {
+		return fmt.Errorf("failed to get component manager: %w", err)
+	}
+
+	values := map[string]any{
+		"ingressController": map[string]any{
+			"enabled":                false,
+			"defaultSecretNamespace": "",
+			"defaultSecretName":      "",
+			"enableProxyProtocol":    false,
+		},
+	}
+	err = manager.Refresh("network", values)
+	if err != nil {
+		return fmt.Errorf("failed to disable ingress component: %w", err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -49,6 +49,9 @@ func EnableNetworkComponent(s snap.Snap) error {
 	}
 
 	values := map[string]any{
+		"socketLB": map[string]any{
+			"enabled": true,
+		},
 		"cni": map[string]any{
 			"confPath": "/etc/cni/net.d",
 			"binPath":  "/opt/cni/bin",
@@ -101,7 +104,7 @@ func DisableNetworkComponent(s snap.Snap) error {
 
 	err = manager.Disable("network")
 	if err != nil {
-		return fmt.Errorf("failed to enable network component: %w", err)
+		return fmt.Errorf("failed to disable network component: %w", err)
 	}
 
 	return nil

--- a/src/k8s/pkg/component/storage.go
+++ b/src/k8s/pkg/component/storage.go
@@ -29,7 +29,7 @@ func DisableStorageComponent(s snap.Snap) error {
 
 	err = manager.Disable("storage")
 	if err != nil {
-		return fmt.Errorf("failed to enable storage component: %w", err)
+		return fmt.Errorf("failed to disable storage component: %w", err)
 	}
 
 	return nil

--- a/src/k8s/pkg/k8s/client/component.go
+++ b/src/k8s/pkg/k8s/client/component.go
@@ -58,3 +58,15 @@ func (c *Client) UpdateStorageComponent(ctx context.Context, request api.UpdateS
 	}
 	return nil
 }
+
+func (c *Client) UpdateIngressComponent(ctx context.Context, request api.UpdateIngressComponentRequest) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	var response api.UpdateIngressComponentResponse
+	err := c.mc.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "ingress"), request, &response)
+	if err != nil {
+		return fmt.Errorf("failed to enable ingress component: %w", err)
+	}
+	return nil
+}

--- a/src/k8s/pkg/k8sd/api/component.go
+++ b/src/k8s/pkg/k8sd/api/component.go
@@ -124,17 +124,25 @@ func ingressComponentPut(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("failed to decode request: %w", err))
 	}
 
-	if req.Status == api.ComponentEnable {
+	switch req.Status {
+	case api.ComponentEnable:
 		err = component.EnableIngressComponent(
 			snap,
 			req.Config.DefaultTLSSecret,
 			req.Config.EnableProxyProtocol,
 		)
-	} else {
+		if err != nil {
+			return response.SmartError(fmt.Errorf("failed to enable ingress: %w", err))
+		}
+		break
+	case api.ComponentDisable:
 		err = component.DisableIngressComponent(snap)
-	}
-	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to %s %s: %w", req.Status, "ingress", err))
+		if err != nil {
+			return response.SmartError(fmt.Errorf("failed to disable ingress: %w", err))
+		}
+		break
+	default:
+		return response.SmartError(fmt.Errorf("invalid component status %s", req.Status))
 	}
 
 	return response.SyncResponse(true, &api.UpdateIngressComponentResponse{})

--- a/src/k8s/pkg/k8sd/api/component.go
+++ b/src/k8s/pkg/k8sd/api/component.go
@@ -35,6 +35,11 @@ var k8sdStorageComponent = rest.Endpoint{
 	Put:  rest.EndpointAction{Handler: storageComponentPut, AllowUntrusted: false},
 }
 
+var k8sdIngressComponent = rest.Endpoint{
+	Path: "k8sd/components/ingress",
+	Put:  rest.EndpointAction{Handler: ingressComponentPut, AllowUntrusted: false},
+}
+
 func componentsGet(s *state.State, r *http.Request) response.Response {
 	snap := snap.SnapFromContext(s.Context)
 
@@ -108,4 +113,29 @@ func storageComponentPut(s *state.State, r *http.Request) response.Response {
 		err = component.DisableStorageComponent(snap)
 	}
 	return response.SyncResponse(true, &api.UpdateDNSComponentResponse{})
+}
+
+func ingressComponentPut(s *state.State, r *http.Request) response.Response {
+	var req api.UpdateIngressComponentRequest
+	snap := snap.SnapFromContext(s.Context)
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("failed to decode request: %w", err))
+	}
+
+	if req.Status == api.ComponentEnable {
+		err = component.EnableIngressComponent(
+			snap,
+			req.Config.DefaultTLSSecret,
+			req.Config.EnableProxyProtocol,
+		)
+	} else {
+		err = component.DisableIngressComponent(snap)
+	}
+	if err != nil {
+		return response.SmartError(fmt.Errorf("failed to %s %s: %w", req.Status, "ingress", err))
+	}
+
+	return response.SyncResponse(true, &api.UpdateIngressComponentResponse{})
 }

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -10,6 +10,7 @@ var Endpoints = []rest.Endpoint{
 	k8sdDNSComponent,
 	k8sdNetworkComponent,
 	k8sdStorageComponent,
+	k8sdIngressComponent,
 	k8sdComponents,
 	k8sdConfig,
 

--- a/src/k8s/pkg/utils/k8s/restart_daemonset.go
+++ b/src/k8s/pkg/utils/k8s/restart_daemonset.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RestartDaemonset updates the restartedAt field to trigger a rollout restart for the given DaemonSet.
+func RestartDaemonset(ctx context.Context, client *k8sClient, name, namespace string) error {
+	if namespace == "" {
+		namespace = "default"
+	}
+	daemonset, err := client.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if daemonset.Spec.Template.ObjectMeta.Annotations == nil {
+		daemonset.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	daemonset.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+	_, err = client.AppsV1().DaemonSets(namespace).Update(ctx, daemonset, metav1.UpdateOptions{})
+	return err
+}

--- a/src/k8s/pkg/utils/k8s/restart_daemonset.go
+++ b/src/k8s/pkg/utils/k8s/restart_daemonset.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +15,7 @@ func RestartDaemonset(ctx context.Context, client *k8sClient, name, namespace st
 	}
 	daemonset, err := client.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to get daemonset %s in %s: %w", name, namespace, err)
 	}
 
 	if daemonset.Spec.Template.ObjectMeta.Annotations == nil {
@@ -23,5 +24,8 @@ func RestartDaemonset(ctx context.Context, client *k8sClient, name, namespace st
 	daemonset.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 
 	_, err = client.AppsV1().DaemonSets(namespace).Update(ctx, daemonset, metav1.UpdateOptions{})
-	return err
+	if err != nil {
+		return fmt.Errorf("Failed to rollout restart daemonset %s in %s: %w", name, namespace, err)
+	}
+	return nil
 }

--- a/src/k8s/pkg/utils/k8s/restart_deployment.go
+++ b/src/k8s/pkg/utils/k8s/restart_deployment.go
@@ -1,0 +1,27 @@
+package k8s
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RestartDeployment updates the restartedAt field to trigger a rollout restart for the given Deployment.
+func RestartDeployment(ctx context.Context, client *k8sClient, name, namespace string) error {
+	if namespace == "" {
+		namespace = "default"
+	}
+	deployment, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+		deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+	_, err = client.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	return err
+}

--- a/tests/e2e/lxd-profile.yaml
+++ b/tests/e2e/lxd-profile.yaml
@@ -1,7 +1,7 @@
 description: "LXD profile for Canonical Kubernetes"
 config:
   boot.autostart: "true"
-  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,br_netfilter
+  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,iptable_raw,netlink_diag,nf_nat,overlay,br_netfilter,xt_socket
   raw.lxc: |
     lxc.apparmor.profile=unconfined
     lxc.mount.auto=proc:rw sys:rw cgroup:rw

--- a/tests/e2e/templates/ingress-test.yaml
+++ b/tests/e2e/templates/ingress-test.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: my-nginx
+    spec:
+      containers:
+      - name: my-nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx
+  labels:
+    run: my-nginx
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: my-nginx
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+spec:
+  ingressClassName: cilium
+  rules:
+  - host: "foo.bar.com"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: my-nginx
+            port:
+              number: 80

--- a/tests/e2e/tests/test_ingress.py
+++ b/tests/e2e/tests/test_ingress.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+import logging
+from pathlib import Path
+
+import pytest
+from e2e_util import config, harness, util
+from e2e_util.config import MANIFESTS_DIR
+
+LOG = logging.getLogger(__name__)
+
+
+def test_ingress(h: harness.Harness, tmp_path: Path):
+    if not config.SNAP:
+        pytest.fail("Set TEST_SNAP to the path where the snap is")
+
+    snap_path = (tmp_path / "k8s.snap").as_posix()
+
+    LOG.info("Create instance")
+    instance_id = h.new_instance()
+
+    util.setup_k8s_snap(h, instance_id, snap_path)
+    h.exec(instance_id, ["k8s", "bootstrap"])
+    util.setup_network(h, instance_id)
+
+    out = h.exec(
+        instance_id,
+        ["k8s", "enable", "ingress"],
+        capture_output=True,
+    )
+    assert out.returncode == 0
+
+    util.stubbornly(retries=5, delay_s=2).on(h, instance_id).until(
+        lambda p: "cilium-ingress" in p.stdout.decode()
+    ).exec(["k8s", "kubectl", "get", "service", "-n", "kube-system", "-o", "json"])
+
+    p = h.exec(
+        instance_id,
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "service",
+            "-n",
+            "kube-system",
+            "cilium-ingress",
+            "-o=jsonpath='{.spec.ports[?(@.name==\"http\")].nodePort}'",
+        ],
+        capture_output=True,
+    )
+    ingress_http_port = p.stdout.decode().replace("'", "")
+
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-n",
+            "kube-system",
+            "-l",
+            "io.cilium/app=operator",
+            "--timeout",
+            "180s",
+        ]
+    )
+
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-n",
+            "kube-system",
+            "-l",
+            "k8s-app=cilium",
+            "--timeout",
+            "180s",
+        ]
+    )
+
+    manifest = MANIFESTS_DIR / "ingress-test.yaml"
+    h.exec(
+        instance_id,
+        ["k8s", "kubectl", "apply", "-f", "-"],
+        input=Path(manifest).read_bytes(),
+    )
+
+    LOG.info("Waiting for nginx pod to show up...")
+    util.stubbornly(retries=5, delay_s=10).on(h, instance_id).until(
+        lambda p: "my-nginx" in p.stdout.decode()
+    ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
+    LOG.info("Nginx pod showed up.")
+
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-l",
+            "run=my-nginx",
+            "--timeout",
+            "180s",
+        ]
+    )
+
+    p = h.exec(
+        instance_id,
+        ["curl", f"localhost:{ingress_http_port}", "-H", "Host: foo.bar.com"],
+        capture_output=True,
+    )
+    assert "Welcome to nginx!" in p.stdout.decode()
+
+    h.cleanup()


### PR DESCRIPTION
Added ingress support through Cilium. I've also modified the `Component` manager and let components declare parents to update their configuration.

Currently everything seems to operate normally without the kube-proxy replacement which is listed as a [requirement](https://docs.cilium.io/en/stable/network/servicemesh/ingress/#prerequisites).