### PR TITLE
Add tmate to Github CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,29 +43,29 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      #- name: Setup Python
-        #uses: actions/setup-python@v4
-        #with:
-          #python-version: '3.8'
-      #- name: Install tox
-        #run: pip install tox
-      #- name: Install lxd
-        #run: |
-          #sudo snap refresh lxd --channel 5.19/stable
-          #sudo lxd init --auto
-          #sudo usermod --append --groups lxd $USER
-          #sg lxd -c 'lxc version'
-      #- name: Download snap
-        #uses: actions/download-artifact@v3.0.2
-        #with:
-          #name: k8s.snap
-          #path: build
-      #- name: Run end to end tests
-        #run: |
-          #export TEST_SNAP="$PWD/build/k8s.snap"
-          #export TEST_SUBSTRATE=lxd
-          #export TEST_LXD_IMAGE=${{ matrix.os }}
-          #cd tests/e2e && sg lxd -c 'tox -e e2e'
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Install tox
+        run: pip install tox
+      - name: Install lxd
+        run: |
+          sudo snap refresh lxd --channel 5.19/stable
+          sudo lxd init --auto
+          sudo usermod --append --groups lxd $USER
+          sg lxd -c 'lxc version'
+      - name: Download snap
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: k8s.snap
+          path: build
+      - name: Run end to end tests
+        run: |
+          export TEST_SNAP="$PWD/build/k8s.snap"
+          export TEST_SUBSTRATE=lxd
+          export TEST_LXD_IMAGE=${{ matrix.os }}
+          cd tests/e2e && sg lxd -c 'tox -e e2e'
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:
@@ -75,4 +75,4 @@ jobs:
           detached: true
           # Only the user who started the workflow can access the tmate session.
           limit-access-to-actor: true
-        #if: ${{ failure() }}
+        if: ${{ failure() }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,26 +43,36 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      #- name: Setup Python
+        #uses: actions/setup-python@v4
+        #with:
+          #python-version: '3.8'
+      #- name: Install tox
+        #run: pip install tox
+      #- name: Install lxd
+        #run: |
+          #sudo snap refresh lxd --channel 5.19/stable
+          #sudo lxd init --auto
+          #sudo usermod --append --groups lxd $USER
+          #sg lxd -c 'lxc version'
+      #- name: Download snap
+        #uses: actions/download-artifact@v3.0.2
+        #with:
+          #name: k8s.snap
+          #path: build
+      #- name: Run end to end tests
+        #run: |
+          #export TEST_SNAP="$PWD/build/k8s.snap"
+          #export TEST_SUBSTRATE=lxd
+          #export TEST_LXD_IMAGE=${{ matrix.os }}
+          #cd tests/e2e && sg lxd -c 'tox -e e2e'
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
         with:
-          python-version: '3.8'
-      - name: Install tox
-        run: pip install tox
-      - name: Install lxd
-        run: |
-          sudo snap refresh lxd --channel 5.19/stable
-          sudo lxd init --auto
-          sudo usermod --append --groups lxd $USER
-          sg lxd -c 'lxc version'
-      - name: Download snap
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: k8s.snap
-          path: build
-      - name: Run end to end tests
-        run: |
-          export TEST_SNAP="$PWD/build/k8s.snap"
-          export TEST_SUBSTRATE=lxd
-          export TEST_LXD_IMAGE=${{ matrix.os }}
-          cd tests/e2e && sg lxd -c 'tox -e e2e'
+          # Print connection details and continue with the job.
+          # Waits at the end of the job for the tmate session to exit.
+          # If no user connects within 10min the connection exits gracefully.
+          detached: true
+          # Only the user who started the workflow can access the tmate session.
+          limit-access-to-actor: true
+        #if: ${{ failure() }}


### PR DESCRIPTION
This will spin up a TMate session whenever the e2e run fails. You then can connect to the session by using the credentials printed out in the build step.

Make sure to have your SSH keys setup in your GH profile as only the actor (mostly the PR author) will be able to access the session. The session will close within 10 min if no one connects to it.