### PR TITLE
Ensure CI runs when pushing to autoupdate/strict branch

### DIFF
--- a/.github/workflows/strict.yaml
+++ b/.github/workflows/strict.yaml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY_TO_UPDATE_STRICT_BRANCH }}
       - name: Apply strict patch
         run: |
           git checkout -b autoupdate/strict
-          git config --global user.email k8s-bot@canonical.com
-          git config --global user.name k8s-bot
           git am ./build-scripts/patches/strict/*.patch
       - name: Push to autoupdate/strict branch
         run: |


### PR DESCRIPTION
Ensure CI runs when pushing to autoupdate/strict branch from GitHub Actions