### PR TITLE
Abort e2e tests after first test failure

### DIFF
--- a/tests/e2e/tox.ini
+++ b/tests/e2e/tox.ini
@@ -35,6 +35,7 @@ deps =
     -r {tox_root}/requirements-test.txt
 commands =
     pytest -v \
+           -x \
            --tb native \
            --log-cli-level DEBUG \
            --disable-warnings \


### PR DESCRIPTION
Stop the CI if one test fails. Right now, we continue to run all tests which accumulates several hours of "wasted" GH runner time.

Let's save some company money...