### PR TITLE
Add machinery to make errors human-readable

### DIFF
--- a/src/k8s/api/v1/errors.go
+++ b/src/k8s/api/v1/errors.go
@@ -1,0 +1,20 @@
+package v1
+
+import (
+	"github.com/canonical/k8s/pkg/utils/errors"
+)
+
+var Errors = []error{
+	&ErrNotBootstrapped{},
+}
+
+// Server-side errors
+type ErrNotBootstrapped struct{}
+
+func (e ErrNotBootstrapped) Error() string {
+	return "no such file or directory"
+}
+
+func (e ErrNotBootstrapped) Is(err error) bool {
+	return errors.DeeplyUnwrapError(err).Error() == e.Error()
+}

--- a/src/k8s/cmd/k8s/errors/types.go
+++ b/src/k8s/cmd/k8s/errors/types.go
@@ -1,0 +1,5 @@
+package errors
+
+// Contains custom error types that can pop up on the client.
+var ErrAlreadyBootstrapped error
+var ErrConnectionFailed error

--- a/src/k8s/cmd/k8s/errors/wrapper.go
+++ b/src/k8s/cmd/k8s/errors/wrapper.go
@@ -1,0 +1,59 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+
+	v1 "github.com/canonical/k8s/api/v1"
+	"github.com/spf13/cobra"
+)
+
+var genericErrorMsgs = map[error]string{
+	&v1.ErrNotBootstrapped{}: fmt.Sprintln("The cluster has not been initialized yet. Please call:\n\n    sudo k8s bootstrap")
+	ErrConnectionFailed: `Unable to connect to the local cluster.`,
+}
+
+type ErrorWrapper struct {
+	err             error
+	CustomErrorMsgs map[error]string
+}
+
+// RunE fails to proceed further in case of error resulting in not executing PostRun actions
+func (w *ErrorWrapper) Run(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) {
+	fmt.Println("test")
+	return func(cmd *cobra.Command, args []string) {
+		err := f(cmd, args)
+		fmt.Println(err)
+		w.err = err
+	}
+}
+
+func (w *ErrorWrapper) TransformToHumanError() func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Transform to human error: %v", w.err)
+		return w.toHumanError()
+	}
+}
+
+func (w *ErrorWrapper) toHumanError() error {
+	fmt.Println("Error is:", w.err)
+	if w.err == nil {
+		return nil
+	}
+
+	if ew.CustomErrorMsgs != nil {
+		// CustomErrorMsgs should have higher prio then generic ones, so we don't merge them.
+		for errorType, msg := range ew.CustomErrorMsgs {
+			if errors.Is(w.err, errorType) {
+				return errors.New(msg)
+			}
+		}
+	}
+
+	for errorType, msg := range genericErrorMsgs {
+		if errors.Is(w.err, errorType) {
+			return errors.New(msg)
+		}
+	}
+	return w.err
+}

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/cmd/k8s/errors"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,8 @@ var (
 		logVerbose bool
 	}
 
+	ew = errors.ErrorWrapper{}
+
 	rootCmd = &cobra.Command{
 		Use:   "k8s",
 		Short: "Canonical Kubernetes CLI",
@@ -22,11 +25,13 @@ var (
 				return fmt.Errorf("failed to check if command runs as root: %w", err)
 			}
 			if !withRoot {
-				return fmt.Errorf("k8s CLI needs to run with root priviledge.")
+				return fmt.Errorf("You do not have enough permissions. Please run the command with sudo.")
 			}
 			return nil
 		},
-		SilenceUsage: true,
+		PersistentPostRunE: ew.TransformToHumanError(),
+		SilenceUsage:       true,
+		SilenceErrors:      true,
 	}
 )
 

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/cmd/k8s/errors"
 	"github.com/canonical/k8s/pkg/k8s/client"
 	"github.com/spf13/cobra"
 )
@@ -17,11 +18,17 @@ var (
 		interactive bool
 	}
 
+	bootstrapCmdErrorMsgs = map[error]string{
+		errors.ErrAlreadyBootstrapped: "K8s cluster already bootstrapped.",
+	}
+
 	boostrapCmd = &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Bootstrap a k8s cluster on this node.",
 		Long:  "Initialize the necessary folders, permissions, service arguments, certificates and start up the Kubernetes services.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: ew.Run(func(cmd *cobra.Command, args []string) (err error) {
+			ew.CustomErrorMsgs = bootstrapCmdErrorMsgs
+
 			c, err := client.NewClient(cmd.Context(), client.ClusterOpts{
 				StateDir: clusterCmdOpts.stateDir,
 				Verbose:  rootCmdOpts.logVerbose,
@@ -49,7 +56,7 @@ var (
 
 			fmt.Printf("Bootstrapped k8s cluster on %q (%s).\n", cluster.Name, cluster.Address)
 			return nil
-		},
+		}),
 	}
 )
 

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -21,7 +21,7 @@ var (
 		Use:    "status",
 		Short:  "Retrieve the current status of the cluster",
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: ew.Run(func(cmd *cobra.Command, args []string) error {
 			c, err := client.NewClient(cmd.Context(), client.ClusterOpts{
 				StateDir: clusterCmdOpts.stateDir,
 				Verbose:  rootCmdOpts.logVerbose,
@@ -49,7 +49,7 @@ var (
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}
 			return f.Print(clusterStatus)
-		},
+		}),
 	}
 )
 

--- a/src/k8s/cmd/k8s/main.go
+++ b/src/k8s/cmd/k8s/main.go
@@ -1,11 +1,13 @@
 package k8s
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func Main() {
-	if rootCmd.Execute() != nil {
-		// TODO: We need to define actionable error message in the future
-		// That tell the user what went wrong on a high-level and - if possible - how it can be fixed.
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(rootCmd.ErrOrStderr(), err)
 		os.Exit(1)
 	}
 }

--- a/src/k8s/pkg/k8s/client/client_test.go
+++ b/src/k8s/pkg/k8s/client/client_test.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	v1 "github.com/canonical/k8s/api/v1"
+	. "github.com/onsi/gomega"
+)
+
+func TestResolveError(t *testing.T) {
+	g := NewWithT(t)
+	myErr := errors.New("Daemon not yet initialized")
+	err := resolveError(myErr)
+	g.Expect(errors.Is(err, &v1.ErrNotBootstrapped{})).To(BeTrue())
+}

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -62,7 +62,7 @@ func (c *Client) Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapC
 func (c *Client) ClusterStatus(ctx context.Context, waitReady bool) (apiv1.ClusterStatus, error) {
 	var response apiv1.GetClusterStatusResponse
 	err := control.WaitUntilReady(ctx, func() (bool, error) {
-		err := c.mc.Query(ctx, "GET", api.NewURL().Path("k8sd", "cluster"), nil, &response)
+		err := c.Query(ctx, "GET", api.NewURL().Path("k8sd", "cluster"), nil, &response)
 		if err != nil {
 			return false, err
 		}
@@ -77,7 +77,7 @@ func (c *Client) KubeConfig(ctx context.Context) (string, error) {
 	defer cancel()
 
 	var response apiv1.GetKubeConfigResponse
-	err := c.mc.Query(queryCtx, "GET", api.NewURL().Path("k8sd", "kubeconfig"), nil, &response)
+	err := c.Query(queryCtx, "GET", api.NewURL().Path("k8sd", "kubeconfig"), nil, &response)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return "", fmt.Errorf("failed to query endpoint GET /k8sd/kubeconfig on %q: %w", clientURL.String(), err)

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -23,7 +23,7 @@ func (c *Client) JoinCluster(ctx context.Context, name string, address string, t
 		Token:   token,
 	}
 	var response apiv1.JoinClusterResponse
-	err := c.mc.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster", "join"), request, &response)
+	err := c.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster", "join"), request, &response)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed with error:", err)
 

--- a/src/k8s/pkg/k8s/client/component.go
+++ b/src/k8s/pkg/k8s/client/component.go
@@ -15,7 +15,7 @@ func (c *Client) ListComponents(ctx context.Context) ([]api.Component, error) {
 	defer cancel()
 
 	var response api.GetComponentsResponse
-	err := c.mc.Query(queryCtx, "GET", lxdApi.NewURL().Path("k8sd", "components"), nil, &response)
+	err := c.Query(queryCtx, "GET", lxdApi.NewURL().Path("k8sd", "components"), nil, &response)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return nil, fmt.Errorf("failed to query endpoint GET /k8sd/components on %q: %w", clientURL.String(), err)
@@ -28,7 +28,7 @@ func (c *Client) UpdateDNSComponent(ctx context.Context, request api.UpdateDNSCo
 	defer cancel()
 
 	var response api.UpdateDNSComponentResponse
-	err := c.mc.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "dns"), request, &response)
+	err := c.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "dns"), request, &response)
 	if err != nil {
 		return fmt.Errorf("failed to enable dns component: %w", err)
 	}
@@ -40,7 +40,7 @@ func (c *Client) UpdateNetworkComponent(ctx context.Context, request api.UpdateN
 	defer cancel()
 
 	var response api.UpdateNetworkComponentResponse
-	err := c.mc.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "network"), request, &response)
+	err := c.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "network"), request, &response)
 	if err != nil {
 		return fmt.Errorf("failed to enable network component: %w", err)
 	}
@@ -52,7 +52,7 @@ func (c *Client) UpdateStorageComponent(ctx context.Context, request api.UpdateS
 	defer cancel()
 
 	var response api.UpdateStorageComponentResponse
-	err := c.mc.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "storage"), request, &response)
+	err := c.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "storage"), request, &response)
 	if err != nil {
 		return fmt.Errorf("failed to enable storage component: %w", err)
 	}
@@ -64,7 +64,7 @@ func (c *Client) UpdateIngressComponent(ctx context.Context, request api.UpdateI
 	defer cancel()
 
 	var response api.UpdateIngressComponentResponse
-	err := c.mc.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "ingress"), request, &response)
+	err := c.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "ingress"), request, &response)
 	if err != nil {
 		return fmt.Errorf("failed to enable ingress component: %w", err)
 	}
@@ -76,7 +76,7 @@ func (c *Client) UpdateGatewayComponent(ctx context.Context, request api.UpdateG
 	defer cancel()
 
 	var response api.UpdateGatewayComponentResponse
-	err := c.mc.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "gateway"), request, &response)
+	err := c.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "gateway"), request, &response)
 	if err != nil {
 		return fmt.Errorf("failed to enable gateway component: %w", err)
 	}
@@ -88,7 +88,7 @@ func (c *Client) UpdateLoadBalancerComponent(ctx context.Context, request api.Up
 	defer cancel()
 
 	var response api.UpdateLoadBalancerComponentResponse
-	if err := c.mc.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "loadbalancer"), request, &response); err != nil {
+	if err := c.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "components", "loadbalancer"), request, &response); err != nil {
 		return fmt.Errorf("failed to enable loadbalancer component: %w", err)
 	}
 	return nil

--- a/src/k8s/pkg/k8s/client/kubernetes_auth_tokens.go
+++ b/src/k8s/pkg/k8s/client/kubernetes_auth_tokens.go
@@ -17,7 +17,7 @@ func (c *Client) GenerateAuthToken(ctx context.Context, username string, groups 
 	request := apiv1.CreateKubernetesAuthTokenRequest{Username: username, Groups: groups}
 	response := apiv1.CreateKubernetesAuthTokenResponse{}
 
-	err := c.mc.Query(queryCtx, "POST", api.NewURL().Path("kubernetes", "auth", "tokens"), request, &response)
+	err := c.Query(queryCtx, "POST", api.NewURL().Path("kubernetes", "auth", "tokens"), request, &response)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return "", fmt.Errorf("failed to query endpoint POST /kubernetes/auth/tokens on %q: %w", clientURL.String(), err)

--- a/src/k8s/pkg/k8s/client/tokens.go
+++ b/src/k8s/pkg/k8s/client/tokens.go
@@ -15,7 +15,7 @@ func (c *Client) CreateJoinToken(ctx context.Context, name string, worker bool) 
 	}
 	response := apiv1.TokensResponse{}
 
-	err := c.mc.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster", "tokens"), request, &response)
+	err := c.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster", "tokens"), request, &response)
 	if err != nil {
 		return "", fmt.Errorf("failed to query endpoint POST /k8sd/cluster/tokens: %w", err)
 	}

--- a/src/k8s/pkg/utils/errors/errors.go
+++ b/src/k8s/pkg/utils/errors/errors.go
@@ -1,0 +1,16 @@
+package errors
+
+import "errors"
+
+// DeeplyUnwrapError unwraps an wrapped error.
+// DeeplyUnwrapError will return the innermost error for deeply nested errors.
+// DeeplyUnwrapError will return the existing error if the error is not wrapped.
+func DeeplyUnwrapError(err error) error {
+	for {
+		cause := errors.Unwrap(err)
+		if cause == nil {
+			return err
+		}
+		err = cause
+	}
+}

--- a/src/k8s/pkg/utils/errors/errors_test.go
+++ b/src/k8s/pkg/utils/errors/errors_test.go
@@ -1,0 +1,46 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestDeeplyUnwrapError(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Run("when error is not wrapped", func(t *testing.T) {
+		err := errors.New("test error")
+		unwrapped := DeeplyUnwrapError(err)
+
+		g.Expect(unwrapped).To(gomega.Equal(err))
+	})
+
+	t.Run("when error is wrapped once", func(t *testing.T) {
+		innerErr := errors.New("inner error")
+		err := fmt.Errorf("outer wrapper: %w", innerErr)
+
+		unwrapped := DeeplyUnwrapError(err)
+
+		g.Expect(unwrapped).To(gomega.Equal(innerErr))
+	})
+
+	t.Run("when error is deeply nested", func(t *testing.T) {
+		innermostErr := errors.New("innermost error")
+		innerErr := fmt.Errorf("middle wrapper: %w", innermostErr)
+		err := fmt.Errorf("outer wrapper: %w", innerErr)
+
+		unwrapped := DeeplyUnwrapError(err)
+
+		g.Expect(unwrapped).To(gomega.Equal(innermostErr))
+	})
+
+	t.Run("when error is nil", func(t *testing.T) {
+		var err error
+		unwrapped := DeeplyUnwrapError(err)
+
+		g.Expect(unwrapped).To(gomega.BeNil())
+	})
+}


### PR DESCRIPTION
We face four different kinds of errors in the k8s-snap. This commit adds machinery to handle all of them:

On the server-side there are:

1. microcluster errors: errors that directly come from microcluster. They are untyped and we need to rely on the error string to handle them.

2. server-side errors: error that happen in our system and that we can formally define.

The errors are not preserved on the client. Microcluster simply sends the error message and creates a new error on the client. This means we cannot rely on error types by default. But we can define custom errors in `api/v1/errors.go` that support a direct string comparison by implementing the `Error` and `Is` interfaces.

For server-side errors we can simply use the exposed error types and the string comparison will always work. The error is basically just serialized on the server and deserialized on the client.

For the microcluster errors we need to be careful on library upgrades. The error messages are not recognized anymore, if microcluster changes the error messages. We can avoid this by adding strict integration tests that validate the explicit CLI output.

On the client-side there are:

3. generic client-side errors: errors that pop up on the client/CLI, e.g. cannot connect to k8sd and apply for all commands.

4. custom client-side errors: errors that are unique for a specific command, e.g. ErrAlreadyBootstrapped.

This commit generically resolve those error by defining an error wrapper (`cmd/k8s/errors/wrapper.go`) that is injected at the root `k8s` CLI command and tries to resolve any error to a human-readable message. Generic errors translations are defined in the wrapper module, custom error messages can be defined in the command (see e.g. `k8s_bootstrap.go`)