### PR TITLE
Use PreRunE for sub-commands

### DIFF
--- a/src/k8s/cmd/k8s/k8s_add_node.go
+++ b/src/k8s/cmd/k8s/k8s_add_node.go
@@ -19,9 +19,9 @@ var (
 
 func newAddNodeCmd() *cobra.Command {
 	addNodeCmd := &cobra.Command{
-		Use:               "add-node <name>",
-		Short:             "Create a connection token for a node to join the cluster",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "add-node <name>",
+		Short:   "Create a connection token for a node to join the cluster",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
 				return fmt.Errorf("too many arguments: provide only the node name to add")

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -29,10 +29,10 @@ var (
 
 func newBootstrapCmd() *cobra.Command {
 	bootstrapCmd := &cobra.Command{
-		Use:               "bootstrap",
-		Short:             "Bootstrap a k8s cluster on this node.",
-		Long:              "Initialize the necessary folders, permissions, service arguments, certificates and start up the Kubernetes services.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "bootstrap",
+		Short:   "Bootstrap a k8s cluster on this node.",
+		Long:    "Initialize the necessary folders, permissions, service arguments, certificates and start up the Kubernetes services.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, bootstrapCmdErrorMsgs)
 

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -9,10 +9,10 @@ import (
 
 func newKubeConfigCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "config",
-		Short:             "Generate a kubeconfig that can be used to access the Kubernetes cluster",
-		Hidden:            true,
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "config",
+		Short:   "Generate a kubeconfig that can be used to access the Kubernetes cluster",
+		Hidden:  true,
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_disable_dns.go
+++ b/src/k8s/cmd/k8s/k8s_disable_dns.go
@@ -10,9 +10,9 @@ import (
 
 func newDisableDNSCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "dns",
-		Short:             "Disable the DNS component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "dns",
+		Short:   "Disable the DNS component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_disable_gateway.go
+++ b/src/k8s/cmd/k8s/k8s_disable_gateway.go
@@ -10,9 +10,9 @@ import (
 
 func newDisableGatewayCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "gateway",
-		Short:             "Disable the Gateway component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "gateway",
+		Short:   "Disable the Gateway component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_disable_ingress.go
+++ b/src/k8s/cmd/k8s/k8s_disable_ingress.go
@@ -10,9 +10,9 @@ import (
 
 func newDisableIngressCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "ingress",
-		Short:             "Disable the Ingress component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "ingress",
+		Short:   "Disable the Ingress component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_disable_loadbalancer.go
+++ b/src/k8s/cmd/k8s/k8s_disable_loadbalancer.go
@@ -10,9 +10,9 @@ import (
 
 func newDisableLoadBalancerCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "loadbalancer",
-		Short:             "Disable the LoadBalancer component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "loadbalancer",
+		Short:   "Disable the LoadBalancer component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_disable_metrics_server.go
+++ b/src/k8s/cmd/k8s/k8s_disable_metrics_server.go
@@ -10,9 +10,9 @@ import (
 
 func newDisableMetricsServerCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "metrics-server",
-		Short:             "Disable the Metrics-Server component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "metrics-server",
+		Short:   "Disable the Metrics-Server component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_disable_network.go
+++ b/src/k8s/cmd/k8s/k8s_disable_network.go
@@ -10,9 +10,9 @@ import (
 
 func newDisableNetworkCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "network",
-		Short:             "Disable the Network component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "network",
+		Short:   "Disable the Network component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_disable_storage.go
+++ b/src/k8s/cmd/k8s/k8s_disable_storage.go
@@ -10,9 +10,9 @@ import (
 
 func newDisableStorageCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "storage",
-		Short:             "Disable the Network component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "storage",
+		Short:   "Disable the Network component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_enable_dns.go
+++ b/src/k8s/cmd/k8s/k8s_enable_dns.go
@@ -16,9 +16,9 @@ var enableDNSCmdConfig struct {
 
 func newEnableDNSCmd() *cobra.Command {
 	enableDNSCmd := &cobra.Command{
-		Use:               "dns",
-		Short:             "Enable the DNS component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "dns",
+		Short:   "Enable the DNS component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_enable_gateway.go
+++ b/src/k8s/cmd/k8s/k8s_enable_gateway.go
@@ -10,9 +10,9 @@ import (
 
 func newEnableGatewayCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "gateway",
-		Short:             "Enable the Gateway component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "gateway",
+		Short:   "Enable the Gateway component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_enable_ingress.go
+++ b/src/k8s/cmd/k8s/k8s_enable_ingress.go
@@ -15,9 +15,9 @@ var enableIngressCmdOpts struct {
 
 func newEnableIngressCmd() *cobra.Command {
 	enableIngressCmd := &cobra.Command{
-		Use:               "ingress",
-		Short:             "Enable the Ingress component in the cluster",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "ingress",
+		Short:   "Enable the Ingress component in the cluster",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_enable_loadbalancer.go
+++ b/src/k8s/cmd/k8s/k8s_enable_loadbalancer.go
@@ -21,9 +21,9 @@ var enableLoadBalancerCmdOpts struct {
 
 func newEnableLoadBalancerCmd() *cobra.Command {
 	enableLoadBalancerCmd := &cobra.Command{
-		Use:               "loadbalancer",
-		Short:             "Enable the LoadBalancer component in the cluster",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "loadbalancer",
+		Short:   "Enable the LoadBalancer component in the cluster",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_enable_metrics_server.go
+++ b/src/k8s/cmd/k8s/k8s_enable_metrics_server.go
@@ -10,9 +10,9 @@ import (
 
 func newEnableMetricsServerCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "metrics-server",
-		Short:             "Enable the Metrics-Server component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "metrics-server",
+		Short:   "Enable the Metrics-Server component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_enable_network.go
+++ b/src/k8s/cmd/k8s/k8s_enable_network.go
@@ -10,9 +10,9 @@ import (
 
 func newEnableNetworkCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "network",
-		Short:             "Enable the Network component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "network",
+		Short:   "Enable the Network component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_enable_storage.go
+++ b/src/k8s/cmd/k8s/k8s_enable_storage.go
@@ -10,9 +10,9 @@ import (
 
 func newEnableStorageCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:               "storage",
-		Short:             "Enable the Storage component in the cluster.",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "storage",
+		Short:   "Enable the Storage component in the cluster.",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_generate_auth_token.go
+++ b/src/k8s/cmd/k8s/k8s_generate_auth_token.go
@@ -17,10 +17,10 @@ var (
 
 func newGenerateAuthTokenCmd() *cobra.Command {
 	generateAuthTokenCmd := &cobra.Command{
-		Use:               "generate-auth-token --username <user> [--groups <group1>,<group2>]",
-		Short:             "Generate an auth token for Kubernetes",
-		Hidden:            true,
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "generate-auth-token --username <user> [--groups <group1>,<group2>]",
+		Short:   "Generate an auth token for Kubernetes",
+		Hidden:  true,
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -31,9 +31,9 @@ var (
 
 func newJoinNodeCmd() *cobra.Command {
 	joinNodeCmd := &cobra.Command{
-		Use:               "join-cluster <token>",
-		Short:             "Join a cluster",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "join-cluster <token>",
+		Short:   "Join a cluster",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
 				return fmt.Errorf("too many arguments: provide only the token that was generated with `sudo k8s add-node <node-name>`")

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -18,9 +18,9 @@ var (
 
 func newRemoveNodeCmd() *cobra.Command {
 	removeNodeCmd := &cobra.Command{
-		Use:               "remove-node <name>",
-		Short:             "Remove a node from the cluster",
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "remove-node <name>",
+		Short:   "Remove a node from the cluster",
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
 				return fmt.Errorf("too many arguments: provide only the name of the node to remove")

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -21,10 +21,10 @@ var (
 
 func newStatusCmd() *cobra.Command {
 	statusCmd := &cobra.Command{
-		Use:               "status",
-		Short:             "Retrieve the current status of the cluster",
-		Hidden:            true,
-		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
+		Use:     "status",
+		Short:   "Retrieve the current status of the cluster",
+		Hidden:  true,
+		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 


### PR DESCRIPTION
By default, PersistentPreRun hooks are not chained. If a child command overwrites this, the parent hook is not executed.

This caused the global permissions check to be overwritten in the sub-commands and caused misleading error messages when running commands without root permission.

There is a flag to introduce the chaining behavior but this unnecessarily complicates the commands. Since we have shallow command, using `PreRun` hooks is just fine. 

Btw, we are not the only ones that got confused by this feature: https://github.com/spf13/cobra/issues/252