### PR TITLE
Update e2e lxd-profile and kube-proxy config

### DIFF
--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -98,7 +98,11 @@ func EnableNetworkComponent(ctx context.Context, s snap.Snap, podCIDR string) er
 			return fmt.Errorf("failed to get mount propagation for %s: %w", p, err)
 		}
 		if p == "private" {
-			if s.OnLXD(ctx) {
+			onLXD, err := s.OnLXD(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to check if on lxd: %w", err)
+			}
+			if onLXD {
 				return fmt.Errorf("/sys is not a shared mount on the LXD container, this might be resolved by updating LXD on the host to version 5.0.2 or newer")
 			}
 			return fmt.Errorf("/sys is not a shared mount")

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -3,6 +3,7 @@ package component
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"strings"
 
@@ -100,7 +101,7 @@ func EnableNetworkComponent(ctx context.Context, s snap.Snap, podCIDR string) er
 		if p == "private" {
 			onLXD, err := s.OnLXD(ctx)
 			if err != nil {
-				return fmt.Errorf("failed to check if on lxd: %w", err)
+				log.Printf("failed to check if on lxd: %v", err)
 			}
 			if onLXD {
 				return fmt.Errorf("/sys is not a shared mount on the LXD container, this might be resolved by updating LXD on the host to version 5.0.2 or newer")

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -127,7 +127,7 @@ func onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	if err := setup.KubeletWorker(snap, s.Name(), nodeIP, response.ClusterDNS, response.ClusterDomain, response.CloudProvider); err != nil {
 		return fmt.Errorf("failed to configure kubelet: %w", err)
 	}
-	if err := setup.KubeProxy(snap, s.Name(), response.PodCIDR); err != nil {
+	if err := setup.KubeProxy(s.Context, snap, s.Name(), response.PodCIDR); err != nil {
 		return fmt.Errorf("failed to configure kube-proxy: %w", err)
 	}
 	if err := setup.K8sAPIServerProxy(snap, response.APIServers); err != nil {
@@ -234,7 +234,7 @@ func onBootstrapControlPlane(s *state.State, initConfig map[string]string) error
 	if err := setup.KubeletControlPlane(snap, s.Name(), nodeIP, cfg.Kubelet.ClusterDNS, cfg.Kubelet.ClusterDomain, cfg.Kubelet.CloudProvider); err != nil {
 		return fmt.Errorf("failed to configure kubelet: %w", err)
 	}
-	if err := setup.KubeProxy(snap, s.Name(), cfg.Network.PodCIDR); err != nil {
+	if err := setup.KubeProxy(s.Context, snap, s.Name(), cfg.Network.PodCIDR); err != nil {
 		return fmt.Errorf("failed to configure kube-proxy: %w", err)
 	}
 	if err := setup.KubeControllerManager(snap); err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -111,7 +111,7 @@ func onPostJoin(s *state.State, initConfig map[string]string) error {
 	if err := setup.KubeletControlPlane(snap, s.Name(), nodeIP, cfg.Kubelet.ClusterDNS, cfg.Kubelet.ClusterDomain, cfg.Kubelet.CloudProvider); err != nil {
 		return fmt.Errorf("failed to configure kubelet: %w", err)
 	}
-	if err := setup.KubeProxy(snap, s.Name(), cfg.Network.PodCIDR); err != nil {
+	if err := setup.KubeProxy(s.Context, snap, s.Name(), cfg.Network.PodCIDR); err != nil {
 		return fmt.Errorf("failed to configure kube-proxy: %w", err)
 	}
 	if err := setup.KubeControllerManager(snap); err != nil {

--- a/src/k8s/pkg/k8sd/setup/kube-proxy
+++ b/src/k8s/pkg/k8sd/setup/kube-proxy
@@ -1,0 +1,6 @@
+--cluster-cidr=10.1.0.0/16
+--conntrack-max-per-core=0
+--healthz-bind-address=127.0.0.1
+--hostname-override=myhostname
+--kubeconfig=/tmp/TestKubeProxy185807947/001/kubernetes/proxy.conf
+--profiling=false

--- a/src/k8s/pkg/k8sd/setup/kube-proxy
+++ b/src/k8s/pkg/k8sd/setup/kube-proxy
@@ -1,6 +1,0 @@
---cluster-cidr=10.1.0.0/16
---conntrack-max-per-core=0
---healthz-bind-address=127.0.0.1
---hostname-override=myhostname
---kubeconfig=/tmp/TestKubeProxy185807947/001/kubernetes/proxy.conf
---profiling=false

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -19,7 +19,11 @@ func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR str
 		"--profiling":            "false",
 	}
 
-	if snap.OnLXD(ctx) {
+	onLXD, err := snap.OnLXD(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if on lxd: %w", err)
+	}
+	if onLXD {
 		// A container cannot set this sysctl config in LXD. So, we disable it by setting it to "0".
 		// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/
 		serviceArgs["--conntrack-max-per-core"] = "0"

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"context"
 	"fmt"
+	"log"
 	"path"
 
 	"github.com/canonical/k8s/pkg/snap"
@@ -21,7 +22,7 @@ func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR str
 
 	onLXD, err := snap.OnLXD(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to check if on lxd: %w", err)
+		log.Printf("failed to check if on lxd: %v", err)
 	}
 	if onLXD {
 		// A container cannot set this sysctl config in LXD. So, we disable it by setting it to "0".

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"path"
 
@@ -9,14 +10,22 @@ import (
 )
 
 // KubeProxy configures kube-proxy on the local node.
-func KubeProxy(snap snap.Snap, hostname string, podCIDR string) error {
-	if _, err := snaputil.UpdateServiceArguments(snap, "kube-proxy", map[string]string{
+func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR string) error {
+	serviceArgs := map[string]string{
 		"--cluster-cidr":         podCIDR,
 		"--healthz-bind-address": "127.0.0.1",
 		"--hostname-override":    hostname,
 		"--kubeconfig":           path.Join(snap.KubernetesConfigDir(), "proxy.conf"),
 		"--profiling":            "false",
-	}, nil); err != nil {
+	}
+
+	if snap.OnLXD(ctx) {
+		// A container cannot set this sysctl config in LXD. So, we disable it by setting it to "0".
+		// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/
+		serviceArgs["--conntrack-max-per-core=0"] = "0"
+	}
+
+	if _, err := snaputil.UpdateServiceArguments(snap, "kube-proxy", serviceArgs, nil); err != nil {
 		return fmt.Errorf("failed to render arguments file: %w", err)
 	}
 	return nil

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -22,7 +22,7 @@ func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR str
 	if snap.OnLXD(ctx) {
 		// A container cannot set this sysctl config in LXD. So, we disable it by setting it to "0".
 		// See: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/
-		serviceArgs["--conntrack-max-per-core=0"] = "0"
+		serviceArgs["--conntrack-max-per-core"] = "0"
 	}
 
 	if _, err := snaputil.UpdateServiceArguments(snap, "kube-proxy", serviceArgs, nil); err != nil {

--- a/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
@@ -1,0 +1,72 @@
+package setup_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/k8sd/setup"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	. "github.com/onsi/gomega"
+)
+
+func TestKubeProxy(t *testing.T) {
+	g := NewWithT(t)
+
+	dir := t.TempDir()
+
+	s := &mock.Snap{
+		Mock: mock.Mock{
+			KubernetesConfigDir: path.Join(dir, "kubernetes"),
+			OnLXD:               false,
+			UID:                 os.Getuid(),
+			GID:                 os.Getgid(),
+		},
+	}
+
+	g.Expect(setup.EnsureAllDirectories(s)).To(BeNil())
+
+	t.Run("Args", func(t *testing.T) {
+		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16")).To(BeNil())
+
+		for key, expectedVal := range map[string]string{
+			"--cluster-cidr":           "10.1.0.0/16",
+			"--healthz-bind-address":   "127.0.0.1",
+			"--hostname-override":      "myhostname",
+			"--kubeconfig":             path.Join(dir, "kubernetes", "proxy.conf"),
+			"--profiling":              "false",
+			"--conntrack-max-per-core": "",
+		} {
+			t.Run(key, func(t *testing.T) {
+				g := NewWithT(t)
+				val, err := snaputil.GetServiceArgument(s, "kube-proxy", key)
+				g.Expect(err).To(BeNil())
+				g.Expect(val).To(Equal(expectedVal))
+			})
+		}
+	})
+
+	s.Mock.OnLXD = true
+	t.Run("ArgsOnLXD", func(t *testing.T) {
+		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16")).To(BeNil())
+
+		for key, expectedVal := range map[string]string{
+			"--cluster-cidr":           "10.1.0.0/16",
+			"--healthz-bind-address":   "127.0.0.1",
+			"--hostname-override":      "myhostname",
+			"--kubeconfig":             path.Join(dir, "kubernetes", "proxy.conf"),
+			"--profiling":              "false",
+			"--conntrack-max-per-core": "0",
+		} {
+			t.Run(key, func(t *testing.T) {
+				g := NewWithT(t)
+				val, err := snaputil.GetServiceArgument(s, "kube-proxy", key)
+				g.Expect(err).To(BeNil())
+				g.Expect(val).To(Equal(expectedVal))
+			})
+		}
+	})
+
+}

--- a/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
@@ -20,6 +20,7 @@ func TestKubeProxy(t *testing.T) {
 	s := &mock.Snap{
 		Mock: mock.Mock{
 			KubernetesConfigDir: path.Join(dir, "kubernetes"),
+			ServiceArgumentsDir: path.Join(dir, "args"),
 			OnLXD:               false,
 			UID:                 os.Getuid(),
 			GID:                 os.Getgid(),
@@ -53,11 +54,6 @@ func TestKubeProxy(t *testing.T) {
 		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16")).To(BeNil())
 
 		for key, expectedVal := range map[string]string{
-			"--cluster-cidr":           "10.1.0.0/16",
-			"--healthz-bind-address":   "127.0.0.1",
-			"--hostname-override":      "myhostname",
-			"--kubeconfig":             path.Join(dir, "kubernetes", "proxy.conf"),
-			"--profiling":              "false",
 			"--conntrack-max-per-core": "0",
 		} {
 			t.Run(key, func(t *testing.T) {

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -10,8 +10,8 @@ import (
 
 // Snap abstracts file system paths and interacting with the k8s services.
 type Snap interface {
-	Strict() bool               // Strict returns true if the snap is installed with strict confinement.
-	OnLXD(context.Context) bool // OnLXD returns true if the host runs on LXD.
+	Strict() bool                        // Strict returns true if the snap is installed with strict confinement.
+	OnLXD(context.Context) (bool, error) // OnLXD returns true if the host runs on LXD.
 
 	UID() int // UID is the user ID to set on config files.
 	GID() int // GID is the group ID to set on config files.

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -12,6 +12,7 @@ import (
 type Mock struct {
 	Strict                      bool
 	OnLXD                       bool
+	OnLXDErr                    error
 	UID                         int
 	GID                         int
 	KubernetesConfigDir         string
@@ -77,8 +78,8 @@ func (s *Snap) RestartService(ctx context.Context, name string) error {
 func (s *Snap) Strict() bool {
 	return s.Mock.Strict
 }
-func (s *Snap) OnLXD(context.Context) bool {
-	return s.Mock.OnLXD
+func (s *Snap) OnLXD(context.Context) (bool, error) {
+	return s.Mock.OnLXD, s.Mock.OnLXDErr
 }
 func (s *Snap) UID() int {
 	return s.Mock.UID

--- a/tests/e2e/lxd-profile.yaml
+++ b/tests/e2e/lxd-profile.yaml
@@ -10,18 +10,10 @@ config:
   security.nesting: "true"
   security.privileged: "true"
 devices:
-  aadisable:
-    path: /sys/module/nf_conntrack/parameters/hashsize
-    source: /sys/module/nf_conntrack/parameters/hashsize
-    type: disk
   aadisable2:
     path: /dev/kmsg
     source: /dev/kmsg
     type: unix-char
-  aadisable4:
-    path: /proc/sys/net/netfilter/nf_conntrack_max
-    source: /proc/sys/net/netfilter/nf_conntrack_max
-    type: disk
   dev-loop-control:
     major: "10"
     minor: "237"


### PR DESCRIPTION
Juju only supports specific devices. This commit removes the unsupported ones.

Also, the container cannot modify the sysctl config on LXD, thus we disable this setting in kube-proxy.