### PR TITLE
CLI feedback messages

### DIFF
--- a/docs/src/explanation/about.md
+++ b/docs/src/explanation/about.md
@@ -12,7 +12,7 @@ Snaps are self-contained, simple to install, secure, cross-platform, and
 dependency-free. They can be installed on any Linux system which supports the
 `snapd` service (see the [snapd documentation] for more information). Security
 and robustness are their key features, alongside being easy to install, easy to
-maintain and easy to upgrade. 
+maintain and easy to upgrade.
 
 ## What else comes with it?
 

--- a/docs/src/howto/install/snap.md
+++ b/docs/src/howto/install/snap.md
@@ -49,9 +49,9 @@ Installing the snap sets up all the parts required to run Kubernetes. The next s
 sudo k8s bootstrap
 ```
 
-This command will output a message confirming the services have been started.
+This command will output a message confirming local cluster services have been started.
 
-## Confirm the services are running
+## Confirm the cluster is ready
 
 It is recommended to ensure that the cluster initialises properly and is running with no issues. Run the command:
 

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -27,7 +27,7 @@ func NewRootCmd() *cobra.Command {
 				return fmt.Errorf("failed to check if command runs as root: %w", err)
 			}
 			if !withRoot {
-				return fmt.Errorf("You do not have enough permissions. Please run the command with sudo.")
+				return fmt.Errorf("insufficient permissions: run the command with sudo")
 			}
 			return nil
 		},

--- a/src/k8s/cmd/k8s/k8s_add_node.go
+++ b/src/k8s/cmd/k8s/k8s_add_node.go
@@ -24,10 +24,10 @@ func newAddNodeCmd() *cobra.Command {
 		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
-				return fmt.Errorf("Too many arguments. Please, only provide the node name to add.")
+				return fmt.Errorf("too many arguments: provide only the node name to add")
 			}
 			if len(args) < 1 {
-				return fmt.Errorf("Not enough arguments. Please, provide the node name to add.")
+				return fmt.Errorf("missing argument: provide the node name to add")
 			}
 
 			defer errors.Transform(&err, addNodeCmdErrorMsgs)

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -52,13 +52,13 @@ func newBootstrapCmd() *cobra.Command {
 				config.SetDefaults()
 			}
 
-			fmt.Println("Bootstrapping the cluster. This may take some seconds...")
+			fmt.Println("Bootstrapping the cluster. This may take some time, please wait.")
 			cluster, err := k8sdClient.Bootstrap(cmd.Context(), config)
 			if err != nil {
 				return fmt.Errorf("failed to bootstrap cluster: %w", err)
 			}
 
-			fmt.Printf("Bootstrapped k8s cluster on %q (%s).\n", cluster.Name, cluster.Address)
+			fmt.Printf("Cluster services have started on %q.\nPlease allow some time for initial Kubernetes node registration.\n", cluster.Name)
 			return nil
 		},
 	}

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -15,13 +15,13 @@ func newDisableCmd() *cobra.Command {
 		Long:  fmt.Sprintf("Disable one of the specific components: %s.", strings.Join(componentList, ",")),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
-				return fmt.Errorf("Too many arguments. Please, only provide the name of the component that should be disabled.")
+				return fmt.Errorf("too many arguments: provide only the name of the component that should be disabled")
 			}
 			if len(args) < 1 {
-				return fmt.Errorf("Not enough arguments. Please, provide the name of the component that should be disabled.")
+				return fmt.Errorf("missing argument: provide the name of the component that should be disabled")
 			}
 			if !slices.Contains(componentList, args[0]) {
-				return fmt.Errorf("Unknown component %q. Needs to be one of: %s", args[0], strings.Join(componentList, ", "))
+				return fmt.Errorf("unknown component %q; needs to be one of: %s", args[0], strings.Join(componentList, ", "))
 			}
 			return nil
 		},

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -19,13 +19,13 @@ func newEnableCmd() *cobra.Command {
 		Long:  fmt.Sprintf("Enable one of the specific components: %s.", strings.Join(componentList, ", ")),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
-				return fmt.Errorf("Too many arguments. Please, only provide the name of the component that should be enabled.")
+				return fmt.Errorf("too many arguments: provide only the name of the component that should be enabled")
 			}
 			if len(args) < 1 {
-				return fmt.Errorf("Not enough arguments. Please, provide the name of the component that should be enabled.")
+				return fmt.Errorf("missing argument: provide the name of the component that should be enabled")
 			}
 			if !slices.Contains(componentList, args[0]) {
-				return fmt.Errorf("Unknown component %q. Needs to be one of: %s", args[0], strings.Join(componentList, ", "))
+				return fmt.Errorf("unknown component %q; needs to be one of: %s", args[0], strings.Join(componentList, ", "))
 			}
 			return nil
 		},

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -73,12 +73,12 @@ func newJoinNodeCmd() *cobra.Command {
 			timeoutCtx, cancel := context.WithTimeout(cmd.Context(), joinNodeCmdOpts.timeout)
 			defer cancel()
 
-			fmt.Println("Joining the cluster. This may take some seconds...")
+			fmt.Println("Joining the cluster. This may take some time, please wait.")
 			if err := k8sdClient.JoinCluster(timeoutCtx, joinNodeCmdOpts.name, joinNodeCmdOpts.address, token); err != nil {
 				return fmt.Errorf("failed to join cluster: %w", err)
 			}
 
-			fmt.Println("Joined the cluster.")
+			fmt.Printf("Joined the cluster as %q.\nPlease allow some time for Kubernetes node registration.\n", joinNodeCmdOpts.name)
 			return nil
 		},
 	}

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -36,10 +36,10 @@ func newJoinNodeCmd() *cobra.Command {
 		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
-				return fmt.Errorf("Too many arguments. Please, only provide the token that was generated with `sudo k8s add-node <node-name>`.")
+				return fmt.Errorf("too many arguments: provide only the token that was generated with `sudo k8s add-node <node-name>`")
 			}
 			if len(args) < 1 {
-				return fmt.Errorf("Not enough arguments. Please, provide the token that was generated with `sudo k8s add-node <node-name>`.")
+				return fmt.Errorf("missing argument: provide the token that was generated with `sudo k8s add-node <node-name>`")
 			}
 
 			defer errors.Transform(&err, joinNodeCmdErrorMsgs)

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -23,10 +23,10 @@ func newRemoveNodeCmd() *cobra.Command {
 		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
-				return fmt.Errorf("Too many arguments. Please, only provide the name of the node to remove.")
+				return fmt.Errorf("too many arguments: provide only the name of the node to remove")
 			}
 			if len(args) < 1 {
-				return fmt.Errorf("Not enough arguments. Please, provide the name of the node to remove.")
+				return fmt.Errorf("missing argument: provide the name of the node to remove")
 			}
 
 			defer errors.Transform(&err, nil)


### PR DESCRIPTION
### Summary

Report more information about what potentially long-running commands are doing. Ensure CLI feedback messages are consistent.

### Changes

- Tweak the bootstrap/join cli output so users know a bit more about what's going on.
- Addresses [ST1005](https://staticcheck.io/docs/checks#ST1005) and makes error strings consistent throughout `./cmd/k8s`.