### PR TITLE
Retrieve Kubernetes REST Client from the snap interface

### DIFF
--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -26,6 +26,7 @@ require (
 	helm.sh/helm/v3 v3.13.2
 	k8s.io/api v0.28.2
 	k8s.io/apimachinery v0.28.2
+	k8s.io/cli-runtime v0.28.2
 	k8s.io/client-go v0.28.2
 )
 
@@ -192,7 +193,6 @@ require (
 	gotest.tools/v3 v3.5.1 // indirect
 	k8s.io/apiextensions-apiserver v0.28.2 // indirect
 	k8s.io/apiserver v0.28.2 // indirect
-	k8s.io/cli-runtime v0.28.2 // indirect
 	k8s.io/component-base v0.28.2 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -15,7 +15,7 @@ import (
 
 // defaultHelmConfigProvider implements the HelmConfigInitializer interface
 type defaultHelmConfigProvider struct {
-	client genericclioptions.RESTClientGetter
+	restClientGetter func() genericclioptions.RESTClientGetter
 }
 
 // helmClient implements the ComponentManager interface
@@ -33,7 +33,7 @@ type Component struct {
 // InitializeHelmClientConfig initializes a Helm Configuration, ensures the use of a fresh configuration
 func (r *defaultHelmConfigProvider) New(namespace string) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(r.client, namespace, os.Getenv("HELM_DRIVER"), logAdapter); err != nil {
+	if err := actionConfig.Init(r.restClientGetter(), namespace, os.Getenv("HELM_DRIVER"), logAdapter); err != nil {
 		return nil, fmt.Errorf("failed to initialize action config: %w", err)
 	}
 	return actionConfig, nil
@@ -47,7 +47,7 @@ func logAdapter(format string, v ...any) {
 func NewHelmClient(snap snap.Snap, initializer HelmConfigProvider) (*helmClient, error) {
 	if initializer == nil {
 		// If no initializer provided, use a default one
-		initializer = &defaultHelmConfigProvider{client: snap.KubernetesRESTClientGetter()}
+		initializer = &defaultHelmConfigProvider{restClientGetter: snap.KubernetesRESTClientGetter}
 	}
 
 	return &helmClient{

--- a/src/k8s/pkg/component/component.go
+++ b/src/k8s/pkg/component/component.go
@@ -15,7 +15,7 @@ import (
 
 // defaultHelmConfigProvider implements the HelmConfigInitializer interface
 type defaultHelmConfigProvider struct {
-	restClientGetter func() genericclioptions.RESTClientGetter
+	restClientGetter func(namespace string) genericclioptions.RESTClientGetter
 }
 
 // helmClient implements the ComponentManager interface
@@ -33,7 +33,7 @@ type Component struct {
 // InitializeHelmClientConfig initializes a Helm Configuration, ensures the use of a fresh configuration
 func (r *defaultHelmConfigProvider) New(namespace string) (*action.Configuration, error) {
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(r.restClientGetter(), namespace, os.Getenv("HELM_DRIVER"), logAdapter); err != nil {
+	if err := actionConfig.Init(r.restClientGetter(namespace), namespace, os.Getenv("HELM_DRIVER"), logAdapter); err != nil {
 		return nil, fmt.Errorf("failed to initialize action config: %w", err)
 	}
 	return actionConfig, nil
@@ -46,7 +46,6 @@ func logAdapter(format string, v ...any) {
 // NewHelmClient creates a new Component manager instance.
 func NewHelmClient(snap snap.Snap, initializer HelmConfigProvider) (*helmClient, error) {
 	if initializer == nil {
-		// If no initializer provided, use a default one
 		initializer = &defaultHelmConfigProvider{restClientGetter: snap.KubernetesRESTClientGetter}
 	}
 

--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 // EnableDNSComponent enables DNS on the cluster.
@@ -73,7 +74,7 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 		return "", "", fmt.Errorf("failed to enable dns component: %w", err)
 	}
 
-	client, err := s.KubernetesClient()
+	client, err := k8s.NewClient(s)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
-	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 // EnableDNSComponent enables DNS on the cluster.
@@ -70,12 +69,11 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 		service["clusterIP"] = serviceIP
 	}
 
-	err = manager.Enable("dns", values)
-	if err != nil {
+	if err := manager.Enable("dns", values); err != nil {
 		return "", "", fmt.Errorf("failed to enable dns component: %w", err)
 	}
 
-	client, err := k8s.NewClient(s)
+	client, err := s.KubernetesClient()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
@@ -83,7 +81,7 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	dnsIP, err := k8s.GetServiceClusterIP(ctx, client, "coredns", "kube-system")
+	dnsIP, err := client.GetServiceClusterIP(ctx, "coredns", "kube-system")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get dns service: %w", err)
 	}
@@ -100,8 +98,7 @@ func EnableDNSComponent(s snap.Snap, clusterDomain, serviceIP string, upstreamNa
 		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		err = s.RestartService(ctx, "kubelet")
-		if err != nil {
+		if err := s.RestartService(ctx, "kubelet"); err != nil {
 			return "", "", fmt.Errorf("failed to restart kubelet to apply new dns configuration: %w", err)
 		}
 	}
@@ -114,8 +111,7 @@ func DisableDNSComponent(s snap.Snap) error {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
 
-	err = manager.Disable("dns")
-	if err != nil {
+	if err := manager.Disable("dns"); err != nil {
 		return fmt.Errorf("failed to disable dns component: %w", err)
 	}
 
@@ -128,8 +124,7 @@ func DisableDNSComponent(s snap.Snap) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		err = s.RestartService(ctx, "kubelet")
-		if err != nil {
+		if err := s.RestartService(ctx, "kubelet"); err != nil {
 			return fmt.Errorf("failed to restart service 'kubelet': %w", err)
 		}
 	}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 func EnableGatewayComponent(s snap.Snap) error {
@@ -30,7 +31,7 @@ func EnableGatewayComponent(s snap.Snap) error {
 		return fmt.Errorf("failed to enable gateway component: %w", err)
 	}
 
-	client, err := s.KubernetesClient()
+	client, err := k8s.NewClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyProtocol bool) error {
@@ -28,7 +29,7 @@ func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyPro
 		return fmt.Errorf("failed to enable ingress component: %w", err)
 	}
 
-	client, err := s.KubernetesClient()
+	client, err := k8s.NewClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/snap"
-	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyProtocol bool) error {
@@ -25,12 +24,11 @@ func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyPro
 		},
 	}
 
-	err = manager.Refresh("network", values)
-	if err != nil {
+	if err := manager.Refresh("network", values); err != nil {
 		return fmt.Errorf("failed to enable ingress component: %w", err)
 	}
 
-	client, err := k8s.NewClient(s)
+	client, err := s.KubernetesClient()
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
@@ -38,14 +36,11 @@ func EnableIngressComponent(s snap.Snap, defaultTLSSecret string, enableProxyPro
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err = k8s.RestartDeployment(ctx, client, "cilium-operator", "kube-system")
-	if err != nil {
+	if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 	}
-
-	err = k8s.RestartDaemonset(ctx, client, "cilium", "kube-system")
-	if err != nil {
-		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
+	if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
+		return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 	}
 
 	return nil
@@ -65,8 +60,7 @@ func DisableIngressComponent(s snap.Snap) error {
 			"enableProxyProtocol":    false,
 		},
 	}
-	err = manager.Refresh("network", values)
-	if err != nil {
+	if err := manager.Refresh("network", values); err != nil {
 		return fmt.Errorf("failed to disable ingress component: %w", err)
 	}
 

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 func EnableLoadBalancerComponent(s snap.Snap, cidrs []string, l2Enabled bool, l2Interfaces []string, bgpEnabled bool, bgpLocalASN int, bgpPeerAddress string, bgpPeerASN int, bgpPeerPort int) error {
@@ -67,7 +68,7 @@ func EnableLoadBalancerComponent(s snap.Snap, cidrs []string, l2Enabled bool, l2
 		return fmt.Errorf("failed to enable loadbalancer component: %w", err)
 	}
 
-	client, err := s.KubernetesClient()
+	client, err := k8s.NewClient(s)
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -93,8 +93,7 @@ func EnableNetworkComponent(s snap.Snap, podCIDR string) error {
 		}
 	}
 
-	err = manager.Enable("network", values)
-	if err != nil {
+	if err := manager.Enable("network", values); err != nil {
 		return fmt.Errorf("failed to enable network component: %w", err)
 	}
 
@@ -107,8 +106,7 @@ func DisableNetworkComponent(s snap.Snap) error {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
 
-	err = manager.Disable("network")
-	if err != nil {
+	if err := manager.Disable("network"); err != nil {
 		return fmt.Errorf("failed to disable network component: %w", err)
 	}
 

--- a/src/k8s/pkg/component/storage.go
+++ b/src/k8s/pkg/component/storage.go
@@ -37,8 +37,7 @@ func EnableStorageComponent(s snap.Snap) error {
 		},
 	}
 
-	err = manager.Enable("storage", values)
-	if err != nil {
+	if err := manager.Enable("storage", values); err != nil {
 		return fmt.Errorf("failed to enable storage component: %w", err)
 	}
 
@@ -51,8 +50,7 @@ func DisableStorageComponent(s snap.Snap) error {
 		return fmt.Errorf("failed to get component manager: %w", err)
 	}
 
-	err = manager.Disable("storage")
-	if err != nil {
+	if err := manager.Disable("storage"); err != nil {
 		return fmt.Errorf("failed to disable storage component: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/api/impl/k8sd.go
+++ b/src/k8s/pkg/k8sd/api/impl/k8sd.go
@@ -15,17 +15,16 @@ import (
 func GetClusterStatus(ctx context.Context, s *state.State) (apiv1.ClusterStatus, error) {
 	snap := snap.SnapFromContext(s.Context)
 
-	k8sClient, err := k8s.NewClient(snap)
+	client, err := k8s.NewClient(snap)
 	if err != nil {
 		return apiv1.ClusterStatus{}, fmt.Errorf("failed to create k8s client: %w", err)
 	}
 
-	err = k8s.WaitApiServerReady(ctx, k8sClient)
-	if err != nil {
+	if err := client.WaitApiServerReady(ctx); err != nil {
 		return apiv1.ClusterStatus{}, fmt.Errorf("k8s api server did not become ready in time: %w", err)
 	}
 
-	ready, err := k8s.ClusterReady(ctx, k8sClient)
+	ready, err := client.ClusterReady(ctx)
 	if err != nil {
 		return apiv1.ClusterStatus{}, fmt.Errorf("failed to get cluster components: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -70,7 +70,7 @@ func postWorkerInfo(s *state.State, r *http.Request) response.Response {
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to create kubernetes client: %w", err))
 	}
-	servers, err := k8s.GetKubeAPIServerEndpoints(s.Context, client)
+	servers, err := client.GetKubeAPIServerEndpoints(s.Context)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to retrieve list of known kube-apiserver endpoints: %w", err))
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -253,13 +253,12 @@ func onBootstrapControlPlane(s *state.State, initConfig map[string]string) error
 	}
 
 	// Wait for API server to come up
-	k8sClient, err := k8s.NewClient(snap)
+	client, err := k8s.NewClient(snap)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client: %w", err)
 	}
 
-	err = k8s.WaitApiServerReady(s.Context, k8sClient)
-	if err != nil {
+	if err := client.WaitApiServerReady(s.Context); err != nil {
 		return fmt.Errorf("k8s api server did not become ready in time: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -132,14 +132,13 @@ func onPostJoin(s *state.State, initConfig map[string]string) error {
 	}
 
 	// Wait for API server to come up
-	k8sClient, err := k8s.NewClient(snap)
+	client, err := k8s.NewClient(snap)
 	if err != nil {
-		return fmt.Errorf("failed to create k8s client: %w", err)
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	err = k8s.WaitApiServerReady(s.Context, k8sClient)
-	if err != nil {
-		return fmt.Errorf("k8s api server did not become ready in time: %w", err)
+	if err := client.WaitApiServerReady(s.Context); err != nil {
+		return fmt.Errorf("kube-apiserver did not become ready: %w", err)
 	}
 
 	return nil

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
-	"github.com/canonical/k8s/pkg/utils/k8s"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // Snap abstracts file system paths and interacting with the k8s services.
@@ -41,5 +41,5 @@ type Snap interface {
 
 	Components() map[string]types.Component // available components
 
-	KubernetesClient() (*k8s.Client, error) // admin kubernetes client
+	KubernetesRESTClientGetter() genericclioptions.RESTClientGetter // admin kubernetes client
 }

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 // Snap abstracts file system paths and interacting with the k8s services.
@@ -39,4 +40,6 @@ type Snap interface {
 	ServiceExtraConfigDir() string // /var/snap/k8s/common/args/conf.d
 
 	Components() map[string]types.Component // available components
+
+	KubernetesClient() (*k8s.Client, error) // admin kubernetes client
 }

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -41,5 +41,5 @@ type Snap interface {
 
 	Components() map[string]types.Component // available components
 
-	KubernetesRESTClientGetter() genericclioptions.RESTClientGetter // admin kubernetes client
+	KubernetesRESTClientGetter(namespace string) genericclioptions.RESTClientGetter // admin kubernetes client
 }

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
-	"github.com/canonical/k8s/pkg/utils/k8s"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 type Mock struct {
@@ -30,7 +30,7 @@ type Mock struct {
 	ServiceArgumentsDir         string
 	ServiceExtraConfigDir       string
 	Components                  map[string]types.Component
-	KubernetesClient            *k8s.Client
+	KubernetesRESTClientGetter  genericclioptions.RESTClientGetter
 }
 
 // Snap is a mock implementation for snap.Snap.
@@ -133,8 +133,8 @@ func (s *Snap) ServiceExtraConfigDir() string {
 func (s *Snap) Components() map[string]types.Component {
 	return s.Mock.Components
 }
-func (s *Snap) KubernetesClient() (*k8s.Client, error) {
-	return s.Mock.KubernetesClient, nil
+func (s *Snap) KubernetesRESTClientGetter() genericclioptions.RESTClientGetter {
+	return s.Mock.KubernetesRESTClientGetter
 }
 
 var _ snap.Snap = &Snap{}

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -133,7 +133,7 @@ func (s *Snap) ServiceExtraConfigDir() string {
 func (s *Snap) Components() map[string]types.Component {
 	return s.Mock.Components
 }
-func (s *Snap) KubernetesRESTClientGetter() genericclioptions.RESTClientGetter {
+func (s *Snap) KubernetesRESTClientGetter(namespace string) genericclioptions.RESTClientGetter {
 	return s.Mock.KubernetesRESTClientGetter
 }
 

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 )
 
 type Mock struct {
@@ -29,6 +30,7 @@ type Mock struct {
 	ServiceArgumentsDir         string
 	ServiceExtraConfigDir       string
 	Components                  map[string]types.Component
+	KubernetesClient            *k8s.Client
 }
 
 // Snap is a mock implementation for snap.Snap.
@@ -130,6 +132,9 @@ func (s *Snap) ServiceExtraConfigDir() string {
 }
 func (s *Snap) Components() map[string]types.Component {
 	return s.Mock.Components
+}
+func (s *Snap) KubernetesClient() (*k8s.Client, error) {
+	return s.Mock.KubernetesClient, nil
 }
 
 var _ snap.Snap = &Snap{}

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
-	"github.com/canonical/k8s/pkg/utils/k8s"
 	"gopkg.in/yaml.v2"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // snap implements the Snap interface.
@@ -205,12 +205,10 @@ func (s *snap) Components() map[string]types.Component {
 	}
 }
 
-func (s *snap) KubernetesClient() (*k8s.Client, error) {
-	client, err := k8s.NewClientFromKubeconfig("/etc/kubernetes/admin.conf")
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve admin kubernetes client: %w", err)
+func (s *snap) KubernetesRESTClientGetter() genericclioptions.RESTClientGetter {
+	return &genericclioptions.ConfigFlags{
+		KubeConfig: &[]string{"/etc/kubernetes/admin.conf"}[0],
 	}
-	return client, nil
 }
 
 var _ Snap = &snap{}

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 	"gopkg.in/yaml.v2"
 )
 
@@ -202,6 +203,14 @@ func (s *snap) Components() map[string]types.Component {
 			Namespace:    "kube-system",
 		},
 	}
+}
+
+func (s *snap) KubernetesClient() (*k8s.Client, error) {
+	client, err := k8s.NewClientFromKubeconfig("/etc/kubernetes/admin.conf")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve admin kubernetes client: %w", err)
+	}
+	return client, nil
 }
 
 var _ Snap = &snap{}

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -205,10 +205,14 @@ func (s *snap) Components() map[string]types.Component {
 	}
 }
 
-func (s *snap) KubernetesRESTClientGetter() genericclioptions.RESTClientGetter {
-	return &genericclioptions.ConfigFlags{
+func (s *snap) KubernetesRESTClientGetter(namespace string) genericclioptions.RESTClientGetter {
+	flags := &genericclioptions.ConfigFlags{
 		KubeConfig: &[]string{"/etc/kubernetes/admin.conf"}[0],
 	}
+	if namespace != "" {
+		flags.Namespace = &namespace
+	}
+	return flags
 }
 
 var _ Snap = &snap{}

--- a/src/k8s/pkg/utils/k8s/client.go
+++ b/src/k8s/pkg/utils/k8s/client.go
@@ -3,8 +3,8 @@ package k8s
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/snap"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Client is a wrapper around the kubernetes.Interface.
@@ -12,8 +12,8 @@ type Client struct {
 	kubernetes.Interface
 }
 
-func NewClientFromKubeconfig(kubeconfigPath string) (*Client, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+func NewClient(snap snap.Snap) (*Client, error) {
+	config, err := snap.KubernetesRESTClientGetter().ToRESTConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build Kubernetes REST config: %w", err)
 	}

--- a/src/k8s/pkg/utils/k8s/client.go
+++ b/src/k8s/pkg/utils/k8s/client.go
@@ -13,7 +13,7 @@ type Client struct {
 }
 
 func NewClient(snap snap.Snap) (*Client, error) {
-	config, err := snap.KubernetesRESTClientGetter().ToRESTConfig()
+	config, err := snap.KubernetesRESTClientGetter("").ToRESTConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build Kubernetes REST config: %w", err)
 	}

--- a/src/k8s/pkg/utils/k8s/client.go
+++ b/src/k8s/pkg/utils/k8s/client.go
@@ -2,36 +2,24 @@ package k8s
 
 import (
 	"fmt"
-	"path"
 
-	"github.com/canonical/k8s/pkg/snap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// k8sClient is a wrapper around the k8s clientset
-type k8sClient struct {
+// Client is a wrapper around the kubernetes.Interface.
+type Client struct {
 	kubernetes.Interface
 }
 
-// NewClient creates a client to the k8s cluster.
-//
-// TODO:
-// There is no way for the user to overwrite this kubeconfig.
-// We might need to add this functionality similar to `k8s kubectl`.
-// However, simply querying the KUBECONFIG env will not work for remote clients.
-func NewClient(snap snap.Snap) (*k8sClient, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", path.Join(snap.KubernetesConfigDir(), "admin.conf"))
+func NewClientFromKubeconfig(kubeconfigPath string) (*Client, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create k8s kubeconfig: %w", err)
+		return nil, fmt.Errorf("failed to build Kubernetes REST config: %w", err)
 	}
-
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create k8s clientset: %w", err)
+		return nil, fmt.Errorf("failed to create Kubernetes clientset: %w", err)
 	}
-
-	return &k8sClient{
-		clientset,
-	}, nil
+	return &Client{clientset}, nil
 }

--- a/src/k8s/pkg/utils/k8s/endpoints.go
+++ b/src/k8s/pkg/utils/k8s/endpoints.go
@@ -10,8 +10,8 @@ import (
 
 // GetKubeAPIServerEndpoints retrieves the known kube-apiserver endpoints of the cluster.
 // GetKubeAPIServerEndpoints returns an error if the list of endpoints is empty.
-func GetKubeAPIServerEndpoints(ctx context.Context, client *k8sClient) ([]string, error) {
-	endpoint, err := client.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+func (c *Client) GetKubeAPIServerEndpoints(ctx context.Context) ([]string, error) {
+	endpoint, err := c.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get endpoints for kubernetes service: %w", err)
 	}

--- a/src/k8s/pkg/utils/k8s/endpoints_test.go
+++ b/src/k8s/pkg/utils/k8s/endpoints_test.go
@@ -102,9 +102,9 @@ func TestGetKubeAPIServerEndpoints(t *testing.T) {
 			g := NewWithT(t)
 
 			clientset := fake.NewSimpleClientset(tc.objects...)
-			k8sClient := &k8sClient{Interface: clientset}
+			client := &Client{Interface: clientset}
 
-			servers, err := GetKubeAPIServerEndpoints(context.Background(), k8sClient)
+			servers, err := client.GetKubeAPIServerEndpoints(context.Background())
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(servers).To(BeEmpty())

--- a/src/k8s/pkg/utils/k8s/restart_daemonset.go
+++ b/src/k8s/pkg/utils/k8s/restart_daemonset.go
@@ -9,13 +9,13 @@ import (
 )
 
 // RestartDaemonset updates the restartedAt field to trigger a rollout restart for the given DaemonSet.
-func RestartDaemonset(ctx context.Context, client *k8sClient, name, namespace string) error {
+func (c *Client) RestartDaemonset(ctx context.Context, name, namespace string) error {
 	if namespace == "" {
 		namespace = "default"
 	}
-	daemonset, err := client.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	daemonset, err := c.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed to get daemonset %s in %s: %w", name, namespace, err)
+		return fmt.Errorf("failed to get daemonset %s in namespace %s: %w", name, namespace, err)
 	}
 
 	if daemonset.Spec.Template.ObjectMeta.Annotations == nil {
@@ -23,9 +23,9 @@ func RestartDaemonset(ctx context.Context, client *k8sClient, name, namespace st
 	}
 	daemonset.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 
-	_, err = client.AppsV1().DaemonSets(namespace).Update(ctx, daemonset, metav1.UpdateOptions{})
+	_, err = c.AppsV1().DaemonSets(namespace).Update(ctx, daemonset, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed to rollout restart daemonset %s in %s: %w", name, namespace, err)
+		return fmt.Errorf("failed to set restartedAt annotation for daemonset %s in namespace %s: %w", name, namespace, err)
 	}
 	return nil
 }

--- a/src/k8s/pkg/utils/k8s/restart_daemonset_test.go
+++ b/src/k8s/pkg/utils/k8s/restart_daemonset_test.go
@@ -1,0 +1,76 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRestartDaemonset(t *testing.T) {
+	tests := []struct {
+		name        string
+		objects     []runtime.Object
+		expectError bool
+	}{
+		{
+			name:        "missing",
+			expectError: true,
+		},
+		{
+			name: "daemonset",
+			objects: []runtime.Object{
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "namespace",
+					},
+				},
+			},
+		},
+		{
+			name: "daemonset with other annotations",
+			objects: []runtime.Object{
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "namespace",
+					},
+					Spec: appsv1.DaemonSetSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"test": "val",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			clientset := fake.NewSimpleClientset(tc.objects...)
+			client := &Client{Interface: clientset}
+
+			err := client.RestartDaemonset(context.Background(), "test", "namespace")
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).To(BeNil())
+				ds, err := client.AppsV1().DaemonSets("namespace").Get(context.Background(), "test", metav1.GetOptions{})
+				g.Expect(err).To(BeNil())
+				g.Expect(ds.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]).NotTo(BeEmpty())
+			}
+		})
+	}
+}

--- a/src/k8s/pkg/utils/k8s/restart_deployment.go
+++ b/src/k8s/pkg/utils/k8s/restart_deployment.go
@@ -9,13 +9,10 @@ import (
 )
 
 // RestartDeployment updates the restartedAt field to trigger a rollout restart for the given Deployment.
-func RestartDeployment(ctx context.Context, client *k8sClient, name, namespace string) error {
-	if namespace == "" {
-		namespace = "default"
-	}
-	deployment, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+func (c *Client) RestartDeployment(ctx context.Context, name, namespace string) error {
+	deployment, err := c.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed to get deployment %s in %s: %w", name, namespace, err)
+		return fmt.Errorf("failed to get deployment %s in namespace %s: %w", name, namespace, err)
 	}
 
 	if deployment.Spec.Template.ObjectMeta.Annotations == nil {
@@ -23,9 +20,9 @@ func RestartDeployment(ctx context.Context, client *k8sClient, name, namespace s
 	}
 	deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 
-	_, err = client.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	_, err = c.AppsV1().Deployments(namespace).Update(ctx, deployment, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed to rollout restart deployment %s in %s: %w", name, namespace, err)
+		return fmt.Errorf("failed to set restartedAt annotation for deployment %s in namespace %s: %w", name, namespace, err)
 	}
 	return nil
 }

--- a/src/k8s/pkg/utils/k8s/restart_deployment_test.go
+++ b/src/k8s/pkg/utils/k8s/restart_deployment_test.go
@@ -25,7 +25,7 @@ func TestRestartDeployment(t *testing.T) {
 		{
 			name: "deployment",
 			objects: []runtime.Object{
-				&appsv1.DaemonSet{
+				&appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "namespace",
@@ -62,7 +62,7 @@ func TestRestartDeployment(t *testing.T) {
 			clientset := fake.NewSimpleClientset(tc.objects...)
 			client := &Client{Interface: clientset}
 
-			err := client.RestartDaemonset(context.Background(), "test", "namespace")
+			err := client.RestartDeployment(context.Background(), "test", "namespace")
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/src/k8s/pkg/utils/k8s/restart_deployment_test.go
+++ b/src/k8s/pkg/utils/k8s/restart_deployment_test.go
@@ -1,0 +1,76 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRestartDeployment(t *testing.T) {
+	tests := []struct {
+		name        string
+		objects     []runtime.Object
+		expectError bool
+	}{
+		{
+			name:        "missing",
+			expectError: true,
+		},
+		{
+			name: "deployment",
+			objects: []runtime.Object{
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "namespace",
+					},
+				},
+			},
+		},
+		{
+			name: "deployment with other annotations",
+			objects: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "namespace",
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"test": "val",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			clientset := fake.NewSimpleClientset(tc.objects...)
+			client := &Client{Interface: clientset}
+
+			err := client.RestartDaemonset(context.Background(), "test", "namespace")
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).To(BeNil())
+				deploy, err := client.AppsV1().Deployments("namespace").Get(context.Background(), "test", metav1.GetOptions{})
+				g.Expect(err).To(BeNil())
+				g.Expect(deploy.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]).NotTo(BeEmpty())
+			}
+		})
+	}
+}

--- a/src/k8s/pkg/utils/k8s/services.go
+++ b/src/k8s/pkg/utils/k8s/services.go
@@ -8,13 +8,8 @@ import (
 )
 
 // GetServiceClusterIP retrieves the ClusterIP from a Kubernetes service.
-// An empty namespace will default to "default".
-func GetServiceClusterIP(ctx context.Context, client *k8sClient, name, namespace string) (string, error) {
-	if namespace == "" {
-		namespace = "default"
-	}
-
-	svc, err := client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+func (c *Client) GetServiceClusterIP(ctx context.Context, name, namespace string) (string, error) {
+	svc, err := c.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get service '%s' in namespace '%s': %w", name, namespace, err)
 	}

--- a/src/k8s/pkg/utils/k8s/services_test.go
+++ b/src/k8s/pkg/utils/k8s/services_test.go
@@ -53,9 +53,9 @@ func TestGetServiceClusterIP(t *testing.T) {
 			g := NewWithT(t)
 
 			clientset := fake.NewSimpleClientset(tt.serviceObjects...)
-			k8sClient := &k8sClient{Interface: clientset}
+			client := &Client{Interface: clientset}
 
-			ip, err := GetServiceClusterIP(context.Background(), k8sClient, tt.serviceName, tt.namespace)
+			ip, err := client.GetServiceClusterIP(context.Background(), tt.serviceName, tt.namespace)
 
 			if tt.expectError {
 				g.Expect(err).To(HaveOccurred())

--- a/src/k8s/pkg/utils/k8s/status_test.go
+++ b/src/k8s/pkg/utils/k8s/status_test.go
@@ -89,9 +89,9 @@ func TestClusterReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			clientset := fake.NewSimpleClientset(tt.nodes...)
-			k8sClient := &k8sClient{Interface: clientset}
+			client := &Client{Interface: clientset}
 
-			ready, err := ClusterReady(context.Background(), k8sClient)
+			ready, err := client.ClusterReady(context.Background())
 
 			g.Expect(err).To(BeNil())
 			g.Expect(ready).To(Equal(tt.expectedReady))


### PR DESCRIPTION
### Summary

Extend `type Snap interface` with a `KubernetesRESTClientGetter()`, and use it for initializing Kubernetes clients.

### Changes

- Also cleanup some `if err := ...; err != nil {}` checks in files.