### PR TITLE
Cleanup API endpoint definitions and error codes

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster.go
+++ b/src/k8s/pkg/k8sd/api/cluster.go
@@ -6,16 +6,10 @@ import (
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/api/impl"
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
 )
 
-var k8sdCluster = rest.Endpoint{
-	Path: "k8sd/cluster",
-	Get:  rest.EndpointAction{Handler: clusterGet, AllowUntrusted: false},
-}
-
-func clusterGet(s *state.State, r *http.Request) response.Response {
+func getClusterStatus(s *state.State, r *http.Request) response.Response {
 	status, err := impl.GetClusterStatus(r.Context(), s)
 	if err != nil {
 		response.InternalError(err)

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -15,7 +15,7 @@ func getKubeconfig(s *state.State, r *http.Request) response.Response {
 	//       when the config can be altered via request parameters.
 	config, err := os.ReadFile("/etc/kubernetes/admin.conf")
 	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to read admin kubeconfig: %w", err))
+		return response.InternalError(fmt.Errorf("failed to read admin kubeconfig: %w", err))
 	}
 
 	result := apiv1.GetKubeConfigResponse{

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -7,16 +7,10 @@ import (
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
 )
 
-var k8sdConfig = rest.Endpoint{
-	Path: "k8sd/kubeconfig",
-	Get:  rest.EndpointAction{Handler: clusterConfigGet, AllowUntrusted: false},
-}
-
-func clusterConfigGet(s *state.State, r *http.Request) response.Response {
+func getKubeconfig(s *state.State, r *http.Request) response.Response {
 	// TODO: Render a new kubeconfig instead of reading the existing one
 	//       when the config can be altered via request parameters.
 	config, err := os.ReadFile("/etc/kubernetes/admin.conf")

--- a/src/k8s/pkg/k8sd/api/component.go
+++ b/src/k8s/pkg/k8sd/api/component.go
@@ -11,41 +11,10 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/api/impl"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
 )
 
-var k8sdComponents = rest.Endpoint{
-	Path: "k8sd/components",
-	Get:  rest.EndpointAction{Handler: componentsGet, AllowUntrusted: false},
-}
-
-var k8sdDNSComponent = rest.Endpoint{
-	Path: "k8sd/components/dns",
-	Put:  rest.EndpointAction{Handler: dnsComponentPut, AllowUntrusted: false},
-}
-
-var k8sdNetworkComponent = rest.Endpoint{
-	Path: "k8sd/components/network",
-	Put:  rest.EndpointAction{Handler: networkComponentPut, AllowUntrusted: false},
-}
-
-var k8sdStorageComponent = rest.Endpoint{
-	Path: "k8sd/components/storage",
-	Put:  rest.EndpointAction{Handler: storageComponentPut, AllowUntrusted: false},
-}
-
-var k8sdIngressComponent = rest.Endpoint{
-	Path: "k8sd/components/ingress",
-	Put:  rest.EndpointAction{Handler: ingressComponentPut, AllowUntrusted: false},
-}
-
-var k8sdGatewayComponent = rest.Endpoint{
-	Path: "k8sd/components/gateway",
-	Put:  rest.EndpointAction{Handler: gatewayComponentPut, AllowUntrusted: false},
-}
-
-func componentsGet(s *state.State, r *http.Request) response.Response {
+func getComponents(s *state.State, r *http.Request) response.Response {
 	snap := snap.SnapFromContext(s.Context)
 
 	components, err := impl.GetComponents(snap)
@@ -60,7 +29,7 @@ func componentsGet(s *state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, &result)
 }
 
-func dnsComponentPut(s *state.State, r *http.Request) response.Response {
+func putDNSComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateDNSComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
@@ -92,7 +61,7 @@ func dnsComponentPut(s *state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, &api.UpdateDNSComponentResponse{})
 }
 
-func networkComponentPut(s *state.State, r *http.Request) response.Response {
+func putNetworkComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateNetworkComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
@@ -119,7 +88,7 @@ func networkComponentPut(s *state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, &api.UpdateNetworkComponentResponse{})
 }
 
-func storageComponentPut(s *state.State, r *http.Request) response.Response {
+func putStorageComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateStorageComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
@@ -146,7 +115,7 @@ func storageComponentPut(s *state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, &api.UpdateStorageComponentResponse{})
 }
 
-func ingressComponentPut(s *state.State, r *http.Request) response.Response {
+func putIngressComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateIngressComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
@@ -177,7 +146,7 @@ func ingressComponentPut(s *state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, &api.UpdateIngressComponentResponse{})
 }
 
-func gatewayComponentPut(s *state.State, r *http.Request) response.Response {
+func putGatewayComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateGatewayComponentRequest
 
 	snap := snap.SnapFromContext(s.Context)

--- a/src/k8s/pkg/k8sd/api/component.go
+++ b/src/k8s/pkg/k8sd/api/component.go
@@ -19,13 +19,12 @@ func getComponents(s *state.State, r *http.Request) response.Response {
 
 	components, err := impl.GetComponents(snap)
 	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to get components: %w", err))
+		return response.InternalError(fmt.Errorf("failed to get components: %w", err))
 	}
 
 	result := api.GetComponentsResponse{
 		Components: components,
 	}
-
 	return response.SyncResponse(true, &result)
 }
 
@@ -33,29 +32,21 @@ func putDNSComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateDNSComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to decode request: %w", err))
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to decode request: %w", err))
 	}
 
 	switch req.Status {
 	case api.ComponentEnable:
-		err = component.EnableDNSComponent(
-			snap,
-			req.Config.ClusterDomain,
-			req.Config.ServiceIP,
-			req.Config.UpstreamNameservers,
-		)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to enable dns: %w", err))
+		if err := component.EnableDNSComponent(snap, req.Config.ClusterDomain, req.Config.ServiceIP, req.Config.UpstreamNameservers); err != nil {
+			return response.InternalError(fmt.Errorf("failed to enable dns: %w", err))
 		}
 	case api.ComponentDisable:
-		err = component.DisableDNSComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to disable dns: %w", err))
+		if err := component.DisableDNSComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to disable dns: %w", err))
 		}
 	default:
-		return response.SmartError(fmt.Errorf("invalid component status %s", req.Status))
+		return response.BadRequest(fmt.Errorf("invalid component status %s", req.Status))
 	}
 
 	return response.SyncResponse(true, &api.UpdateDNSComponentResponse{})
@@ -65,24 +56,21 @@ func putNetworkComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateNetworkComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to decode request: %w", err))
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to decode request: %w", err))
 	}
 
 	switch req.Status {
 	case api.ComponentEnable:
-		err = component.EnableNetworkComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to enable network: %w", err))
+		if err := component.EnableNetworkComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to enable network: %w", err))
 		}
 	case api.ComponentDisable:
-		err = component.DisableNetworkComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to disable network: %w", err))
+		if err := component.DisableNetworkComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to disable network: %w", err))
 		}
 	default:
-		return response.SmartError(fmt.Errorf("invalid component status %s", req.Status))
+		return response.BadRequest(fmt.Errorf("invalid component status %s", req.Status))
 	}
 
 	return response.SyncResponse(true, &api.UpdateNetworkComponentResponse{})
@@ -92,24 +80,21 @@ func putStorageComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateStorageComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to decode request: %w", err))
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to decode request: %w", err))
 	}
 
 	switch req.Status {
 	case api.ComponentEnable:
-		err = component.EnableStorageComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to enable storage: %w", err))
+		if err := component.EnableStorageComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to enable storage: %w", err))
 		}
 	case api.ComponentDisable:
-		err = component.DisableStorageComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to disable storage: %w", err))
+		if err := component.DisableStorageComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to disable storage: %w", err))
 		}
 	default:
-		return response.SmartError(fmt.Errorf("invalid component status %s", req.Status))
+		return response.BadRequest(fmt.Errorf("invalid component status %s", req.Status))
 	}
 
 	return response.SyncResponse(true, &api.UpdateStorageComponentResponse{})
@@ -119,28 +104,21 @@ func putIngressComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateIngressComponentRequest
 	snap := snap.SnapFromContext(s.Context)
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to decode request: %w", err))
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to decode request: %w", err))
 	}
 
 	switch req.Status {
 	case api.ComponentEnable:
-		err = component.EnableIngressComponent(
-			snap,
-			req.Config.DefaultTLSSecret,
-			req.Config.EnableProxyProtocol,
-		)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to enable ingress: %w", err))
+		if err := component.EnableIngressComponent(snap, req.Config.DefaultTLSSecret, req.Config.EnableProxyProtocol); err != nil {
+			return response.InternalError(fmt.Errorf("failed to enable ingress: %w", err))
 		}
 	case api.ComponentDisable:
-		err = component.DisableIngressComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to disable ingress: %w", err))
+		if err := component.DisableIngressComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to disable ingress: %w", err))
 		}
 	default:
-		return response.SmartError(fmt.Errorf("invalid component status %s", req.Status))
+		return response.BadRequest(fmt.Errorf("invalid component status %s", req.Status))
 	}
 
 	return response.SyncResponse(true, &api.UpdateIngressComponentResponse{})
@@ -148,27 +126,23 @@ func putIngressComponent(s *state.State, r *http.Request) response.Response {
 
 func putGatewayComponent(s *state.State, r *http.Request) response.Response {
 	var req api.UpdateGatewayComponentRequest
-
 	snap := snap.SnapFromContext(s.Context)
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		return response.SmartError(fmt.Errorf("failed to decode request: %w", err))
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to decode request: %w", err))
 	}
 
 	switch req.Status {
 	case api.ComponentEnable:
-		err = component.EnableGatewayComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to enable gateway: %w", err))
+		if err := component.EnableGatewayComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to enable gateway API: %w", err))
 		}
 	case api.ComponentDisable:
-		err = component.DisableGatewayComponent(snap)
-		if err != nil {
-			return response.SmartError(fmt.Errorf("failed to disable gateway: %w", err))
+		if err := component.DisableGatewayComponent(snap); err != nil {
+			return response.InternalError(fmt.Errorf("failed to disable gateway API: %w", err))
 		}
 	default:
-		return response.SmartError(fmt.Errorf("invalid component status %s", req.Status))
+		return response.BadRequest(fmt.Errorf("invalid component status %s", req.Status))
 	}
 
 	return response.SyncResponse(true, &api.UpdateGatewayComponentResponse{})

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -6,18 +6,72 @@ import (
 )
 
 var Endpoints = []rest.Endpoint{
-	k8sdCluster,
-	k8sdDNSComponent,
-	k8sdNetworkComponent,
-	k8sdStorageComponent,
-	k8sdIngressComponent,
-	k8sdGatewayComponent,
-	k8sdComponents,
-	k8sdConfig,
-
-	kubernetesAuthTokens,
-	kubernetesAuthWebhook,
-
-	k8sdWorkerToken,
-	k8sdWorkerInfo,
+	// Cluster status
+	{
+		Name: "ClusterStatus",
+		Path: "k8sd/cluster",
+		Get:  rest.EndpointAction{Handler: getClusterStatus},
+	},
+	// Worker nodes
+	{
+		Name: "WorkerToken",
+		Path: "k8sd/worker/token",
+		Post: rest.EndpointAction{Handler: postWorkerToken},
+	},
+	{
+		Name: "WorkerInfo",
+		Path: "k8sd/worker/info",
+		// This endpoint is used by worker nodes that are not part of the microcluster.
+		// We authenticate by passing a token through an HTTP header instead.
+		Post: rest.EndpointAction{Handler: postWorkerInfo, AllowUntrusted: true},
+	},
+	// Kubeconfig
+	{
+		Name: "Kubeconfig",
+		Path: "k8sd/kubeconfig",
+		Get:  rest.EndpointAction{Handler: getKubeconfig},
+	},
+	// Cluster components
+	{
+		Name: "Components",
+		Path: "k8sd/components",
+		Get:  rest.EndpointAction{Handler: getComponents},
+	},
+	{
+		Name: "DNSComponent",
+		Path: "k8sd/components/dns",
+		Put:  rest.EndpointAction{Handler: putDNSComponent},
+	},
+	{
+		Name: "NetworkComponent",
+		Path: "k8sd/components/network",
+		Put:  rest.EndpointAction{Handler: putNetworkComponent},
+	},
+	{
+		Name: "StorageComponent",
+		Path: "k8sd/components/storage",
+		Put:  rest.EndpointAction{Handler: putStorageComponent},
+	},
+	{
+		Name: "IngressComponent",
+		Path: "k8sd/components/ingress",
+		Put:  rest.EndpointAction{Handler: putIngressComponent},
+	},
+	{
+		Name: "GatewayComponent",
+		Path: "k8sd/components/gateway",
+		Put:  rest.EndpointAction{Handler: putGatewayComponent},
+	},
+	// Kubernetes auth tokens and token review webhook for kube-apiserver
+	{
+		Name: "KubernetesAuthTokens",
+		Path: "kubernetes/auth/tokens",
+		Get:  rest.EndpointAction{Handler: getKubernetesAuthToken, AllowUntrusted: true},
+		Post: rest.EndpointAction{Handler: postKubernetesAuthToken},
+	},
+	{
+		Name: "KubernetesAuthWebhook",
+		Path: "kubernetes/auth/webhook",
+		Post: rest.EndpointAction{Handler: postKubernetesAuthWebhook, AllowUntrusted: true},
+	},
 }

--- a/src/k8s/pkg/k8sd/api/kubernetes_auth_tokens.go
+++ b/src/k8s/pkg/k8sd/api/kubernetes_auth_tokens.go
@@ -13,22 +13,7 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
-)
-
-var (
-	kubernetesAuthTokens = rest.Endpoint{
-		Name: "KubernetesAuthTokens",
-		Path: "kubernetes/auth/tokens",
-		Get:  rest.EndpointAction{Handler: getKubernetesAuthToken, AllowUntrusted: true},
-		Post: rest.EndpointAction{Handler: postKubernetesAuthToken},
-	}
-	kubernetesAuthWebhook = rest.Endpoint{
-		Name: "KubernetesAuthWebhook",
-		Path: "kubernetes/auth/webhook",
-		Post: rest.EndpointAction{Handler: kubernetesAuthTokenReviewWebhook, AllowUntrusted: true},
-	}
 )
 
 func getKubernetesAuthToken(state *state.State, r *http.Request) response.Response {
@@ -61,9 +46,9 @@ func postKubernetesAuthToken(state *state.State, r *http.Request) response.Respo
 	return response.SyncResponse(true, apiv1.CreateKubernetesAuthTokenResponse{Token: token})
 }
 
-// kubernetesAuthTokenReviewWebhook is used by kube-apiserver to handle TokenReview objects.
+// postKubernetesAuthWebhook is used by kube-apiserver to handle TokenReview objects.
 // Note that we do not use the normal response.SyncResponse here, because it breaks the response format that kube-apiserver expects.
-func kubernetesAuthTokenReviewWebhook(state *state.State, r *http.Request) response.Response {
+func postKubernetesAuthWebhook(state *state.State, r *http.Request) response.Response {
 	review := apiv1.TokenReview{
 		APIVersion: "authentication.k8s.io/v1",
 		Kind:       "TokenReview",

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -12,24 +12,10 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils/k8s"
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/state"
 )
 
-var (
-	k8sdWorkerToken = rest.Endpoint{
-		Path: "k8sd/worker/token",
-		Post: rest.EndpointAction{Handler: k8sdWorkerTokenPost},
-	}
-	k8sdWorkerInfo = rest.Endpoint{
-		Path: "k8sd/worker/info",
-		// This endpoint is used by worker nodes that are not part of the microcluster.
-		// We authenticate by passing a token through an HTTP header instead.
-		Post: rest.EndpointAction{Handler: k8sdWorkerInfoPost, AllowUntrusted: true},
-	}
-)
-
-func k8sdWorkerTokenPost(s *state.State, r *http.Request) response.Response {
+func postWorkerToken(s *state.State, r *http.Request) response.Response {
 	var token string
 	if err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
@@ -60,7 +46,7 @@ func k8sdWorkerTokenPost(s *state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, &apiv1.WorkerNodeTokenResponse{EncodedToken: token})
 }
 
-func k8sdWorkerInfoPost(s *state.State, r *http.Request) response.Response {
+func postWorkerInfo(s *state.State, r *http.Request) response.Response {
 	// TODO: move authentication through the HTTP token to an AccessHandler for the endpoint.
 	token := r.Header.Get("k8sd-token")
 	if token == "" {


### PR DESCRIPTION
### Summary

Move the endpoint definitions in `endpoints.go`, such that we can easily look up the available APIs. Add missing endpoint names, comments and use a consistent naming scheme for the handlers.

In a similar vein, cleanup some parts of the components to return consistent error codes, depending on the error that occurs.