### PR TITLE
Unit testing harness for ComponentManager

### DIFF
--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.0
-	github.com/stretchr/testify v1.8.4
 	go.etcd.io/etcd/api/v3 v3.5.10
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10
 	go.etcd.io/etcd/client/v3 v3.5.10
@@ -157,6 +156,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.0
+	github.com/stretchr/testify v1.8.4
 	go.etcd.io/etcd/api/v3 v3.5.10
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10
 	go.etcd.io/etcd/client/v3 v3.5.10
@@ -156,7 +157,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -177,21 +177,25 @@ func (h *helmClient) List() ([]Component, error) {
 
 	list := action.NewList(actionConfig)
 	releases, err := list.Run()
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to list components: %w", err)
 	}
 
-	allComponents := make([]Component, len(h.config))
+	allComponents := make([]Component, 0)
 	componentsMap := make(map[string]int)
+
+	// Loop through components and populate allComponents and componentsMap
 	for name, component := range h.config {
 		index := len(componentsMap)
-		allComponents[index] = Component{Name: name}
+
+		allComponents = append(allComponents, Component{Name: name})
 		componentsMap[component.ReleaseName] = index
 	}
 
+	// Loop through releases and update statuses in allComponents
 	for _, release := range releases {
-		index, ok := componentsMap[release.Name]
-		if ok {
+		if index, ok := componentsMap[release.Name]; ok {
 			allComponents[index].Status = true
 		}
 	}

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -78,20 +78,28 @@ func logAdapter(format string, v ...any) {
 }
 
 // NewManager creates a new Component manager instance.
-func NewManager(snap snap.Snap, initializer HelmConfigInitializer) (*helmClient, error) {
-	if initializer == nil {
+func NewManager(snap snap.Snap, initializers ...HelmConfigInitializer) (*helmClient, error) {
+	var initializer HelmConfigInitializer
+
+	if len(initializers) > 0 {
+		initializer = initializers[0]
+	} else {
+		// If no initializer provided, use a default one
 		initializer = &HelmClientIntitializer{}
 	}
 
 	viper.SetConfigName("components")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(snap.Path("k8s/components"))
-	err := viper.ReadInConfig()
-	if err != nil {
+
+	if err := viper.ReadInConfig(); err != nil {
 		return nil, err
 	}
+
 	config := make(map[string]componentDefinition)
-	err = viper.Unmarshal(&config)
+	if err := viper.Unmarshal(&config); err != nil {
+		return nil, err
+	}
 
 	return &helmClient{
 		config:      config,

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -13,8 +13,8 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 )
 
-// HelmClientIntitializer implements the HelmConfigInitializer interface
-type HelmClientIntitializer struct{}
+// HelmClientInitializer implements the HelmConfigInitializer interface
+type HelmClientInitializer struct{}
 
 // componentDefinition defines each component metadata.
 type componentDefinition struct {
@@ -38,7 +38,7 @@ type Component struct {
 }
 
 // InitializeHelmClientConfig initializes a Helm Configuration, ensures the use of a fresh configuration
-func (r *HelmClientIntitializer) InitializeHelmClientConfig() (*action.Configuration, error) {
+func (r *HelmClientInitializer) New() (*action.Configuration, error) {
 	settings := cli.New()
 	settings.KubeConfig = "/etc/kubernetes/admin.conf"
 
@@ -64,7 +64,7 @@ func logAdapter(format string, v ...any) {
 func NewHelmClient(snap snap.Snap, initializer HelmConfigInitializer) (*helmClient, error) {
 	if initializer == nil {
 		// If no initializer provided, use a default one
-		initializer = &HelmClientIntitializer{}
+		initializer = &HelmClientInitializer{}
 	}
 
 	viper.SetConfigName("components")
@@ -94,7 +94,7 @@ func (h *helmClient) Enable(name string, values map[string]any) error {
 		return fmt.Errorf("invalid component %s", name)
 	}
 
-	actionConfig, err := h.initializer.InitializeHelmClientConfig()
+	actionConfig, err := h.initializer.New()
 	if err != nil {
 		return fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}
@@ -127,7 +127,7 @@ func (h *helmClient) Enable(name string, values map[string]any) error {
 
 // isComponentEnabled checks if a component is enabled.
 func (h *helmClient) isComponentEnabled(name, namespace string) (bool, error) {
-	actionConfig, err := h.initializer.InitializeHelmClientConfig()
+	actionConfig, err := h.initializer.New()
 	if err != nil {
 		return false, fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}
@@ -149,7 +149,7 @@ func (h *helmClient) isComponentEnabled(name, namespace string) (bool, error) {
 
 // List lists the status of each k8s component.
 func (h *helmClient) List() ([]Component, error) {
-	actionConfig, err := h.initializer.InitializeHelmClientConfig()
+	actionConfig, err := h.initializer.New()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}
@@ -188,7 +188,7 @@ func (h *helmClient) List() ([]Component, error) {
 
 // Disable disables a specified component.
 func (h *helmClient) Disable(name string) error {
-	actionConfig, err := h.initializer.InitializeHelmClientConfig()
+	actionConfig, err := h.initializer.New()
 	if err != nil {
 		return fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}
@@ -218,7 +218,7 @@ func (h *helmClient) Disable(name string) error {
 
 // Refresh refreshes a specified component.
 func (h *helmClient) Refresh(name string, values map[string]any) error {
-	actionConfig, err := h.initializer.InitializeHelmClientConfig()
+	actionConfig, err := h.initializer.New()
 	if err != nil {
 		return fmt.Errorf("failed to initialize Helm client configuration: %w", err)
 	}

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -3,6 +3,7 @@ package component
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/sirupsen/logrus"
@@ -77,8 +78,8 @@ func logAdapter(format string, v ...any) {
 	logrus.Debugf(format, v...)
 }
 
-// NewManager creates a new Component manager instance.
-func NewManager(snap snap.Snap, initializers ...HelmConfigInitializer) (*helmClient, error) {
+// NewHelmClient creates a new Component manager instance.
+func NewHelmClient(snap snap.Snap, initializers ...HelmConfigInitializer) (*helmClient, error) {
 	var initializer HelmConfigInitializer
 
 	if len(initializers) > 0 {
@@ -182,7 +183,7 @@ func (h *helmClient) List() ([]Component, error) {
 		return nil, fmt.Errorf("failed to list components: %w", err)
 	}
 
-	allComponents := make([]Component, 0)
+	allComponents := make([]Component, 0, len(h.config))
 	componentsMap := make(map[string]int)
 
 	// Loop through components and populate allComponents and componentsMap
@@ -199,6 +200,10 @@ func (h *helmClient) List() ([]Component, error) {
 			allComponents[index].Status = true
 		}
 	}
+
+	sort.Slice(allComponents, func(i, j int) bool {
+		return allComponents[i].Name < allComponents[j].Name
+	})
 
 	return allComponents, nil
 }

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -13,8 +13,8 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 )
 
-// HelmClientInitializer implements the HelmConfigInitializer interface
-type HelmClientInitializer struct{}
+// defaultHelmConfigProvider implements the HelmConfigInitializer interface
+type defaultHelmConfigProvider struct{}
 
 // componentDefinition defines each component metadata.
 type componentDefinition struct {
@@ -28,7 +28,7 @@ type componentDefinition struct {
 type helmClient struct {
 	config      map[string]componentDefinition
 	snap        snap.Snap
-	initializer HelmConfigInitializer
+	initializer HelmConfigProvider
 }
 
 // Component defines the name and status of a k8s Component.
@@ -38,7 +38,7 @@ type Component struct {
 }
 
 // InitializeHelmClientConfig initializes a Helm Configuration, ensures the use of a fresh configuration
-func (r *HelmClientInitializer) New() (*action.Configuration, error) {
+func (r *defaultHelmConfigProvider) New() (*action.Configuration, error) {
 	settings := cli.New()
 	settings.KubeConfig = "/etc/kubernetes/admin.conf"
 
@@ -61,10 +61,10 @@ func logAdapter(format string, v ...any) {
 }
 
 // NewHelmClient creates a new Component manager instance.
-func NewHelmClient(snap snap.Snap, initializer HelmConfigInitializer) (*helmClient, error) {
+func NewHelmClient(snap snap.Snap, initializer HelmConfigProvider) (*helmClient, error) {
 	if initializer == nil {
 		// If no initializer provided, use a default one
-		initializer = &HelmClientInitializer{}
+		initializer = &defaultHelmConfigProvider{}
 	}
 
 	viper.SetConfigName("components")

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -13,24 +13,6 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 )
 
-// ComponentManager defines an interface for managing k8s components.
-type ComponentManager interface {
-	// Enable enables a k8s component, optionally specifying custom configuration options.
-	Enable(name string, values map[string]any) error
-	// List returns a list of enabled components.
-	List() ([]Component, error)
-	// Disable disables a component from the cluster.
-	Disable(name string) error
-	// Refresh updates a k8s component.
-	Refresh(name string) error
-}
-
-// HelmConfigInitializer defines an interface for initializing a Helm Configuration, allowing a Mock implementation
-type HelmConfigInitializer interface {
-	// Initializes a fresh Helm Configuration
-	InitializeHelmClientConfig() (*action.Configuration, error)
-}
-
 // HelmClientIntitializer implements the HelmConfigInitializer interface
 type HelmClientIntitializer struct{}
 

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -61,12 +61,8 @@ func logAdapter(format string, v ...any) {
 }
 
 // NewHelmClient creates a new Component manager instance.
-func NewHelmClient(snap snap.Snap, initializers ...HelmConfigInitializer) (*helmClient, error) {
-	var initializer HelmConfigInitializer
-
-	if len(initializers) > 0 {
-		initializer = initializers[0]
-	} else {
+func NewHelmClient(snap snap.Snap, initializer HelmConfigInitializer) (*helmClient, error) {
+	if initializer == nil {
 		// If no initializer provided, use a default one
 		initializer = &HelmClientIntitializer{}
 	}

--- a/src/k8s/pkg/component/component_test.go
+++ b/src/k8s/pkg/component/component_test.go
@@ -3,14 +3,22 @@ package component
 import (
 	"flag"
 	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/registry"
+	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/time"
 )
 
 var verbose = flag.Bool("test.log", false, "enable test logging")
@@ -37,6 +45,216 @@ func actionConfigFixture(t *testing.T) *action.Configuration {
 	}
 }
 
+var manifestWithHook = `kind: ConfigMap
+metadata:
+  name: test-cm
+  annotations:
+    "helm.sh/hook": post-install,pre-delete,post-upgrade
+data:
+  name: value`
+
+var manifestWithTestHook = `kind: Pod
+  metadata:
+	name: finding-nemo,
+	annotations:
+	  "helm.sh/hook": test
+  spec:
+	containers:
+	- name: nemo-test
+	  image: fake-image
+	  cmd: fake-command
+  `
+
+var rbacManifests = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: schedule-agents
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/exec", "pods/log"]
+  verbs: ["*"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: schedule-agents
+  namespace: {{ default .Release.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: schedule-agents
+subjects:
+- kind: ServiceAccount
+  name: schedule-agents
+  namespace: {{ .Release.Namespace }}
+`
+
+type chartOptions struct {
+	*chart.Chart
+}
+
+type chartOption func(*chartOptions)
+
+func buildChart(opts ...chartOption) *chart.Chart {
+	c := &chartOptions{
+		Chart: &chart.Chart{
+			// TODO: This should be more complete.
+			Metadata: &chart.Metadata{
+				APIVersion: "v1",
+				Name:       "hello",
+				Version:    "0.1.0",
+			},
+			// This adds a basic template and hooks.
+			Templates: []*chart.File{
+				{Name: "templates/hello", Data: []byte("hello: world")},
+				{Name: "templates/hooks", Data: []byte(manifestWithHook)},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c.Chart
+}
+
+func withName(name string) chartOption {
+	return func(opts *chartOptions) {
+		opts.Metadata.Name = name
+	}
+}
+
+func withSampleValues() chartOption {
+	values := map[string]interface{}{
+		"someKey": "someValue",
+		"nestedKey": map[string]interface{}{
+			"simpleKey": "simpleValue",
+			"anotherNestedKey": map[string]interface{}{
+				"yetAnotherNestedKey": map[string]interface{}{
+					"youReadyForAnotherNestedKey": "No",
+				},
+			},
+		},
+	}
+	return func(opts *chartOptions) {
+		opts.Values = values
+	}
+}
+
+func withValues(values map[string]interface{}) chartOption {
+	return func(opts *chartOptions) {
+		opts.Values = values
+	}
+}
+
+func withNotes(notes string) chartOption {
+	return func(opts *chartOptions) {
+		opts.Templates = append(opts.Templates, &chart.File{
+			Name: "templates/NOTES.txt",
+			Data: []byte(notes),
+		})
+	}
+}
+
+func withDependency(dependencyOpts ...chartOption) chartOption {
+	return func(opts *chartOptions) {
+		opts.AddDependency(buildChart(dependencyOpts...))
+	}
+}
+
+func withMetadataDependency(dependency chart.Dependency) chartOption {
+	return func(opts *chartOptions) {
+		opts.Metadata.Dependencies = append(opts.Metadata.Dependencies, &dependency)
+	}
+}
+
+func withSampleTemplates() chartOption {
+	return func(opts *chartOptions) {
+		sampleTemplates := []*chart.File{
+			// This adds basic templates and partials.
+			{Name: "templates/goodbye", Data: []byte("goodbye: world")},
+			{Name: "templates/empty", Data: []byte("")},
+			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
+			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
+		}
+		opts.Templates = append(opts.Templates, sampleTemplates...)
+	}
+}
+
+func withSampleIncludingIncorrectTemplates() chartOption {
+	return func(opts *chartOptions) {
+		sampleTemplates := []*chart.File{
+			// This adds basic templates and partials.
+			{Name: "templates/goodbye", Data: []byte("goodbye: world")},
+			{Name: "templates/empty", Data: []byte("")},
+			{Name: "templates/incorrect", Data: []byte("{{ .Values.bad.doh }}")},
+			{Name: "templates/with-partials", Data: []byte(`hello: {{ template "_planet" . }}`)},
+			{Name: "templates/partials/_planet", Data: []byte(`{{define "_planet"}}Earth{{end}}`)},
+		}
+		opts.Templates = append(opts.Templates, sampleTemplates...)
+	}
+}
+
+func withMultipleManifestTemplate() chartOption {
+	return func(opts *chartOptions) {
+		sampleTemplates := []*chart.File{
+			{Name: "templates/rbac", Data: []byte(rbacManifests)},
+		}
+		opts.Templates = append(opts.Templates, sampleTemplates...)
+	}
+}
+
+func withKube(version string) chartOption {
+	return func(opts *chartOptions) {
+		opts.Metadata.KubeVersion = version
+	}
+}
+
+// releaseStub creates a release stub, complete with the chartStub as its chart.
+func releaseStub() *release.Release {
+	return namedReleaseStub("angry-panda", release.StatusDeployed)
+}
+
+func namedReleaseStub(name string, status release.Status) *release.Release {
+	now := time.Now()
+	return &release.Release{
+		Name: name,
+		Info: &release.Info{
+			FirstDeployed: now,
+			LastDeployed:  now,
+			Status:        status,
+			Description:   "Named Release Stub",
+		},
+		Chart:   buildChart(withSampleTemplates()),
+		Config:  map[string]interface{}{"name": "value"},
+		Version: 1,
+		Hooks: []*release.Hook{
+			{
+				Name:     "test-cm",
+				Kind:     "ConfigMap",
+				Path:     "test-cm",
+				Manifest: manifestWithHook,
+				Events: []release.HookEvent{
+					release.HookPostInstall,
+					release.HookPreDelete,
+				},
+			},
+			{
+				Name:     "finding-nemo",
+				Kind:     "Pod",
+				Path:     "finding-nemo",
+				Manifest: manifestWithTestHook,
+				Events: []release.HookEvent{
+					release.HookTest,
+				},
+			},
+		},
+	}
+}
+
 // "Mock" Initializer
 type MockHelmClientInitializer struct {
 	actionConfig *action.Configuration
@@ -46,7 +264,105 @@ func (r *MockHelmClientInitializer) InitializeHelmClientConfig() (*action.Config
 	return r.actionConfig, nil
 }
 
-func TestList(t *testing.T) {
+func makeMeSomeReleases(store *storage.Storage, t *testing.T) {
+	t.Helper()
+	one := releaseStub()
+	one.Name = "one"
+	one.Namespace = "default"
+	one.Version = 1
+	two := releaseStub()
+	two.Name = "two"
+	two.Namespace = "default"
+	two.Version = 2
+	three := releaseStub()
+	three.Name = "three"
+	three.Namespace = "default"
+	three.Version = 3
+
+	for _, rel := range []*release.Release{one, two, three} {
+		if err := store.Create(rel); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all, err := store.ListReleases()
+	assert.NoError(t, err)
+	assert.Len(t, all, 3, "sanity test: three items added")
+}
+
+var components = `
+network:
+  release: "ck-network"
+  chart: "cilium-1.14.1.tgz"
+  namespace: "kube-system"
+dns:
+  release: "ck-dns"
+  chart: "coredns-1.29.0.tgz"
+  namespace: "kube-system"
+`
+
+func createTemporaryTestDirectory(t *testing.T) string {
+	// Create a temporary test directory
+	// <tempDir>
+	// └── k8s/components
+	// 	├── charts
+	// 	└── component.yaml
+	tempDir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k8sComponentsDir := filepath.Join(tempDir, "k8s", "components")
+	err = os.MkdirAll(k8sComponentsDir, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k8sComponentsChartsDir := filepath.Join(k8sComponentsDir, "charts")
+	err = os.MkdirAll(k8sComponentsChartsDir, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tempDir
+}
+
+func addConfigToTestDir(t *testing.T, path string, data string) {
+	// Create a file and add some configs
+	err := ioutil.WriteFile(path, []byte(data), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	// Create a mock actionConfig for testing
+	mockActionConfig := actionConfigFixture(t)
+	// Create a mock HelmClient with the desired behavior for testing
+	mockClient := &MockHelmClientInitializer{actionConfig: mockActionConfig}
+
+	// create test directory
+	tempDir := createTemporaryTestDirectory(t)
+	defer os.RemoveAll(tempDir)
+
+	// Create a file and add some configs
+	addConfigToTestDir(t, filepath.Join(tempDir, "k8s", "components", "components.yaml"), components)
+
+	// Create mock snap
+	snap := &mock.Snap{
+		PathPrefix: tempDir, //make a test dir?
+	}
+	//Create a mock ComponentManager with the mock HelmClient
+	mockComponentManager, err := NewManager(snap, mockClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotNil(t, mockComponentManager)
+	assert.IsType(t, &helmClient{}, mockComponentManager)
+}
+
+func TestListEmpty(t *testing.T) {
 	// Create a mock actionConfig for testing
 	mockActionConfig := actionConfigFixture(t)
 	// Create a mock HelmClient with the desired behavior for testing
@@ -66,4 +382,27 @@ func TestList(t *testing.T) {
 	if len(components) != 0 {
 		t.Errorf("Expected 0 components, got %d", len(components))
 	}
+}
+
+func TestList(t *testing.T) {
+	// Create a mock actionConfig for testing
+	mockActionConfig := actionConfigFixture(t)
+	// Create a mock HelmClient with the desired behavior for testing
+	mockClient := &MockHelmClientInitializer{actionConfig: mockActionConfig}
+
+	//Create a mock ComponentManager with the mock HelmClient
+	mockHelmClient := &helmClient{
+		initializer: mockClient,
+	}
+
+	// Create releases in the mock actionConfig
+	makeMeSomeReleases(mockActionConfig.Releases, t)
+
+	// Call the List function with the mock HelmClient
+	components, err := mockHelmClient.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotNil(t, components)
 }

--- a/src/k8s/pkg/component/component_test.go
+++ b/src/k8s/pkg/component/component_test.go
@@ -1,0 +1,69 @@
+package component
+
+import (
+	"flag"
+	"io"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/registry"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+)
+
+var verbose = flag.Bool("test.log", false, "enable test logging")
+
+func actionConfigFixture(t *testing.T) *action.Configuration {
+	t.Helper()
+
+	registryClient, err := registry.NewClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &action.Configuration{
+		Releases:       storage.Init(driver.NewMemory()),
+		KubeClient:     &kubefake.FailingKubeClient{PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard}},
+		Capabilities:   chartutil.DefaultCapabilities,
+		RegistryClient: registryClient,
+		Log: func(format string, v ...interface{}) {
+			t.Helper()
+			if *verbose {
+				t.Logf(format, v...)
+			}
+		},
+	}
+}
+
+// "Mock" Initializer
+type MockHelmClientInitializer struct {
+	actionConfig *action.Configuration
+}
+
+func (r *MockHelmClientInitializer) InitializeHelmClientConfig() (*action.Configuration, error) {
+	return r.actionConfig, nil
+}
+
+func TestList(t *testing.T) {
+	// Create a mock actionConfig for testing
+	mockActionConfig := actionConfigFixture(t)
+	// Create a mock HelmClient with the desired behavior for testing
+	mockClient := &MockHelmClientInitializer{actionConfig: mockActionConfig}
+
+	//Create a mock ComponentManager with the mock HelmClient
+	mockHelmClient := &helmClient{
+		initializer: mockClient,
+	}
+
+	// Call the List function with the mock HelmClient
+	components, err := mockHelmClient.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(components) != 0 {
+		t.Errorf("Expected 0 components, got %d", len(components))
+	}
+}

--- a/src/k8s/pkg/component/component_test.go
+++ b/src/k8s/pkg/component/component_test.go
@@ -3,7 +3,6 @@ package component
 import (
 	"flag"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -155,7 +154,7 @@ func createTemporaryTestDirectory(t *testing.T) string {
 
 func addConfigToTestDir(t *testing.T, path string, data string) {
 	// Create a file and add some configs
-	err := ioutil.WriteFile(path, []byte(data), 0644)
+	err := os.WriteFile(path, []byte(data), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +188,7 @@ func createNewManager(t *testing.T, components string) (*helmClient, string, *ac
 	return mockComponentManager, tempDir, mockActionConfig
 }
 
-func TestNewManager(t *testing.T) {
+func TestNewManagerWithValidConfig(t *testing.T) {
 	// Create a mock actionConfig for testing
 	mockHelmClient, tempDir, mockActionConfig := createNewManager(t, components)
 	defer os.RemoveAll(tempDir)
@@ -202,7 +201,7 @@ func TestNewManager(t *testing.T) {
 	assert.DirExists(t, tempDir)
 }
 
-func TestListEmpty(t *testing.T) {
+func TestListEmptyComponents(t *testing.T) {
 	// Create a mock ComponentManager with no components
 	mockHelmClient, tempDir, _ := createNewManager(t, componentsNone)
 	defer os.RemoveAll(tempDir)
@@ -218,7 +217,7 @@ func TestListEmpty(t *testing.T) {
 	}
 }
 
-func TestList(t *testing.T) {
+func TestListComponentsWithReleases(t *testing.T) {
 	// Create a mock ComponentManager with the mock HelmClient
 	// This mock uses components.yaml for the snap mock components
 

--- a/src/k8s/pkg/component/component_test.go
+++ b/src/k8s/pkg/component/component_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	mocks "github.com/canonical/k8s/pkg/component/mock"
-	"github.com/canonical/k8s/pkg/snap/mock"
+	componentmock "github.com/canonical/k8s/pkg/component/mock"
+	snapmock "github.com/canonical/k8s/pkg/snap/mock"
 	. "github.com/onsi/gomega"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
@@ -141,7 +141,7 @@ func mustCreateNewHelmClient(t *testing.T, components string) (*helmClient, stri
 	// Create a mock actionConfig for testing
 	mockActionConfig := actionConfigFixture(t)
 	// Create a mock HelmClient with the desired behavior for testing
-	mockClient := &mocks.HelmClientInitializer{ActionConfig: mockActionConfig}
+	mockClient := &componentmock.HelmClientInitializer{ActionConfig: mockActionConfig}
 
 	// create test directory to use for the snap mock
 	tempDir := mustCreateTemporaryTestDirectory(t)
@@ -150,7 +150,7 @@ func mustCreateNewHelmClient(t *testing.T, components string) (*helmClient, stri
 	mustAddConfigToTestDir(t, filepath.Join(tempDir, "k8s", "components", "components.yaml"), components)
 
 	// Create mock snap
-	snap := &mock.Snap{
+	snap := &snapmock.Snap{
 		PathPrefix: tempDir,
 	}
 

--- a/src/k8s/pkg/component/component_test.go
+++ b/src/k8s/pkg/component/component_test.go
@@ -163,22 +163,6 @@ func mustCreateNewHelmClient(t *testing.T, components string) (*helmClient, stri
 	return mockHelmCLient, tempDir, mockActionConfig
 }
 
-func TestNewHelmClientWithValidConfig(t *testing.T) {
-	g := NewWithT(t)
-	// Create a mock actionConfig for testing
-	mockHelmClient, tempDir, mockActionConfig := mustCreateNewHelmClient(t, components)
-	defer os.RemoveAll(tempDir)
-
-	g.Expect(mockHelmClient).ToNot(BeNil())
-	g.Expect(mockHelmClient).To(BeAssignableToTypeOf(&helmClient{}))
-
-	g.Expect(mockHelmClient.initializer).To(BeAssignableToTypeOf(&mocks.HelmClientInitializer{}))
-	g.Expect(mockHelmClient.snap).To(BeAssignableToTypeOf(&mock.Snap{}))
-	g.Expect(mockHelmClient.config).To(HaveLen(3))
-	g.Expect(mockActionConfig).ToNot(BeNil())
-	g.Expect(tempDir).To(BeADirectory())
-}
-
 func TestListEmptyComponents(t *testing.T) {
 	g := NewWithT(t)
 	// Create a mock ComponentManager with no components

--- a/src/k8s/pkg/component/component_test.go
+++ b/src/k8s/pkg/component/component_test.go
@@ -141,7 +141,7 @@ func mustCreateNewHelmClient(t *testing.T, components string) (*helmClient, stri
 	// Create a mock actionConfig for testing
 	mockActionConfig := actionConfigFixture(t)
 	// Create a mock HelmClient with the desired behavior for testing
-	mockClient := &componentmock.HelmClientInitializer{ActionConfig: mockActionConfig}
+	mockClient := &componentmock.MockHelmConfigProvider{ActionConfig: mockActionConfig}
 
 	// create test directory to use for the snap mock
 	tempDir := mustCreateTemporaryTestDirectory(t)

--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -11,7 +11,7 @@ import (
 )
 
 func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNameservers []string) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -106,7 +106,7 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 }
 
 func DisableDNSComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -11,7 +11,7 @@ import (
 )
 
 func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNameservers []string) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -106,7 +106,7 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 }
 
 func DisableDNSComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -11,7 +11,7 @@ import (
 )
 
 func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNameservers []string) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -106,7 +106,7 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 }
 
 func DisableDNSComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -11,7 +11,7 @@ import (
 )
 
 func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNameservers []string) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -106,7 +106,7 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 }
 
 func DisableDNSComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableGatewayComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -55,7 +55,7 @@ func EnableGatewayComponent(s snap.Snap) error {
 }
 
 func DisableGatewayComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableGatewayComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -55,7 +55,7 @@ func EnableGatewayComponent(s snap.Snap) error {
 }
 
 func DisableGatewayComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableGatewayComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -55,7 +55,7 @@ func EnableGatewayComponent(s snap.Snap) error {
 }
 
 func DisableGatewayComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableGatewayComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -55,7 +55,7 @@ func EnableGatewayComponent(s snap.Snap) error {
 }
 
 func DisableGatewayComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyProtocol bool) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -52,7 +52,7 @@ func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyPro
 }
 
 func DisableIngressComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyProtocol bool) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -52,7 +52,7 @@ func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyPro
 }
 
 func DisableIngressComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyProtocol bool) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -52,7 +52,7 @@ func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyPro
 }
 
 func DisableIngressComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyProtocol bool) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -52,7 +52,7 @@ func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyPro
 }
 
 func DisableIngressComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/interface.go
+++ b/src/k8s/pkg/component/interface.go
@@ -2,8 +2,8 @@ package component
 
 import "helm.sh/helm/v3/pkg/action"
 
-// HelmComponentManager defines an interface for managing k8s components.
-type HelmComponentManager interface {
+// ComponentManager defines an interface for managing k8s components.
+type ComponentManager interface {
 	// Enable enables a k8s component, optionally specifying custom configuration options.
 	Enable(name string, values map[string]any) error
 	// List returns a list of enabled components.

--- a/src/k8s/pkg/component/interface.go
+++ b/src/k8s/pkg/component/interface.go
@@ -14,8 +14,8 @@ type ComponentManager interface {
 	Refresh(name string) error
 }
 
-// HelmConfigInitializer defines an interface for initializing a Helm Configuration, allowing a Mock implementation
-type HelmConfigInitializer interface {
+// HelmConfigProvider defines an interface for initializing a Helm Configuration, allowing a Mock implementation
+type HelmConfigProvider interface {
 	// Initializes a fresh Helm Configuration
 	New() (*action.Configuration, error)
 }

--- a/src/k8s/pkg/component/interface.go
+++ b/src/k8s/pkg/component/interface.go
@@ -17,5 +17,5 @@ type ComponentManager interface {
 // HelmConfigInitializer defines an interface for initializing a Helm Configuration, allowing a Mock implementation
 type HelmConfigInitializer interface {
 	// Initializes a fresh Helm Configuration
-	InitializeHelmClientConfig() (*action.Configuration, error)
+	New() (*action.Configuration, error)
 }

--- a/src/k8s/pkg/component/interface.go
+++ b/src/k8s/pkg/component/interface.go
@@ -1,0 +1,21 @@
+package component
+
+import "helm.sh/helm/v3/pkg/action"
+
+// HelmComponentManager defines an interface for managing k8s components.
+type HelmComponentManager interface {
+	// Enable enables a k8s component, optionally specifying custom configuration options.
+	Enable(name string, values map[string]any) error
+	// List returns a list of enabled components.
+	List() ([]Component, error)
+	// Disable disables a component from the cluster.
+	Disable(name string) error
+	// Refresh updates a k8s component.
+	Refresh(name string) error
+}
+
+// HelmConfigInitializer defines an interface for initializing a Helm Configuration, allowing a Mock implementation
+type HelmConfigInitializer interface {
+	// Initializes a fresh Helm Configuration
+	InitializeHelmClientConfig() (*action.Configuration, error)
+}

--- a/src/k8s/pkg/component/mock/mock.go
+++ b/src/k8s/pkg/component/mock/mock.go
@@ -1,4 +1,4 @@
-package mocks
+package mock
 
 import "helm.sh/helm/v3/pkg/action"
 

--- a/src/k8s/pkg/component/mock/mock.go
+++ b/src/k8s/pkg/component/mock/mock.go
@@ -3,10 +3,10 @@ package mock
 import "helm.sh/helm/v3/pkg/action"
 
 // "Mock" Initializer
-type HelmClientInitializer struct {
+type MockHelmConfigProvider struct {
 	ActionConfig *action.Configuration
 }
 
-func (r *HelmClientInitializer) New() (*action.Configuration, error) {
+func (r *MockHelmConfigProvider) New() (*action.Configuration, error) {
 	return r.ActionConfig, nil
 }

--- a/src/k8s/pkg/component/mock/mock.go
+++ b/src/k8s/pkg/component/mock/mock.go
@@ -7,6 +7,6 @@ type HelmClientInitializer struct {
 	ActionConfig *action.Configuration
 }
 
-func (r *HelmClientInitializer) InitializeHelmClientConfig() (*action.Configuration, error) {
+func (r *HelmClientInitializer) New() (*action.Configuration, error) {
 	return r.ActionConfig, nil
 }

--- a/src/k8s/pkg/component/mock/mock.go
+++ b/src/k8s/pkg/component/mock/mock.go
@@ -1,0 +1,12 @@
+package mocks
+
+import "helm.sh/helm/v3/pkg/action"
+
+// "Mock" Initializer
+type HelmClientInitializer struct {
+	ActionConfig *action.Configuration
+}
+
+func (r *HelmClientInitializer) InitializeHelmClientConfig() (*action.Configuration, error) {
+	return r.ActionConfig, nil
+}

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableNetworkComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -97,7 +97,7 @@ func EnableNetworkComponent(s snap.Snap) error {
 }
 
 func DisableNetworkComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableNetworkComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -97,7 +97,7 @@ func EnableNetworkComponent(s snap.Snap) error {
 }
 
 func DisableNetworkComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableNetworkComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -97,7 +97,7 @@ func EnableNetworkComponent(s snap.Snap) error {
 }
 
 func DisableNetworkComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -10,7 +10,7 @@ import (
 )
 
 func EnableNetworkComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -97,7 +97,7 @@ func EnableNetworkComponent(s snap.Snap) error {
 }
 
 func DisableNetworkComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/storage.go
+++ b/src/k8s/pkg/component/storage.go
@@ -7,7 +7,7 @@ import (
 )
 
 func EnableStorageComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -22,7 +22,7 @@ func EnableStorageComponent(s snap.Snap) error {
 }
 
 func DisableStorageComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewHelmClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/storage.go
+++ b/src/k8s/pkg/component/storage.go
@@ -7,7 +7,7 @@ import (
 )
 
 func EnableStorageComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -22,7 +22,7 @@ func EnableStorageComponent(s snap.Snap) error {
 }
 
 func DisableStorageComponent(s snap.Snap) error {
-	manager, err := NewHelmClient(s)
+	manager, err := NewHelmClient(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/storage.go
+++ b/src/k8s/pkg/component/storage.go
@@ -7,7 +7,7 @@ import (
 )
 
 func EnableStorageComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -22,7 +22,7 @@ func EnableStorageComponent(s snap.Snap) error {
 }
 
 func DisableStorageComponent(s snap.Snap) error {
-	manager, err := NewManager(s)
+	manager, err := NewManager(s, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/component/storage.go
+++ b/src/k8s/pkg/component/storage.go
@@ -7,7 +7,7 @@ import (
 )
 
 func EnableStorageComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
@@ -22,7 +22,7 @@ func EnableStorageComponent(s snap.Snap) error {
 }
 
 func DisableStorageComponent(s snap.Snap) error {
-	manager, err := NewManager(s, nil)
+	manager, err := NewManager(s)
 	if err != nil {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/api/impl/component.go
+++ b/src/k8s/pkg/k8sd/api/impl/component.go
@@ -10,7 +10,7 @@ import (
 
 // GetComponent returns the current status of the k8s components.
 func GetComponents(snap snap.Snap) ([]api.Component, error) {
-	manager, err := component.NewHelmClient(snap)
+	manager, err := component.NewHelmClient(snap, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get component manager: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/api/impl/component.go
+++ b/src/k8s/pkg/k8sd/api/impl/component.go
@@ -10,7 +10,7 @@ import (
 
 // GetComponent returns the current status of the k8s components.
 func GetComponents(snap snap.Snap) ([]api.Component, error) {
-	manager, err := component.NewManager(snap)
+	manager, err := component.NewHelmClient(snap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get component manager: %w", err)
 	}


### PR DESCRIPTION
## Description
This PR adds unit test harness(fixtures and mocks) to our `ComponentManager` utility which interacts with the helm client/cli to operate on components. 

#### Interface
In order to be able to override the mocked Helm action configuration, @bschimke95  advised me to use an `HelmConfigInitializer` interface that calls the real or fake `InitializeHelmClientConfig` function. This function either returns a fake action Configuration or the real one. 
The interface is added to the Helm Client and set when the new Component manager instance is created. This required adding the initializer as an argument to the Component manager and update references to the function.

#### Mock Snap
The mock for the snap builds on the snap mock in this repo. I used the snap mock's pathprefix to be able to give the snap a fake `k8s/components/components.yaml` file to build it's configuration from.

#### Mock Action
My Mock for the `helmClient.actionConfig` is heavily inspired by the helm action package and its associated tests and uses parts to create the `actionConfig`, as well as mocks for component releases.

#### Test Set-up
The `createNewManager` function is supposed to make adding new tests easier and is supposed to provide the default HelmClient mock to test the other functions with. I'm open to suggestions on making it easier to use all the mocks and fixtures since there are indeed a lot of them in here.

#### The Bug
During unit testing a little bug crawled out of the List() function:

Instead of setting `allComponents[index] = Component{Name: name}`, I changed it to  `allComponents = append(allComponents, Component{Name: name})` to avoid overwriting components at the same index.

Previously, the `componentsMap` did not change its length so the index didn’t increment so we were just overwriting the component.
```
for name, component := range h.config {
		index := len(componentsMap)
```

[Bug Fix Commit](https://github.com/canonical/k8s-snap/commit/fb5eae50ac7bb415f66300f553eb3172daa1c2fc)

We could consider doing the bug-fix in a separate PR.