### PR TITLE
Enable components specified during bootstrap by default

### DIFF
--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -20,7 +20,7 @@ type BootstrapConfig struct {
 
 // SetDefaults sets the fields to default values.
 func (b *BootstrapConfig) SetDefaults() {
-	b.Components = []string{"dns", "network"}
+	b.Components = []string{"dns", "metrics-server", "network"}
 	b.ClusterCIDR = "10.1.0.0/16"
 	b.EnableRBAC = &[]bool{true}[0]
 	b.K8sDqlitePort = 9000

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	componentList = []string{"network", "dns", "gateway", "ingress", "rbac", "storage", "loadbalancer", "metrics-server"}
+	componentList = []string{"network", "dns", "gateway", "ingress", "storage", "loadbalancer", "metrics-server"}
 )
 
 func newEnableCmd() *cobra.Command {

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -73,13 +73,13 @@ func EnableLoadBalancerComponent(ctx context.Context, s snap.Snap, cidrs []strin
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
+	if err := client.RestartDeployment(timeoutCtx, "cilium-operator", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 	}
-	if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
+	if err := client.RestartDaemonset(timeoutCtx, "cilium", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 	}
 

--- a/tests/e2e/tests/conftest.py
+++ b/tests/e2e/tests/conftest.py
@@ -88,7 +88,6 @@ def instances(
 
     first_node, *_ = instances
     first_node.exec(["k8s", "bootstrap"])
-    util.setup_network(first_node)
 
     yield instances
 

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -126,13 +126,33 @@ def stubbornly(
     return Retriable()
 
 
-def setup_dns(instance: harness.Instance):
-    LOG.info("Waiting for dns to be enabled...")
-    stubbornly(retries=15, delay_s=5).on(instance).exec(
-        ["k8s", "enable", "dns", "--cluster-domain=foo.local"]
-    )
-    LOG.info("DNS enabled.")
+# Installs and setups the k8s snap on the given instance and connects the interfaces.
+def setup_k8s_snap(instance: harness.Instance, snap_path: Path):
+    LOG.info("Install k8s snap")
+    instance.send_file(config.SNAP, snap_path)
+    instance.exec(["snap", "install", snap_path, "--classic", "--dangerous"])
 
+    LOG.info("Ensure k8s interfaces and network requirements")
+    instance.exec(["/snap/k8s/current/k8s/hack/init.sh"], stdout=subprocess.DEVNULL)
+
+
+# Validates that the K8s node is in Ready state.
+def wait_until_k8s_ready(
+    control_node: harness.Instance, instances: List[harness.Instance]
+):
+    for instance in instances:
+        host = hostname(instance)
+        result = (
+            stubbornly(retries=15, delay_s=5)
+            .on(control_node)
+            .until(lambda p: " Ready" in p.stdout.decode())
+            .exec(["k8s", "kubectl", "get", "node", host, "--no-headers"])
+        )
+    LOG.info("Kubelet registered successfully!")
+    LOG.info("%s", result.stdout.decode())
+
+
+def wait_for_dns(instance: harness.Instance):
     LOG.info("Waiting for CoreDNS pod to show up...")
     stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "coredns" in p.stdout.decode()
@@ -156,11 +176,7 @@ def setup_dns(instance: harness.Instance):
     )
 
 
-def setup_network(instance: harness.Instance):
-    LOG.info("Waiting for network to be enabled...")
-    stubbornly(retries=15, delay_s=5).on(instance).exec(["k8s", "enable", "network"])
-    LOG.info("Network enabled.")
-
+def wait_for_network(instance: harness.Instance):
     LOG.info("Waiting for cilium pods to show up...")
     stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "cilium" in p.stdout.decode()
@@ -200,32 +216,6 @@ def setup_network(instance: harness.Instance):
             "180s",
         ]
     )
-
-
-# Installs and setups the k8s snap on the given instance and connects the interfaces.
-def setup_k8s_snap(instance: harness.Instance, snap_path: Path):
-    LOG.info("Install k8s snap")
-    instance.send_file(config.SNAP, snap_path)
-    instance.exec(["snap", "install", snap_path, "--classic", "--dangerous"])
-
-    LOG.info("Ensure k8s interfaces and network requirements")
-    instance.exec(["/snap/k8s/current/k8s/hack/init.sh"], stdout=subprocess.DEVNULL)
-
-
-# Validates that the K8s node is in Ready state.
-def wait_until_k8s_ready(
-    control_node: harness.Instance, instances: List[harness.Instance]
-):
-    for instance in instances:
-        host = hostname(instance)
-        result = (
-            stubbornly(retries=15, delay_s=5)
-            .on(control_node)
-            .until(lambda p: " Ready" in p.stdout.decode())
-            .exec(["k8s", "kubectl", "get", "node", host, "--no-headers"])
-        )
-    LOG.info("Kubelet registered successfully!")
-    LOG.info("%s", result.stdout.decode())
 
 
 def hostname(instance: harness.Instance) -> str:

--- a/tests/e2e/tests/test_cleanup.py
+++ b/tests/e2e/tests/test_cleanup.py
@@ -13,7 +13,8 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.node_count(1)
 def test_node_cleanup(instances: List[harness.Instance]):
     instance = instances[0]
-    util.setup_dns(instance)
+    util.wait_for_dns(instance)
+    util.wait_for_network(instance)
 
     LOG.info("Uninstall k8s...")
     instance.exec(["snap", "remove", "k8s", "--purge"])

--- a/tests/e2e/tests/test_dns.py
+++ b/tests/e2e/tests/test_dns.py
@@ -12,6 +12,7 @@ LOG = logging.getLogger(__name__)
 def test_dns(instances: List[harness.Instance]):
     instance = instances[0]
     util.wait_for_dns(instance)
+    util.wait_for_network(instance)
 
     instance.exec(
         [

--- a/tests/e2e/tests/test_dns.py
+++ b/tests/e2e/tests/test_dns.py
@@ -11,7 +11,7 @@ LOG = logging.getLogger(__name__)
 
 def test_dns(instances: List[harness.Instance]):
     instance = instances[0]
-    util.setup_dns(instance)
+    util.wait_for_dns(instance)
 
     instance.exec(
         [
@@ -46,7 +46,7 @@ def test_dns(instances: List[harness.Instance]):
         capture_output=True,
     )
 
-    assert "10.152.183.1 kubernetes.default.svc.foo.local" in result.stdout.decode()
+    assert "10.152.183.1 kubernetes.default.svc.cluster.local" in result.stdout.decode()
 
     result = instance.exec(
         ["k8s", "kubectl", "exec", "busybox", "--", "nslookup", "canonical.com"],

--- a/tests/e2e/tests/test_gateway.py
+++ b/tests/e2e/tests/test_gateway.py
@@ -13,6 +13,9 @@ LOG = logging.getLogger(__name__)
 
 def test_gateway(instances: List[harness.Instance]):
     instance = instances[0]
+    util.wait_for_network(instance)
+    util.wait_for_dns(instance)
+
     instance.exec(["k8s", "enable", "gateway"])
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(

--- a/tests/e2e/tests/test_ingress.py
+++ b/tests/e2e/tests/test_ingress.py
@@ -13,6 +13,9 @@ LOG = logging.getLogger(__name__)
 
 def test_ingress(instances: List[harness.Instance]):
     instance = instances[0]
+    util.wait_for_network(instance)
+    util.wait_for_dns(instance)
+
     instance.exec(["k8s", "enable", "ingress"])
 
     util.stubbornly(retries=5, delay_s=2).on(instance).until(

--- a/tests/e2e/tests/test_loadbalancer.py
+++ b/tests/e2e/tests/test_loadbalancer.py
@@ -61,6 +61,9 @@ def find_suitable_cidr(parent_cidr: str, excluded_ips: List[str]):
 @pytest.mark.node_count(2)
 def test_loadbalancer(instances: List[harness.Instance]):
     instance = instances[0]
+    util.wait_for_dns(instance)
+    util.wait_for_network(instance)
+
     tester_instance = instances[1]
 
     instance_default_ip = get_default_ip(instance)

--- a/tests/e2e/tests/test_metrics_server.py
+++ b/tests/e2e/tests/test_metrics_server.py
@@ -15,6 +15,8 @@ def test_metrics_server(instances: List[harness.Instance]):
         pytest.fail("Set TEST_SNAP to the path where the snap is")
 
     instance = instances[0]
+    util.wait_for_dns(instance)
+    util.wait_for_network(instance)
     instance.exec(["k8s", "enable", "metrics-server"])
 
     LOG.info("Waiting for metrics-server pod to show up...")

--- a/tests/e2e/tests/test_network.py
+++ b/tests/e2e/tests/test_network.py
@@ -14,6 +14,8 @@ LOG = logging.getLogger(__name__)
 
 def test_network(instances: List[harness.Instance]):
     instance = instances[0]
+    util.wait_for_dns(instance)
+    util.wait_for_network(instance)
 
     p = instance.exec(
         [


### PR DESCRIPTION
### Summary

Enable components after a successful `k8s bootstrap`. These will include `dns` and `network` by default, or any valid set of component names that the user provided during bootstrap.

### Changes

- Giant switch

### Rationale

We maintain various lists of components in `cmd/k8s/k8s_enable`, `pkg/snap/snap`, a couple interfaces, and as part of our v1 api endpoint list.  We should consolidate those to a single source-of-truth where names, attrs, and methods can be managed together.

But that's not what this PR is about.  This PR ensures that default components are enabled after a successful bootstrap, e.g.:

```bash
$ sudo k8s bootstrap -v -d --interactive
Which components would you like to enable? () [dns, network]: dns, ham, network, storanges
Please set the Cluster CIDR? [10.1.0.0/16]: 
Bootstrapping the cluster. This may take some seconds...
Enabling bootstrap components.
 dns enabled
 skipping unknown component: ham
 network enabled
 skipping unknown component: storanges
Bootstrapped k8s cluster on "ip-172-31-53-214" (172.31.53.214).

$ sudo k8s status 
k8s is ready.
high-availability: no

control-plane nodes:
  ip-172-31-53-214: 172.31.53.214

components:
  dns        enabled
  gateway    disabled
  ingress    disabled
  loadbalancer disabled
  metrics-server disabled
  network    enabled
  storage    disabled

```