### PR TITLE
Increase snap start-timeout

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -213,7 +213,7 @@ apps:
     # https://forum.snapcraft.io/t/process-lifecycle-on-snap-refresh/140/37
     stop-mode: sigterm
     restart-condition: always
-    start-timeout: 3s
+    start-timeout: 5m
     plugs:
       - network-bind
       - docker-privileged


### PR DESCRIPTION
Starting the k8s snap sometimes timeouted because containerd failed to come up in time. Increasing the timeout fixes this.