### PR TITLE
[WIP] KU-307/unit test component manager enable

### DIFF
--- a/src/k8s/pkg/component/component_test.go
+++ b/src/k8s/pkg/component/component_test.go
@@ -116,9 +116,10 @@ func mustCreateNewHelmClient(t *testing.T, components map[string]types.Component
 	}
 
 	mockLoader := &mock.ChartLoader{}
+	mockInstaller := &mock.ChartInstaller{}
 
 	//Create a mock ComponentManager with the mock HelmClient
-	mockHelmCLient, err := NewHelmClient(snap, mockClient, WithChartLoader(mockLoader))
+	mockHelmCLient, err := NewHelmClient(snap, mockClient, WithChartLoader(mockLoader), WithChartInstaller(mockInstaller))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,16 +190,6 @@ func TestComponentEnableDisable(t *testing.T) {
 			Namespace:    "default",
 			ManifestPath: "chunky-tuna-1.14.1.tgz",
 		},
-		"two": {
-			ReleaseName:  "whiskas-2",
-			Namespace:    "default",
-			ManifestPath: "chunky-tuna-1.14.1.tgz",
-		},
-		"three": {
-			ReleaseName:  "whiskas-3",
-			Namespace:    "default",
-			ManifestPath: "chunky-tuna-1.14.1.tgz",
-		},
 	})
 
 	os.RemoveAll(tempDir)
@@ -208,5 +199,4 @@ func TestComponentEnableDisable(t *testing.T) {
 
 	err := mockHelmClient.Enable("one", map[string]any{"key": "value"})
 	g.Expect(err).To(BeNil())
-	g.Expect(mockHelmClient.isComponentEnabled("whiskas-1", "default")).To(BeTrue())
 }

--- a/src/k8s/pkg/component/mock/installer.go
+++ b/src/k8s/pkg/component/mock/installer.go
@@ -1,0 +1,19 @@
+package mock
+
+import (
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+type ChartInstaller struct {
+	enabledComponents map[string]bool
+}
+
+func (m *ChartInstaller) Run(install *action.Install, chart *chart.Chart, values map[string]any) error {
+	m.enabledComponents[install.ReleaseName] = true
+	return nil
+}
+
+func (m *ChartInstaller) NewInstall(actionConfig *action.Configuration) *action.Install {
+	return nil
+}

--- a/src/k8s/pkg/component/mock/loader.go
+++ b/src/k8s/pkg/component/mock/loader.go
@@ -1,0 +1,12 @@
+package mock
+
+import "helm.sh/helm/v3/pkg/chart"
+
+type ChartLoader struct {
+	Chart *chart.Chart
+	Err   error
+}
+
+func (m *ChartLoader) Load(path string) (*chart.Chart, error) {
+	return m.Chart, m.Err
+}


### PR DESCRIPTION
This is WIP.

I attempt to abstract dependencies from the Enable and isComponentEnabled functions.

I think this is needed to properly unit test the Enable/Disable functions. Here is what makes testing the functions in their current implementation difficult:

`Enable` relies on:
```go
chart, err := loader.Load(component.ManifestPath) // Calls filesystem
...
releases, err := list.Run() // Calls helm library
```

`isComponentEnabled` relies on:
```go
list := action.NewList(actionConfig) // Calls helm library
releases, err := list.Run() // Calls helm library
```

To mitigate this, I implemented the functional options pattern to be able to inject the objects we need, and this allows us to do something like.

```go
mockHelmCLient, err := NewHelmClient(snap, mockClient, WithChartLoader(mockLoader), WithChartInstaller(mockInstaller))
``` 

Consequently, `Enable` and `isComponentEnabled` can now use `h.chartInstaller.Run`, `h.chartLoader.Load`, etc. 

This makes it possible to mock the dependencies and unit test the functions. 