### PR TITLE
Update E2E test's retry logic to use tenacity

### DIFF
--- a/tests/e2e/requirements-test.txt
+++ b/tests/e2e/requirements-test.txt
@@ -1,2 +1,3 @@
 coverage[toml]==7.2.5
 pytest==7.3.1
+tenacity==8.2.3

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
 

--- a/tests/e2e/tests/e2e_util/config.py
+++ b/tests/e2e/tests/e2e_util/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import os
 from pathlib import Path

--- a/tests/e2e/tests/e2e_util/harness/__init__.py
+++ b/tests/e2e/tests/e2e_util/harness/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 from e2e_util.harness.base import Harness, HarnessError
 from e2e_util.harness.juju import JujuHarness

--- a/tests/e2e/tests/e2e_util/harness/base.py
+++ b/tests/e2e/tests/e2e_util/harness/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import subprocess
 

--- a/tests/e2e/tests/e2e_util/harness/juju.py
+++ b/tests/e2e/tests/e2e_util/harness/juju.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
 import shlex

--- a/tests/e2e/tests/e2e_util/harness/local.py
+++ b/tests/e2e/tests/e2e_util/harness/local.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 
 import logging

--- a/tests/e2e/tests/e2e_util/harness/lxd.py
+++ b/tests/e2e/tests/e2e_util/harness/lxd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
 import os
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from e2e_util import config
 from e2e_util.harness import Harness, HarnessError
-from e2e_util.util import run, run_with_retry
+from e2e_util.util import run, stubbornly
 
 LOG = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class LXDHarness(Harness):
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:
-            run_with_retry(
+            stubbornly(retries=3, delay_s=1)(
                 [
                     "lxc",
                     "launch",

--- a/tests/e2e/tests/e2e_util/harness/lxd.py
+++ b/tests/e2e/tests/e2e_util/harness/lxd.py
@@ -61,7 +61,7 @@ class LXDHarness(Harness):
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:
-            stubbornly(retries=3, delay_s=1)(
+            stubbornly(retries=3, delay_s=1).exec(
                 [
                     "lxc",
                     "launch",

--- a/tests/e2e/tests/e2e_util/harness/multipass.py
+++ b/tests/e2e/tests/e2e_util/harness/multipass.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
 import os

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -57,7 +57,7 @@ def stubbornly(retries=3, delay_s=1, exceptions: Optional[tuple] = None):
         )
         def exec(
             self,
-            command_args: Union[str, List[str]],
+            command_args: List[str],
             harness: Optional[harness.Harness] = None,
             instance: str = "",
             **command_kwds,
@@ -65,14 +65,11 @@ def stubbornly(retries=3, delay_s=1, exceptions: Optional[tuple] = None):
             """
             Execute a command against a harness or locally with subprocess to be retried.
 
-            :param str | List[str]       command_args: The command to be executed, as a str or list of str
-            :param Map[str,str]          command_kwds: Additional keyword arguments to be passed to exec
-            :param Optional[Harness]          harness: test Harness object, to run the command on
-            :param str                       instance: Instance id in the test harness.
+            :param  List[str]        command_args: The command to be executed, as a str or list of str
+            :param Map[str,str]      command_kwds: Additional keyword arguments to be passed to exec
+            :param Optional[Harness]      harness: test Harness object, to run the command on
+            :param str                   instance: Instance id in the test harness.
             """
-            if isinstance(command_args, str):
-                # Safely split the string command into command arguments
-                command_args = shlex.split(command_args)
 
             try:
                 if harness is not None:

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -219,10 +219,7 @@ def setup_k8s_snap(h: harness.Harness, instance_id: str, snap_path: Path):
 
 
 # Validates that the K8s node is in Ready state.
-def wait_until_k8s_ready(h: harness.Harness, instances: Union[str, List[str]]):
-    if isinstance(instances, str):
-        instances = [instances]
-
+def wait_until_k8s_ready(h: harness.Harness, instances: List[str]):
     for instance in instances:
         hostname = (
             h.exec(instance, ["hostname"], capture_output=True).stdout.decode().strip()
@@ -230,7 +227,7 @@ def wait_until_k8s_ready(h: harness.Harness, instances: Union[str, List[str]]):
         result = (
             stubbornly(retries=15, delay_s=5)
             .on(h, instance)
-            .until(lambda p: "Ready" in p.stdout.decode())
+            .until(lambda p: " Ready" in p.stdout.decode())
             .exec(["k8s", "kubectl", "get", "node", hostname, "--no-headers"])
         )
     LOG.info("Kubelet registered successfully!")

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -101,6 +101,7 @@ def stubbornly(
                 raise
             if self.condition:
                 assert self.condition(resp), "Failed to meet condition"
+            return resp
 
         def on(self, harness: harness.Harness, instance_id: str) -> "Retriable":
             """

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -216,7 +216,7 @@ def wait_until_k8s_ready(h: harness.Harness, instances: Union[str, List[str]]):
         result = (
             stubbornly(retries=15, delay_s=5)
             .until(lambda p: "Ready" in p.stdout.decode())
-            .exec(f"k8s kubectl get node {hostname} --no-headers")
+            .exec(["k8s", "kubectl", "get", "node", hostname, "--no-headers"])
         )
     LOG.info("Kubelet registered successfully!")
     LOG.info("%s", result.stdout.decode())

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -144,9 +144,7 @@ def setup_network(h: harness.Harness, instance_id: str):
     h.exec(instance_id, ["/snap/k8s/current/k8s/network-requirements.sh"])
 
     LOG.info("Waiting for network to be enabled...")
-    stubbornly(retries=15, delay_s=5).until(
-        lambda p: "enabled" in p.stdout.decode()
-    ).exec(["k8s", "enable", "network"], h, instance_id)
+    stubbornly(retries=15, delay_s=5).exec(["k8s", "enable", "network"], h, instance_id)
     LOG.info("Network enabled.")
 
     LOG.info("Waiting for cilium pods to show up...")

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -155,17 +155,45 @@ def setup_network(h: harness.Harness, instance_id: str):
     LOG.info("Waiting for cilium pods to show up...")
     stubbornly(retries=15, delay_s=5).until(
         lambda p: "cilium" in p.stdout.decode()
-    ).exec("k8s kubectl get pod -n kube-system -o json", h, instance_id)
+    ).exec(
+        ["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"],
+        h,
+        instance_id,
+    )
     LOG.info("Cilium pods showed up.")
 
     stubbornly().exec(
-        "k8s kubectl wait --for=condition=ready pod -n kube-system -l io.cilium/app=operator --timeout=180s",
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-n",
+            "kube-system",
+            "-l",
+            "io.cilium/app=operator",
+            "--timeout",
+            "180s",
+        ],
         h,
         instance_id,
     )
 
     stubbornly().exec(
-        "k8s kubectl wait --for=condition=ready pod -n kube-system -l k8s-app=cilium --timeout=180s",
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-n",
+            "kube-system",
+            "-l",
+            "k8s-app=cilium",
+            "--timeout",
+            "180s",
+        ],
         h,
         instance_id,
     )

--- a/tests/e2e/tests/test_cilium_e2e.py
+++ b/tests/e2e/tests/test_cilium_e2e.py
@@ -76,7 +76,7 @@ def test_cilium_e2e(h: harness.Harness, tmp_path: Path):
     h.exec(instance_id, ["./cilium", "version", "--client"])
 
     # TODO(neoaggelos): replace with "k8s status --wait-ready"
-    util.stubbornly(retries=15, delay_s=5).until(
+    util.stubbornly(retries=15, delay_s=5).on(h, instance_id).until(
         lambda p: "OK" == p.stdout.decode().strip()
     ).exec(
         [
@@ -93,9 +93,7 @@ def test_cilium_e2e(h: harness.Harness, tmp_path: Path):
             "cilium",
             "status",
             "--brief",
-        ],
-        h,
-        instance_id,
+        ]
     )
 
     # Run cilium e2e tests

--- a/tests/e2e/tests/test_cilium_e2e.py
+++ b/tests/e2e/tests/test_cilium_e2e.py
@@ -79,7 +79,21 @@ def test_cilium_e2e(h: harness.Harness, tmp_path: Path):
     util.stubbornly(retries=15, delay_s=5).until(
         lambda p: "OK" == p.stdout.decode().strip()
     ).exec(
-        "k8s kubectl exec -it ds/cilium -n kube-system -c cilium-agent -- cilium status --brief",
+        [
+            "k8s",
+            "kubectl",
+            "exec",
+            "-it",
+            "ds/cilium",
+            "-n",
+            "kube-system",
+            "-c",
+            "cilium-agent",
+            "--",
+            "cilium",
+            "status",
+            "--brief",
+        ],
         h,
         instance_id,
     )

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
 from pathlib import Path

--- a/tests/e2e/tests/test_dns.py
+++ b/tests/e2e/tests/test_dns.py
@@ -40,7 +40,7 @@ def test_dns(h: harness.Harness, tmp_path: Path):
         ],
     )
 
-    util.stubbornly(retries=3, delay_s=1).exec(
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
         [
             "k8s",
             "kubectl",
@@ -51,9 +51,7 @@ def test_dns(h: harness.Harness, tmp_path: Path):
             "run=busybox",
             "--timeout",
             "180s",
-        ],
-        h,
-        instance_id,
+        ]
     )
 
     result = h.exec(

--- a/tests/e2e/tests/test_dns.py
+++ b/tests/e2e/tests/test_dns.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
 from pathlib import Path

--- a/tests/e2e/tests/test_dns.py
+++ b/tests/e2e/tests/test_dns.py
@@ -40,9 +40,7 @@ def test_dns(h: harness.Harness, tmp_path: Path):
         ],
     )
 
-    util.retry_until_condition(
-        h,
-        instance_id,
+    util.stubbornly(retries=3, delay_s=1).exec(
         [
             "k8s",
             "kubectl",
@@ -54,8 +52,8 @@ def test_dns(h: harness.Harness, tmp_path: Path):
             "--timeout",
             "180s",
         ],
-        max_retries=3,
-        delay_between_retries=1,
+        h,
+        instance_id,
     )
 
     result = h.exec(

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -77,7 +77,17 @@ def test_network(h: harness.Harness, tmp_path: Path):
     )
 
     util.stubbornly().exec(
-        "k8s kubectl wait --for=condition=ready pod -l app=nginx --timeout 180s",
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-l",
+            "app=nginx",
+            "--timeout",
+            "180s",
+        ],
         h,
         instance_id,
     )

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -76,7 +76,7 @@ def test_network(h: harness.Harness, tmp_path: Path):
         input=Path(manifest).read_bytes(),
     )
 
-    util.stubbornly(retries=3, delay_s=1).exec(
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
         [
             "k8s",
             "kubectl",
@@ -87,9 +87,7 @@ def test_network(h: harness.Harness, tmp_path: Path):
             "app=nginx",
             "--timeout",
             "180s",
-        ],
-        h,
-        instance_id,
+        ]
     )
 
     p = h.exec(

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import json
 import logging
@@ -76,22 +76,10 @@ def test_network(h: harness.Harness, tmp_path: Path):
         input=Path(manifest).read_bytes(),
     )
 
-    util.retry_until_condition(
+    util.stubbornly().exec(
+        "k8s kubectl wait --for=condition=ready pod -l app=nginx --timeout 180s",
         h,
         instance_id,
-        [
-            "k8s",
-            "kubectl",
-            "wait",
-            "--for=condition=ready",
-            "pod",
-            "-l",
-            "app=nginx",
-            "--timeout",
-            "180s",
-        ],
-        max_retries=3,
-        delay_between_retries=1,
     )
 
     p = h.exec(

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -76,7 +76,7 @@ def test_network(h: harness.Harness, tmp_path: Path):
         input=Path(manifest).read_bytes(),
     )
 
-    util.stubbornly().exec(
+    util.stubbornly(retries=3, delay_s=1).exec(
         [
             "k8s",
             "kubectl",

--- a/tests/e2e/tests/test_retry.py
+++ b/tests/e2e/tests/test_retry.py
@@ -1,8 +1,0 @@
-#
-# Copyright 2024 Canonical, Ltd.
-#
-from e2e_util import util
-
-
-def test_retry():
-    util.stubbornly().exec("boo")

--- a/tests/e2e/tests/test_retry.py
+++ b/tests/e2e/tests/test_retry.py
@@ -1,0 +1,8 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+from e2e_util import util
+
+
+def test_retry():
+    util.stubbornly().exec("boo")

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
 from pathlib import Path

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -23,6 +23,6 @@ def test_smoke(h: harness.Harness, tmp_path: Path):
     h.exec(instance_id, ["k8s", "bootstrap"])
     util.setup_network(h, instance_id)
 
-    util.wait_until_k8s_ready(h, instance_id)
+    util.wait_until_k8s_ready(h, [instance_id])
 
     h.cleanup()

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -44,12 +44,27 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     LOG.info("Waiting for storage provisioner pod to show up...")
     util.stubbornly(retries=15, delay_s=5).until(
         lambda p: "ck-storage" in p.stdout.decode()
-    ).exec("k8s kubectl get pod -n kube-system -o json", h, instance_id)
+    ).exec(
+        ["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"],
+        h,
+        instance_id,
+    )
     LOG.info("Storage provisioner pod showed up.")
 
     util.stubbornly().exec(
-        "k8s kubectl wait --for=condition=ready pod -n kube-system "
-        "-l app.kubernetes.io/instance=ck-storage --timeout 180s",
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-n",
+            "kube-system",
+            "-l",
+            "app.kubernetes.io/instance=ck-storage",
+            "--timeout",
+            "180s",
+        ],
         h,
         instance_id,
     )
@@ -64,36 +79,56 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     LOG.info("Waiting for storage writer pod to show up...")
     util.stubbornly(delay_s=10).until(
         lambda p: "storage-writer-pod" in p.stdout.decode()
-    ).exec("k8s kubectl get pod -o json", h, instance_id)
+    ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"], h, instance_id)
     LOG.info("Storage writer pod showed up.")
 
     util.stubbornly().exec(
-        "k8s kubectl wait --for=condition=ready pod -l k8s-api=storage-writer-pod --timeout 180s",
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-l",
+            "k8s-app=storage-writer-pod",
+            "--timeout",
+            "180s",
+        ],
         h,
         instance_id,
     )
 
     LOG.info("Waiting for storage to get provisioned...")
     util.stubbornly().until(check_pvc_bound).exec(
-        "k8s kubectl get pvc -o json", h, instance_id
+        ["k8s", "kubectl", "get", "pvc", "-o", "json"], h, instance_id
     )
     LOG.info("Storage got provisioned and pvc is bound.")
 
     LOG.info("Waiting for storage reader pod to show up...")
     util.stubbornly(delay_s=10).until(
         lambda p: "storage-reader-pod" in p.stdout.decode()
-    ).exec("k8s kubectl get pod -o json", h, instance_id)
+    ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"], h, instance_id)
     LOG.info("Storage reader pod showed up.")
 
     util.stubbornly().exec(
-        "k8s kubectl wait --for=condition=ready pod -l k8s-api=storage-reader-pod --timeout 180s",
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "-l",
+            "k8s-app=storage-reader-pod",
+            "--timeout",
+            "180s",
+        ],
         h,
         instance_id,
     )
 
     util.stubbornly(retries=5, delay_s=10).until(
         lambda p: "LOREM IPSUM" in p.stdout.decode()
-    ).exec("k8s kubectl logs storage-reader-pod", h, instance_id)
+    ).exec(["k8s", "kubectl", "logs", "storage-reader-pod"], h, instance_id)
 
     LOG.info("Data can be read between pods.")
 

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -42,16 +42,12 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     assert out.returncode == 0
 
     LOG.info("Waiting for storage provisioner pod to show up...")
-    util.stubbornly(retries=15, delay_s=5).until(
+    util.stubbornly(retries=15, delay_s=5).on(h, instance_id).until(
         lambda p: "ck-storage" in p.stdout.decode()
-    ).exec(
-        ["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"],
-        h,
-        instance_id,
-    )
+    ).exec(["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"])
     LOG.info("Storage provisioner pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).exec(
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
         [
             "k8s",
             "kubectl",
@@ -64,9 +60,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
             "app.kubernetes.io/instance=ck-storage",
             "--timeout",
             "180s",
-        ],
-        h,
-        instance_id,
+        ]
     )
 
     manifest = MANIFESTS_DIR / "storage-test.yaml"
@@ -77,12 +71,12 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     )
 
     LOG.info("Waiting for storage writer pod to show up...")
-    util.stubbornly(retries=3, delay_s=10).until(
+    util.stubbornly(retries=3, delay_s=10).on(h, instance_id).until(
         lambda p: "storage-writer-pod" in p.stdout.decode()
-    ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"], h, instance_id)
+    ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
     LOG.info("Storage writer pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).exec(
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
         [
             "k8s",
             "kubectl",
@@ -93,24 +87,22 @@ def test_storage(h: harness.Harness, tmp_path: Path):
             "k8s-app=storage-writer-pod",
             "--timeout",
             "180s",
-        ],
-        h,
-        instance_id,
+        ]
     )
 
     LOG.info("Waiting for storage to get provisioned...")
-    util.stubbornly(retries=3, delay_s=1).until(check_pvc_bound).exec(
-        ["k8s", "kubectl", "get", "pvc", "-o", "json"], h, instance_id
-    )
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).until(
+        check_pvc_bound
+    ).exec(["k8s", "kubectl", "get", "pvc", "-o", "json"])
     LOG.info("Storage got provisioned and pvc is bound.")
 
     LOG.info("Waiting for storage reader pod to show up...")
-    util.stubbornly(retries=3, delay_s=10).until(
+    util.stubbornly(retries=3, delay_s=10).on(h, instance_id).until(
         lambda p: "storage-reader-pod" in p.stdout.decode()
-    ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"], h, instance_id)
+    ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
     LOG.info("Storage reader pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).exec(
+    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
         [
             "k8s",
             "kubectl",
@@ -121,14 +113,12 @@ def test_storage(h: harness.Harness, tmp_path: Path):
             "k8s-app=storage-reader-pod",
             "--timeout",
             "180s",
-        ],
-        h,
-        instance_id,
+        ]
     )
 
-    util.stubbornly(retries=5, delay_s=10).until(
+    util.stubbornly(retries=5, delay_s=10).on(h, instance_id).until(
         lambda p: "LOREM IPSUM" in p.stdout.decode()
-    ).exec(["k8s", "kubectl", "logs", "storage-reader-pod"], h, instance_id)
+    ).exec(["k8s", "kubectl", "logs", "storage-reader-pod"])
 
     LOG.info("Data can be read between pods.")
 

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import json
 import logging
@@ -42,32 +42,16 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     assert out.returncode == 0
 
     LOG.info("Waiting for storage provisioner pod to show up...")
-    util.retry_until_condition(
-        h,
-        instance_id,
-        ["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"],
-        condition=lambda p: "ck-storage" in p.stdout.decode(),
-    )
+    util.stubbornly(retries=15, delay_s=5).until(
+        lambda p: "ck-storage" in p.stdout.decode()
+    ).exec("k8s kubectl get pod -n kube-system -o json", h, instance_id)
     LOG.info("Storage provisioner pod showed up.")
 
-    util.retry_until_condition(
+    util.stubbornly().exec(
+        "k8s kubectl wait --for=condition=ready pod -n kube-system "
+        "-l app.kubernetes.io/instance=ck-storage --timeout 180s",
         h,
         instance_id,
-        [
-            "k8s",
-            "kubectl",
-            "wait",
-            "--for=condition=ready",
-            "pod",
-            "-n",
-            "kube-system",
-            "-l",
-            "app.kubernetes.io/instance=ck-storage",
-            "--timeout",
-            "180s",
-        ],
-        max_retries=3,
-        delay_between_retries=1,
     )
 
     manifest = MANIFESTS_DIR / "storage-test.yaml"
@@ -78,78 +62,39 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     )
 
     LOG.info("Waiting for storage writer pod to show up...")
-    util.retry_until_condition(
-        h,
-        instance_id,
-        ["k8s", "kubectl", "get", "pod", "-o", "json"],
-        condition=lambda p: "storage-writer-pod" in p.stdout.decode(),
-        delay_between_retries=10,
-    )
+    util.stubbornly(delay_s=10).until(
+        lambda p: "storage-writer-pod" in p.stdout.decode()
+    ).exec("k8s kubectl get pod -o json", h, instance_id)
     LOG.info("Storage writer pod showed up.")
 
-    util.retry_until_condition(
+    util.stubbornly().exec(
+        "k8s kubectl wait --for=condition=ready pod -l k8s-api=storage-writer-pod --timeout 180s",
         h,
         instance_id,
-        [
-            "k8s",
-            "kubectl",
-            "wait",
-            "--for=condition=ready",
-            "pod",
-            "-l",
-            "k8s-app=storage-writer-pod",
-            "--timeout",
-            "180s",
-        ],
-        max_retries=3,
-        delay_between_retries=1,
     )
 
     LOG.info("Waiting for storage to get provisioned...")
-    util.retry_until_condition(
-        h,
-        instance_id,
-        ["k8s", "kubectl", "get", "pvc", "-o", "json"],
-        condition=check_pvc_bound,
+    util.stubbornly().until(check_pvc_bound).exec(
+        "k8s kubectl get pvc -o json", h, instance_id
     )
     LOG.info("Storage got provisioned and pvc is bound.")
 
     LOG.info("Waiting for storage reader pod to show up...")
-    util.retry_until_condition(
-        h,
-        instance_id,
-        ["k8s", "kubectl", "get", "pod", "-o", "json"],
-        condition=lambda p: "storage-reader-pod" in p.stdout.decode(),
-        delay_between_retries=10,
-    )
+    util.stubbornly(delay_s=10).until(
+        lambda p: "storage-reader-pod" in p.stdout.decode()
+    ).exec("k8s kubectl get pod -o json", h, instance_id)
     LOG.info("Storage reader pod showed up.")
 
-    util.retry_until_condition(
+    util.stubbornly().exec(
+        "k8s kubectl wait --for=condition=ready pod -l k8s-api=storage-reader-pod --timeout 180s",
         h,
         instance_id,
-        [
-            "k8s",
-            "kubectl",
-            "wait",
-            "--for=condition=ready",
-            "pod",
-            "-l",
-            "k8s-app=storage-reader-pod",
-            "--timeout",
-            "180s",
-        ],
-        max_retries=3,
-        delay_between_retries=1,
     )
 
-    util.retry_until_condition(
-        h,
-        instance_id,
-        ["k8s", "kubectl", "logs", "storage-reader-pod"],
-        condition=lambda p: "LOREM IPSUM" in p.stdout.decode(),
-        max_retries=5,
-        delay_between_retries=10,
-    )
+    util.stubbornly(retries=5, delay_s=10).until(
+        lambda p: "LOREM IPSUM" in p.stdout.decode()
+    ).exec("k8s kubectl logs storage-reader-pod", h, instance_id)
+
     LOG.info("Data can be read between pods.")
 
     h.cleanup()

--- a/tests/e2e/tests/test_storage.py
+++ b/tests/e2e/tests/test_storage.py
@@ -51,7 +51,7 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     )
     LOG.info("Storage provisioner pod showed up.")
 
-    util.stubbornly().exec(
+    util.stubbornly(retries=3, delay_s=1).exec(
         [
             "k8s",
             "kubectl",
@@ -77,12 +77,12 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     )
 
     LOG.info("Waiting for storage writer pod to show up...")
-    util.stubbornly(delay_s=10).until(
+    util.stubbornly(retries=3, delay_s=10).until(
         lambda p: "storage-writer-pod" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"], h, instance_id)
     LOG.info("Storage writer pod showed up.")
 
-    util.stubbornly().exec(
+    util.stubbornly(retries=3, delay_s=1).exec(
         [
             "k8s",
             "kubectl",
@@ -99,18 +99,18 @@ def test_storage(h: harness.Harness, tmp_path: Path):
     )
 
     LOG.info("Waiting for storage to get provisioned...")
-    util.stubbornly().until(check_pvc_bound).exec(
+    util.stubbornly(retries=3, delay_s=1).until(check_pvc_bound).exec(
         ["k8s", "kubectl", "get", "pvc", "-o", "json"], h, instance_id
     )
     LOG.info("Storage got provisioned and pvc is bound.")
 
     LOG.info("Waiting for storage reader pod to show up...")
-    util.stubbornly(delay_s=10).until(
+    util.stubbornly(retries=3, delay_s=10).until(
         lambda p: "storage-reader-pod" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"], h, instance_id)
     LOG.info("Storage reader pod showed up.")
 
-    util.stubbornly().exec(
+    util.stubbornly(retries=3, delay_s=1).exec(
         [
             "k8s",
             "kubectl",


### PR DESCRIPTION
With some spare cycles, i noticed there was a `TODO` on the e2e testing to improve the retry logic.

This PR wraps tenacity's retry logic to run commands on harnesses or on local commands
