### PR TITLE
Add machinery to configure cluster on bootstrap

### DIFF
--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -1,11 +1,5 @@
 package v1
 
-import (
-	"fmt"
-	"net"
-	"strings"
-)
-
 // GetClusterStatusRequest is used to request the current status of the cluster.
 type GetClusterStatusRequest struct{}
 
@@ -20,67 +14,4 @@ type GetKubeConfigRequest struct{}
 // GetKubeConfigResponse is the response for "GET 1.0/k8sd/cluster/config".
 type GetKubeConfigResponse struct {
 	KubeConfig string `json:"kubeconfig"`
-}
-
-// ClusterMember holds information about a node in the k8s cluster.
-type ClusterMember struct {
-	Name        string `mapstructure:"name,omitempty"`
-	Address     string `mapstructure:"address,omitempty"`
-	Role        string `mapstructure:"role,omitempty"`
-	Fingerprint string `mapstructure:"fingerprint,omitempty"`
-	Status      string `mapstructure:"status,omitempty"`
-}
-
-// ClusterStatus holds information about the cluster, e.g. its current members
-type ClusterStatus struct {
-	// Ready is true if at least one node in the cluster is in READY state.
-	Ready      bool            `mapstructure:"ready,omitempty"`
-	Members    []ClusterMember `mapstructure:"members,omitempty"`
-	Components []Component     `mapstructure:"components,omitempty"`
-}
-
-// HaClusterFormed returns true if the cluster is in high-availability mode (more than two voter nodes).
-func (c ClusterStatus) HaClusterFormed() bool {
-	voters := 0
-	for _, member := range c.Members {
-		if member.Role == "voter" {
-			voters++
-		}
-	}
-	return voters > 2
-}
-
-func (c ClusterStatus) String() string {
-	result := strings.Builder{}
-
-	if c.Ready {
-		result.WriteString("k8s is ready.")
-	} else {
-		result.WriteString("k8s is not ready.\n")
-		return result.String()
-	}
-	result.WriteString("\n")
-
-	result.WriteString("high-availability: ")
-	if c.HaClusterFormed() {
-		result.WriteString("yes")
-	} else {
-		result.WriteString("no")
-	}
-	result.WriteString("\n\n")
-	result.WriteString("control-plane nodes:\n")
-	for _, member := range c.Members {
-		// There is not much that we can do if the hostport is wrong.
-		// Thus, ignore the error and just display an empty IP field.
-		apiServerIp, _, _ := net.SplitHostPort(member.Address)
-		result.WriteString(fmt.Sprintf("  %s: %s\n", member.Name, apiServerIp))
-	}
-	result.WriteString("\n")
-
-	result.WriteString("components:\n")
-	for _, component := range c.Components {
-		result.WriteString(fmt.Sprintf("  %-10s %s\n", component.Name, component.Status))
-	}
-
-	return result.String()
 }

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -1,0 +1,111 @@
+package v1
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type BootstrapConfig struct {
+	// Components are the components that should be enabled on bootstrap.
+	Components []string
+	// ClusterCIDR is the CIDR of the cluster.
+	ClusterCIDR string
+}
+
+// SetDefaults sets the fields to default values.
+func (b *BootstrapConfig) SetDefaults() {
+	b.Components = []string{"dns", "network"}
+	b.ClusterCIDR = "10.1.0.0/16"
+}
+
+// ToMap marshals the BootstrapConfig into yaml and map it to "bootstrapConfig".
+// TODO: should we move those helpers to utils?
+func (b *BootstrapConfig) ToMap() (map[string]string, error) {
+	config := map[string]any{
+		"components":   b.Components,
+		"cluster-cidr": b.ClusterCIDR,
+	}
+	c, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config map: %w", err)
+	}
+	return map[string]string{
+		"bootstrapConfig": string(c),
+	}, nil
+}
+
+// BootstrapConfigFromMap converts a string map to a BootstrapConfig struct.
+func BootstrapConfigFromMap(m map[string]string) (*BootstrapConfig, error) {
+	config := &BootstrapConfig{}
+	err := yaml.Unmarshal([]byte(m["bootstrapConfig"]), config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal bootstrap config: %w", err)
+	}
+	return config, nil
+}
+
+// ClusterMember holds information about a node in the k8s cluster.
+type ClusterMember struct {
+	Name        string `mapstructure:"name,omitempty"`
+	Address     string `mapstructure:"address,omitempty"`
+	Role        string `mapstructure:"role,omitempty"`
+	Fingerprint string `mapstructure:"fingerprint,omitempty"`
+	Status      string `mapstructure:"status,omitempty"`
+}
+
+// ClusterStatus holds information about the cluster, e.g. its current members
+type ClusterStatus struct {
+	// Ready is true if at least one node in the cluster is in READY state.
+	Ready      bool            `mapstructure:"ready,omitempty"`
+	Members    []ClusterMember `mapstructure:"members,omitempty"`
+	Components []Component     `mapstructure:"components,omitempty"`
+}
+
+// HaClusterFormed returns true if the cluster is in high-availability mode (more than two voter nodes).
+func (c ClusterStatus) HaClusterFormed() bool {
+	voters := 0
+	for _, member := range c.Members {
+		if member.Role == "voter" {
+			voters++
+		}
+	}
+	return voters > 2
+}
+
+func (c ClusterStatus) String() string {
+	result := strings.Builder{}
+
+	if c.Ready {
+		result.WriteString("k8s is ready.")
+	} else {
+		result.WriteString("k8s is not ready.\n")
+		return result.String()
+	}
+	result.WriteString("\n")
+
+	result.WriteString("high-availability: ")
+	if c.HaClusterFormed() {
+		result.WriteString("yes")
+	} else {
+		result.WriteString("no")
+	}
+	result.WriteString("\n\n")
+	result.WriteString("control-plane nodes:\n")
+	for _, member := range c.Members {
+		// There is not much that we can do if the hostport is wrong.
+		// Thus, ignore the error and just display an empty IP field.
+		apiServerIp, _, _ := net.SplitHostPort(member.Address)
+		result.WriteString(fmt.Sprintf("  %s: %s\n", member.Name, apiServerIp))
+	}
+	result.WriteString("\n")
+
+	result.WriteString("components:\n")
+	for _, component := range c.Components {
+		result.WriteString(fmt.Sprintf("  %-10s %s\n", component.Name, component.Status))
+	}
+
+	return result.String()
+}

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -1,13 +1,22 @@
 package k8s
 
 import (
+	"bufio"
+	"context"
 	"fmt"
+	"os"
+	"strings"
 
+	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8s/client"
 	"github.com/spf13/cobra"
 )
 
 var (
+	bootstrapCmdOpts struct {
+		interactive bool
+	}
+
 	boostrapCmd = &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Bootstrap a k8s cluster on this node.",
@@ -22,7 +31,14 @@ var (
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			cluster, err := c.Bootstrap(cmd.Context())
+			config := apiv1.BootstrapConfig{}
+			if bootstrapCmdOpts.interactive {
+				config = getConfigInteractively(cmd.Context())
+			} else {
+				config.SetDefaults()
+			}
+
+			cluster, err := c.Bootstrap(cmd.Context(), config)
 			if err != nil {
 				return fmt.Errorf("failed to initialize k8s cluster: %w", err)
 			}
@@ -35,4 +51,44 @@ var (
 
 func init() {
 	rootCmd.AddCommand(boostrapCmd)
+	boostrapCmd.PersistentFlags().BoolVar(&bootstrapCmdOpts.interactive, "interactive", false,
+		"Interactively configure the most important cluster options.")
+}
+
+func getConfigInteractively(ctx context.Context) apiv1.BootstrapConfig {
+	config := apiv1.BootstrapConfig{}
+	config.SetDefaults()
+
+	components := askQuestion("Which components would you like to enable?", componentList, strings.Join(config.Components, ", "))
+	// TODO: Validate components
+	config.Components = strings.Split(strings.ReplaceAll(components, " ", ""), ",")
+
+	config.ClusterCIDR = askQuestion("Please set the Cluster CIDR?", nil, config.ClusterCIDR)
+	return config
+}
+
+func askQuestion(question string, options []string, defaultVal string) string {
+	if options != nil {
+		question = fmt.Sprintf("%s (%s)", question, strings.Join(options, ", "))
+	}
+	if defaultVal != "" {
+		question = fmt.Sprintf("%s [%s]:", question, defaultVal)
+	}
+	question = fmt.Sprintf("%s ", question)
+
+	var s string
+	r := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Fprint(os.Stdout, question)
+		s, _ = r.ReadString('\n')
+		if s != "" {
+			break
+		}
+	}
+	s = strings.TrimSpace(s)
+
+	if s == "" {
+		return defaultVal
+	}
+	return s
 }

--- a/src/k8s/pkg/k8s/setup/k8s_dqlite.go
+++ b/src/k8s/pkg/k8s/setup/k8s_dqlite.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/k8sd/database/clusterconfigs"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/cert"
@@ -26,7 +26,7 @@ func JoinK8sDqliteCluster(ctx context.Context, state *state.State, snap snap.Sna
 	// TODO: Cleanup once the cluster config is fully fetched from the database and not from the RPC endpoint above.
 	var crt, key string
 	if err := state.Database.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		config, err := database.GetClusterConfig(ctx, tx)
+		config, err := clusterconfigs.GetClusterConfig(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("failed to get k8s-dqlite cert and key from database: %w", err)
 		}

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -9,6 +9,7 @@ import (
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/k8sd/database/clusterconfigs"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils/k8s"
 	"github.com/canonical/lxd/lxd/response"
@@ -90,10 +91,10 @@ func k8sdWorkerInfoPost(s *state.State, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("node name cannot be empty"))
 	}
 
-	var clusterConfig database.ClusterConfig
+	var clusterConfig clusterconfigs.ClusterConfig
 	if err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
-		clusterConfig, err = database.GetClusterConfig(ctx, tx)
+		clusterConfig, err = clusterconfigs.GetClusterConfig(ctx, tx)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve cluster configuration: %w", err)
 		}

--- a/src/k8s/pkg/k8sd/app/hooks.go
+++ b/src/k8s/pkg/k8sd/app/hooks.go
@@ -9,7 +9,7 @@ import (
 	"path"
 
 	"github.com/canonical/k8s/pkg/k8s/setup"
-	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/k8sd/database/clusterconfigs"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils/cert"
 	"github.com/canonical/microcluster/state"
@@ -20,10 +20,10 @@ import (
 func onPostJoin(s *state.State, initConfig map[string]string) error {
 	snap := snap.SnapFromContext(s.Context)
 
-	var clusterConfig database.ClusterConfig
+	var clusterConfig clusterconfigs.ClusterConfig
 	if err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
-		clusterConfig, err = database.GetClusterConfig(ctx, tx)
+		clusterConfig, err = clusterconfigs.GetClusterConfig(ctx, tx)
 		return err
 	}); err != nil {
 		return fmt.Errorf("failed to retrieve the cluster configuration from the database: %w", err)

--- a/src/k8s/pkg/k8sd/database/cluster_configs_test.go
+++ b/src/k8s/pkg/k8sd/database/cluster_configs_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/k8sd/database/clusterconfigs"
 	. "github.com/onsi/gomega"
 )
 
@@ -13,8 +13,8 @@ func TestClusterConfig(t *testing.T) {
 	WithDB(t, func(ctx context.Context, d DB) {
 		t.Run("Set", func(t *testing.T) {
 			g := NewWithT(t)
-			expectedClusterConfig := database.ClusterConfig{
-				Certificates: database.ClusterConfigCertificates{
+			expectedClusterConfig := clusterconfigs.ClusterConfig{
+				Certificates: clusterconfigs.Certificates{
 					CACert: "CA CERT DATA",
 					CAKey:  "CA KEY DATA",
 				},
@@ -22,7 +22,7 @@ func TestClusterConfig(t *testing.T) {
 
 			// Write some config to the database
 			err := d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-				err := database.SetClusterConfig(context.Background(), tx, expectedClusterConfig)
+				err := clusterconfigs.SetClusterConfig(context.Background(), tx, expectedClusterConfig)
 				g.Expect(err).To(BeNil())
 				return nil
 			})
@@ -30,7 +30,7 @@ func TestClusterConfig(t *testing.T) {
 
 			// Retrieve it and map it to the struct
 			err = d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-				clusterConfig, err := database.GetClusterConfig(ctx, tx)
+				clusterConfig, err := clusterconfigs.GetClusterConfig(ctx, tx)
 				g.Expect(err).To(BeNil())
 				g.Expect(clusterConfig).To(Equal(expectedClusterConfig))
 				return nil
@@ -41,16 +41,16 @@ func TestClusterConfig(t *testing.T) {
 		t.Run("CannotUpdateCA", func(t *testing.T) {
 			// TODO(neoaggelos): extend this test for all fields that cannot be updated
 			g := NewWithT(t)
-			expectedClusterConfig := database.ClusterConfig{
-				Certificates: database.ClusterConfigCertificates{
+			expectedClusterConfig := clusterconfigs.ClusterConfig{
+				Certificates: clusterconfigs.Certificates{
 					CACert: "CA CERT DATA",
 					CAKey:  "CA KEY DATA",
 				},
 			}
 
 			err := d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-				err := database.SetClusterConfig(context.Background(), tx, database.ClusterConfig{
-					Certificates: database.ClusterConfigCertificates{
+				err := clusterconfigs.SetClusterConfig(context.Background(), tx, clusterconfigs.ClusterConfig{
+					Certificates: clusterconfigs.Certificates{
 						CACert: "CA CERT NEW DATA",
 					},
 				})
@@ -60,7 +60,7 @@ func TestClusterConfig(t *testing.T) {
 			g.Expect(err).To(HaveOccurred())
 
 			err = d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-				clusterConfig, err := database.GetClusterConfig(ctx, tx)
+				clusterConfig, err := clusterconfigs.GetClusterConfig(ctx, tx)
 				g.Expect(err).To(BeNil())
 				g.Expect(clusterConfig).To(Equal(expectedClusterConfig))
 				return nil
@@ -71,31 +71,31 @@ func TestClusterConfig(t *testing.T) {
 		t.Run("Update", func(t *testing.T) {
 			// TODO(neoaggelos): extend this test for all fields that can be updated
 			g := NewWithT(t)
-			expectedClusterConfig := database.ClusterConfig{
-				Certificates: database.ClusterConfigCertificates{
+			expectedClusterConfig := clusterconfigs.ClusterConfig{
+				Certificates: clusterconfigs.Certificates{
 					CACert:        "CA CERT DATA",
 					CAKey:         "CA KEY DATA",
 					K8sDqliteCert: "CERT DATA",
 					K8sDqliteKey:  "KEY DATA",
 				},
-				Kubelet: database.ClusterConfigKubelet{
+				Kubelet: clusterconfigs.Kubelet{
 					ClusterDNS: "10.152.183.10",
 				},
-				APIServer: database.ClusterConfigAPIServer{
+				APIServer: clusterconfigs.APIServer{
 					ServiceAccountKey: "SA KEY DATA",
 				},
 			}
 
 			err := d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-				err := database.SetClusterConfig(context.Background(), tx, database.ClusterConfig{
-					Kubelet: database.ClusterConfigKubelet{
+				err := clusterconfigs.SetClusterConfig(context.Background(), tx, clusterconfigs.ClusterConfig{
+					Kubelet: clusterconfigs.Kubelet{
 						ClusterDNS: "10.152.183.10",
 					},
-					Certificates: database.ClusterConfigCertificates{
+					Certificates: clusterconfigs.Certificates{
 						K8sDqliteCert: "CERT DATA",
 						K8sDqliteKey:  "KEY DATA",
 					},
-					APIServer: database.ClusterConfigAPIServer{
+					APIServer: clusterconfigs.APIServer{
 						ServiceAccountKey: "SA KEY DATA",
 					},
 				})
@@ -105,7 +105,7 @@ func TestClusterConfig(t *testing.T) {
 			g.Expect(err).To(BeNil())
 
 			err = d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-				clusterConfig, err := database.GetClusterConfig(ctx, tx)
+				clusterConfig, err := clusterconfigs.GetClusterConfig(ctx, tx)
 				g.Expect(err).To(BeNil())
 				g.Expect(clusterConfig).To(Equal(expectedClusterConfig))
 				return nil

--- a/src/k8s/pkg/k8sd/database/clusterconfigs/cluster_configs_merge.go
+++ b/src/k8s/pkg/k8sd/database/clusterconfigs/cluster_configs_merge.go
@@ -1,4 +1,4 @@
-package database
+package clusterconfigs
 
 import "fmt"
 
@@ -13,10 +13,10 @@ func mergeValue[T comparable](old T, new T, allowChange bool) (T, error) {
 	return old, nil
 }
 
-// mergeConfig applies updates from non-empty values of the new ClusterConfig to an existing one.
-// mergeConfig will return an error if we try to update a config that must not be updated. once such an operation is implemented in the future, we can allow the change here.
-// mergeConfig will create a new ClusterConfig object to avoid mutating the existing config objects.
-func mergeConfig(existing ClusterConfig, new ClusterConfig) (ClusterConfig, error) {
+// Merge applies updates from non-empty values of the new ClusterConfig to an existing one.
+// Merge will return an error if we try to update a config that must not be updated. once such an operation is implemented in the future, we can allow the change here.
+// Merge will create a new ClusterConfig object to avoid mutating the existing config objects.
+func Merge(existing ClusterConfig, new ClusterConfig) (ClusterConfig, error) {
 	var (
 		config ClusterConfig
 		err    error
@@ -37,6 +37,7 @@ func mergeConfig(existing ClusterConfig, new ClusterConfig) (ClusterConfig, erro
 		{name: "apiserver-to-kubelet key", val: &config.Certificates.APIServerToKubeletKey, old: existing.Certificates.APIServerToKubeletKey, new: new.Certificates.APIServerToKubeletKey, allowChange: true},
 		{name: "front proxy CA certificate", val: &config.Certificates.FrontProxyCACert, old: existing.Certificates.FrontProxyCACert, new: new.Certificates.FrontProxyCACert, allowChange: true},
 		{name: "front proxy CA key", val: &config.Certificates.FrontProxyCAKey, old: existing.Certificates.FrontProxyCAKey, new: new.Certificates.FrontProxyCAKey, allowChange: true},
+		{name: "authorization-mode", val: &config.APIServer.AuthorizationMode, old: existing.APIServer.AuthorizationMode, new: new.APIServer.AuthorizationMode, allowChange: true},
 		{name: "service account key", val: &config.APIServer.ServiceAccountKey, old: existing.APIServer.ServiceAccountKey, new: new.APIServer.ServiceAccountKey},
 		{name: "cluster cidr", val: &config.Cluster.CIDR, old: existing.Cluster.CIDR, new: new.Cluster.CIDR},
 		{name: "datastore", val: &config.APIServer.Datastore, old: existing.APIServer.Datastore, new: new.APIServer.Datastore, allowChange: true},

--- a/src/k8s/pkg/k8sd/database/kubernetes_auth_tokens.go
+++ b/src/k8s/pkg/k8sd/database/kubernetes_auth_tokens.go
@@ -15,11 +15,11 @@ import (
 
 var (
 	k8sdTokensStmts = map[string]int{
-		"insert-token":       mustPrepareStatement("kubernetes-auth-tokens", "insert-token.sql"),
-		"select-by-token":    mustPrepareStatement("kubernetes-auth-tokens", "select-by-token.sql"),
-		"select-by-username": mustPrepareStatement("kubernetes-auth-tokens", "select-by-username.sql"),
-		"delete-by-token":    mustPrepareStatement("kubernetes-auth-tokens", "delete-by-token.sql"),
-		"delete-by-username": mustPrepareStatement("kubernetes-auth-tokens", "delete-by-username.sql"),
+		"insert-token":       MustPrepareStatement("kubernetes-auth-tokens", "insert-token.sql"),
+		"select-by-token":    MustPrepareStatement("kubernetes-auth-tokens", "select-by-token.sql"),
+		"select-by-username": MustPrepareStatement("kubernetes-auth-tokens", "select-by-username.sql"),
+		"delete-by-token":    MustPrepareStatement("kubernetes-auth-tokens", "delete-by-token.sql"),
+		"delete-by-username": MustPrepareStatement("kubernetes-auth-tokens", "delete-by-username.sql"),
 	}
 )
 

--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -39,7 +39,8 @@ func schemaApplyMigration(migrationPath ...string) schema.Update {
 	}
 }
 
-func mustPrepareStatement(queryPath ...string) int {
+// MustPrepareStatement reads and registers a SQL query.
+func MustPrepareStatement(queryPath ...string) int {
 	path := filepath.Join(append([]string{"sql", "queries"}, queryPath...)...)
 	b, err := sqlQueries.ReadFile(path)
 	if err != nil {

--- a/src/k8s/pkg/k8sd/database/worker.go
+++ b/src/k8s/pkg/k8sd/database/worker.go
@@ -13,13 +13,13 @@ import (
 
 var (
 	workerStmts = map[string]int{
-		"insert-node": mustPrepareStatement("worker-nodes", "insert.sql"),
-		"select-node": mustPrepareStatement("worker-nodes", "select.sql"),
-		"delete-node": mustPrepareStatement("worker-nodes", "delete.sql"),
+		"insert-node": MustPrepareStatement("worker-nodes", "insert.sql"),
+		"select-node": MustPrepareStatement("worker-nodes", "select.sql"),
+		"delete-node": MustPrepareStatement("worker-nodes", "delete.sql"),
 
-		"insert-token": mustPrepareStatement("cluster-configs", "insert-worker-token.sql"),
-		"select-token": mustPrepareStatement("cluster-configs", "select-worker-token.sql"),
-		"delete-token": mustPrepareStatement("cluster-configs", "delete-worker-token.sql"),
+		"insert-token": MustPrepareStatement("cluster-configs", "insert-worker-token.sql"),
+		"select-token": MustPrepareStatement("cluster-configs", "select-worker-token.sql"),
+		"delete-token": MustPrepareStatement("cluster-configs", "delete-worker-token.sql"),
 	}
 )
 

--- a/src/k8s/pkg/utils/cert/storage.go
+++ b/src/k8s/pkg/utils/cert/storage.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/k8sd/database/clusterconfigs"
 	"github.com/canonical/microcluster/state"
 	"github.com/sirupsen/logrus"
 )
@@ -40,7 +40,7 @@ func WriteCertKeyPairToK8sd(ctx context.Context, state *state.State, certName st
 	logrus.WithField("cert_length", len(string(cert))).WithField("key_length", len(string(key))).Debugf("Writing %s cert and key to database", certName)
 	if err := state.Database.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		// TODO: this is a hack until we completely replace WriteCertKeyPairToK8sd()
-		var clusterConfig database.ClusterConfig
+		var clusterConfig clusterconfigs.ClusterConfig
 		switch certName {
 		case "certificates-ca":
 			clusterConfig.Certificates.CACert = string(cert)
@@ -51,7 +51,7 @@ func WriteCertKeyPairToK8sd(ctx context.Context, state *state.State, certName st
 		default:
 			panic("only 'certificates-ca' or 'certificate-k8s-dqlite' is allowed")
 		}
-		if err := database.SetClusterConfig(ctx, tx, clusterConfig); err != nil {
+		if err := clusterconfigs.SetClusterConfig(ctx, tx, clusterConfig); err != nil {
 			return fmt.Errorf("failed to set cluster config: %w", err)
 		}
 		return nil

--- a/src/k8s/pkg/utils/clusterconfigs.go
+++ b/src/k8s/pkg/utils/clusterconfigs.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/k8sd/database/clusterconfigs"
+)
+
+// ConvertBootstrapToClusterConfig extracts the cluster config parts from the BootstrapConfig
+// and maps them to a ClusterConfig.
+func ConvertBootstrapToClusterConfig(b *apiv1.BootstrapConfig) clusterconfigs.ClusterConfig {
+	return clusterconfigs.ClusterConfig{
+		Cluster: clusterconfigs.Cluster{
+			CIDR: b.ClusterCIDR,
+		},
+	}
+}

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -60,6 +60,9 @@ def test_clustering(h: harness.Harness, tmp_path: Path):
     util.wait_until_k8s_ready(h, cluster_node, instances)
 
     # TODO: Remove if --wait-ready for `join-cluster` is implemented.
-    h.exec(cluster_node, ["k8s", "remove-node", util.hostname(h, joining_node)])
+    hostname = util.hostname(h, joining_node)
+    util.stubbornly(retries=5, delay_s=3).on(h, cluster_node).exec(
+        ["k8s", "remove-node", hostname]
+    )
 
     h.cleanup()


### PR DESCRIPTION
Introduces a more flexible approach for modifying cluster configuration during bootstrap with the addition of a --interactive flag to the k8s bootstrap command.

To improve code organization and readability, relocates the cluster configuration logic into a dedicated package, as exemplified by clusterconfigs.NewDefault().

Addresses an issue in clusterconfig.Merge where Authorization config was missing and ensures proper calculation of the microcluster timeout. The timeout now accurately reflects values provided via the --timeout flag by considering the context.

Note: I only added two configs to demonstrate the concept and get this signed-off. More parameters will be added in follow-up PRs.