### PR TITLE
Add delegated auth config for `kube-scheduler` and `kube-controller-manager`

### DIFF
--- a/k8s/args/kube-controller-manager
+++ b/k8s/args/kube-controller-manager
@@ -1,4 +1,6 @@
 --kubeconfig=/etc/kubernetes/controller-manager.conf
+--authorization-kubeconfig=/etc/kubernetes/controller-manager.conf
+--authentication-kubeconfig=/etc/kubernetes/controller-manager.conf
 --service-account-private-key-file=/etc/kubernetes/pki/serviceaccount.key
 --root-ca-file=/etc/kubernetes/pki/ca.crt
 --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt

--- a/k8s/args/kube-scheduler
+++ b/k8s/args/kube-scheduler
@@ -1,4 +1,6 @@
 --kubeconfig=/etc/kubernetes/scheduler.conf
+--authorization-kubeconfig=/etc/kubernetes/scheduler.conf
+--authentication-kubeconfig=/etc/kubernetes/scheduler.conf
 --leader-elect-lease-duration=30s
 --leader-elect-renew-deadline=15s
 --profiling=false


### PR DESCRIPTION
## Overview
This pull request introduces delegated authentication configuration for both `kube-scheduler` and`kube-controller-manager` components.
### Rationale
Our upcoming work on observability integration requires the functionality to scrape metrics from the cluster components. Currently, certain services fail to validate authentication requests because they lack the necessary configuration to perform token based validation. Specifically, they cannot handle TokenAccessReview and SubjectAccessReview for requests arriving via the secure port.  Delegated authentication will address this issue, ensuring that all components can securely validate the requests from external scrapers

## Further information
https://github.com/kubernetes/kubernetes/pull/72491