### PR TITLE
Shrinkify many tests using a setup fixture

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -140,32 +140,19 @@ A typical end to end test for feature `<feature>` should look like this:
 ```python
 # tests/e2e/tests/test_<feature>.py
 #
-# Copyright 2023 Canonical, Ltd.
+# Copyright 2024 Canonical, Ltd.
 #
 import logging
-import subprocess
-import time
-from pathlib import Path
 
-import pytest
-from e2e_util import config, harness
+from e2e_util import harness, util
 
 LOG = logging.getLogger(__name__)
+FEATURE_NODE_COUNT = 3  # number of machines necessary for the test
 
 
-def test_feature(h: harness.Harness, tmp_path: Path):
-    if not config.SNAP:
-        pytest.fail("Set TEST_SNAP to the path where the snap is")
-
-    snap_path = (tmp_path / "k8s.snap").as_posix()
-
-    LOG.info("Create instance")
-    instance_id = h.new_instance()
-
-    LOG.info("Install snap")
-    h.send_file(instance_id, config.SNAP, snap_path)
-    h.exec(instance_id, ["snap", "install", snap_path, "--dangerous"])
-
-    LOG.info("Test something")
-    # h.exec(...)
+@pytest.mark.node_count(FEATURE_NODE_COUNT)
+def test_feature(instances: List[harness.Instance]):
+    # The cluster is bootstrapped, with only networking setup.
+    first_node, *others_nodes = instances
+    first_node.exec(["k8s", "something"])
 ```

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -77,7 +77,8 @@ def instances(
         instances.append(instance)
         util.setup_k8s_snap(instance, snap_path)
 
-    instances[0].exec(["k8s", "bootstrap"])
-    util.setup_network(instances[0])
+    first_node, *_ = instances
+    first_node[0].exec(["k8s", "bootstrap"])
+    util.setup_network(first_node)
 
     yield instances

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -11,6 +11,19 @@ from e2e_util import config, harness, util
 LOG = logging.getLogger(__name__)
 
 
+def _harness_clean(h: harness.Harness):
+    "Clean up created instances within the test harness."
+
+    if config.SKIP_CLEANUP:
+        LOG.warning(
+            "Skipping harness cleanup. "
+            "It is your job now to clean up cloud resources"
+        )
+    else:
+        LOG.debug("Cleanup")
+        h.cleanup()
+
+
 @pytest.fixture(scope="session")
 def h() -> harness.Harness:
     LOG.debug("Create harness for %s", config.SUBSTRATE)
@@ -29,11 +42,7 @@ def h() -> harness.Harness:
 
     yield h
 
-    if config.SKIP_CLEANUP:
-        return
-
-    LOG.debug("Cleanup")
-    h.cleanup()
+    _harness_clean(h)
 
 
 def pytest_configure(config):
@@ -82,3 +91,5 @@ def instances(
     util.setup_network(first_node)
 
     yield instances
+
+    _harness_clean(h)

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -2,9 +2,11 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
+from pathlib import Path
+from typing import List
 
 import pytest
-from e2e_util import config, harness
+from e2e_util import config, harness, util
 
 LOG = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ LOG = logging.getLogger(__name__)
 def h() -> harness.Harness:
     LOG.debug("Create harness for %s", config.SUBSTRATE)
     if config.SUBSTRATE == "local":
-        h = harness.local.LocalHarness()
+        h = harness.LocalHarness()
     elif config.SUBSTRATE == "lxd":
         h = harness.LXDHarness()
     elif config.SUBSTRATE == "multipass":
@@ -32,3 +34,50 @@ def h() -> harness.Harness:
 
     LOG.debug("Cleanup")
     h.cleanup()
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "node_count: Mark a test to specify how many instance nodes need to be created",
+    )
+
+
+@pytest.fixture(scope="function")
+def node_count(request) -> int:
+    node_count_marker = request.node.get_closest_marker("node_count")
+    if not node_count_marker:
+        return 1
+    node_count_arg, *_ = node_count_marker.args
+    return int(node_count_arg)
+
+
+@pytest.fixture(scope="function")
+def instances(
+    h: harness.Harness, node_count: int, tmp_path: Path
+) -> List[harness.Instance]:
+    """Construct instances for a cluster.
+
+    Bootstrap and setup networking on the first instance.
+    """
+    if not config.SNAP:
+        pytest.fail("Set TEST_SNAP to the path where the snap is")
+
+    if not node_count:
+        pytest.xfail("Test requested 0 instances, skip this test.")
+
+    snap_path = (tmp_path / "k8s.snap").as_posix()
+
+    LOG.info(f"Creating {node_count} instances")
+    instances: List[util.Instance] = []
+
+    for _ in range(node_count):
+        # Create <node_count> instances and setup the k8s snap in each.
+        instance = h.new_instance()
+        instances.append(instance)
+        util.setup_k8s_snap(instance, snap_path)
+
+    instances[0].exec(["k8s", "bootstrap"])
+    util.setup_network(instances[0])
+
+    yield instances

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -3,7 +3,7 @@
 #
 import logging
 from pathlib import Path
-from typing import List
+from typing import Generator, List
 
 import pytest
 from e2e_util import config, harness, util
@@ -55,7 +55,7 @@ def node_count(request) -> int:
 @pytest.fixture(scope="function")
 def instances(
     h: harness.Harness, node_count: int, tmp_path: Path
-) -> List[harness.Instance]:
+) -> Generator[List[harness.Instance], None, None]:
     """Construct instances for a cluster.
 
     Bootstrap and setup networking on the first instance.

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -63,8 +63,8 @@ def instances(
     if not config.SNAP:
         pytest.fail("Set TEST_SNAP to the path where the snap is")
 
-    if not node_count:
-        pytest.xfail("Test requested 0 instances, skip this test.")
+    if node_count <= 0:
+        pytest.xfail("Test requested 0 or fewer instances, skip this test.")
 
     snap_path = (tmp_path / "k8s.snap").as_posix()
 

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -78,7 +78,7 @@ def instances(
         util.setup_k8s_snap(instance, snap_path)
 
     first_node, *_ = instances
-    first_node[0].exec(["k8s", "bootstrap"])
+    first_node.exec(["k8s", "bootstrap"])
     util.setup_network(first_node)
 
     yield instances

--- a/tests/e2e/tests/e2e_util/harness/__init__.py
+++ b/tests/e2e/tests/e2e_util/harness/__init__.py
@@ -1,7 +1,7 @@
 #
 # Copyright 2024 Canonical, Ltd.
 #
-from e2e_util.harness.base import Harness, HarnessError
+from e2e_util.harness.base import Harness, HarnessError, Instance
 from e2e_util.harness.juju import JujuHarness
 from e2e_util.harness.local import LocalHarness
 from e2e_util.harness.lxd import LXDHarness
@@ -10,6 +10,7 @@ from e2e_util.harness.multipass import MultipassHarness
 __all__ = [
     HarnessError,
     Harness,
+    Instance,
     JujuHarness,
     LocalHarness,
     LXDHarness,

--- a/tests/e2e/tests/e2e_util/harness/local.py
+++ b/tests/e2e/tests/e2e_util/harness/local.py
@@ -9,7 +9,7 @@ import socket
 import subprocess
 from pathlib import Path
 
-from e2e_util.harness import Harness, HarnessError
+from e2e_util.harness import Harness, HarnessError, Instance
 from e2e_util.util import run
 
 LOG = logging.getLogger(__name__)
@@ -18,6 +18,8 @@ LOG = logging.getLogger(__name__)
 class LocalHarness(Harness):
     """A Harness that uses the local machine. Asking for more than 1 instance will fail."""
 
+    name = "local"
+
     def __init__(self):
         super(LocalHarness, self).__init__()
         self.initialized = False
@@ -25,7 +27,7 @@ class LocalHarness(Harness):
 
         LOG.debug("Configured local substrate")
 
-    def new_instance(self) -> str:
+    def new_instance(self) -> Instance:
         if self.initialized:
             raise HarnessError("local substrate only supports up to one instance")
 
@@ -36,7 +38,7 @@ class LocalHarness(Harness):
         except subprocess.CalledProcessError as e:
             raise HarnessError("failed to wait for snapd seed") from e
 
-        return self.hostname
+        return Instance(self, self.hostname)
 
     def send_file(self, _: str, source: str, destination: str):
         if not self.initialized:

--- a/tests/e2e/tests/e2e_util/harness/lxd.py
+++ b/tests/e2e/tests/e2e_util/harness/lxd.py
@@ -8,7 +8,7 @@ import subprocess
 from pathlib import Path
 
 from e2e_util import config
-from e2e_util.harness import Harness, HarnessError
+from e2e_util.harness import Harness, HarnessError, Instance
 from e2e_util.util import run, stubbornly
 
 LOG = logging.getLogger(__name__)
@@ -16,6 +16,8 @@ LOG = logging.getLogger(__name__)
 
 class LXDHarness(Harness):
     """A Harness that creates an LXD container for each instance."""
+
+    name = "lxd"
 
     def next_id(self) -> int:
         self._next_id += 1
@@ -56,7 +58,7 @@ class LXDHarness(Harness):
             "Configured LXD substrate (profile %s, image %s)", self.profile, self.image
         )
 
-    def new_instance(self) -> str:
+    def new_instance(self) -> Instance:
         instance_id = f"k8s-e2e-{os.urandom(3).hex()}-{self.next_id()}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
@@ -79,7 +81,7 @@ class LXDHarness(Harness):
         self.instances.add(instance_id)
 
         self.exec(instance_id, ["snap", "wait", "system", "seed.loaded"])
-        return instance_id
+        return Instance(self, instance_id)
 
     def send_file(self, instance_id: str, source: str, destination: str):
         if instance_id not in self.instances:

--- a/tests/e2e/tests/e2e_util/harness/multipass.py
+++ b/tests/e2e/tests/e2e_util/harness/multipass.py
@@ -8,7 +8,7 @@ import subprocess
 from pathlib import Path
 
 from e2e_util import config
-from e2e_util.harness import Harness, HarnessError
+from e2e_util.harness import Harness, HarnessError, Instance
 from e2e_util.util import run
 
 LOG = logging.getLogger(__name__)
@@ -16,6 +16,8 @@ LOG = logging.getLogger(__name__)
 
 class MultipassHarness(Harness):
     """A Harness that creates a Multipass VM for each instance."""
+
+    name = "multipass"
 
     def next_id(self) -> int:
         self._next_id += 1
@@ -34,7 +36,7 @@ class MultipassHarness(Harness):
 
         LOG.debug("Configured Multipass substrate (image %s)", self.image)
 
-    def new_instance(self) -> str:
+    def new_instance(self) -> Instance:
         instance_id = f"k8s-e2e-{os.urandom(3).hex()}-{self.next_id()}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
@@ -60,7 +62,7 @@ class MultipassHarness(Harness):
         self.instances.add(instance_id)
 
         self.exec(instance_id, ["snap", "wait", "system", "seed.loaded"])
-        return instance_id
+        return Instance(self, instance_id)
 
     def send_file(self, instance_id: str, source: str, destination: str):
         if instance_id not in self.instances:

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -95,9 +95,9 @@ def stubbornly(
             try:
                 resp = self._run(command_args, **command_kwds)
             except subprocess.CalledProcessError as e:
-                LOG.error(f"  rc={e.returncode}")
-                LOG.error(f"  stdout={e.stdout.decode()}")
-                LOG.error(f"  stderr={e.stderr.decode()}")
+                LOG.warning(f"  rc={e.returncode}")
+                LOG.warning(f"  stdout={e.stdout.decode()}")
+                LOG.warning(f"  stderr={e.stderr.decode()}")
                 raise
             if self._condition:
                 assert self._condition(resp), "Failed to meet condition"

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -208,13 +208,13 @@ def setup_network(instance: harness.Instance):
 
 
 # Installs and setups the k8s snap on the given instance and connects the interfaces.
-def setup_k8s_snap(i: harness.Instance, snap_path: Path):
+def setup_k8s_snap(instance: harness.Instance, snap_path: Path):
     LOG.info("Install snap")
-    i.send_file(config.SNAP, snap_path)
-    i.exec(["snap", "install", snap_path, "--dangerous"])
+    instance.send_file(config.SNAP, snap_path)
+    instance.exec(["snap", "install", snap_path, "--dangerous"])
 
     LOG.info("Initialize Kubernetes")
-    i.exec(["/snap/k8s/current/k8s/connect-interfaces.sh"])
+    instance.exec(["/snap/k8s/current/k8s/connect-interfaces.sh"])
 
 
 # Validates that the K8s node is in Ready state.

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -50,7 +50,7 @@ def stubbornly(
     : param    retries              int: convenience param to use stop=retry.stop_after_attempt(<int>)
     : param    delay_s        float|int: convenience param to use wait=retry.wait_fixed(delay_s)
     : param exceptions Tuple[Exception]: convenience param to use retry=retry.retry_if_exception_type(exceptions)
-    : param retry_kds               Map: direct interface to all tenacity arguments for retrying
+    : param retry_kds           Mapping: direct interface to all tenacity arguments for retrying
     """
 
     def _before_sleep(retry_state: RetryCallState):
@@ -76,8 +76,8 @@ def stubbornly(
 
     class Retriable:
         def __init__(self) -> None:
-            self.condition = None
-            self.run = subprocess.run
+            self._condition = None
+            self._run = subprocess.run
 
         @retry(**_retry_args)
         def exec(
@@ -89,28 +89,27 @@ def stubbornly(
             Execute a command against a harness or locally with subprocess to be retried.
 
             :param  List[str]        command_args: The command to be executed, as a str or list of str
-            :param Map[str,str]      command_kwds: Additional keyword arguments to be passed to exec
+            :param Mapping[str,str]      command_kwds: Additional keyword arguments to be passed to exec
             """
 
             try:
-                resp = self.run(command_args, **command_kwds)
+                resp = self._run(command_args, **command_kwds)
             except subprocess.CalledProcessError as e:
                 LOG.error(f"  rc={e.returncode}")
                 LOG.error(f"  stdout={e.stdout.decode()}")
                 LOG.error(f"  stderr={e.stderr.decode()}")
                 raise
-            if self.condition:
-                assert self.condition(resp), "Failed to meet condition"
+            if self._condition:
+                assert self._condition(resp), "Failed to meet condition"
             return resp
 
-        def on(self, harness: harness.Harness, instance_id: str) -> "Retriable":
+        def on(self, instance: harness.Instance) -> "Retriable":
             """
-            Target the command at some other instance.
+            Target the command at some instance.
 
-            :param Harness  harness: test Harness object, to run the command on
-            :param str      instance: Instance id in the test harness.
+            :param instance Instance: Instance on a test harness.
             """
-            self.run = partial(harness.exec, instance_id, capture_output=True)
+            self._run = partial(instance.exec, capture_output=True)
             return self
 
         def until(
@@ -121,26 +120,26 @@ def stubbornly(
 
             :param Callable condition: a callable which returns a truth about the command output
             """
-            self.condition = condition
+            self._condition = condition
             return self
 
     return Retriable()
 
 
-def setup_dns(h: harness.Harness, instance_id: str):
+def setup_dns(instance: harness.Instance):
     LOG.info("Waiting for dns to be enabled...")
-    stubbornly(retries=15, delay_s=5).on(h, instance_id).exec(
+    stubbornly(retries=15, delay_s=5).on(instance).exec(
         ["k8s", "enable", "dns", "--cluster-domain=foo.local"]
     )
     LOG.info("DNS enabled.")
 
     LOG.info("Waiting for CoreDNS pod to show up...")
-    stubbornly(retries=15, delay_s=5).on(h, instance_id).until(
+    stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "coredns" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"])
     LOG.info("CoreDNS pod showed up.")
 
-    stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+    stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -157,29 +156,25 @@ def setup_dns(h: harness.Harness, instance_id: str):
     )
 
 
-def setup_network(h: harness.Harness, instance_id: str):
+def setup_network(instance: harness.Instance):
     time.sleep(30)
-    h.exec(
-        instance_id,
-        ["/snap/k8s/current/k8s/network-requirements.sh"],
-        stdout=subprocess.DEVNULL,
+    instance.exec(
+        ["/snap/k8s/current/k8s/network-requirements.sh"], stdout=subprocess.DEVNULL
     )
 
     LOG.info("Waiting for network to be enabled...")
-    stubbornly(retries=15, delay_s=5).on(h, instance_id).exec(
-        ["k8s", "enable", "network"]
-    )
+    stubbornly(retries=15, delay_s=5).on(instance).exec(["k8s", "enable", "network"])
     LOG.info("Network enabled.")
 
     LOG.info("Waiting for cilium pods to show up...")
-    stubbornly(retries=15, delay_s=5).on(h, instance_id).until(
+    stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "cilium" in p.stdout.decode()
     ).exec(
         ["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"],
     )
     LOG.info("Cilium pods showed up.")
 
-    stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+    stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -195,7 +190,7 @@ def setup_network(h: harness.Harness, instance_id: str):
         ],
     )
 
-    stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+    stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -213,22 +208,24 @@ def setup_network(h: harness.Harness, instance_id: str):
 
 
 # Installs and setups the k8s snap on the given instance and connects the interfaces.
-def setup_k8s_snap(h: harness.Harness, instance_id: str, snap_path: Path):
+def setup_k8s_snap(i: harness.Instance, snap_path: Path):
     LOG.info("Install snap")
-    h.send_file(instance_id, config.SNAP, snap_path)
-    h.exec(instance_id, ["snap", "install", snap_path, "--dangerous"])
+    i.send_file(config.SNAP, snap_path)
+    i.exec(["snap", "install", snap_path, "--dangerous"])
 
     LOG.info("Initialize Kubernetes")
-    h.exec(instance_id, ["/snap/k8s/current/k8s/connect-interfaces.sh"])
+    i.exec(["/snap/k8s/current/k8s/connect-interfaces.sh"])
 
 
 # Validates that the K8s node is in Ready state.
-def wait_until_k8s_ready(h: harness.Harness, control_node: str, instances: List[str]):
+def wait_until_k8s_ready(
+    control_node: harness.Instance, instances: List[harness.Instance]
+):
     for instance in instances:
-        host = hostname(h, instance)
+        host = hostname(instance)
         result = (
             stubbornly(retries=15, delay_s=5)
-            .on(h, control_node)
+            .on(control_node)
             .until(lambda p: " Ready" in p.stdout.decode())
             .exec(["k8s", "kubectl", "get", "node", host, "--no-headers"])
         )
@@ -236,8 +233,7 @@ def wait_until_k8s_ready(h: harness.Harness, control_node: str, instances: List[
     LOG.info("%s", result.stdout.decode())
 
 
-# Returns the hostname for the given instance.
-def hostname(h: harness.Harness, instance_id: str) -> str:
-    return (
-        h.exec(instance_id, ["hostname"], capture_output=True).stdout.decode().strip()
-    )
+def hostname(instance: harness.Instance) -> str:
+    """Return the hostname for a given instance."""
+    resp = instance.exec(["hostname"], capture_output=True)
+    return resp.stdout.decode().strip()

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -36,12 +36,6 @@ def test_clustering(instances: List[harness.Instance]):
 
     util.wait_until_k8s_ready(cluster_node, instances)
 
-    # TODO: Remove if --wait-ready for `join-cluster` is implemented.
-    hostname = util.hostname(joining_node)
-    util.stubbornly(retries=5, delay_s=3).on(cluster_node).exec(
-        ["k8s", "remove-node", hostname]
-    )
-
 
 @pytest.mark.node_count(2)
 def test_worker_nodes(instances: List[harness.Instance]):

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -2,7 +2,6 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from pathlib import Path
 from typing import List
 
 import pytest
@@ -11,58 +10,45 @@ from e2e_util import config, harness, util
 LOG = logging.getLogger(__name__)
 
 
-# Create <num_instances> instances and setup the k8s snap in each.
-def setup_k8s_instances(
-    h: harness.Harness, snap_path: str, num_instances: int
-) -> List[str]:
-    instances = []
-
-    for _ in range(num_instances):
-        instance_id = h.new_instance()
-        instances.append(instance_id)
-        util.setup_k8s_snap(h, instance_id, snap_path)
-
-    return instances
-
-
 # Create a token to join a node to an existing cluster
-def add_node(h: harness.Harness, cluster_node: str, joining_node: str) -> str:
-    out = h.exec(
-        cluster_node,
-        ["k8s", "add-node", joining_node],
+def add_node(
+    cluster_node: harness.Instance, joining_node: harness.Instance, *args: str
+) -> str:
+    out = cluster_node.exec(
+        ["k8s", "add-node", joining_node.id, *args],
         capture_output=True,
     )
     return out.stdout.decode().strip()
 
 
 # Join an existing cluster.
-def join_cluster(h: harness.Harness, instance_id, token):
-    h.exec(instance_id, ["k8s", "join-cluster", token])
+def join_cluster(instance, token):
+    instance.exec(["k8s", "join-cluster", token])
 
 
-def test_clustering(h: harness.Harness, tmp_path: Path):
-    if not config.SNAP:
-        pytest.fail("Set TEST_SNAP to the path where the snap is")
-
-    snap_path = (tmp_path / "k8s.snap").as_posix()
-    instances = setup_k8s_instances(h, snap_path, num_instances=2)
+@pytest.mark.node_count(2)
+def test_clustering(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_node = instances[1]
 
-    h.exec(cluster_node, ["k8s", "bootstrap"])
-    util.setup_network(h, cluster_node)
+    token = add_node(cluster_node, joining_node)
+    join_cluster(joining_node, token)
 
-    h.exec(cluster_node, ["k8s", "kubectl", "get", "nodes", "-A"])
-
-    token = add_node(h, cluster_node, joining_node)
-    join_cluster(h, joining_node, token)
-
-    util.wait_until_k8s_ready(h, cluster_node, instances)
+    util.wait_until_k8s_ready(cluster_node, instances)
 
     # TODO: Remove if --wait-ready for `join-cluster` is implemented.
-    hostname = util.hostname(h, joining_node)
-    util.stubbornly(retries=5, delay_s=3).on(h, cluster_node).exec(
+    hostname = util.hostname(joining_node)
+    util.stubbornly(retries=5, delay_s=3).on(cluster_node).exec(
         ["k8s", "remove-node", hostname]
     )
 
-    h.cleanup()
+
+@pytest.mark.node_count(2)
+def test_worker_nodes(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_node = instances[1]
+
+    token = add_node(cluster_node, joining_node, "--worker")
+    join_cluster(joining_node, token)
+
+    util.wait_until_k8s_ready(cluster_node, instances)

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from e2e_util import config, harness, util
+from e2e_util import harness, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/e2e/tests/test_ingress.py
+++ b/tests/e2e/tests/test_ingress.py
@@ -3,40 +3,23 @@
 #
 import logging
 from pathlib import Path
+from typing import List
 
-import pytest
-from e2e_util import config, harness, util
+from e2e_util import harness, util
 from e2e_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
 
 
-def test_ingress(h: harness.Harness, tmp_path: Path):
-    if not config.SNAP:
-        pytest.fail("Set TEST_SNAP to the path where the snap is")
+def test_ingress(instances: List[harness.Instance]):
+    instance = instances[0]
+    instance.exec(["k8s", "enable", "ingress"])
 
-    snap_path = (tmp_path / "k8s.snap").as_posix()
-
-    LOG.info("Create instance")
-    instance_id = h.new_instance()
-
-    util.setup_k8s_snap(h, instance_id, snap_path)
-    h.exec(instance_id, ["k8s", "bootstrap"])
-    util.setup_network(h, instance_id)
-
-    out = h.exec(
-        instance_id,
-        ["k8s", "enable", "ingress"],
-        capture_output=True,
-    )
-    assert out.returncode == 0
-
-    util.stubbornly(retries=5, delay_s=2).on(h, instance_id).until(
+    util.stubbornly(retries=5, delay_s=2).on(instance).until(
         lambda p: "cilium-ingress" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "service", "-n", "kube-system", "-o", "json"])
 
-    p = h.exec(
-        instance_id,
+    p = instance.exec(
         [
             "k8s",
             "kubectl",
@@ -51,7 +34,7 @@ def test_ingress(h: harness.Harness, tmp_path: Path):
     )
     ingress_http_port = p.stdout.decode().replace("'", "")
 
-    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -67,7 +50,7 @@ def test_ingress(h: harness.Harness, tmp_path: Path):
         ]
     )
 
-    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -84,19 +67,18 @@ def test_ingress(h: harness.Harness, tmp_path: Path):
     )
 
     manifest = MANIFESTS_DIR / "ingress-test.yaml"
-    h.exec(
-        instance_id,
+    instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
         input=Path(manifest).read_bytes(),
     )
 
     LOG.info("Waiting for nginx pod to show up...")
-    util.stubbornly(retries=5, delay_s=10).on(h, instance_id).until(
+    util.stubbornly(retries=5, delay_s=10).on(instance).until(
         lambda p: "my-nginx" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
     LOG.info("Nginx pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(h, instance_id).exec(
+    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -110,11 +92,8 @@ def test_ingress(h: harness.Harness, tmp_path: Path):
         ]
     )
 
-    p = h.exec(
-        instance_id,
+    p = instance.exec(
         ["curl", f"localhost:{ingress_http_port}", "-H", "Host: foo.bar.com"],
         capture_output=True,
     )
     assert "Welcome to nginx!" in p.stdout.decode()
-
-    h.cleanup()

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -2,27 +2,12 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from pathlib import Path
+from typing import List
 
-import pytest
-from e2e_util import config, harness, util
+from e2e_util import harness, util
 
 LOG = logging.getLogger(__name__)
 
 
-def test_smoke(h: harness.Harness, tmp_path: Path):
-    if not config.SNAP:
-        pytest.fail("Set TEST_SNAP to the path where the snap is")
-
-    snap_path = (tmp_path / "k8s.snap").as_posix()
-
-    LOG.info("Create instance")
-    instance_id = h.new_instance()
-
-    util.setup_k8s_snap(h, instance_id, snap_path)
-    h.exec(instance_id, ["k8s", "bootstrap"])
-    util.setup_network(h, instance_id)
-
-    util.wait_until_k8s_ready(h, instance_id, [instance_id])
-
-    h.cleanup()
+def test_smoke(instances: List[harness.Instance]):
+    util.wait_until_k8s_ready(instances[0], instances)


### PR DESCRIPTION
I noticed that many of the e2e tests were doing the complete same tasks again and again.  I've pushed this reuse through to conftest.py into a pytest fixture called "instances" which starts the requested number of instances for a test, bootstraps the first node, then yields the instances as a list to the test procedure. 

While testing, i was using the juju test harness and have applied a number of improvements to that harness

The exec method now behaves more like the lxd and multipass harness in that it uses juju's stderr, stdout, returncode and even provides a way to pass in stdin through the `input` argument. 

Lastly, this creates a new `Instance` object that's returned from harness.new_instance which maps through the common harness methods like send_file, pull_file, exec, and delete_instance so you don't have to keep calling `h.exec(instance_id, ...`  but instead `instance.exec(....)` which is just much easier to read