### PR TITLE
Improve k8s get-join-token output

### DIFF
--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -19,8 +19,8 @@ def get_join_token(
         ["k8s", "get-join-token", joining_node.id, "--output-format", "json", *args],
         capture_output=True,
     )
-    result = out.stdout.decode().strip()
-    return json.loads(result)["join-token"]
+    result = json.loads(out.stdout.decode())
+    return result["join-token"]
 
 
 # Join an existing cluster.

--- a/tests/e2e/tests/test_clustering.py
+++ b/tests/e2e/tests/test_clustering.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2024 Canonical, Ltd.
 #
+import json
 import logging
 from typing import List
 
@@ -15,10 +16,11 @@ def get_join_token(
     cluster_node: harness.Instance, joining_node: harness.Instance, *args: str
 ) -> str:
     out = cluster_node.exec(
-        ["k8s", "get-join-token", joining_node.id, *args],
+        ["k8s", "get-join-token", joining_node.id, "--output-format", "json", *args],
         capture_output=True,
     )
-    return out.stdout.decode().strip()
+    result = out.stdout.decode().strip()
+    return json.loads(result)["join-token"]
 
 
 # Join an existing cluster.


### PR DESCRIPTION
* Add guidance on what to do with the join token
* Add `--output-format` flag


Example output:

```
ubuntu@alice:~/k8s$ sudo k8s get-join-token node1
On the node you want to join call:

  sudo k8s join-cluster eyJuYW1lIjoibm9kZTEiLCJzZWNyZXQiOiJlMzFkYjZlOTM0OTZmYjkxOTVkMjlmNTY0NTY0ODNiZTY1MmVjNWQ0Y2M4YzI0YjlhODAwNWQ4OTczYWNiMzBhIiwiZmluZ2VycHJpbnQiOiJjMTEwNGMxZGRiNDU4NjdhODJhOWU4ZWNiZWYwZTFjODA1NWNlOThiZDE3NDZkMDQ4OWI1ZWJlNzg1OWJkMWU5Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuODQuMjIwLjIzNzo2NDAwIl19

ubuntu@alice:~/k8s$ sudo k8s get-join-token node2 -o json
{"join-token":"eyJuYW1lIjoibm9kZTIiLCJzZWNyZXQiOiI1NmJjZWI4MDY0NGM2NWIyYjc4ZTNhNWUzNGQ0NTMzOTBlMDFjMWZiODFiOWM0MDE3NTFiNTMxMGY2MjhhOTBlIiwiZmluZ2VycHJpbnQiOiJjMTEwNGMxZGRiNDU4NjdhODJhOWU4ZWNiZWYwZTFjODA1NWNlOThiZDE3NDZkMDQ4OWI1ZWJlNzg1OWJkMWU5Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuODQuMjIwLjIzNzo2NDAwIl19"}

ubuntu@alice:~/k8s$ sudo k8s get-join-token node3 -o yaml
join-token: eyJuYW1lIjoibm9kZTMiLCJzZWNyZXQiOiI2NmU0NGY1NDQ5MTVjNzMyODZjYTc3NDliZjE0M2NlNGVhNjg3ZmMwN2JmOTAzZGRiNWZjZTk5M2JkNDViZDljIiwiZmluZ2VycHJpbnQiOiJjMTEwNGMxZGRiNDU4NjdhODJhOWU4ZWNiZWYwZTFjODA1NWNlOThiZDE3NDZkMDQ4OWI1ZWJlNzg1OWJkMWU5Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuODQuMjIwLjIzNzo2NDAwIl19
```