### PR TITLE
chore: run go mod tidy

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,8 +29,11 @@ jobs:
 
       - name: check diff
         run: |
-          if ! git diff; then
+          if ! [ -z "$(git diff)" ]; then
             echo "Detected changes that have not been committed to the repository"
+            echo "Please run 'cd src/k8s && make go.fmt'"
+            echo "git diff:"
+            git diff
             exit 1
           fi
 

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/canonical/lxd v0.0.0-20231002162033-38796399c135
 	github.com/canonical/microcluster v0.0.0-20240122235408-1525f8ea8d7a
 	github.com/docker/docker v24.0.7+incompatible
-	github.com/gorilla/mux v1.8.0
 	github.com/mattn/go-sqlite3 v1.14.18
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/sys/mountinfo v0.6.2
@@ -86,6 +85,7 @@ require (
 	github.com/google/renameio v1.0.1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.4.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/schema v1.2.0 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -527,8 +527,6 @@ github.com/muhlemmer/httpforwarded v0.1.0/go.mod h1:yo9czKedo2pdZhoXe+yDkGVbU0TJ
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/neoaggelos/microcluster v0.0.0-20240122183258-10c6f6779a0b h1:Y72TX9A0FM57dwd6SmUf8xUNQrcNbdFWx/9Q1MXmSD8=
-github.com/neoaggelos/microcluster v0.0.0-20240122183258-10c6f6779a0b/go.mod h1:pqKGCjymAfdqHmUC77AMSKq9sRTazucRyPLjFDI2muM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=


### PR DESCRIPTION
### Summary

Run `go mod tidy`, and update the CI to properly check for uncommitted diffs