### PR TITLE
Improve remove hook

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -76,14 +76,14 @@ k8s::remove::containers() {
   k8s::common::setup_env
 
   # kill all container shims and pause processes
-  k8s::cmd::k8s x-print-shim-pids | xargs -r -t kill -SIGKILL
+  k8s::cmd::k8s x-print-shim-pids | xargs -r -t kill -SIGKILL || true
 
   # delete cni network namespaces
-  ip netns list | cut -f1 -d' ' | grep -- "^cni-" | xargs -n1 -r -t ip netns delete
+  ip netns list | cut -f1 -d' ' | grep -- "^cni-" | xargs -n1 -r -t ip netns delete || true
 
   # unmount volumes
-  cat /proc/mounts | grep /run/containerd/io.containerd. | cut -f2 -d' ' | xargs -r -t umount
-  cat /proc/mounts | grep /var/lib/kubelet/pods | cut -f2 -d' ' | xargs -r -t umount
+  cat /proc/mounts | grep /run/containerd/io.containerd. | cut -f2 -d' ' | xargs -r -t umount || true
+  cat /proc/mounts | grep /var/lib/kubelet/pods | cut -f2 -d' ' | xargs -r -t umount || true
 }
 
 # Run a ctr command against the local containerd socket


### PR DESCRIPTION
### Summary

`test_node_cleanup` e2e test fails often. Looks like sometimes we do not clear containerd mounts

The change attempts to address the following error:

```
Status  Spawn               Ready               Summary
Done    today at 09:25 UTC  today at 09:26 UTC  Stop snap "k8s" services
Done    today at 09:25 UTC  today at 09:26 UTC  Run remove hook of "k8s" snap if present
Done    today at 09:25 UTC  today at 09:26 UTC  Disconnect interfaces of snap "k8s"
Done    today at 09:25 UTC  today at 09:26 UTC  Remove aliases for snap "k8s"
Done    today at 09:25 UTC  today at 09:26 UTC  Make snap "k8s" unavailable to the system
Done    today at 09:25 UTC  today at 09:26 UTC  Remove security profile for snap "k8s" (x1)
Done    today at 09:25 UTC  today at 09:26 UTC  Remove data for snap "k8s" (x1)
Done    today at 09:25 UTC  today at 09:26 UTC  Remove snap "k8s" (x1) from the system

......................................................................
Stop snap "k8s" services

2024-02-28T09:25:44Z INFO Waiting for "snap.k8s.kube-apiserver.service" to stop.

......................................................................
Run remove hook of "k8s" snap if present

2024-02-28T09:26:13Z ERROR ignoring failure in hook "remove": 
-----
kill -SIGKILL 3865 3933 3986 4268 4288 2473 2518 3979 3986 2496 3246 3602 2520 3831 5299 5319 3865 3661 3640 7053 6786 3661 6951 6216 6257 2518 3959 3979 6319 6217 6256 2520
kill: (3979): No such process
-----
```