### PR TITLE
Automatically label control-plane and worker nodes

### DIFF
--- a/build-scripts/components/kubernetes/patches/default/0002-Allow-node-role-labels-on-kubelet-registration.patch
+++ b/build-scripts/components/kubernetes/patches/default/0002-Allow-node-role-labels-on-kubelet-registration.patch
@@ -1,0 +1,26 @@
+From b3a0ec7ca54f91c006bf36b8d18ea60a2ef44857 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Mon, 19 Feb 2024 21:13:32 +0200
+Subject: [PATCH] Allow node-role labels on kubelet registration
+
+---
+ .../src/k8s.io/kubelet/pkg/apis/canonical_k8s_labels.go   | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ create mode 100644 staging/src/k8s.io/kubelet/pkg/apis/canonical_k8s_labels.go
+
+diff --git a/staging/src/k8s.io/kubelet/pkg/apis/canonical_k8s_labels.go b/staging/src/k8s.io/kubelet/pkg/apis/canonical_k8s_labels.go
+new file mode 100644
+index 00000000000..fcc6acada75
+--- /dev/null
++++ b/staging/src/k8s.io/kubelet/pkg/apis/canonical_k8s_labels.go
+@@ -0,0 +1,8 @@
++package apis
++
++func init() {
++	kubeletLabels.Insert(
++		"node-role.kubernetes.io/control-plane",
++		"node-role.kubernetes.io/worker",
++	)
++}
+--
+2.34.1

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -122,7 +122,7 @@ func onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	if err := setup.Containerd(snap); err != nil {
 		return fmt.Errorf("failed to configure containerd: %w", err)
 	}
-	if err := setup.Kubelet(snap, s.Name(), nodeIP, response.ClusterDNS, response.ClusterDomain, response.CloudProvider); err != nil {
+	if err := setup.KubeletWorker(snap, s.Name(), nodeIP, response.ClusterDNS, response.ClusterDomain, response.CloudProvider); err != nil {
 		return fmt.Errorf("failed to configure kubelet: %w", err)
 	}
 	if err := setup.KubeProxy(snap, s.Name(), response.PodCIDR); err != nil {
@@ -229,7 +229,7 @@ func onBootstrapControlPlane(s *state.State, initConfig map[string]string) error
 	if err := setup.Containerd(snap); err != nil {
 		return fmt.Errorf("failed to configure containerd: %w", err)
 	}
-	if err := setup.Kubelet(snap, s.Name(), nodeIP, cfg.Kubelet.ClusterDNS, cfg.Kubelet.ClusterDomain, cfg.Kubelet.CloudProvider); err != nil {
+	if err := setup.KubeletControlPlane(snap, s.Name(), nodeIP, cfg.Kubelet.ClusterDNS, cfg.Kubelet.ClusterDomain, cfg.Kubelet.CloudProvider); err != nil {
 		return fmt.Errorf("failed to configure kubelet: %w", err)
 	}
 	if err := setup.KubeProxy(snap, s.Name(), cfg.Network.PodCIDR); err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -108,7 +108,7 @@ func onPostJoin(s *state.State, initConfig map[string]string) error {
 	if err := setup.Containerd(snap); err != nil {
 		return fmt.Errorf("failed to configure containerd: %w", err)
 	}
-	if err := setup.Kubelet(snap, s.Name(), nodeIP, cfg.Kubelet.ClusterDNS, cfg.Kubelet.ClusterDomain, cfg.Kubelet.CloudProvider); err != nil {
+	if err := setup.KubeletControlPlane(snap, s.Name(), nodeIP, cfg.Kubelet.ClusterDNS, cfg.Kubelet.ClusterDomain, cfg.Kubelet.CloudProvider); err != nil {
 		return fmt.Errorf("failed to configure kubelet: %w", err)
 	}
 	if err := setup.KubeProxy(snap, s.Name(), cfg.Network.PodCIDR); err != nil {

--- a/src/k8s/pkg/k8sd/setup/kubelet.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet.go
@@ -22,11 +22,11 @@ var kubeletTLSCipherSuites = []string{
 }
 
 var kubeletControlPlaneLabels = []string{
-	"node-role.kubernetes.io/control-plane=control-plane",
+	"node-role.kubernetes.io/control-plane=",
 }
 
 var kubeletWorkerLabels = []string{
-	"node-role.kubernetes.io/worker=worker",
+	"node-role.kubernetes.io/worker=",
 }
 
 // KubeletControlPlane configures kubelet on a control plane node.

--- a/src/k8s/pkg/k8sd/setup/kubelet.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet.go
@@ -21,8 +21,26 @@ var kubeletTLSCipherSuites = []string{
 	"TLS_RSA_WITH_AES_256_GCM_SHA384",
 }
 
-// Kubelet configures kubelet on the local node.
-func Kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, clusterDomain string, cloudProvider string) error {
+var kubeletControlPlaneLabels = []string{
+	"node-role.kubernetes.io/control-plane=control-plane",
+}
+
+var kubeletWorkerLabels = []string{
+	"node-role.kubernetes.io/worker=worker",
+}
+
+// KubeletControlPlane configures kubelet on a control plane node.
+func KubeletControlPlane(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, clusterDomain string, cloudProvider string) error {
+	return kubelet(snap, hostname, nodeIP, clusterDNS, clusterDomain, cloudProvider, nil, kubeletControlPlaneLabels)
+}
+
+// KubeletWorker configures kubelet on a worker node.
+func KubeletWorker(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, clusterDomain string, cloudProvider string) error {
+	return kubelet(snap, hostname, nodeIP, clusterDNS, clusterDomain, cloudProvider, nil, kubeletWorkerLabels)
+}
+
+// kubelet configures kubelet on the local node.
+func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, clusterDomain string, cloudProvider string, taints []string, labels []string) error {
 	args := map[string]string{
 		"--anonymous-auth":               "false",
 		"--authentication-token-webhook": "true",
@@ -34,7 +52,9 @@ func Kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, 
 		"--fail-swap-on":                 "false",
 		"--hostname-override":            hostname,
 		"--kubeconfig":                   path.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
+		"--node-labels":                  strings.Join(labels, ","),
 		"--read-only-port":               "0",
+		"--register-with-taints":         strings.Join(taints, ","),
 		"--root-dir":                     snap.KubeletRootDir(),
 		"--serialize-image-pulls":        "false",
 		"--tls-cipher-suites":            strings.Join(kubeletTLSCipherSuites, ","),


### PR DESCRIPTION
### Summary

Automatically label worker node and control plane nodes.

Example output from a cluster with two control-plane and one worker node:

```
root@t1:~# k8s kubectl get node
NAME   STATUS   ROLES           AGE   VERSION
t1     Ready    control-plane   14m   v1.29.2
t2     Ready    worker          13m   v1.29.2
t3     Ready    control-plane   11m   v1.29.2
```
