### PR TITLE
enable rbac by default, configurable on bootstrap

### DIFF
--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -13,12 +13,17 @@ type BootstrapConfig struct {
 	Components []string `yaml:"components"`
 	// ClusterCIDR is the CIDR of the cluster.
 	ClusterCIDR string `yaml:"cluster-cidr"`
+	// EnableRBAC determines if RBAC will be enabled; *bool to know true/false/unset.
+	EnableRBAC *bool `yaml:"enable-rbac"`
 }
 
 // SetDefaults sets the fields to default values.
 func (b *BootstrapConfig) SetDefaults() {
+	defaultRBAC := true
+
 	b.Components = []string{"dns", "network"}
 	b.ClusterCIDR = "10.1.0.0/16"
+	b.EnableRBAC = &defaultRBAC
 }
 
 // ToMap marshals the BootstrapConfig into yaml and map it to "bootstrapConfig".

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -19,11 +19,9 @@ type BootstrapConfig struct {
 
 // SetDefaults sets the fields to default values.
 func (b *BootstrapConfig) SetDefaults() {
-	defaultRBAC := true
-
 	b.Components = []string{"dns", "network"}
 	b.ClusterCIDR = "10.1.0.0/16"
-	b.EnableRBAC = &defaultRBAC
+	b.EnableRBAC = &[]bool{true}[0]
 }
 
 // ToMap marshals the BootstrapConfig into yaml and map it to "bootstrapConfig".

--- a/src/k8s/api/v1/types_test.go
+++ b/src/k8s/api/v1/types_test.go
@@ -10,8 +10,9 @@ func TestBootstrapConfigFromMap(t *testing.T) {
 	g := NewWithT(t)
 	// Create a new BootstrapConfig with default values
 	bc := &BootstrapConfig{
-		Components:  []string{"dns", "network", "storage"},
 		ClusterCIDR: "10.1.0.0/16",
+		Components:  []string{"dns", "network", "storage"},
+		EnableRBAC:  &[]bool{true}[0],
 	}
 
 	// Convert the BootstrapConfig to a map

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -11,6 +11,7 @@ import (
 	apiv1 "github.com/canonical/k8s/api/v1"
 	v1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/cmd/k8s/errors"
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -79,6 +80,9 @@ func getConfigInteractively(ctx context.Context) apiv1.BootstrapConfig {
 	config.Components = strings.Split(strings.ReplaceAll(components, " ", ""), ",")
 
 	config.ClusterCIDR = askQuestion("Please set the Cluster CIDR?", nil, config.ClusterCIDR)
+
+	rbac := askBool("Enable Role Based Access Control (RBAC)?", []string{"yes", "no"}, "yes")
+	*config.EnableRBAC = rbac
 	return config
 }
 
@@ -106,4 +110,19 @@ func askQuestion(question string, options []string, defaultVal string) string {
 		return defaultVal
 	}
 	return s
+}
+
+// askBool asks a question and expect a yes/no answer.
+func askBool(question string, options []string, defaultVal string) bool {
+	for {
+		answer := askQuestion(question, options, defaultVal)
+
+		if utils.ValueInSlice(strings.ToLower(answer), []string{"yes", "y"}) {
+			return true
+		} else if utils.ValueInSlice(strings.ToLower(answer), []string{"no", "n"}) {
+			return false
+		}
+
+		fmt.Fprintf(os.Stderr, "Invalid input, try again.\n\n")
+	}
 }

--- a/src/k8s/pkg/k8sd/types/cluster_config.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config.go
@@ -95,7 +95,16 @@ func (c *ClusterConfig) SetDefaults() {
 // ClusterConfigFromBootstrapConfig extracts the cluster config parts from the BootstrapConfig
 // and maps them to a ClusterConfig.
 func ClusterConfigFromBootstrapConfig(b *apiv1.BootstrapConfig) ClusterConfig {
+	authzMode := "Node,RBAC"
+	// Only disable rbac if explicitly set to false during bootstrap
+	if !(*b.EnableRBAC) {
+		authzMode = "AlwaysAllow"
+	}
+
 	return ClusterConfig{
+		APIServer: APIServer{
+			AuthorizationMode: authzMode,
+		},
 		Network: Network{
 			PodCIDR: b.ClusterCIDR,
 		},

--- a/src/k8s/pkg/k8sd/types/cluster_config.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config.go
@@ -97,7 +97,7 @@ func (c *ClusterConfig) SetDefaults() {
 func ClusterConfigFromBootstrapConfig(b *apiv1.BootstrapConfig) ClusterConfig {
 	authzMode := "Node,RBAC"
 	// Only disable rbac if explicitly set to false during bootstrap
-	if !(*b.EnableRBAC) {
+	if v := b.EnableRBAC; v != nil && !*v {
 		authzMode = "AlwaysAllow"
 	}
 

--- a/src/k8s/pkg/k8sd/types/cluster_config_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_test.go
@@ -14,9 +14,13 @@ func TestClusterConfigFromBootstrapConfig(t *testing.T) {
 	bootstrapConfig := apiv1.BootstrapConfig{
 		ClusterCIDR: "10.1.0.0/16",
 		Components:  []string{"dns", "network"},
+		EnableRBAC:  &[]bool{true}[0],
 	}
 
 	expectedConfig := types.ClusterConfig{
+		APIServer: types.APIServer{
+			AuthorizationMode: "Node,RBAC",
+		},
 		Network: types.Network{
 			PodCIDR: "10.1.0.0/16",
 		},

--- a/src/k8s/pkg/k8sd/types/cluster_config_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_test.go
@@ -51,6 +51,34 @@ func TestValidateCIDR(t *testing.T) {
 	g.Expect(err).ToNot(BeNil())
 }
 
+func TestUnsetRBAC(t *testing.T) {
+	g := NewWithT(t)
+	// Ensure unset rbac yields rbac authz
+	bootstrapConfig := apiv1.BootstrapConfig{
+		EnableRBAC: nil,
+	}
+	expectedConfig := types.ClusterConfig{
+		APIServer: types.APIServer{
+			AuthorizationMode: "Node,RBAC",
+		},
+	}
+	g.Expect(types.ClusterConfigFromBootstrapConfig(&bootstrapConfig)).To(Equal(expectedConfig))
+}
+
+func TestFalseRBAC(t *testing.T) {
+	g := NewWithT(t)
+	// Ensure false rbac yields open authz
+	bootstrapConfig := apiv1.BootstrapConfig{
+		EnableRBAC: &[]bool{false}[0],
+	}
+	expectedConfig := types.ClusterConfig{
+		APIServer: types.APIServer{
+			AuthorizationMode: "AlwaysAllow",
+		},
+	}
+	g.Expect(types.ClusterConfigFromBootstrapConfig(&bootstrapConfig)).To(Equal(expectedConfig))
+}
+
 func TestSetDefaults(t *testing.T) {
 	g := NewWithT(t)
 	clusterConfig := types.ClusterConfig{}

--- a/src/k8s/pkg/utils/file.go
+++ b/src/k8s/pkg/utils/file.go
@@ -127,3 +127,14 @@ func FileExists(path ...string) (bool, error) {
 	}
 	return true, nil
 }
+
+// ValueInSlice returns true if key is in list.
+func ValueInSlice[T comparable](key T, list []T) bool {
+	for _, entry := range list {
+		if entry == key {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Ensure rbac is enabled during bootstrap by default.  Only disable it if user explicitly sets enable = `false`.