### PR TITLE
k8s status should return immediately if the api server is down

### DIFF
--- a/src/k8s/api/v1/errors.go
+++ b/src/k8s/api/v1/errors.go
@@ -21,5 +21,8 @@ var ErrTimeout = errors.New("context deadline exceeded")
 // ErrConnectionFailed indicates that a connection to the k8sd daemon could not be established.
 var ErrConnectionFailed = errors.New("dial unix")
 
+// ErrAPIServerFailed indicates that a connection to the kube-apiserver could not be established.
+var ErrAPIServerFailed = errors.New("failed connecting to kube-apiserver")
+
 // ErrUnknown indicates that the server returns an unknown error.
 var ErrUnknown = errors.New("unknown error")

--- a/src/k8s/api/v1/errors.go
+++ b/src/k8s/api/v1/errors.go
@@ -21,8 +21,8 @@ var ErrTimeout = errors.New("context deadline exceeded")
 // ErrConnectionFailed indicates that a connection to the k8sd daemon could not be established.
 var ErrConnectionFailed = errors.New("dial unix")
 
-// ErrAPIServerFailed indicates that a connection to the kube-apiserver could not be established.
-var ErrAPIServerFailed = errors.New("failed connecting to kube-apiserver")
+// ErrAPIServerFailed indicates that kube-apiserver endpoint(s) could not be determined.
+var ErrAPIServerFailed = errors.New("failed to get kube-apiserver endpoints")
 
 // ErrUnknown indicates that the server returns an unknown error.
 var ErrUnknown = errors.New("unknown error")

--- a/src/k8s/cmd/k8s/errors/errors.go
+++ b/src/k8s/cmd/k8s/errors/errors.go
@@ -9,10 +9,10 @@ import (
 )
 
 var genericErrorMsgs = map[error]string{
-	v1.ErrNotBootstrapped: fmt.Sprintln("The cluster has not been initialized yet. Please call:\n\n    sudo k8s bootstrap"),
+	v1.ErrNotBootstrapped: "The cluster has not been initialized yet. Please call:\n\n sudo k8s bootstrap",
 	v1.ErrConnectionFailed: "Unable to connect to the cluster. Verify k8s services are running:\n\n sudo snap services k8s\n\n" +
 		"and see logs for more details:\n\n sudo journalctl -n 300 -u snap.k8s.k8sd\n\n",
-	v1.ErrAPIServerFailed: "Unable to connect to the Kubernetes API server. Verify k8s services are running:\n\n sudo snap services k8s\n\n" +
+	v1.ErrAPIServerFailed: "Unable to get Kubernetes API server endpoints. Verify k8s services are running:\n\n sudo snap services k8s\n\n" +
 		"and see logs for more details:\n\n sudo journalctl -n 300 -u snap.k8s.kube-apiserver\n\n",
 	v1.ErrTimeout: "Command timed out. See logs for more details:\n\n" +
 		" sudo journalctl -n 300 -u snap.k8s.k8sd\n\n" +

--- a/src/k8s/cmd/k8s/errors/errors.go
+++ b/src/k8s/cmd/k8s/errors/errors.go
@@ -10,8 +10,10 @@ import (
 
 var genericErrorMsgs = map[error]string{
 	v1.ErrNotBootstrapped: fmt.Sprintln("The cluster has not been initialized yet. Please call:\n\n    sudo k8s bootstrap"),
-	v1.ErrConnectionFailed: "Unable to connect to the cluster. Verify that that the services are running:\n\n sudo snap services k8s\n\n" +
+	v1.ErrConnectionFailed: "Unable to connect to the cluster. Verify k8s services are running:\n\n sudo snap services k8s\n\n" +
 		"and see logs for more details:\n\n sudo journalctl -n 300 -u snap.k8s.k8sd\n\n",
+	v1.ErrAPIServerFailed: "Unable to connect to the Kubernetes API server. Verify k8s services are running:\n\n sudo snap services k8s\n\n" +
+		"and see logs for more details:\n\n sudo journalctl -n 300 -u snap.k8s.kube-apiserver\n\n",
 	v1.ErrTimeout: "Command timed out. See logs for more details:\n\n" +
 		" sudo journalctl -n 300 -u snap.k8s.k8sd\n\n" +
 		"You may increase the timeout with `--timeout 3m`.",

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	v1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/cmd/k8s/errors"
 	"github.com/canonical/k8s/cmd/k8s/formatter"
 	"github.com/spf13/cobra"
@@ -27,10 +28,14 @@ func newStatusCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 
-			// if we're not explicitly waiting, fail fast when kube-apiserver is down
+			// fail fast if we're not bootstrapped
+			if ! k8sdClient.IsBootstrapped(cmd.Context()) {
+				return v1.ErrNotBootstrapped
+			}
+			// fail fast if we're not explicitly waiting and we can't get kube-apiserver endpoints
 			if ! statusCmdOpts.waitReady {
 				if ready := k8sdClient.IsKubernetesAPIServerReady(cmd.Context()); !ready {
-					return fmt.Errorf("failed connecting to kube-apiserver; cluster status is unavailable")
+					return fmt.Errorf("failed to get kube-apiserver endpoints; cluster status is unavailable")
 				}
 			}
 

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -29,11 +29,11 @@ func newStatusCmd() *cobra.Command {
 			defer errors.Transform(&err, nil)
 
 			// fail fast if we're not bootstrapped
-			if ! k8sdClient.IsBootstrapped(cmd.Context()) {
+			if !k8sdClient.IsBootstrapped(cmd.Context()) {
 				return v1.ErrNotBootstrapped
 			}
 			// fail fast if we're not explicitly waiting and we can't get kube-apiserver endpoints
-			if ! statusCmdOpts.waitReady {
+			if !statusCmdOpts.waitReady {
 				if ready := k8sdClient.IsKubernetesAPIServerReady(cmd.Context()); !ready {
 					return fmt.Errorf("failed to get kube-apiserver endpoints; cluster status is unavailable")
 				}

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -9,6 +9,7 @@ import (
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/config"
 	"github.com/canonical/k8s/pkg/utils/control"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -83,4 +84,19 @@ func (c *k8sdClient) KubeConfig(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to query endpoint GET /k8sd/kubeconfig on %q: %w", clientURL.String(), err)
 	}
 	return response.KubeConfig, nil
+}
+
+// IsKubernetesAPIServerReady checks if kube-apiserver is reachable.
+func (c *k8sdClient) IsKubernetesAPIServerReady(ctx context.Context) bool {
+	kc, err := k8s.NewClient(c.opts.Snap)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to create Kubernetes client:", err)
+		return false
+	}
+	_, err = kc.GetKubeAPIServerEndpoints(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to get Kubernetes endpoints:", err)
+		return false
+	}
+	return err == nil
 }

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -90,12 +90,10 @@ func (c *k8sdClient) KubeConfig(ctx context.Context) (string, error) {
 func (c *k8sdClient) IsKubernetesAPIServerReady(ctx context.Context) bool {
 	kc, err := k8s.NewClient(c.opts.Snap)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "failed to create Kubernetes client:", err)
 		return false
 	}
 	_, err = kc.GetKubeAPIServerEndpoints(ctx)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "failed to get Kubernetes endpoints:", err)
 		return false
 	}
 	return err == nil

--- a/src/k8s/pkg/k8s/client/interface.go
+++ b/src/k8s/pkg/k8s/client/interface.go
@@ -12,6 +12,8 @@ import (
 type Client interface {
 	// Bootstrap initializes a new cluster member using the provided bootstrap configuration.
 	Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapConfig) (apiv1.ClusterMember, error)
+	// IsKubernetesAPIServerReady checks if kube-apiserver is reachable.
+	IsKubernetesAPIServerReady(ctx context.Context) bool
 	// IsBootstrapped checks whether the current node is already bootstrapped.
 	IsBootstrapped(ctx context.Context) bool
 	// CleanupNode performs cleanup operations for a specific node in the cluster.


### PR DESCRIPTION
### Summary

Make the `k8s status` command fail fast in situations where status is unlikely to be forthcoming -- e.g. when the api-server is unavailable and we have not explicitly asked for `--wait-ready`.

### Changes

- New `k8sdClient.IsKubernetesAPIServerReady` function that attempts to get cluster endpoints
- Call this new func in `k8s_status.go` before any waiting/timeout context
- Present helpful message when we're unable to get apiserver endpoints

### Rationale

The `k8s status` command has a `--timeout` option that can return quickly (3s) if configured, though the default is 90s. Prior to this PR, status will happily wait the entire `timeout` until `k8sdClient.ClusterStatus` fails if `client-go` can't talk to kubernetes. With this PR, status will fail fast if:

- we're not bootstrapped
- `client-go` can't reach a kube-apiserver (connection refused)
- `client-go` can't get cluster endpoints

I could have used most any kubernetes api resource to determine if `kube-apiserver` was down, but I chose cluster endpoints because either a dead apiserver or an empty cluster endpoint imply cluster problems that you should debug before trying to get meaningful status.

I also made the fast fail conditional on the absence of `--wait-ready` in case (for some reason) a user *really* wants to wait for `k8sdClient.ClusterStatus` even if it means waiting for a timeout that we're fairly sure will happen. The flag is off by default, making this a foot-gun for now in case users want to use it.