### PR TITLE
Improve clustering resilience and CLI

### DIFF
--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -81,8 +81,7 @@ func (c ClusterStatus) String() string {
 	if c.Ready {
 		result.WriteString("k8s is ready.")
 	} else {
-		result.WriteString("k8s is not ready.\n")
-		return result.String()
+		result.WriteString("k8s is not ready.")
 	}
 	result.WriteString("\n")
 

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -1,6 +1,9 @@
 package k8s
 
 import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -11,8 +14,18 @@ var (
 	}
 
 	rootCmd = &cobra.Command{
-		Use:          "k8s",
-		Short:        "Canonical Kubernetes CLI",
+		Use:   "k8s",
+		Short: "Canonical Kubernetes CLI",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			withRoot, err := utils.RunsWithRootPrivilege(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("failed to check if command runs as root: %w", err)
+			}
+			if !withRoot {
+				return fmt.Errorf("k8s CLI needs to run with root priviledge.")
+			}
+			return nil
+		},
 		SilenceUsage: true,
 	}
 )

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -32,7 +32,7 @@ var (
 			}
 
 			if c.IsBootstrapped(cmd.Context()) {
-				return fmt.Errorf("Node is already bootstrapped.")
+				return fmt.Errorf("k8s cluster already bootstrapped")
 			}
 
 			config := apiv1.BootstrapConfig{}

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -31,6 +31,10 @@ var (
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
+			if c.IsBootstrapped(cmd.Context()) {
+				return fmt.Errorf("Node is already bootstrapped.")
+			}
+
 			config := apiv1.BootstrapConfig{}
 			if bootstrapCmdOpts.interactive {
 				config = getConfigInteractively(cmd.Context())

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -51,11 +51,11 @@ var (
 			}
 
 			if c.IsBootstrapped(cmd.Context()) {
-				return fmt.Errorf("A k8s cluster is already running on this node.")
+				return fmt.Errorf("k8s cluster already bootstrapped")
 			}
 			const minTimeout = 3 * time.Second
 			if joinNodeCmdOpts.timeout < minTimeout {
-				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", joinNodeCmdOpts.timeout, minTimeout, minTimeout)
+				cmd.PrintErrf("Timeout %v is less than minimum of %v, using the minimum %v instead.\n", joinNodeCmdOpts.timeout, minTimeout, minTimeout)
 				joinNodeCmdOpts.timeout = minTimeout
 			}
 

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -53,10 +53,10 @@ var (
 			if c.IsBootstrapped(cmd.Context()) {
 				return fmt.Errorf("A k8s cluster is already running on this node.")
 			}
-			const minTimeout = 3
-			if joinNodeCmdOpts.timeout < minTimeout*time.Second {
-				cmd.PrintErrf("Timeout %v is less than minimum of %ds. Using the minimum %ds instead.\n", joinNodeCmdOpts.timeout, minTimeout, minTimeout)
-				joinNodeCmdOpts.timeout = minTimeout * time.Second
+			const minTimeout = 3 * time.Second
+			if joinNodeCmdOpts.timeout < minTimeout {
+				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", joinNodeCmdOpts.timeout, minTimeout, minTimeout)
+				joinNodeCmdOpts.timeout = minTimeout
 			}
 
 			timeoutCtx, cancel := context.WithTimeout(cmd.Context(), joinNodeCmdOpts.timeout)

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -31,10 +31,10 @@ var (
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			const minTimeout = 3
-			if statusCmdOpts.timeout < minTimeout*time.Second {
-				cmd.PrintErrf("Timeout %v is less than minimum of %ds. Using the minimum %ds instead.\n", statusCmdOpts.timeout, minTimeout, minTimeout)
-				statusCmdOpts.timeout = minTimeout * time.Second
+			const minTimeout = 3 * time.Second
+			if statusCmdOpts.timeout < minTimeout {
+				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", statusCmdOpts.timeout, minTimeout, minTimeout)
+				statusCmdOpts.timeout = minTimeout
 			}
 
 			timeoutCtx, cancel := context.WithTimeout(cmd.Context(), statusCmdOpts.timeout)

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -82,7 +82,6 @@ func (c *Client) WaitForDqliteNodeToBeReady(ctx context.Context, nodeName string
 // CleanupNode resets the nodes configuration and cluster state.
 // The cleanup will happen on a best-effort base. Any error that occurs will be ignored.
 func (c *Client) CleanupNode(ctx context.Context, nodeName string) {
-	sn := snap.NewDefaultSnap()
 
 	// For self-removal, microcluster expects the dqlite node to not be in pending state.
 	c.WaitForDqliteNodeToBeReady(ctx, nodeName)
@@ -95,5 +94,5 @@ func (c *Client) CleanupNode(ctx context.Context, nodeName string) {
 	// joining another cluster.
 	c.ResetNode(ctx, nodeName, true)
 
-	snap.StopServices(ctx, sn, snap.ControlPlaneServices)
+	snap.StopControlPlaneServices(ctx, snap.NewDefaultSnap())
 }

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/control"
 )
 
 func (c *Client) joinWorkerNode(ctx context.Context, name, address, token string) error {
@@ -26,16 +28,72 @@ func (c *Client) JoinNode(ctx context.Context, name string, address string, toke
 	if info.Decode(token) == nil {
 		// valid worker node token
 		if err := c.joinWorkerNode(ctx, name, address, token); err != nil {
+
+			// TODO: Handle worker node specific cleanup.
+			// If the node setup unrecoverably fails after the worker has
+			// registered itself to the cluster, the worker needs to remove itself again.
+			// For that:
+			//  - we need an endpoint on the control-plane with which workers can remove themselves.
+			//  - we need unique worker tokens (right now, all workers share the same one) so that
+			//    each worker kann only remove itself and not other workers.
 			return fmt.Errorf("failed to join k8sd cluster as worker: %w", err)
 		}
 	} else {
 		if err := c.joinControlPlaneNode(ctx, name, address, token); err != nil {
+			c.CleanupNode(ctx, name)
 			return fmt.Errorf("failed to join k8sd cluster as control plane: %w", err)
 		}
 	}
+
+	c.WaitForDqliteNodeToBeReady(ctx, name)
 	return nil
 }
 
 func (c *Client) RemoveNode(ctx context.Context, name string, force bool) error {
 	return c.mc.DeleteClusterMember(ctx, name, force)
+}
+
+func (c *Client) ResetNode(ctx context.Context, name string, force bool) error {
+	return c.mc.ResetClusterMember(ctx, name, force)
+}
+
+// WaitForDqliteNodeToBeReady waits until the underlying dqlite node of the microcluster is not in PENDING state.
+// While microcluster checkReady will validate that the nodes API server is ready, it will not check if the
+// dqlite node is properly setup yet.
+func (c *Client) WaitForDqliteNodeToBeReady(ctx context.Context, nodeName string) error {
+	return control.WaitUntilReady(ctx, func() (bool, error) {
+		clusterStatus, err := c.ClusterStatus(ctx, false)
+		if err != nil {
+			return false, fmt.Errorf("failed to get cluster status: %w", err)
+		}
+
+		for _, member := range clusterStatus.Members {
+			if member.Name == nodeName {
+				if member.Role == "PENDING" {
+					return false, nil
+				}
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("cluster does not contain node %s", nodeName)
+	})
+}
+
+// CleanupNode resets the nodes configuration and cluster state.
+// The cleanup will happen on a best-effort base. Any error that occurs will be ignored.
+func (c *Client) CleanupNode(ctx context.Context, nodeName string) {
+	sn := snap.NewDefaultSnap()
+
+	// For self-removal, microcluster expects the dqlite node to not be in pending state.
+	c.WaitForDqliteNodeToBeReady(ctx, nodeName)
+
+	// Delete the node from the cluster.
+	// This will fail if this is the only member in the cluster.
+	c.RemoveNode(ctx, nodeName, false)
+	// Reset the local state and daemon.
+	// This is required to reset a bootstrapped node before
+	// joining another cluster.
+	c.ResetNode(ctx, nodeName, true)
+
+	snap.StopServices(ctx, sn, snap.ControlPlaneServices)
 }

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -35,7 +35,7 @@ func (c *Client) JoinNode(ctx context.Context, name string, address string, toke
 			// For that:
 			//  - we need an endpoint on the control-plane with which workers can remove themselves.
 			//  - we need unique worker tokens (right now, all workers share the same one) so that
-			//    each worker kann only remove itself and not other workers.
+			//    each worker can only remove itself and not other workers.
 			return fmt.Errorf("failed to join k8sd cluster as worker: %w", err)
 		}
 	} else {

--- a/src/k8s/pkg/k8s/setup/containerd.go
+++ b/src/k8s/pkg/k8s/setup/containerd.go
@@ -3,23 +3,24 @@ package setup
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
 )
 
 // InitContainerd handles the setup of containerd.
 //   - Copies required files and binaries needed by Containerd to the correct paths.
-func InitContainerd(containerConfigPath string, cniBinaryPath string) error {
-	err := utils.CopyFile(containerConfigPath, "/etc/containerd/config.toml")
+func InitContainerd(snap snap.Snap) error {
+	err := utils.CopyFile(snap.Path("k8s/config/containerd/config.toml"), snap.CommonPath("/etc/containerd/config.toml"))
 	if err != nil {
 		return fmt.Errorf("failed to copy containerd config: %w", err)
 	}
 
-	err = utils.CopyDirectory(cniBinaryPath, "/opt/cni/bin")
+	err = utils.CopyDirectory(snap.Path("opt/cni/bin/"), snap.CommonPath("opt/cni/bin/"))
 	if err != nil {
 		return fmt.Errorf("failed to copy cni/bin: %w", err)
 	}
 
-	err = utils.ChmodRecursive("/opt/cni/bin", 0700)
+	err = utils.ChmodRecursive(snap.CommonPath("opt/cni/bin/"), 0700)
 	if err != nil {
 		return fmt.Errorf("failed to adjust permissions of /opt/cni/bin: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/canonical/k8s/pkg/k8sd/api"
 	"github.com/canonical/k8s/pkg/k8sd/database"
@@ -31,11 +30,7 @@ type App struct {
 
 // New initializes a new microcluster instance from configuration.
 func New(ctx context.Context, cfg Config) (*App, error) {
-	snapCtx := snap.ContextWithSnap(ctx, snap.NewSnap(
-		os.Getenv("SNAP"),
-		os.Getenv("SNAP_DATA"),
-		os.Getenv("SNAP_COMMON"),
-	))
+	snapCtx := snap.ContextWithSnap(ctx, snap.NewDefaultSnap())
 
 	cluster, err := microcluster.App(snapCtx, microcluster.Args{
 		Verbose:    cfg.Verbose,

--- a/src/k8s/pkg/k8sd/app/hooks.go
+++ b/src/k8s/pkg/k8sd/app/hooks.go
@@ -44,7 +44,7 @@ func onPostJoin(s *state.State, initConfig map[string]string) error {
 		return fmt.Errorf("failed to setup service arguments: %w", err)
 	}
 
-	if err := setup.InitContainerd(snap.Path("k8s/config/containerd/config.toml"), snap.Path("opt/cni/bin/")); err != nil {
+	if err := setup.InitContainerd(snap); err != nil {
 		return fmt.Errorf("failed to initialize containerd: %w", err)
 	}
 

--- a/src/k8s/pkg/snap/services.go
+++ b/src/k8s/pkg/snap/services.go
@@ -1,6 +1,7 @@
 package snap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -8,6 +9,39 @@ import (
 
 	"github.com/canonical/k8s/pkg/utils"
 )
+
+var (
+	// WorkerServices contains all k8s services that run on a worker node except of k8sd.
+	WorkerServices = []string{"containerd", "k8s-apiserver-proxy", "kubelet", "kube-proxy"}
+	// ControlPlaneServices contains all k8s services that run on a control plane except of k8sd.
+	ControlPlaneServices = []string{
+		"containerd", "k8s-dqlite", "kube-apiserver",
+		"kube-controller-manager", "kube-proxy",
+		"kube-scheduler", "kubelet", "k8s-apiserver-proxy",
+	}
+)
+
+// StartServices starts a list of services.
+// StartServices will return on the first failing service.
+func StartServices(ctx context.Context, snap Snap, services []string) error {
+	for _, service := range services {
+		if err := snap.StartService(ctx, service); err != nil {
+			return fmt.Errorf("failed to start service %s: %w", service, err)
+		}
+	}
+	return nil
+}
+
+// StopServices stops a list of services.
+// StopServices will return on the first failing service.
+func StopServices(ctx context.Context, snap Snap, services []string) error {
+	for _, service := range services {
+		if err := snap.StopService(ctx, service); err != nil {
+			return fmt.Errorf("failed to start service %s: %w", service, err)
+		}
+	}
+	return nil
+}
 
 // GetServiceArgument retrieves the value of a specific argument from the $SNAP_DATA/args/$service file.
 // The argument name should include preceding dashes (e.g. "--secure-port").

--- a/src/k8s/pkg/snap/services.go
+++ b/src/k8s/pkg/snap/services.go
@@ -21,10 +21,10 @@ var (
 	}
 )
 
-// StartServices starts a list of services.
-// StartServices will return on the first failing service.
-func StartServices(ctx context.Context, snap Snap, services []string) error {
-	for _, service := range services {
+// StartWorkerServices starts the worker services.
+// StartWorkerServices will return on the first failing service.
+func StartWorkerServices(ctx context.Context, snap Snap) error {
+	for _, service := range WorkerServices {
 		if err := snap.StartService(ctx, service); err != nil {
 			return fmt.Errorf("failed to start service %s: %w", service, err)
 		}
@@ -32,12 +32,34 @@ func StartServices(ctx context.Context, snap Snap, services []string) error {
 	return nil
 }
 
-// StopServices stops a list of services.
-// StopServices will return on the first failing service.
-func StopServices(ctx context.Context, snap Snap, services []string) error {
-	for _, service := range services {
-		if err := snap.StopService(ctx, service); err != nil {
+// StartControlPlaneServices starts the control plane services.
+// StartControlPlaneServices will return on the first failing service.
+func StartControlPlaneServices(ctx context.Context, snap Snap) error {
+	for _, service := range ControlPlaneServices {
+		if err := snap.StartService(ctx, service); err != nil {
 			return fmt.Errorf("failed to start service %s: %w", service, err)
+		}
+	}
+	return nil
+}
+
+// StopWorkerServices stors the worker services.
+// StopWorkerServices will return on the first failing service.
+func StopWorkerServices(ctx context.Context, snap Snap) error {
+	for _, service := range WorkerServices {
+		if err := snap.StopService(ctx, service); err != nil {
+			return fmt.Errorf("failed to stop service %s: %w", service, err)
+		}
+	}
+	return nil
+}
+
+// StopControlPlaneServices stops the control plane services.
+// StopControlPlaneServices will return on the first failing service.
+func StopControlPlaneServices(ctx context.Context, snap Snap) error {
+	for _, service := range ControlPlaneServices {
+		if err := snap.StopService(ctx, service); err != nil {
+			return fmt.Errorf("failed to stop service %s: %w", service, err)
 		}
 	}
 	return nil

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -35,11 +35,7 @@ func NewSnap(snapDir, snapDataDir, snapCommonDir string, options ...func(s *snap
 
 // NewDefaultSnap returns a snap configured with the default snap environment.
 func NewDefaultSnap() Snap {
-	return NewSnap(
-		os.Getenv("SNAP"),
-		os.Getenv("SNAP_DATA"),
-		os.Getenv("SNAP_COMMON"),
-	)
+	return NewSnap(os.Getenv("SNAP"), os.Getenv("SNAP_DATA"), os.Getenv("SNAP_COMMON"))
 }
 
 type snapContextKey struct{}

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -33,6 +33,15 @@ func NewSnap(snapDir, snapDataDir, snapCommonDir string, options ...func(s *snap
 	return s
 }
 
+// NewDefaultSnap returns a snap configured with the default snap environment.
+func NewDefaultSnap() Snap {
+	return NewSnap(
+		os.Getenv("SNAP"),
+		os.Getenv("SNAP_DATA"),
+		os.Getenv("SNAP_COMMON"),
+	)
+}
+
 type snapContextKey struct{}
 
 // SnapFromContext extracts the snap instance from the provided context.

--- a/src/k8s/pkg/utils/control/wait.go
+++ b/src/k8s/pkg/utils/control/wait.go
@@ -1,4 +1,4 @@
-package utils
+package control
 
 import (
 	"context"

--- a/src/k8s/pkg/utils/control/wait_test.go
+++ b/src/k8s/pkg/utils/control/wait_test.go
@@ -1,4 +1,4 @@
-package utils
+package control
 
 import (
 	"context"

--- a/src/k8s/pkg/utils/k8s/status.go
+++ b/src/k8s/pkg/utils/k8s/status.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/k8s/pkg/utils/control"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // WaitApiServerReady waits until the kube-apiserver becomes available.
 func WaitApiServerReady(ctx context.Context, client *k8sClient) error {
-	return utils.WaitUntilReady(ctx, func() (bool, error) {
+	return control.WaitUntilReady(ctx, func() (bool, error) {
 		_, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		// We want to retry if an error occurs (=API server not ready)
 		// returning the error would abort, thus checking for nil

--- a/src/k8s/pkg/utils/sys.go
+++ b/src/k8s/pkg/utils/sys.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 )
 
 // runCommand executes a command with a given context.
@@ -21,4 +22,12 @@ func RunCommand(ctx context.Context, command ...string) error {
 		return fmt.Errorf("command %v failed with exit code %d: %w", command, cmd.ProcessState.ExitCode(), err)
 	}
 	return nil
+}
+
+func RunsWithRootPrivilege(ctx context.Context) (bool, error) {
+	u, err := user.Current()
+	if err != nil {
+		return false, fmt.Errorf("failed to check current user: %w", err)
+	}
+	return u.Uid == "0", nil
 }

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -36,6 +36,8 @@ def test_clustering(instances: List[harness.Instance]):
 
     util.wait_until_k8s_ready(cluster_node, instances)
 
+    cluster_node.exec(["k8s", "remove-node", joining_node.id])
+
 
 @pytest.mark.node_count(2)
 def test_worker_nodes(instances: List[harness.Instance]):


### PR DESCRIPTION
## Summary
By default, microcluster commands are not retriable if something fails in the hooks (other microcluster apps ignore this, a fix is expected to be delivered this cycle). For now, we manually roll back node assignments and configs in the CLI.
Additionally, several checks and flags were added to improve CLI handling and resilience.

Note that this PR only cleans up control-plane nodes. Workers need a bit more work (see TODO in code) that will be tackled in follow-up PRs.

## Changes

* Cleanup node if `k8s bootstrap` or `k8s join-cluster` fails
* Add proper error message if k8s is not run with root
* `k8s join-cluster` checks if the node is already bootstrapped and provides an actionable error message.
* `k8s status` shows nodes and components even if k8s is not ready.
* `k8s bootstrap` check if the node is already bootstrapped.
* Add snap convenience functions.
* Add test to remove a node in `test_clustering.py` again as `--wait-ready` makes this check reliably pass now.