### PR TITLE
ensure all k8s binaries are symlinks

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,7 +56,7 @@ parts:
       mkdir -p "${INSTALL}"
 
       for binary in k8s k8sd k8s-dqlite k8s-apiserver-proxy dqlite; do
-        cp "bin/static/${binary}" "${INSTALL}/${binary}"
+        cp -P "bin/static/${binary}" "${INSTALL}/${binary}"
       done
 
   cni:


### PR DESCRIPTION
### Summary

Ensure symlinked binaries are symlinks on the resulting snap. Reduces the size of the unpacked snap (by default, the `cp` command would create multiple identical binaries).

