### PR TITLE
Refactor ParseArgumentLine to support Kubernetes label values

### DIFF
--- a/src/k8s/pkg/utils/file.go
+++ b/src/k8s/pkg/utils/file.go
@@ -18,6 +18,8 @@ import (
 func ParseArgumentLine(line string) (key string, value string) {
 	line = strings.TrimSpace(line) // Trim leading and trailing white spaces
 
+	// parse "--argument value", "--argument=value", "--argument=value=,othervalue=" variants
+
 	// Find the index of the first occurrence of "=" and space
 	indexEqual := strings.Index(line, "=")
 	indexSpace := strings.Index(line, " ")

--- a/src/k8s/pkg/utils/file.go
+++ b/src/k8s/pkg/utils/file.go
@@ -16,20 +16,32 @@ import (
 // ParseArgumentLine parses a command-line argument from a single line.
 // The returned key includes any dash prefixes.
 func ParseArgumentLine(line string) (key string, value string) {
-	line = strings.TrimSpace(line)
+	line = strings.TrimSpace(line) // Trim leading and trailing white spaces
 
-	// parse "--argument value" and "--argument=value" variants
-	if parts := strings.Split(line, "="); len(parts) >= 2 {
-		key = parts[0]
-		value = parts[1]
-	} else if parts := strings.Split(line, " "); len(parts) >= 2 {
-		key = parts[0]
-		value = strings.Join(parts[1:], " ")
-	} else {
-		key = line
+	// Find the index of the first occurrence of "=" and space
+	indexEqual := strings.Index(line, "=")
+	indexSpace := strings.Index(line, " ")
+
+	// Determine the split index based on the first occurrence of "=" or space
+	splitIndex := -1
+	if indexEqual == -1 && indexSpace != -1 { // Space but no "="
+		splitIndex = indexSpace
+	} else if indexSpace == -1 && indexEqual != -1 { // "=" but no space
+		splitIndex = indexEqual
+	} else if indexSpace != -1 && indexEqual != -1 { // Both "=" and space
+		splitIndex = min(indexEqual, indexSpace)
 	}
 
-	return
+	if splitIndex == -1 {
+		// If neither "=" nor space is found, return the whole line as key
+		return line, ""
+	}
+
+	// Split the line into key and value based on the split index
+	key = line[:splitIndex]
+	value = strings.TrimSpace(line[splitIndex+1:]) // Remove any leading space in value
+
+	return key, value
 }
 
 // Reads an argument file and parses the lines to an <arg, value> map.

--- a/src/k8s/pkg/utils/file.go
+++ b/src/k8s/pkg/utils/file.go
@@ -20,22 +20,16 @@ func ParseArgumentLine(line string) (key string, value string) {
 
 	// parse "--argument value", "--argument=value", "--argument=value=,othervalue=" variants
 
-	// Find the index of the first occurrence of "=" and space
-	indexEqual := strings.Index(line, "=")
-	indexSpace := strings.Index(line, " ")
-
-	// Determine the split index based on the first occurrence of "=" or space
 	splitIndex := -1
-	if indexEqual == -1 && indexSpace != -1 { // Space but no "="
-		splitIndex = indexSpace
-	} else if indexSpace == -1 && indexEqual != -1 { // "=" but no space
-		splitIndex = indexEqual
-	} else if indexSpace != -1 && indexEqual != -1 { // Both "=" and space
-		splitIndex = min(indexEqual, indexSpace)
+	for i, c := range line {
+		if c == ' ' || c == '=' {
+			splitIndex = i
+			break
+		}
 	}
 
 	if splitIndex == -1 {
-		// If neither "=" nor space is found, return the whole line as key
+		// If no space or equal sign is found, return the line as key
 		return line, ""
 	}
 

--- a/src/k8s/pkg/utils/file_test.go
+++ b/src/k8s/pkg/utils/file_test.go
@@ -55,11 +55,13 @@ func TestParseArgumentFile(t *testing.T) {
 	}{
 		{
 			name:    "normal",
-			content: "--key1=value1\n--key2=value2   \n--key3 value3",
+			content: "--key1=value1\n--key2=value2   \n--key3 value3\n--key4=control-plane=,worker=\n--key5 control-plane=",
 			expectedArgs: map[string]string{
 				"--key1": "value1",
 				"--key2": "value2",
 				"--key3": "value3",
+				"--key4": "control-plane=,worker=",
+				"--key5": "control-plane=",
 			},
 		},
 		{

--- a/src/k8s/pkg/utils/file_test.go
+++ b/src/k8s/pkg/utils/file_test.go
@@ -16,15 +16,24 @@ func TestParseArgumentLine(t *testing.T) {
 		line, key, value string
 	}{
 		{line: "--key=value", key: "--key", value: "value"},
+		{line: "--key= value", key: "--key", value: "value"},
 		{line: "--key=value   ", key: "--key", value: "value"},
 		{line: "--key value", key: "--key", value: "value"},
 		{line: "--key value     ", key: "--key", value: "value"},
 		{line: "--key value value", key: "--key", value: "value value"},
 		{line: "--key=value value", key: "--key", value: "value value"},
+		{line: "--key==", key: "--key", value: "="},
+		{line: "--key= =", key: "--key", value: "="},
+		{line: "--key test-value=", key: "--key", value: "test-value="},
+		{line: "--key=test-value=", key: "--key", value: "test-value="},
+		{line: "--key=test-value=,testing=", key: "--key", value: "test-value=,testing="},
+		{line: "--key test-value=,testing=", key: "--key", value: "test-value=,testing="},
 		{line: "--key", key: "--key", value: ""},
 		{line: "--key    ", key: "--key", value: ""},
 		{line: "--key=", key: "--key", value: ""},
 		{line: "--key=    ", key: "--key", value: ""},
+		{line: "--key    =", key: "--key", value: "="},
+		{line: "--key    = a value=", key: "--key", value: "= a value="},
 	} {
 		t.Run(tc.line, func(t *testing.T) {
 			key, value := utils.ParseArgumentLine(tc.line)


### PR DESCRIPTION
With this PR, the following key-value in Kubelet argument file is now supported by the ParseArgumentLine function:

`--node-labels=node-role.kubernetes.io/control-plane=,node-role.kubernetes.io/worker=`

This is needed for KU-447 specifically for unit testing setup.kubelet.