### PR TITLE
Fix bootstrap config conversion

### DIFF
--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -10,9 +10,9 @@ import (
 
 type BootstrapConfig struct {
 	// Components are the components that should be enabled on bootstrap.
-	Components []string
+	Components []string `yaml:"components"`
 	// ClusterCIDR is the CIDR of the cluster.
-	ClusterCIDR string
+	ClusterCIDR string `yaml:"cluster-cidr"`
 }
 
 // SetDefaults sets the fields to default values.
@@ -23,16 +23,13 @@ func (b *BootstrapConfig) SetDefaults() {
 
 // ToMap marshals the BootstrapConfig into yaml and map it to "bootstrapConfig".
 func (b *BootstrapConfig) ToMap() (map[string]string, error) {
-	config := map[string]any{
-		"components":   b.Components,
-		"cluster-cidr": b.ClusterCIDR,
-	}
-	c, err := yaml.Marshal(config)
+	config, err := yaml.Marshal(b)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal config map: %w", err)
 	}
+
 	return map[string]string{
-		"bootstrapConfig": string(c),
+		"bootstrapConfig": string(config),
 	}, nil
 }
 

--- a/src/k8s/api/v1/types_test.go
+++ b/src/k8s/api/v1/types_test.go
@@ -1,0 +1,27 @@
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestBootstrapConfigFromMap(t *testing.T) {
+	g := NewWithT(t)
+	// Create a new BootstrapConfig with default values
+	bc := &BootstrapConfig{}
+	bc.SetDefaults()
+
+	// Convert the BootstrapConfig to a map
+	m, err := bc.ToMap()
+	g.Expect(err).To(BeNil())
+
+	// Unmarshal the YAML string from the map into a new BootstrapConfig instance
+	bcyaml, err := BootstrapConfigFromMap(m)
+
+	// Check for errors
+	g.Expect(err).To(BeNil())
+	// Compare the unmarshaled BootstrapConfig with the original one
+	g.Expect(bcyaml).To(Equal(bc)) // Note the *bc here to compare values, not pointers
+
+}

--- a/src/k8s/api/v1/types_test.go
+++ b/src/k8s/api/v1/types_test.go
@@ -9,8 +9,10 @@ import (
 func TestBootstrapConfigFromMap(t *testing.T) {
 	g := NewWithT(t)
 	// Create a new BootstrapConfig with default values
-	bc := &BootstrapConfig{}
-	bc.SetDefaults()
+	bc := &BootstrapConfig{
+		Components:  []string{"dns", "network", "storage"},
+		ClusterCIDR: "10.1.0.0/16",
+	}
 
 	// Convert the BootstrapConfig to a map
 	m, err := bc.ToMap()


### PR DESCRIPTION
### Description
Currently, any bootstrap config specified during k8s bootstrap is ignored, because the marshal/unmarshal implementation is broken.
This PR ensures that the conversion of the bootstrap from a map to yaml and back works.

There is a bug because we need tags to ensure proper marshaling and unmarshaling of the bootstrap config.

Adding the yaml tags solves our problem:
```
type BootstrapConfig struct {
  Components []string `yaml:"components"`
  ClusterCIDR string `yaml:"cluster-cidr"`
}
```