### PR TITLE
Update k8s status command

### DIFF
--- a/src/k8s/api/v1/cluster_config.go
+++ b/src/k8s/api/v1/cluster_config.go
@@ -14,55 +14,55 @@ type UpdateClusterConfigResponse struct {
 }
 
 type UserFacingClusterConfig struct {
-	Network       *NetworkConfig       `json:"network,omitempty" yaml:"network"`
-	DNS           *DNSConfig           `json:"dns,omitempty" yaml:"dns"`
-	Ingress       *IngressConfig       `json:"ingress,omitempty" yaml:"ingress"`
-	LoadBalancer  *LoadBalancerConfig  `json:"load-balancer,omitempty" yaml:"load-balancer"`
-	LocalStorage  *LocalStorageConfig  `json:"local-storage,omitempty" yaml:"local-storage"`
-	Gateway       *GatewayConfig       `json:"gateway,omitempty" yaml:"gateway"`
-	MetricsServer *MetricsServerConfig `json:"metrics-server,omitempty" yaml:"metrics-server"`
+	Network       *NetworkConfig       `json:"network,omitempty" yaml:"network,omitempty"`
+	DNS           *DNSConfig           `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Ingress       *IngressConfig       `json:"ingress,omitempty" yaml:"ingress,omitempty"`
+	LoadBalancer  *LoadBalancerConfig  `json:"load-balancer,omitempty" yaml:"load-balancer,omitempty"`
+	LocalStorage  *LocalStorageConfig  `json:"local-storage,omitempty" yaml:"local-storage,omitempty"`
+	Gateway       *GatewayConfig       `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	MetricsServer *MetricsServerConfig `json:"metrics-server,omitempty" yaml:"metrics-server,omitempty"`
 }
 
 type DNSConfig struct {
-	Enabled             *bool    `json:"enabled,omitempty" yaml:"enabled"`
-	ClusterDomain       string   `json:"cluster-domain,omitempty" yaml:"cluster-domain"`
-	ServiceIP           string   `json:"service-ip,omitempty" yaml:"service-ip"`
-	UpstreamNameservers []string `json:"upstream-nameservers,omitempty" yaml:"upstream-nameservers"`
+	Enabled             *bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	ClusterDomain       string   `json:"cluster-domain,omitempty" yaml:"cluster-domain,omitempty"`
+	ServiceIP           string   `json:"service-ip,omitempty" yaml:"service-ip,omitempty"`
+	UpstreamNameservers []string `json:"upstream-nameservers,omitempty" yaml:"upstream-nameservers,omitempty"`
 }
 
 type IngressConfig struct {
-	Enabled             *bool  `json:"enabled,omitempty" yaml:"enabled"`
-	DefaultTLSSecret    string `json:"default-tls-secret,omitempty" yaml:"default-tls-secret"`
-	EnableProxyProtocol *bool  `json:"enable-proxy-protocol,omitempty" yaml:"enable-proxy-protocol"`
+	Enabled             *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	DefaultTLSSecret    string `json:"default-tls-secret,omitempty" yaml:"default-tls-secret,omitempty"`
+	EnableProxyProtocol *bool  `json:"enable-proxy-protocol,omitempty" yaml:"enable-proxy-protocol,omitempty"`
 }
 
 type LoadBalancerConfig struct {
-	Enabled        *bool    `json:"enabled,omitempty" yaml:"enabled"`
-	CIDRs          []string `json:"cidrs,omitempty" yaml:"cidrs"`
-	L2Enabled      *bool    `json:"l2-enabled,omitempty" yaml:"l2-enabled"`
-	L2Interfaces   []string `json:"l2-interfaces,omitempty" yaml:"l2-interfaces"`
-	BGPEnabled     *bool    `json:"bgp-enabled,omitempty" yaml:"bgp-enabled"`
-	BGPLocalASN    int      `json:"bgp-local-asn,omitempty" yaml:"bgp-local-asn"`
-	BGPPeerAddress string   `json:"bgp-peer-address,omitempty" yaml:"bgp-peer-address"`
-	BGPPeerASN     int      `json:"bgp-peer-asn,omitempty" yaml:"bgp-peer-asn"`
-	BGPPeerPort    int      `json:"bgp-peer-port,omitempty" yaml:"bgp-peer-port"`
+	Enabled        *bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	CIDRs          []string `json:"cidrs,omitempty" yaml:"cidrs,omitempty"`
+	L2Enabled      *bool    `json:"l2-enabled,omitempty" yaml:"l2-enabled,omitempty"`
+	L2Interfaces   []string `json:"l2-interfaces,omitempty" yaml:"l2-interfaces,omitempty"`
+	BGPEnabled     *bool    `json:"bgp-enabled,omitempty" yaml:"bgp-enabled,omitempty"`
+	BGPLocalASN    int      `json:"bgp-local-asn,omitempty" yaml:"bgp-local-asn,omitempty"`
+	BGPPeerAddress string   `json:"bgp-peer-address,omitempty" yaml:"bgp-peer-address,omitempty"`
+	BGPPeerASN     int      `json:"bgp-peer-asn,omitempty" yaml:"bgp-peer-asn,omitempty"`
+	BGPPeerPort    int      `json:"bgp-peer-port,omitempty" yaml:"bgp-peer-port,omitempty"`
 }
 
 type LocalStorageConfig struct {
-	Enabled       *bool  `json:"enabled,omitempty" yaml:"enabled"`
-	LocalPath     string `json:"local-path,omitempty" yaml:"local-path"`
-	ReclaimPolicy string `json:"reclaim-policy,omitempty" yaml:"reclaim-policy"`
-	SetDefault    *bool  `json:"set-default,omitempty" yaml:"set-default"`
+	Enabled       *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	LocalPath     string `json:"local-path,omitempty" yaml:"local-path,omitempty"`
+	ReclaimPolicy string `json:"reclaim-policy,omitempty" yaml:"reclaim-policy,omitempty"`
+	SetDefault    *bool  `json:"set-default,omitempty" yaml:"set-default,omitempty"`
 }
 
 type NetworkConfig struct {
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }
 
 type GatewayConfig struct {
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }
 
 type MetricsServerConfig struct {
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }

--- a/src/k8s/api/v1/cluster_config.go
+++ b/src/k8s/api/v1/cluster_config.go
@@ -24,45 +24,45 @@ type UserFacingClusterConfig struct {
 }
 
 type DNSConfig struct {
-	Enabled             *bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	ClusterDomain       string   `json:"cluster-domain,omitempty" yaml:"cluster-domain,omitempty"`
-	ServiceIP           string   `json:"service-ip,omitempty" yaml:"service-ip,omitempty"`
-	UpstreamNameservers []string `json:"upstream-nameservers,omitempty" yaml:"upstream-nameservers,omitempty"`
+	Enabled             *bool    `json:"enabled,omitempty" yaml:"enabled"`
+	ClusterDomain       string   `json:"cluster-domain,omitempty" yaml:"cluster-domain"`
+	ServiceIP           string   `json:"service-ip,omitempty" yaml:"service-ip"`
+	UpstreamNameservers []string `json:"upstream-nameservers,omitempty" yaml:"upstream-nameservers"`
 }
 
 type IngressConfig struct {
-	Enabled             *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	DefaultTLSSecret    string `json:"default-tls-secret,omitempty" yaml:"default-tls-secret,omitempty"`
-	EnableProxyProtocol *bool  `json:"enable-proxy-protocol,omitempty" yaml:"enable-proxy-protocol,omitempty"`
+	Enabled             *bool  `json:"enabled,omitempty" yaml:"enabled"`
+	DefaultTLSSecret    string `json:"default-tls-secret,omitempty" yaml:"default-tls-secret"`
+	EnableProxyProtocol *bool  `json:"enable-proxy-protocol,omitempty" yaml:"enable-proxy-protocol"`
 }
 
 type LoadBalancerConfig struct {
-	Enabled        *bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	CIDRs          []string `json:"cidrs,omitempty" yaml:"cidrs,omitempty"`
-	L2Enabled      *bool    `json:"l2-enabled,omitempty" yaml:"l2-enabled,omitempty"`
-	L2Interfaces   []string `json:"l2-interfaces,omitempty" yaml:"l2-interfaces,omitempty"`
-	BGPEnabled     *bool    `json:"bgp-enabled,omitempty" yaml:"bgp-enabled,omitempty"`
-	BGPLocalASN    int      `json:"bgp-local-asn,omitempty" yaml:"bgp-local-asn,omitempty"`
-	BGPPeerAddress string   `json:"bgp-peer-address,omitempty" yaml:"bgp-peer-address,omitempty"`
-	BGPPeerASN     int      `json:"bgp-peer-asn,omitempty" yaml:"bgp-peer-asn,omitempty"`
-	BGPPeerPort    int      `json:"bgp-peer-port,omitempty" yaml:"bgp-peer-port,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty" yaml:"enabled"`
+	CIDRs          []string `json:"cidrs,omitempty" yaml:"cidrs"`
+	L2Enabled      *bool    `json:"l2-enabled,omitempty" yaml:"l2-enabled"`
+	L2Interfaces   []string `json:"l2-interfaces,omitempty" yaml:"l2-interfaces"`
+	BGPEnabled     *bool    `json:"bgp-enabled,omitempty" yaml:"bgp-enabled"`
+	BGPLocalASN    int      `json:"bgp-local-asn,omitempty" yaml:"bgp-local-asn"`
+	BGPPeerAddress string   `json:"bgp-peer-address,omitempty" yaml:"bgp-peer-address"`
+	BGPPeerASN     int      `json:"bgp-peer-asn,omitempty" yaml:"bgp-peer-asn"`
+	BGPPeerPort    int      `json:"bgp-peer-port,omitempty" yaml:"bgp-peer-port"`
 }
 
 type LocalStorageConfig struct {
-	Enabled       *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	LocalPath     string `json:"local-path,omitempty" yaml:"local-path,omitempty"`
-	ReclaimPolicy string `json:"reclaim-policy,omitempty" yaml:"reclaim-policy,omitempty"`
-	SetDefault    *bool  `json:"set-default,omitempty" yaml:"set-default,omitempty"`
+	Enabled       *bool  `json:"enabled,omitempty" yaml:"enabled"`
+	LocalPath     string `json:"local-path,omitempty" yaml:"local-path"`
+	ReclaimPolicy string `json:"reclaim-policy,omitempty" yaml:"reclaim-policy"`
+	SetDefault    *bool  `json:"set-default,omitempty" yaml:"set-default"`
 }
 
 type NetworkConfig struct {
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
 }
 
 type GatewayConfig struct {
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
 }
 
 type MetricsServerConfig struct {
-	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
 }

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -186,7 +186,6 @@ func (c ClusterStatus) String() string {
 
 	b, _ := yaml.Marshal(printedConfig)
 	result.WriteString(string(b))
-	result.WriteString("\n")
 
 	return result.String()
 }

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/canonical/k8s/pkg/utils/vals"
@@ -87,9 +86,9 @@ type NodeStatus struct {
 // ClusterStatus holds information about the cluster, e.g. its current members
 type ClusterStatus struct {
 	// Ready is true if at least one node in the cluster is in READY state.
-	Ready      bool         `json:"ready,omitempty"`
-	Members    []NodeStatus `json:"members,omitempty"`
-	Components []Component  `json:"components,omitempty"`
+	Ready   bool                    `json:"ready,omitempty"`
+	Members []NodeStatus            `json:"members,omitempty"`
+	Config  UserFacingClusterConfig `json:"config,omitempty"`
 }
 
 // HaClusterFormed returns true if the cluster is in high-availability mode (more than two voter nodes).
@@ -103,13 +102,14 @@ func (c ClusterStatus) HaClusterFormed() bool {
 	return voters > 2
 }
 
+// TODO: Print k8s version. However, multiple nodes can run different version, so we would need to query all nodes.
 func (c ClusterStatus) String() string {
 	result := strings.Builder{}
 
 	if c.Ready {
-		result.WriteString("status: ready.")
+		result.WriteString("status: ready")
 	} else {
-		result.WriteString("status: not ready.")
+		result.WriteString("status: not ready")
 	}
 	result.WriteString("\n")
 
@@ -119,20 +119,74 @@ func (c ClusterStatus) String() string {
 	} else {
 		result.WriteString("no")
 	}
-	result.WriteString("\n\n")
-	result.WriteString("control-plane nodes:\n")
-	for _, member := range c.Members {
-		// There is not much that we can do if the hostport is wrong.
-		// Thus, ignore the error and just display an empty IP field.
-		apiServerIp, _, _ := net.SplitHostPort(member.Address)
-		result.WriteString(fmt.Sprintf("  %s: %s\n", member.Name, apiServerIp))
+	result.WriteString("\n")
+	result.WriteString("datastore:\n")
+
+	voters := make([]NodeStatus, 0, len(c.Members))
+	standBys := make([]NodeStatus, 0, len(c.Members))
+	spares := make([]NodeStatus, 0, len(c.Members))
+	for _, node := range c.Members {
+		switch node.DatastoreRole {
+		case DatastoreRoleVoter:
+			voters = append(voters, node)
+		case DatastoreRoleStandBy:
+			standBys = append(standBys, node)
+		case DatastoreRoleSpare:
+			spares = append(spares, node)
+		}
+	}
+	if len(voters) > 0 {
+		result.WriteString(fmt.Sprintf("  voter-nodes:\n"))
+		for _, voter := range voters {
+			result.WriteString(fmt.Sprintf("    - %s\n", voter.Address))
+		}
+	} else {
+		result.WriteString(fmt.Sprintf("  voter-nodes: none\n"))
+	}
+	if len(standBys) > 0 {
+		result.WriteString(fmt.Sprintf("  standby-nodes:\n"))
+		for _, standBy := range standBys {
+			result.WriteString(fmt.Sprintf("    - %s\n", standBy.Address))
+		}
+	} else {
+		result.WriteString(fmt.Sprintf("  standy-nodes: none\n"))
+	}
+	if len(spares) > 0 {
+		result.WriteString(fmt.Sprintf("  spare-nodes:\n"))
+		for _, spare := range spares {
+			result.WriteString(fmt.Sprintf("    - %s\n", spare.Address))
+		}
+	} else {
+		result.WriteString(fmt.Sprintf("  spare-nodes: none\n"))
 	}
 	result.WriteString("\n")
 
-	result.WriteString("components:\n")
-	for _, component := range c.Components {
-		result.WriteString(fmt.Sprintf("  %-10s %s\n", component.Name, component.Status))
+	printedConfig := UserFacingClusterConfig{}
+	if c.Config.Network.Enabled != nil && *c.Config.Network.Enabled {
+		printedConfig.Network = c.Config.Network
 	}
+	if c.Config.DNS.Enabled != nil && *c.Config.DNS.Enabled {
+		printedConfig.DNS = c.Config.DNS
+	}
+	if c.Config.Ingress.Enabled != nil && *c.Config.Ingress.Enabled {
+		printedConfig.Ingress = c.Config.Ingress
+	}
+	if c.Config.LoadBalancer.Enabled != nil && *c.Config.LoadBalancer.Enabled {
+		printedConfig.LoadBalancer = c.Config.LoadBalancer
+	}
+	if c.Config.LocalStorage.Enabled != nil && *c.Config.LocalStorage.Enabled {
+		printedConfig.LocalStorage = c.Config.LocalStorage
+	}
+	if c.Config.Gateway.Enabled != nil && *c.Config.Gateway.Enabled {
+		printedConfig.Gateway = c.Config.Gateway
+	}
+	if c.Config.MetricsServer.Enabled != nil && *c.Config.MetricsServer.Enabled {
+		printedConfig.MetricsServer = c.Config.MetricsServer
+	}
+
+	b, _ := yaml.Marshal(printedConfig)
+	result.WriteString(string(b))
+	result.WriteString("\n")
 
 	return result.String()
 }

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -149,7 +149,7 @@ func (c ClusterStatus) String() string {
 			result.WriteString(fmt.Sprintf("    - %s\n", standBy.Address))
 		}
 	} else {
-		result.WriteString(fmt.Sprintf("  standy-nodes: none\n"))
+		result.WriteString(fmt.Sprintf("  standby-nodes: none\n"))
 	}
 	if len(spares) > 0 {
 		result.WriteString(fmt.Sprintf("  spare-nodes:\n"))

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
-	"github.com/canonical/k8s/pkg/utils/vals"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/state"
 )
@@ -116,93 +115,9 @@ func putClusterConfig(s *state.State, r *http.Request) response.Response {
 }
 
 func getClusterConfig(s *state.State, r *http.Request) response.Response {
-	cfg, err := utils.GetClusterConfig(r.Context(), s)
+	userFacing, err := utils.GetUserFacingClusterConfig(r.Context(), s)
 	if err != nil {
-		return response.InternalError(fmt.Errorf("failed to get cluster config: %w", err))
-	}
-
-	userFacing := api.UserFacingClusterConfig{
-		Network: &api.NetworkConfig{
-			Enabled: vals.Pointer(true),
-		},
-		DNS: &api.DNSConfig{
-			Enabled:             vals.Pointer(true),
-			UpstreamNameservers: cfg.DNS.UpstreamNameservers,
-			ServiceIP:           cfg.Kubelet.ClusterDNS,
-			ClusterDomain:       cfg.Kubelet.ClusterDomain,
-		},
-		Ingress: &api.IngressConfig{
-			Enabled:             vals.Pointer(false),
-			DefaultTLSSecret:    cfg.Ingress.DefaultTLSSecret,
-			EnableProxyProtocol: vals.Pointer(false),
-		},
-		LoadBalancer: &api.LoadBalancerConfig{
-			Enabled:        vals.Pointer(false),
-			CIDRs:          cfg.LoadBalancer.CIDRs,
-			L2Enabled:      vals.Pointer(false),
-			L2Interfaces:   cfg.LoadBalancer.L2Interfaces,
-			BGPEnabled:     vals.Pointer(false),
-			BGPLocalASN:    cfg.LoadBalancer.BGPLocalASN,
-			BGPPeerAddress: cfg.LoadBalancer.BGPPeerAddress,
-			BGPPeerASN:     cfg.LoadBalancer.BGPPeerASN,
-			BGPPeerPort:    cfg.LoadBalancer.BGPPeerPort,
-		},
-		LocalStorage: &api.LocalStorageConfig{
-			Enabled:       vals.Pointer(false),
-			LocalPath:     cfg.LocalStorage.LocalPath,
-			ReclaimPolicy: cfg.LocalStorage.ReclaimPolicy,
-			SetDefault:    vals.Pointer(true),
-		},
-		Gateway: &api.GatewayConfig{
-			Enabled: vals.Pointer(false),
-		},
-		MetricsServer: &api.MetricsServerConfig{
-			Enabled: vals.Pointer(false),
-		},
-	}
-
-	if cfg.Network.Enabled != nil {
-		userFacing.Network.Enabled = cfg.Network.Enabled
-	}
-
-	if cfg.DNS.Enabled != nil {
-		userFacing.DNS.Enabled = cfg.DNS.Enabled
-	}
-
-	if cfg.Ingress.Enabled != nil {
-		userFacing.Ingress.Enabled = cfg.Ingress.Enabled
-	}
-
-	if cfg.LoadBalancer.Enabled != nil {
-		userFacing.LoadBalancer.Enabled = cfg.LoadBalancer.Enabled
-	}
-
-	if cfg.LocalStorage.Enabled != nil {
-		userFacing.LocalStorage.Enabled = cfg.LocalStorage.Enabled
-	}
-
-	if cfg.Gateway.Enabled != nil {
-		userFacing.Gateway.Enabled = cfg.Gateway.Enabled
-	}
-
-	if cfg.MetricsServer.Enabled != nil {
-		userFacing.MetricsServer.Enabled = cfg.MetricsServer.Enabled
-	}
-
-	if cfg.Ingress.EnableProxyProtocol != nil {
-		userFacing.Ingress.EnableProxyProtocol = cfg.Ingress.EnableProxyProtocol
-	}
-
-	if cfg.LoadBalancer.L2Enabled != nil {
-		userFacing.LoadBalancer.L2Enabled = cfg.LoadBalancer.L2Enabled
-	}
-
-	if cfg.LoadBalancer.BGPEnabled != nil {
-		userFacing.LoadBalancer.BGPEnabled = cfg.LoadBalancer.BGPEnabled
-	}
-
-	if cfg.LocalStorage.SetDefault != nil {
-		userFacing.LocalStorage.SetDefault = cfg.LocalStorage.SetDefault
+		return response.InternalError(fmt.Errorf("failed to get user-facing cluster config: %w", err))
 	}
 
 	result := api.GetClusterConfigResponse{

--- a/src/k8s/pkg/k8sd/api/impl/k8sd.go
+++ b/src/k8s/pkg/k8sd/api/impl/k8sd.go
@@ -36,15 +36,15 @@ func GetClusterStatus(ctx context.Context, s *state.State) (apiv1.ClusterStatus,
 		return apiv1.ClusterStatus{}, fmt.Errorf("failed to get cluster members: %w", err)
 	}
 
-	components, err := GetComponents(snap)
+	config, err := utils.GetUserFacingClusterConfig(ctx, s)
 	if err != nil {
-		return apiv1.ClusterStatus{}, fmt.Errorf("failed to get cluster components: %w", err)
+		return apiv1.ClusterStatus{}, fmt.Errorf("failed to get user-facing cluster config: %w", err)
 	}
 
 	return apiv1.ClusterStatus{
-		Ready:      ready,
-		Members:    members,
-		Components: components,
+		Ready:   ready,
+		Members: members,
+		Config:  config,
 	}, nil
 }
 

--- a/src/k8s/pkg/utils/database.go
+++ b/src/k8s/pkg/utils/database.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 
+	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/utils/vals"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -26,6 +28,99 @@ func GetClusterConfig(ctx context.Context, state *state.State) (types.ClusterCon
 	}
 
 	return clusterConfig, nil
+}
+
+// GetUserFacingClusterConfig returns the public cluster config.
+func GetUserFacingClusterConfig(ctx context.Context, state *state.State) (apiv1.UserFacingClusterConfig, error) {
+	cfg, err := GetClusterConfig(ctx, state)
+	if err != nil {
+		return apiv1.UserFacingClusterConfig{}, fmt.Errorf("failed to get cluster config: %w", err)
+	}
+
+	userFacing := apiv1.UserFacingClusterConfig{
+		Network: &apiv1.NetworkConfig{
+			Enabled: vals.Pointer(true),
+		},
+		DNS: &apiv1.DNSConfig{
+			Enabled:             vals.Pointer(true),
+			UpstreamNameservers: cfg.DNS.UpstreamNameservers,
+			ServiceIP:           cfg.Kubelet.ClusterDNS,
+			ClusterDomain:       cfg.Kubelet.ClusterDomain,
+		},
+		Ingress: &apiv1.IngressConfig{
+			Enabled:             vals.Pointer(false),
+			DefaultTLSSecret:    cfg.Ingress.DefaultTLSSecret,
+			EnableProxyProtocol: vals.Pointer(false),
+		},
+		LoadBalancer: &apiv1.LoadBalancerConfig{
+			Enabled:        vals.Pointer(false),
+			CIDRs:          cfg.LoadBalancer.CIDRs,
+			L2Enabled:      vals.Pointer(false),
+			L2Interfaces:   cfg.LoadBalancer.L2Interfaces,
+			BGPEnabled:     vals.Pointer(false),
+			BGPLocalASN:    cfg.LoadBalancer.BGPLocalASN,
+			BGPPeerAddress: cfg.LoadBalancer.BGPPeerAddress,
+			BGPPeerASN:     cfg.LoadBalancer.BGPPeerASN,
+			BGPPeerPort:    cfg.LoadBalancer.BGPPeerPort,
+		},
+		LocalStorage: &apiv1.LocalStorageConfig{
+			Enabled:       vals.Pointer(false),
+			LocalPath:     cfg.LocalStorage.LocalPath,
+			ReclaimPolicy: cfg.LocalStorage.ReclaimPolicy,
+			SetDefault:    vals.Pointer(true),
+		},
+		Gateway: &apiv1.GatewayConfig{
+			Enabled: vals.Pointer(false),
+		},
+		MetricsServer: &apiv1.MetricsServerConfig{
+			Enabled: vals.Pointer(false),
+		},
+	}
+
+	if cfg.Network.Enabled != nil {
+		userFacing.Network.Enabled = cfg.Network.Enabled
+	}
+
+	if cfg.DNS.Enabled != nil {
+		userFacing.DNS.Enabled = cfg.DNS.Enabled
+	}
+
+	if cfg.Ingress.Enabled != nil {
+		userFacing.Ingress.Enabled = cfg.Ingress.Enabled
+	}
+
+	if cfg.LoadBalancer.Enabled != nil {
+		userFacing.LoadBalancer.Enabled = cfg.LoadBalancer.Enabled
+	}
+
+	if cfg.LocalStorage.Enabled != nil {
+		userFacing.LocalStorage.Enabled = cfg.LocalStorage.Enabled
+	}
+
+	if cfg.Gateway.Enabled != nil {
+		userFacing.Gateway.Enabled = cfg.Gateway.Enabled
+	}
+
+	if cfg.MetricsServer.Enabled != nil {
+		userFacing.MetricsServer.Enabled = cfg.MetricsServer.Enabled
+	}
+
+	if cfg.Ingress.EnableProxyProtocol != nil {
+		userFacing.Ingress.EnableProxyProtocol = cfg.Ingress.EnableProxyProtocol
+	}
+
+	if cfg.LoadBalancer.L2Enabled != nil {
+		userFacing.LoadBalancer.L2Enabled = cfg.LoadBalancer.L2Enabled
+	}
+
+	if cfg.LoadBalancer.BGPEnabled != nil {
+		userFacing.LoadBalancer.BGPEnabled = cfg.LoadBalancer.BGPEnabled
+	}
+
+	if cfg.LocalStorage.SetDefault != nil {
+		userFacing.LocalStorage.SetDefault = cfg.LocalStorage.SetDefault
+	}
+	return userFacing, nil
 }
 
 // CheckWorkerExists is a convenience wrapper around the database call to check if a worker node entry exists.


### PR DESCRIPTION
Example output:
```
ubuntu@alice:~/k8s$ sudo k8s status
status: ready
high-availability: no
datastore:
  master-nodes:
    - 10.84.220.237:6400
  standy-nodes: none
  spare-nodes:
    - 10.84.220.25:6400

network:
  enabled: true
dns:
  enabled: true
  cluster-domain: cluster.local
  service-ip: 10.152.183.108
  upstream-nameservers:
  - /etc/resolv.conf
metrics-server:
  enabled: true
```