### PR TITLE
Warn if /sys mount propagation is not shared

### DIFF
--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -92,6 +92,17 @@ func EnableNetworkComponent(ctx context.Context, s snap.Snap, podCIDR string) er
 			},
 			"hostRoot": cgrMnt,
 		}
+	} else {
+		p, err := utils.GetMountPropagation("/sys")
+		if err != nil {
+			return fmt.Errorf("failed to get mount propagation for %s: %w", p, err)
+		}
+		if p == "private" {
+			if s.OnLXD(ctx) {
+				return fmt.Errorf("/sys is not a shared mount on the LXD container, this might be resolved by updating LXD on the host to version 5.0.2 or newer")
+			}
+			return fmt.Errorf("/sys is not a shared mount")
+		}
 	}
 
 	if err := manager.Enable("network", values); err != nil {

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -10,9 +10,11 @@ import (
 
 // Snap abstracts file system paths and interacting with the k8s services.
 type Snap interface {
-	Strict() bool // Strict returns true if the snap is installed with strict confinement.
-	UID() int     // UID is the user ID to set on config files.
-	GID() int     // GID is the group ID to set on config files.
+	Strict() bool               // Strict returns true if the snap is installed with strict confinement.
+	OnLXD(context.Context) bool // OnLXD returns true if the host runs on LXD.
+
+	UID() int // UID is the user ID to set on config files.
+	GID() int // GID is the group ID to set on config files.
 
 	StartService(ctx context.Context, serviceName string) error   // snapctl start $service
 	StopService(ctx context.Context, serviceName string) error    // snapctl stop $service

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -11,6 +11,7 @@ import (
 
 type Mock struct {
 	Strict                      bool
+	OnLXD                       bool
 	UID                         int
 	GID                         int
 	KubernetesConfigDir         string
@@ -75,6 +76,9 @@ func (s *Snap) RestartService(ctx context.Context, name string) error {
 
 func (s *Snap) Strict() bool {
 	return s.Mock.Strict
+}
+func (s *Snap) OnLXD(context.Context) bool {
+	return s.Mock.OnLXD
 }
 func (s *Snap) UID() int {
 	return s.Mock.UID

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -86,7 +86,7 @@ func (s *snap) Strict() bool {
 }
 
 func (s *snap) OnLXD(ctx context.Context) bool {
-	return utils.RunCommand(ctx, "grep", "-qa", "container=lxc", "/proc/1/environ") == nil
+	return s.runCommand(ctx, "grep", "-qa", "container=lxc", "/proc/1/environ") == nil
 }
 
 func (s *snap) UID() int {

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -85,6 +85,10 @@ func (s *snap) Strict() bool {
 	return meta.Confinement == "strict"
 }
 
+func (s *snap) OnLXD(ctx context.Context) bool {
+	return utils.RunCommand(ctx, "grep", "-qa", "container=lxc", "/proc/1/environ") == nil
+}
+
 func (s *snap) UID() int {
 	return 0
 }

--- a/src/k8s/pkg/utils/file_test.go
+++ b/src/k8s/pkg/utils/file_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -158,4 +159,16 @@ func TestFileExists(t *testing.T) {
 	fileExists, err = utils.FileExists(testFilePath)
 	g.Expect(err).To(BeNil())
 	g.Expect(fileExists).To(BeFalse())
+}
+
+func TestGetMountPropagation(t *testing.T) {
+	g := NewWithT(t)
+
+	mountType, err := utils.GetMountPropagation("/randommount")
+	g.Expect(errors.Is(err, utils.ErrUnknownMount)).To(BeTrue())
+	g.Expect(mountType).To(Equal(""))
+
+	mountType, err = utils.GetMountPropagation("/sys")
+	g.Expect(err).To(BeNil())
+	g.Expect(mountType).To(Equal("shared"))
 }


### PR DESCRIPTION
Cilium fails to deploy if `/sys` is not mount with shared propagation.

This PR adds a check to verify that `/sys` is mounted with the propagation type.