### PR TITLE
Small touches towards a homogeneous CLI

### DIFF
--- a/src/k8s/cmd/k8s/errors/errors.go
+++ b/src/k8s/cmd/k8s/errors/errors.go
@@ -9,14 +9,14 @@ import (
 )
 
 var genericErrorMsgs = map[error]string{
-	v1.ErrNotBootstrapped: "The cluster has not been initialized yet. Please call:\n\n sudo k8s bootstrap",
-	v1.ErrConnectionFailed: "Unable to connect to the cluster. Verify k8s services are running:\n\n sudo snap services k8s\n\n" +
-		"and see logs for more details:\n\n sudo journalctl -n 300 -u snap.k8s.k8sd\n\n",
-	v1.ErrAPIServerFailed: "Unable to get Kubernetes API server endpoints. Verify k8s services are running:\n\n sudo snap services k8s\n\n" +
-		"and see logs for more details:\n\n sudo journalctl -n 300 -u snap.k8s.kube-apiserver\n\n",
+	v1.ErrNotBootstrapped: "The cluster has not been initialized yet. Please call:\n\n  sudo k8s bootstrap\n",
+	v1.ErrConnectionFailed: "Unable to connect to the cluster. Verify k8s services are running:\n\n  sudo snap services k8s\n" +
+		"and see logs for more details:\n\n  sudo journalctl -n 300 -u snap.k8s.k8sd\n",
+	v1.ErrAPIServerFailed: "Unable to get Kubernetes API server endpoints. Verify k8s services are running:\n\n  sudo snap services k8s\n\n" +
+		"and see logs for more details:\n\n  sudo journalctl -n 300 -u snap.k8s.kube-apiserver\n",
 	v1.ErrTimeout: "Command timed out. See logs for more details:\n\n" +
-		" sudo journalctl -n 300 -u snap.k8s.k8sd\n\n" +
-		"You may increase the timeout with `--timeout 3m`.",
+		"  sudo journalctl -n 300 -u snap.k8s.k8sd\n\n" +
+		"You may increase the timeout with `--timeout 3m`.\n",
 }
 
 // Transform checks if the error returned by the server contains a known error message
@@ -28,7 +28,7 @@ func Transform(err *error, extraErrorMessages map[error]string) {
 		return
 	}
 
-	// Unknown error occured. Append the full error message to the result.
+	// Unknown error occurred. Append the full error message to the result.
 	if strings.Contains(strings.ToLower((*err).Error()), strings.ToLower(v1.ErrUnknown.Error())) {
 		var prefix string
 		if msg, ok := extraErrorMessages[v1.ErrUnknown]; ok {

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -35,13 +35,15 @@ func NewRootCmd() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
-	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logDebug, "debug", "d", false, "Show all debug messages")
-	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
+	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "directory with the dqlite datastore")
+	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logDebug, "debug", "d", false, "show all debug messages")
+	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "show all information messages")
 
 	// By default, the state dir is set to a fixed directory in the snap.
 	// This shouldn't be overwritten by the user.
 	rootCmd.PersistentFlags().MarkHidden("state-dir")
+	rootCmd.PersistentFlags().MarkHidden("debug")
+	rootCmd.PersistentFlags().MarkHidden("verbose")
 
 	// General
 	rootCmd.AddCommand(newStatusCmd())

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -22,7 +22,7 @@ var (
 	}
 
 	bootstrapCmdErrorMsgs = map[error]string{
-		apiv1.ErrUnknown:             "An unknown error occured while bootstrapping the cluster:\n",
+		apiv1.ErrUnknown:             "An unknown error occurred while bootstrapping the cluster:\n",
 		apiv1.ErrAlreadyBootstrapped: "K8s cluster already bootstrapped.",
 	}
 	bootstrappableComponents = []string{"network", "dns", "gateway", "ingress", "local-storage", "load-balancer", "metrics-server"}
@@ -31,7 +31,7 @@ var (
 func newBootstrapCmd() *cobra.Command {
 	bootstrapCmd := &cobra.Command{
 		Use:     "bootstrap",
-		Short:   "Bootstrap a k8s cluster on this node.",
+		Short:   "Bootstrap a k8s cluster on this node",
 		Long:    "Initialize the necessary folders, permissions, service arguments, certificates and start up the Kubernetes services.",
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -67,8 +67,8 @@ func newBootstrapCmd() *cobra.Command {
 		},
 	}
 
-	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapCmdOpts.interactive, "interactive", false, "Interactively configure the most important cluster options.")
-	bootstrapCmd.PersistentFlags().DurationVar(&bootstrapCmdOpts.timeout, "timeout", 90*time.Second, "The max time to wait for k8s to bootstrap.")
+	bootstrapCmd.PersistentFlags().BoolVar(&bootstrapCmdOpts.interactive, "interactive", false, "interactively configure the most important cluster options")
+	bootstrapCmd.PersistentFlags().DurationVar(&bootstrapCmdOpts.timeout, "timeout", 90*time.Second, "the max time to wait for k8s to bootstrap")
 
 	return bootstrapCmd
 }

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -14,8 +14,8 @@ import (
 func newDisableCmd() *cobra.Command {
 	disableCmd := &cobra.Command{
 		Use:     "disable <functionality>",
-		Short:   "Disable a specific functionality in the cluster",
-		Long:    fmt.Sprintf("Disable one of the specific functionalities: %s.", strings.Join(componentList, ",")),
+		Short:   "Disable core cluster functionalities",
+		Long:    fmt.Sprintf("Disable one of %s.", strings.Join(componentList, ",")),
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -18,8 +18,8 @@ var (
 func newEnableCmd() *cobra.Command {
 	enableCmd := &cobra.Command{
 		Use:     "enable <functionality>",
-		Short:   "Enable a specific functionality in the cluster",
-		Long:    fmt.Sprintf("Enable one of the specific functionalities: %s.", strings.Join(componentList, ", ")),
+		Short:   "Enable core cluster functionalities",
+		Long:    fmt.Sprintf("Enable one of %s.", strings.Join(componentList, ", ")),
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)

--- a/src/k8s/cmd/k8s/k8s_get.go
+++ b/src/k8s/cmd/k8s/k8s_get.go
@@ -14,7 +14,8 @@ import (
 func newGetCmd() *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:               "get <functionality.key>",
-		Short:             "get functionality configuration",
+		Short: "get cluster configuration",
+		Long:  fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
 		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)

--- a/src/k8s/cmd/k8s/k8s_get.go
+++ b/src/k8s/cmd/k8s/k8s_get.go
@@ -14,8 +14,8 @@ import (
 func newGetCmd() *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:               "get <functionality.key>",
-		Short: "get cluster configuration",
-		Long:  fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
+		Short:             "get cluster configuration",
+		Long:              fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
 		PersistentPreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -24,13 +24,13 @@ type GetJoinTokenResult struct {
 }
 
 func (g GetJoinTokenResult) String() string {
-	return fmt.Sprintf("On the node you want to join call:\n\n  sudo k8s join-cluster %s\n\n", g.JoinToken)
+	return fmt.Sprintf("On the node you want to join call:\n\n  sudo k8s join-cluster %s\n", g.JoinToken)
 }
 
 func newGetJoinTokenCmd() *cobra.Command {
 	getJoinTokenCmd := &cobra.Command{
 		Use:     "get-join-token <node-name>",
-		Short:   "Create a join token for a node to join the cluster",
+		Short:   "Create a token for a node to join the cluster",
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
@@ -60,7 +60,7 @@ func newGetJoinTokenCmd() *cobra.Command {
 		},
 	}
 
-	getJoinTokenCmd.PersistentFlags().StringVarP(&getJoinTokenCmdOpts.outputFormat, "output-format", "o", "plain", "Specify in which format the output should be printed. One of plain, json or yaml")
+	getJoinTokenCmd.PersistentFlags().StringVarP(&getJoinTokenCmdOpts.outputFormat, "output-format", "o", "plain", "set the output format to one of plain, json or yaml")
 	getJoinTokenCmd.PersistentFlags().BoolVar(&getJoinTokenCmdOpts.worker, "worker", false, "generate a join token for a worker node")
 	return getJoinTokenCmd
 }

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -32,7 +32,7 @@ var (
 func newJoinClusterCmd() *cobra.Command {
 	joinNodeCmd := &cobra.Command{
 		Use:     "join-cluster <join-token>",
-		Short:   "Join a cluster",
+		Short:   "Join a cluster using the provided token",
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			if len(args) > 1 {
@@ -82,8 +82,8 @@ func newJoinClusterCmd() *cobra.Command {
 			return nil
 		},
 	}
-	joinNodeCmd.Flags().StringVar(&joinClusterCmdOpts.name, "name", "", "The name of the joining node. defaults to hostname")
-	joinNodeCmd.Flags().StringVar(&joinClusterCmdOpts.address, "address", "", "The address (IP:Port) on which the nodes REST API should be available")
-	joinNodeCmd.Flags().DurationVar(&joinClusterCmdOpts.timeout, "timeout", 90*time.Second, "The max time to wait for the node to be ready.")
+	joinNodeCmd.Flags().StringVar(&joinClusterCmdOpts.name, "name", "", "the name of the joining node. defaults to hostname")
+	joinNodeCmd.Flags().StringVar(&joinClusterCmdOpts.address, "address", "", "the address (IP:Port) on which the nodes REST API should be available")
+	joinNodeCmd.Flags().DurationVar(&joinClusterCmdOpts.timeout, "timeout", 90*time.Second, "the max time to wait for the node to be ready")
 	return joinNodeCmd
 }

--- a/src/k8s/cmd/k8s/k8s_kubectl.go
+++ b/src/k8s/cmd/k8s/k8s_kubectl.go
@@ -16,7 +16,7 @@ import (
 func newKubectlCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "kubectl",
-		Short: "Integrated Kubernetes CLI",
+		Short: "Integrated Kubernetes kubectl client",
 		// All commands should be passed to kubectl
 		DisableFlagParsing: true,
 		PreRunE:            chainPreRunHooks(hookSetupClient),

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -49,8 +49,8 @@ func newRemoveNodeCmd() *cobra.Command {
 			return nil
 		},
 	}
-	removeNodeCmd.Flags().BoolVar(&removeNodeCmdOpts.force, "force", false, "Forcibly remove the cluster member")
-	removeNodeCmd.PersistentFlags().DurationVar(&removeNodeCmdOpts.timeout, "timeout", 180*time.Second, "The max time to wait for the node to be removed.")
+	removeNodeCmd.Flags().BoolVar(&removeNodeCmdOpts.force, "force", false, "forcibly remove the cluster member")
+	removeNodeCmd.PersistentFlags().DurationVar(&removeNodeCmdOpts.timeout, "timeout", 180*time.Second, "the max time to wait for the node to be removed")
 	removeNodeCmd.FlagErrorFunc()
 	return removeNodeCmd
 }

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -14,8 +14,8 @@ import (
 
 func newSetCmd() *cobra.Command {
 	setCmd := &cobra.Command{
-		Use:     "set <functionality.key=value>...",
-		Short:   "Set functionality configuration",
+		Use:   "set <functionality.key=value> ...",
+		Short: "Set cluster configuration",
 		Long:    fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		Args:    cobra.ArbitraryArgs,

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -14,8 +14,8 @@ import (
 
 func newSetCmd() *cobra.Command {
 	setCmd := &cobra.Command{
-		Use:   "set <functionality.key=value> ...",
-		Short: "Set cluster configuration",
+		Use:     "set <functionality.key=value> ...",
+		Short:   "Set cluster configuration",
 		Long:    fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		Args:    cobra.ArbitraryArgs,

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -59,8 +59,8 @@ func newStatusCmd() *cobra.Command {
 			return f.Print(clusterStatus)
 		},
 	}
-	statusCmd.PersistentFlags().StringVar(&statusCmdOpts.outputFormat, "format", "plain", "Specify in which format the output should be printed. One of plain, json or yaml")
-	statusCmd.PersistentFlags().DurationVar(&statusCmdOpts.timeout, "timeout", 90*time.Second, "The max time to wait for the K8s API server to be ready.")
-	statusCmd.PersistentFlags().BoolVar(&statusCmdOpts.waitReady, "wait-ready", false, "If set, the command will block until at least one cluster node is ready.")
+	statusCmd.PersistentFlags().StringVar(&statusCmdOpts.outputFormat, "format", "plain", "specify in which format the output should be printed. One of plain, json or yaml")
+	statusCmd.PersistentFlags().DurationVar(&statusCmdOpts.timeout, "timeout", 90*time.Second, "the max time to wait for the K8s API server to be ready")
+	statusCmd.PersistentFlags().BoolVar(&statusCmdOpts.waitReady, "wait-ready", false, "wait until at least one cluster node is ready")
 	return statusCmd
 }


### PR DESCRIPTION
Changes:
- remove global flags -d and -v
- flag descriptions should start with lowercase and should not end with a '.'
- command descriptions should start with a capital letter and should not end with a '.'
- error messages that suggest you to run a command should prefix the command with an empty line and double space and suffix the command with an empty line
- minor tweaks in the command descriptions
- few spelling errors