### PR TITLE
do not fail if cni plugins already exist

### DIFF
--- a/src/k8s/pkg/k8sd/setup/containerd.go
+++ b/src/k8s/pkg/k8sd/setup/containerd.go
@@ -66,8 +66,8 @@ func Containerd(snap snap.Snap) error {
 
 		// if the destination file is already a symlink to "cni", we don't have to do anything
 		// if not, then attempt to remove the existing file
-		if link, err := os.Readlink(pluginInstallPath); err == nil {
-			if link == "cni" {
+		if _, err := os.Stat(pluginInstallPath); err == nil {
+			if link, err := os.Readlink(pluginInstallPath); err == nil && link == "cni" {
 				continue
 			}
 			if err := os.Remove(pluginInstallPath); err != nil {


### PR DESCRIPTION
### Summary

If any of the cni plugins already exist, do not fail. Fixes the following error:

```
root@t1:~# k8s bootstrap
Failed with error: failed to configure containerd: failed to symlink cni plugin bandwidth: symlink cni /opt/cni/bin/bandwidth: file exists
```