### PR TITLE
Add GET k8sd/node endpoint

### DIFF
--- a/src/k8s/api/v1/node.go
+++ b/src/k8s/api/v1/node.go
@@ -1,0 +1,6 @@
+package v1
+
+// GetNodeStatusResponse is the response for "GET 1.0/k8sd/node".
+type GetNodeStatusResponse struct {
+	NodeStatus NodeStatus `json:"status"`
+}

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -73,22 +73,22 @@ const (
 type NodeStatus struct {
 	// Name is the name for this cluster member that was when joining the cluster.
 	// This is typically the hostname of the node.
-	Name string `mapstructure:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 	// Address is the IP address of the node.
-	Address string `mapstructure:"address,omitempty"`
+	Address string `json:"address,omitempty"`
 	// ClusterRole is the role that the node has within the k8s cluster.
-	ClusterRole ClusterRole `mapstructure:"cluster-role,omitempty"`
+	ClusterRole ClusterRole `json:"cluster-role,omitempty"`
 	// DatastoreRole is the role that the node has within the datastore cluster.
 	// Only applicable for control-plane nodes, empty for workers.
-	DatastoreRole DatastoreRole `mapstructure:"datastore-role,omitempty"`
+	DatastoreRole DatastoreRole `json:"datastore-role,omitempty"`
 }
 
 // ClusterStatus holds information about the cluster, e.g. its current members
 type ClusterStatus struct {
 	// Ready is true if at least one node in the cluster is in READY state.
-	Ready      bool         `mapstructure:"ready,omitempty"`
-	Members    []NodeStatus `mapstructure:"members,omitempty"`
-	Components []Component  `mapstructure:"components,omitempty"`
+	Ready      bool         `json:"ready,omitempty"`
+	Members    []NodeStatus `json:"members,omitempty"`
+	Components []Component  `json:"components,omitempty"`
 }
 
 // HaClusterFormed returns true if the cluster is in high-availability mode (more than two voter nodes).

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -48,28 +48,54 @@ func BootstrapConfigFromMap(m map[string]string) (*BootstrapConfig, error) {
 	return config, nil
 }
 
-// ClusterMember holds information about a node in the k8s cluster.
-type ClusterMember struct {
-	Name        string `mapstructure:"name,omitempty"`
-	Address     string `mapstructure:"address,omitempty"`
-	Role        string `mapstructure:"role,omitempty"`
-	Fingerprint string `mapstructure:"fingerprint,omitempty"`
-	Status      string `mapstructure:"status,omitempty"`
+type ClusterRole string
+
+const (
+	ClusterRoleControlPlane ClusterRole = "control-plane"
+	ClusterRoleWorker       ClusterRole = "worker"
+	// The role of a node is unknown if it has not yet joined a cluster,
+	// currently joining or is about to leave.
+	ClusterRoleUnknown ClusterRole = "unknown"
+)
+
+// DatastoreRole as provided by dqlite
+type DatastoreRole string
+
+const (
+	DatastoreRoleVoter   DatastoreRole = "voter"
+	DatastoreRoleStandBy DatastoreRole = "stand-by"
+	DatastoreRoleSpare   DatastoreRole = "spare"
+	DatastoreRolePending DatastoreRole = "PENDING"
+	DatastoreRoleUnknown DatastoreRole = "unknown"
+)
+
+// NodeStatus holds information about a node in the k8s cluster.
+type NodeStatus struct {
+	// Name is the name for this cluster member that was when joining the cluster.
+	// This is typically the hostname of the node.
+	Name string `mapstructure:"name,omitempty"`
+	// Address is the IP address of the node.
+	Address string `mapstructure:"address,omitempty"`
+	// ClusterRole is the role that the node has within the k8s cluster.
+	ClusterRole ClusterRole `mapstructure:"cluster-role,omitempty"`
+	// DatastoreRole is the role that the node has within the datastore cluster.
+	// Only applicable for control-plane nodes, empty for workers.
+	DatastoreRole DatastoreRole `mapstructure:"datastore-role,omitempty"`
 }
 
 // ClusterStatus holds information about the cluster, e.g. its current members
 type ClusterStatus struct {
 	// Ready is true if at least one node in the cluster is in READY state.
-	Ready      bool            `mapstructure:"ready,omitempty"`
-	Members    []ClusterMember `mapstructure:"members,omitempty"`
-	Components []Component     `mapstructure:"components,omitempty"`
+	Ready      bool         `mapstructure:"ready,omitempty"`
+	Members    []NodeStatus `mapstructure:"members,omitempty"`
+	Components []Component  `mapstructure:"components,omitempty"`
 }
 
 // HaClusterFormed returns true if the cluster is in high-availability mode (more than two voter nodes).
 func (c ClusterStatus) HaClusterFormed() bool {
 	voters := 0
 	for _, member := range c.Members {
-		if member.Role == "voter" {
+		if member.DatastoreRole == DatastoreRoleVoter {
 			voters++
 		}
 	}

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -58,8 +58,9 @@ func NewRootCmd() *cobra.Command {
 
 	// internal
 	rootCmd.AddCommand(newGenerateAuthTokenCmd())
-	rootCmd.AddCommand(newRevokeAuthTokenCmd())
 	rootCmd.AddCommand(newKubeConfigCmd())
+	rootCmd.AddCommand(newLocalNodeStatusCommand())
+	rootCmd.AddCommand(newRevokeAuthTokenCmd())
 	rootCmd.AddCommand(xPrintShimPidsCmd)
 
 	// Those commands replace the executable - no need for error wrapping.

--- a/src/k8s/cmd/k8s/k8s_local_node_status.go
+++ b/src/k8s/cmd/k8s/k8s_local_node_status.go
@@ -1,0 +1,29 @@
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/cmd/k8s/errors"
+	"github.com/spf13/cobra"
+)
+
+func newLocalNodeStatusCommand() *cobra.Command {
+	localNodeStatusCmd := &cobra.Command{
+		Use:     "local-node-status",
+		Short:   "Retrieve the current status of the local node",
+		Hidden:  true,
+		PreRunE: chainPreRunHooks(hookSetupClient),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			defer errors.Transform(&err, nil)
+
+			clusterStatus, err := k8sdClient.NodeStatus(cmd.Context())
+			if err != nil {
+				return fmt.Errorf("failed to get cluster status: %w", err)
+			}
+
+			fmt.Println(clusterStatus)
+			return nil
+		},
+	}
+	return localNodeStatusCmd
+}

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -62,7 +62,7 @@ func (c *k8sdClient) WaitForDqliteNodeToBeReady(ctx context.Context, nodeName st
 
 		for _, member := range clusterStatus.Members {
 			if member.Name == nodeName {
-				if member.Role == "PENDING" {
+				if member.DatastoreRole == apiv1.DatastoreRolePending {
 					return false, nil
 				}
 				return true, nil

--- a/src/k8s/pkg/k8s/client/interface.go
+++ b/src/k8s/pkg/k8s/client/interface.go
@@ -11,7 +11,7 @@ import (
 // Client defines the interface for interacting with a k8s cluster.
 type Client interface {
 	// Bootstrap initializes a new cluster member using the provided bootstrap configuration.
-	Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapConfig) (apiv1.ClusterMember, error)
+	Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error)
 	// IsKubernetesAPIServerReady checks if kube-apiserver is reachable.
 	IsKubernetesAPIServerReady(ctx context.Context) bool
 	// IsBootstrapped checks whether the current node is already bootstrapped.
@@ -20,6 +20,8 @@ type Client interface {
 	CleanupNode(ctx context.Context, snap snap.Snap, nodeName string)
 	// ClusterStatus retrieves the current status of the Kubernetes cluster.
 	ClusterStatus(ctx context.Context, waitReady bool) (apiv1.ClusterStatus, error)
+	// NodeStatus retrieves the current status of the local node.
+	NodeStatus(ctx context.Context) (apiv1.NodeStatus, error)
 	// CreateJoinToken generates a token for a new node to join the cluster.
 	CreateJoinToken(ctx context.Context, name string, worker bool) (string, error)
 	// GenerateAuthToken generates an authentication token for a specific user with given groups.

--- a/src/k8s/pkg/k8s/client/mock/mock.go
+++ b/src/k8s/pkg/k8s/client/mock/mock.go
@@ -10,7 +10,7 @@ import (
 // Client is a mock implementation for k8s Client.
 type Client struct {
 	BootstrapCalledWith    apiv1.BootstrapConfig
-	BootstrapClusterMember apiv1.ClusterMember
+	BootstrapClusterMember apiv1.NodeStatus
 	BootstrapErr           error
 	IsBootstrappedReturn   bool
 	CleanupNodeCalledWith  struct {
@@ -77,7 +77,7 @@ type Client struct {
 	UpdateStorageComponentErr error
 }
 
-func (c *Client) Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapConfig) (apiv1.ClusterMember, error) {
+func (c *Client) Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error) {
 	c.BootstrapCalledWith = bootstrapConfig
 	return c.BootstrapClusterMember, c.BootstrapErr
 }

--- a/src/k8s/pkg/k8s/client/node.go
+++ b/src/k8s/pkg/k8s/client/node.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"context"
+
+	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/lxd/shared/api"
+)
+
+// NodeStatus queries the local node status
+func (c *k8sdClient) NodeStatus(ctx context.Context) (apiv1.NodeStatus, error) {
+	var response apiv1.GetNodeStatusResponse
+	err := c.Query(ctx, "GET", api.NewURL().Path("k8sd", "node"), nil, &response)
+	if err != nil {
+		return apiv1.NodeStatus{}, err
+	}
+	return response.NodeStatus, nil
+}

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -15,6 +15,13 @@ func Endpoints(app *microcluster.MicroCluster) []rest.Endpoint {
 			Path: "k8sd/cluster",
 			Get:  rest.EndpointAction{Handler: getClusterStatus, AccessHandler: RestrictWorkers},
 		},
+		// Node
+		// Returns the status (e.g. current role) of the local node (control-plane, worker or unknown).
+		{
+			Name: "NodeStatus",
+			Path: "k8sd/node",
+			Get:  rest.EndpointAction{Handler: getNodeStatus},
+		},
 		// Clustering
 		// Unified token endpoint for both, control-plane and worker-node.
 		{

--- a/src/k8s/pkg/k8sd/api/impl/k8sd.go
+++ b/src/k8s/pkg/k8sd/api/impl/k8sd.go
@@ -3,11 +3,13 @@ package impl
 import (
 	"context"
 	"fmt"
+	"log"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/k8s"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -47,7 +49,7 @@ func GetClusterStatus(ctx context.Context, s *state.State) (apiv1.ClusterStatus,
 }
 
 // GetClusterMembers retrieves information about the members of the cluster.
-func GetClusterMembers(ctx context.Context, s *state.State) ([]apiv1.ClusterMember, error) {
+func GetClusterMembers(ctx context.Context, s *state.State) ([]apiv1.NodeStatus, error) {
 	c, err := s.Leader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get leader client: %w", err)
@@ -58,21 +60,50 @@ func GetClusterMembers(ctx context.Context, s *state.State) ([]apiv1.ClusterMemb
 		return nil, fmt.Errorf("failed to get cluster members: %w", err)
 	}
 
-	members := make([]apiv1.ClusterMember, len(clusterMembers))
+	members := make([]apiv1.NodeStatus, len(clusterMembers))
 	for i, clusterMember := range clusterMembers {
-		fingerprint, err := shared.CertFingerprintStr(clusterMember.Certificate.String())
-		if err != nil {
-			continue
-		}
-
-		members[i] = apiv1.ClusterMember{
-			Name:        clusterMember.Name,
-			Address:     clusterMember.Address.String(),
-			Role:        clusterMember.Role,
-			Fingerprint: fingerprint,
-			Status:      string(clusterMember.Status),
+		members[i] = apiv1.NodeStatus{
+			Name:          clusterMember.Name,
+			Address:       clusterMember.Address.String(),
+			ClusterRole:   apiv1.ClusterRoleControlPlane,
+			DatastoreRole: utils.DatastoreRoleFromString(clusterMember.Role),
 		}
 	}
 
 	return members, nil
+}
+
+// GetLocalNodeStatus retrieves the status of the local node, including its roles within the cluster.
+// Unlike "GetClusterMembers" this also works on a worker node.
+func GetLocalNodeStatus(ctx context.Context, s *state.State) (apiv1.NodeStatus, error) {
+	snap := snap.SnapFromContext(s.Context)
+
+	// Determine cluster role.
+	clusterRole := apiv1.ClusterRoleUnknown
+	isWorker, err := snaputil.IsWorker(snap)
+	if err != nil {
+		return apiv1.NodeStatus{}, fmt.Errorf("failed to check if node is a worker: %w", err)
+	}
+	if isWorker {
+		clusterRole = apiv1.ClusterRoleWorker
+	} else {
+		node, err := utils.GetControlPlaneNode(ctx, s, s.Name())
+		if err != nil {
+			// The node is likely in a joining or leaving phase where the role is not yet settled.
+			// Use the unknown role but still log this incident for debugging.
+			log.Printf("Failed to check if node is control-plane. This is expected if the node is in a joining/leaving phase. %v", err)
+			clusterRole = apiv1.ClusterRoleUnknown
+		} else {
+			if node != nil {
+				return *node, nil
+			}
+		}
+
+	}
+	return apiv1.NodeStatus{
+		Name:        s.Name(),
+		Address:     s.Address().Hostname(),
+		ClusterRole: clusterRole,
+	}, nil
+
 }

--- a/src/k8s/pkg/k8sd/api/node.go
+++ b/src/k8s/pkg/k8sd/api/node.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"net/http"
+
+	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/k8sd/api/impl"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/state"
+)
+
+func getNodeStatus(s *state.State, r *http.Request) response.Response {
+	status, err := impl.GetLocalNodeStatus(r.Context(), s)
+	if err != nil {
+		response.InternalError(err)
+	}
+
+	result := apiv1.GetNodeStatusResponse{
+		NodeStatus: status,
+	}
+
+	return response.SyncResponse(true, &result)
+}

--- a/src/k8s/pkg/utils/node.go
+++ b/src/k8s/pkg/utils/node.go
@@ -4,27 +4,43 @@ import (
 	"context"
 	"fmt"
 
+	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/microcluster/state"
 )
 
-// IsControlPlaneNode returns true if the given node name belongs to a control-plane in the cluster.
-func IsControlPlaneNode(ctx context.Context, s *state.State, name string) (bool, error) {
+// GetControlPlaneNode returns the node information if the given node name
+// belongs to a control-plane in the cluster or nil if not.
+func GetControlPlaneNode(ctx context.Context, s *state.State, name string) (*apiv1.NodeStatus, error) {
 	client, err := s.Leader()
 	if err != nil {
-		return false, fmt.Errorf("failed to get microcluster leader client: %w", err)
+		return nil, fmt.Errorf("failed to get microcluster leader client: %w", err)
 	}
 
 	members, err := client.GetClusterMembers(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to get microcluster members: %w", err)
+		return nil, fmt.Errorf("failed to get microcluster members: %w", err)
 	}
 
 	for _, member := range members {
 		if member.Name == name {
-			return true, nil
+			return &apiv1.NodeStatus{
+				Name:          member.Name,
+				Address:       member.Address.String(),
+				ClusterRole:   apiv1.ClusterRoleControlPlane,
+				DatastoreRole: DatastoreRoleFromString(member.Role),
+			}, nil
 		}
 	}
-	return false, nil
+	return nil, nil
+}
+
+// IsControlPlaneNode returns true if the given node name belongs to a control-plane node in the cluster.
+func IsControlPlaneNode(ctx context.Context, s *state.State, name string) (bool, error) {
+	node, err := GetControlPlaneNode(ctx, s, name)
+	if err != nil {
+		return false, fmt.Errorf("failed to get control-plane node: %w", err)
+	}
+	return node != nil, nil
 }
 
 // IsWorkerNode returns true if the given node name belongs to a worker node in the cluster.
@@ -34,4 +50,20 @@ func IsWorkerNode(ctx context.Context, s *state.State, name string) (bool, error
 		return false, fmt.Errorf("failed to check if worker node %q exists: %w", name, err)
 	}
 	return exists, nil
+}
+
+// DatastoreRoleFromString converts the string-based role to the enum-based role.
+func DatastoreRoleFromString(role string) apiv1.DatastoreRole {
+	switch role {
+	case "voter":
+		return apiv1.DatastoreRoleVoter
+	case "stand-by":
+		return apiv1.DatastoreRoleStandBy
+	case "spare":
+		return apiv1.DatastoreRoleSpare
+	case "PENDING":
+		return apiv1.DatastoreRolePending
+	default:
+		return apiv1.DatastoreRoleUnknown
+	}
 }

--- a/tests/e2e/tests/e2e_util/util.py
+++ b/tests/e2e/tests/e2e_util/util.py
@@ -234,6 +234,11 @@ def hostname(instance: harness.Instance) -> str:
     return resp.stdout.decode().strip()
 
 
+def get_local_node_status(instance: harness.Instance) -> str:
+    resp = instance.exec(["k8s", "local-node-status"], capture_output=True)
+    return resp.stdout.decode().strip()
+
+
 def ready_nodes(control_node: harness.Instance) -> List[Any]:
     """Get a list of the ready nodes.
 

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -38,6 +38,9 @@ def test_clustering(instances: List[harness.Instance]):
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 2, "node should have joined cluster"
 
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_node)
+
     cluster_node.exec(["k8s", "remove-node", joining_node.id])
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 1, "node should have been removed from cluster"
@@ -57,6 +60,9 @@ def test_worker_nodes(instances: List[harness.Instance]):
     util.wait_until_k8s_ready(cluster_node, instances)
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 2, "worker should have joined cluster"
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "worker" in util.get_local_node_status(joining_node)
 
     cluster_node.exec(["k8s", "remove-node", joining_node.id])
     nodes = util.ready_nodes(cluster_node)


### PR DESCRIPTION
Provides an endpoint to query the current status of the local k8s node. This is especially useful for the charm that wants to know the current role of specific node. It is not possible to query other nodes for security purposes.

Additionally,
* changed `ClusterMember` to `NodeStatus` to better reflect the new shared use
* added a hidden CLI command `k8s local-node-status` for testing.
* added basic test coverage by integrating assertions into the `test_clustering.py` test.
* use enum for datastore and cluster roles to not rely on random strings.