### PR TITLE
Cleanup API naming

### DIFF
--- a/src/k8s/api/v1/worker.go
+++ b/src/k8s/api/v1/worker.go
@@ -5,7 +5,9 @@ type WorkerNodeTokenRequest struct{}
 
 // WorkerNodeTokenResponse is used to return a token for joining worker nodes in the cluster.
 type WorkerNodeTokenResponse struct {
-	EncodedToken string `json:"encodedToken"`
+	// We want to be able to quickly find the worker tokens in the code, but have the same
+	// JSON response for control-plane and worker nodes, thus the discrepancy in naming.
+	EncodedToken string `json:"token"`
 }
 
 // WorkerNodeInfoRequest is used by a worker node to retrieve the required credentials

--- a/src/k8s/pkg/k8s/client/token.go
+++ b/src/k8s/pkg/k8s/client/token.go
@@ -20,9 +20,9 @@ func (c *Client) CreateJoinToken(ctx context.Context, name string, worker bool) 
 	request := apiv1.WorkerNodeTokenRequest{}
 	response := apiv1.WorkerNodeTokenResponse{}
 
-	err := c.mc.Query(ctx, "POST", api.NewURL().Path("k8sd", "worker", "token"), request, &response)
+	err := c.mc.Query(ctx, "POST", api.NewURL().Path("k8sd", "worker", "tokens"), request, &response)
 	if err != nil {
-		return "", fmt.Errorf("failed to query endpoint POST /k8sd/worker/token: %w", err)
+		return "", fmt.Errorf("failed to query endpoint POST /k8sd/worker/tokens: %w", err)
 	}
 	return response.EncodedToken, nil
 }

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -15,7 +15,7 @@ var Endpoints = []rest.Endpoint{
 	// Worker nodes
 	{
 		Name: "WorkerToken",
-		Path: "k8sd/worker/token",
+		Path: "k8sd/worker/tokens",
 		Post: rest.EndpointAction{Handler: postWorkerToken},
 	},
 	{


### PR DESCRIPTION
* Rename worker token response to match the control-plane response
* Rename worker API endpoint to match control-plane tokens endpoint