### PR TITLE
Initialize Helm Client Config

### DIFF
--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -90,6 +90,17 @@ func (h *helmClient) Enable(name string, values map[string]any) error {
 		return fmt.Errorf("invalid component %s", name)
 	}
 
+	actionConfig := new(action.Configuration)
+	err := actionConfig.Init(
+		h.settings.RESTClientGetter(),
+		h.settings.Namespace(),
+		os.Getenv("HELM_DRIVER"),
+		logAdapter,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize component manager configuration: %w", err)
+	}
+
 	install := action.NewInstall(h.actionConfig)
 	install.ReleaseName = component.ReleaseName
 	install.Namespace = component.Namespace
@@ -159,6 +170,17 @@ func (h *helmClient) List() ([]Component, error) {
 
 // Disable disables a specified component.
 func (h *helmClient) Disable(name string) error {
+	actionConfig := new(action.Configuration)
+	err := actionConfig.Init(
+		h.settings.RESTClientGetter(),
+		h.settings.Namespace(),
+		os.Getenv("HELM_DRIVER"),
+		logAdapter,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize component manager configuration: %w", err)
+	}
+
 	uninstall := action.NewUninstall(h.actionConfig)
 	component, ok := h.config[name]
 	if !ok {
@@ -183,6 +205,17 @@ func (h *helmClient) Disable(name string) error {
 
 // Refresh refreshes a specified component.
 func (h *helmClient) Refresh(name string, values map[string]any) error {
+	actionConfig := new(action.Configuration)
+	err := actionConfig.Init(
+		h.settings.RESTClientGetter(),
+		h.settings.Namespace(),
+		os.Getenv("HELM_DRIVER"),
+		logAdapter,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize component manager configuration: %w", err)
+	}
+
 	component, ok := h.config[name]
 	if !ok {
 		return fmt.Errorf("invalid component %s", name)

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -77,7 +77,7 @@ func (h *helmClient) initializeHelmClientConfig() (*action.Configuration, error)
 		logAdapter,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize action config: %w", err)
 	}
 	return actionConfig, nil
 }

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -94,7 +94,7 @@ func (h *helmClient) Enable(name string, values map[string]any) error {
 	}
 
 	if err := h.initializeHelmClientConfig(); err != nil {
-		return fmt.Errorf("failed to set action: %w", err)
+		return fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}
 
 	install := action.NewInstall(h.actionConfig)
@@ -167,7 +167,7 @@ func (h *helmClient) List() ([]Component, error) {
 // Disable disables a specified component.
 func (h *helmClient) Disable(name string) error {
 	if err := h.initializeHelmClientConfig(); err != nil {
-		return fmt.Errorf("failed to set action: %w", err)
+		return fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}
 
 	uninstall := action.NewUninstall(h.actionConfig)
@@ -195,7 +195,7 @@ func (h *helmClient) Disable(name string) error {
 // Refresh refreshes a specified component.
 func (h *helmClient) Refresh(name string, values map[string]any) error {
 	if err := h.initializeHelmClientConfig(); err != nil {
-		return fmt.Errorf("failed to set action: %w", err)
+		return fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}
 
 	component, ok := h.config[name]

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -81,7 +81,7 @@ func (h *helmClient) initializeHelmClientConfig() error {
 		logAdapter,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to initialize Helm client configuration: %w", err)
+		return err
 	}
 	return nil
 }

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -22,10 +22,10 @@ func EnableGatewayComponent(s snap.Snap) error {
 		return fmt.Errorf("failed to enable gateway component: %w", err)
 	}
 
-	manager, err = NewManager(s)
-	if err != nil {
-		return fmt.Errorf("failed to get component manager: %w", err)
-	}
+	// manager, err = NewManager(s)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to get component manager: %w", err)
+	// }
 
 	networkValues := map[string]any{
 		"gatewayAPI": map[string]any{

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -22,11 +22,6 @@ func EnableGatewayComponent(s snap.Snap) error {
 		return fmt.Errorf("failed to enable gateway component: %w", err)
 	}
 
-	// manager, err = NewManager(s)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to get component manager: %w", err)
-	// }
-
 	networkValues := map[string]any{
 		"gatewayAPI": map[string]any{
 			"enabled": true,


### PR DESCRIPTION
### Initialize Helm Client Config

This PR removes the workaround in `src/k8s/pkg/component/gateway.go` where a second manager around the helm client is created. The helm client only needs to know about the updated helm client config, which is done in a new function called `initializeHelmClientConfig()`.

The e2e tests for the k8s-snap confirmed the fix works and shows that the gateway controller does indeed get created.
```
ubuntu@bug-fix:~/k8s-snap/tests/e2e$ lxc shell k8s-e2e-af3fbd-1
root@k8s-e2e-af3fbd-1:~# k8s enable gateway
Component 'Gateway' enabled
root@k8s-e2e-af3fbd-1:~# k8s kubectl get gatewayclass
NAME     CONTROLLER                     ACCEPTED   AGE
cilium   io.cilium/gateway-controller   True       20s
``` 

[KU-286]: https://warthogs.atlassian.net/browse/KU-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ