### PR TITLE
Docs: add community page

### DIFF
--- a/docs/src/reference/community.md
+++ b/docs/src/reference/community.md
@@ -1,41 +1,66 @@
 # Welcome to the Canonical Kubernetes community!
 
-This rapidly growing community is a diverse bunch of people - developers, Kubernetes admins, inventors, researchers, students… and we all share the joy of a reliable, flexible, secure, timely version of upstream Kubernetes. The team recognise the important role each and every user plays in the success of the project as a whole and how valuable your contributions are.
+This rapidly growing community is a diverse bunch of people - developers,
+Kubernetes admins, inventors, researchers, students… and we all share the joy
+of a reliable, flexible, secure, timely version of upstream Kubernetes. The
+team recognise the important role each and every user plays in the success of
+the project as a whole and how valuable your contributions are.
 
 ## Do you have questions?
 
-Do you have questions about Canonical Kubernetes? Perhaps you want some ideas on how to best achieve a certain goal or maybe some aspect of your Kubernetes doesn't behave the way you expect. Perhaps you'd just like some advice from more experienced users. There are a number of ways to get in touch:
+Do you have questions about Canonical Kubernetes? Perhaps you want some ideas
+on how to best achieve a certain goal or maybe some aspect of your Kubernetes
+doesn't behave the way you expect. Perhaps you'd just like some advice from
+more experienced users. There are a number of ways to get in touch:
 
 - Using the [Kubernetes slack][slack]: find us in the #canonical-kubernetes channel
 - In the public [Matrix room][matrix]
 - On the [Ubuntu Discourse][discourse]
 
-For more formal support, please see the support options available to you on the [Ubuntu website][support].
+For more formal support, please see the support options available to you on the
+[Ubuntu website][support].
 
-**Our commitment to you** - we may not always be able to answer your questions, but we promise to respond within three working days.
+**Our commitment to you** - we may not always be able to answer your questions,
+but we promise to respond within three working days.
 
 ## Found a bug?
 
-You can always track what is going on with development by tracking the developments on Github. This is also the best place to file a bug if you find one, or of course you are also welcome to contribute to the code.
+You can always track what is going on with development by tracking the
+developments on Github. This is also the best place to file a bug if you find
+one, or of course you are also welcome to contribute to the code.
 
-**Our commitment to you** - we monitor the issues on github regularly and we aim to triage all bug reports within three working days.
+**Our commitment to you** - we monitor the issues on github regularly and we
+aim to triage all bug reports within three working days.
 
 
 ## Contributing to the code? 
 
-Canonical Kubernetes is proudly open source, published under the GPLv3 license. We welcome and encourage contributions to the code. Please see the [Developer guide] for more information on contributing.
+Canonical Kubernetes is proudly open source, published under the GPLv3 license.
+We welcome and encourage contributions to the code. Please see the [Developer
+guide] for more information on contributing.
 
-**Our commitment to you** - we closely follow activity on the source repository. We aim to respond to any PRs within three working days. 
+**Our commitment to you** - we closely follow activity on the source
+repository. We aim to respond to any PRs within three working days. 
 
 ## Contributing to docs?
 
-Our documentation is extremely important to us and is actively maintained by the entire team. That doesn't mean that it can't be improved though. Every page in the documentation has an "Edit this page" link in the top right which takes you to Github to make small changes. For larger contributions, please see the [Contributing guide].
+Our documentation is extremely important to us and is actively maintained by
+the entire team. That doesn't mean that it can't be improved though. Every page
+in the documentation has an "Edit this page" link in the top right which takes
+you to Github to make small changes. For larger contributions, please see the
+[Contributing guide].
 
-**Our commitment to you**: Comments are usually read daily and we are really grateful for docs improvements.
+**Our commitment to you**: Comments are usually read daily and we are really
+grateful for docs improvements.
 
 ## Code of conduct
 
-Building a fair, open and inclusive community is important to us. We think adopting a code of conduct is a sensible way to make sure that everybody participating understands what the expectations and obligations are. The team adopts the [Ubuntu Code of Conduct 2.0](https://ubuntu.com/community/ethos/code-of-conduct), and we use these as the guidelines for participation.
+Building a fair, open and inclusive community is important to us. We think
+adopting a code of conduct is a sensible way to make sure that everybody
+participating understands what the expectations and obligations are. The team
+adopts the [Ubuntu Code of Conduct
+2.0](https://ubuntu.com/community/ethos/code-of-conduct), and we use these as
+the guidelines for participation.
 
 
 <!-- LINKS -->

--- a/docs/src/reference/community.md
+++ b/docs/src/reference/community.md
@@ -26,10 +26,10 @@ but we promise to respond within three working days.
 ## Found a bug?
 
 You can always track what is going on with development by tracking the
-developments on Github. This is also the best place to file a bug if you find
+developments on GitHub. This is also the best place to file a bug if you find
 one, or of course you are also welcome to contribute to the code.
 
-**Our commitment to you** - we monitor the issues on github regularly and we
+**Our commitment to you** - we monitor the issues on GitHub regularly and we
 aim to triage all bug reports within three working days.
 
 
@@ -47,7 +47,7 @@ repository. We aim to respond to any PRs within three working days.
 Our documentation is extremely important to us and is actively maintained by
 the entire team. That doesn't mean that it can't be improved though. Every page
 in the documentation has an "Edit this page" link in the top right which takes
-you to Github to make small changes. For larger contributions, please see the
+you to GitHub to make small changes. For larger contributions, please see the
 [Contributing guide].
 
 **Our commitment to you**: Comments are usually read daily and we are really

--- a/docs/src/reference/community.md
+++ b/docs/src/reference/community.md
@@ -1,0 +1,49 @@
+# Welcome to the Canonical Kubernetes community!
+
+This rapidly growing community is a diverse bunch of people - developers, Kubernetes admins, inventors, researchers, students… and we all share the joy of a reliable, flexible, secure, timely version of upstream Kubernetes. The team recognise the important role each and every user plays in the success of the project as a whole and how valuable your contributions are.
+
+## Do you have questions?
+
+Do you have questions about Canonical Kubernetes? Perhaps you want some ideas on how to best achieve a certain goal or maybe some aspect of your Kubernetes doesn't behave the way you expect. Perhaps you'd just like some advice from more experienced users. There are a number of ways to get in touch:
+
+- Using the [Kubernetes slack][slack]: find us in the #canonical-kubernetes channel
+- In the public [Matrix room][matrix]
+- On the [Ubuntu Discourse][discourse]
+
+For more formal support, please see the support options available to you on the [Ubuntu website][support].
+
+**Our commitment to you** - we may not always be able to answer your questions, but we promise to respond within three working days.
+
+## Found a bug?
+
+You can always track what is going on with development by tracking the developments on Github. This is also the best place to file a bug if you find one, or of course you are also welcome to contribute to the code.
+
+**Our commitment to you** - we monitor the issues on github regularly and we aim to triage all bug reports within three working days.
+
+
+## Contributing to the code? 
+
+Canonical Kubernetes is proudly open source, published under the GPLv3 license. We welcome and encourage contributions to the code. Please see the [Developer guide] for more information on contributing.
+
+**Our commitment to you** - we closely follow activity on the source repository. We aim to respond to any PRs within three working days. 
+
+## Contributing to docs?
+
+Our documentation is extremely important to us and is actively maintained by the entire team. That doesn't mean that it can't be improved though. Every page in the documentation has an "Edit this page" link in the top right which takes you to Github to make small changes. For larger contributions, please see the [Contributing guide].
+
+**Our commitment to you**: Comments are usually read daily and we are really grateful for docs improvements.
+
+## Code of conduct
+
+Building a fair, open and inclusive community is important to us. We think adopting a code of conduct is a sensible way to make sure that everybody participating understands what the expectations and obligations are. The team adopts the [Ubuntu Code of Conduct 2.0](https://ubuntu.com/community/ethos/code-of-conduct), and we use these as the guidelines for participation.
+
+
+<!-- LINKS -->
+
+[slack]: http://slack.kubernetes.io/
+[matrix]: https://matrix.to/#/#k8s:ubuntu.com
+[Discourse]: https://discourse.ubuntu.com/c/kubernetes/180
+[bugs]: https://github.com/canonical/k8s-snap/issues
+[Contributing guide]: *TODO*
+[Developer guide]: *TODO*
+[support]: https://ubuntu.com/support

--- a/docs/src/reference/index.md
+++ b/docs/src/reference/index.md
@@ -12,6 +12,7 @@ Overview <self>
 :glob:
 :titlesonly:
 /reference/releases
+/reference/community
 ```
 
 Alternatively, the [Tutorials section] contains step-by-step tutorials to help


### PR DESCRIPTION
Adds the community page. There are two links which we don't have anything for yet:

 - contributing to docs
 - contributing to code
which have been marked as TODOs