### PR TITLE
reduce noise in e2e tests

### DIFF
--- a/k8s/connect-interfaces.sh
+++ b/k8s/connect-interfaces.sh
@@ -28,5 +28,5 @@ declare -a INTERFACES=(
 )
 
 for if in "${INTERFACES[@]}"; do
-  bash -x -c "snap connect 'k8s:${if}'"
+  bash -c "snap connect 'k8s:${if}'"
 done

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -159,7 +159,11 @@ def setup_dns(h: harness.Harness, instance_id: str):
 
 def setup_network(h: harness.Harness, instance_id: str):
     time.sleep(30)
-    h.exec(instance_id, ["/snap/k8s/current/k8s/network-requirements.sh"])
+    h.exec(
+        instance_id,
+        ["/snap/k8s/current/k8s/network-requirements.sh"],
+        stdout=subprocess.DEVNULL,
+    )
 
     LOG.info("Waiting for network to be enabled...")
     stubbornly(retries=15, delay_s=5).on(h, instance_id).exec(


### PR DESCRIPTION
### Summary

Reduce more noisy logs from e2e tests, to ensure we can easily locate the problems.