### PR TITLE
Enable NodeRescript admission plugin

### DIFF
--- a/k8s/args/kube-apiserver
+++ b/k8s/args/kube-apiserver
@@ -23,7 +23,7 @@
 --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt
 --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
 #~Enable the aggregation layer
-#--enable-admission-plugins=EventRateLimit
+--enable-admission-plugins=NodeRestriction
 #--admission-control-config-file=${SNAP_DATA}/args/admission-control-config-file.yaml
 --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt
 --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -44,6 +44,7 @@ func KubeAPIServer(snap snap.Snap, serviceCIDR string, authWebhookURL string, en
 		"--allow-privileged":                         "true",
 		"--service-account-issuer":                   "https://kubernetes.default.svc",
 		"--authentication-token-webhook-config-file": authTokenWebhookConfigFile,
+		"--enable-admission-plugins":                 "NodeRestriction",
 		"--kubelet-preferred-address-types":          "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP",
 		"--kubelet-certificate-authority":            path.Join(snap.KubernetesPKIDir(), "ca.crt"),
 	}


### PR DESCRIPTION
enabling the `NodeRestriction` plugin to put restrictions on the kubelet
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction

Among such restrictions are:

> kubelets will only be allowed to modify their own Node API object, and only modify Pod API objects that are bound to their node. kubelets are not allowed to update or remove taints from their Node API object

> Prevents kubelets from adding/removing/updating labels with a node-restriction.kubernetes.io/ prefix. This label prefix is reserved for administrators to label their Node objects for workload isolation purposes, and kubelets will not be allowed to modify labels with that prefix.