### PR TITLE
Docs: add security page

### DIFF
--- a/docs/src/explanation/index.md
+++ b/docs/src/explanation/index.md
@@ -14,7 +14,12 @@ Overview <self>
 :titlesonly:
 /explanation/about
 /explanation/channels
+/explanation/security
 ```
+
+---
+
+## Other documentation types
 
 If you are just getting started, the [Tutorials section] contains
 step-by-step tutorials to help guide you through exploring and using

--- a/docs/src/explanation/security.md
+++ b/docs/src/explanation/security.md
@@ -20,13 +20,13 @@ space.
 ## Security of the OCI images
 
 **Canonical Kubernetes** relies on OCI standard images published as `rocks` to
-deliver the services which run and facilitate the operation of the Kubernetes
-cluster. Many of the frequently used 'standard' OCI images have known security
-vulnerabilities, but the use of `Rockcraft` and `rocks` gives Canonical a way
-to maintain and patch images to remove vulnerabilities at their source, which
-is fundamental to our commitment to a sustainable Long Term Support (LTS)
-release of Kubernetes. For more information on how these images are maintained
-and published, see the [Rockcraft documentation][rocks-security]. 
+deliver the services which run and facilitate the opration of the Kubernetes
+cluster. The use of Rockcraft and `rocks` gives Canonical a way to maintain and
+patch images to remove vulnerabilities at their source, which is fundamental to
+our commitment to a sustainable Long Term Support(LTS) release of Kubernetes
+and overcoming the issues of stale images with known vulnerabilities. For more
+information on how these images are maintained and published, see the
+[Rockcraft documentation][rocks-security]. 
 
 ## Kubernetes Security
 
@@ -44,11 +44,11 @@ have access to your cluster. Describing the security mechanisms of these clouds
 is out of the scope of this documentation, but you may find the following links
 useful.
 
--   Amazon Web Services -	<https://aws.amazon.com/security/>
--   Google Cloud Platform	- <https://cloud.google.com/security/>
--   Metal As A Service(MAAS) -  <https://maas.io/docs/snap/3.0/ui/hardening-your-maas-installation>
--   Microsoft Azure	- <https://docs.microsoft.com/en-us/azure/security/azure-security>
--   VMWare VSphere	- <https://www.vmware.com/security/hardening-guides.html>
+-  Amazon Web Services <https://aws.amazon.com/security/>
+-  Google Cloud Platform <https://cloud.google.com/security/>
+-  Metal As A Service(MAAS) <https://maas.io/docs/snap/3.0/ui/hardening-your-maas-installation>
+-  Microsoft Azure <https://docs.microsoft.com/en-us/azure/security/azure-security>
+-  VMWare VSphere <https://www.vmware.com/security/hardening-guides.html>
 
 ## Security Compliance
 

--- a/docs/src/explanation/security.md
+++ b/docs/src/explanation/security.md
@@ -20,7 +20,7 @@ space.
 ## Security of the OCI images
 
 **Canonical Kubernetes** relies on OCI standard images published as `rocks` to
-deliver the services which run and facilitate the opration of the Kubernetes
+deliver the services which run and facilitate the operation of the Kubernetes
 cluster. Many of the frequently used 'standard' OCI images have known security
 vulnerabilities, but the use of `Rockcraft` and `rocks` gives Canonical a way
 to maintain and patch images to remove vulnerabilities at their source, which

--- a/docs/src/explanation/security.md
+++ b/docs/src/explanation/security.md
@@ -1,0 +1,65 @@
+# Security 
+
+This page provides an overview of various aspects of security to be considered
+when operating a cluster with **Canonical Kubernetes**. To consider security
+properly, this means not just aspects of Kubernetes itself, but also how and
+where it is installed and operated.
+
+A lot of important aspects of security therefore lie outside the direct scope
+of **Canonical Kubernetes**, but links for further reading
+are provided.
+
+## Security of the snap/executable
+
+As detailed in the [snap documentation][], an application installed from a snap
+is inherently more secure than a traditionally installed application.
+Snap-based applications are installed into a sandboxed, self contained
+environment which restricts its ability to interact with the rest of user
+space.
+
+## Security of the OCI images
+
+**Canonical Kubernetes** relies on OCI standard images published as `rocks` to
+deliver the services which run and facilitate the opration of the Kubernetes
+cluster. Many of the frequently used 'standard' OCI images have known security
+vulnerabilities, but the use of `Rockcraft` and `rocks` gives Canonical a way
+to maintain and patch images to remove vulnerabilities at their source, which
+is fundamental to our commitment to a sustainable Long Term Support(LTS)
+release of Kubernetes. For more information on how these images are maintained
+and published, see the [Rockcraft documentation][rocks-security]. 
+
+## Kubernetes Security
+
+The Kubernetes cluster deployed by Canonical Kubernetes can be secured using
+any of the methods and options described by the upstream
+[Kubernetes Security Documentation][].
+
+Canonical Kubernetes enables RBAC(Rules Based Access Control)by default.
+
+## Cloud security
+
+If you are deploying **Canonical Kubernetes** on public or private cloud
+instances, anyone with credentials to the cloud where it is deployed may also
+have access to your cluster. Describing the security mechanisms of these clouds
+is out of the scope of this documentation, but you may find the following links
+useful.
+
+-   Amazon Web Services -	<https://aws.amazon.com/security/>
+-   Google Cloud Platform	- <https://cloud.google.com/security/>
+-   Metal As A Service(MAAS) -  <https://maas.io/docs/snap/3.0/ui/hardening-your-maas-installation>
+-   Microsoft Azure	- <https://docs.microsoft.com/en-us/azure/security/azure-security>
+-   VMWare VSphere	- <https://www.vmware.com/security/hardening-guides.html>
+
+## Security Compliance
+
+As with previously released Kubernetes software from Canonical, we aim to
+satisfy the needs of various security compliance standards. This is a process
+that will take some time however. Please watch out for future announcements and
+check the [roadmap][] for current areas of work.
+
+<!-- LINKS -->
+
+[Kubernetes Security documentation]: https://kubernetes.io/docs/concepts/security/overview/
+[snap documentation]: https://snapcraft.io/docs/security-sandboxing
+[rocks-security]: https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rockcraft/
+[roadmap]: ../reference/roadmap

--- a/docs/src/explanation/security.md
+++ b/docs/src/explanation/security.md
@@ -24,7 +24,7 @@ deliver the services which run and facilitate the operation of the Kubernetes
 cluster. Many of the frequently used 'standard' OCI images have known security
 vulnerabilities, but the use of `Rockcraft` and `rocks` gives Canonical a way
 to maintain and patch images to remove vulnerabilities at their source, which
-is fundamental to our commitment to a sustainable Long Term Support(LTS)
+is fundamental to our commitment to a sustainable Long Term Support (LTS)
 release of Kubernetes. For more information on how these images are maintained
 and published, see the [Rockcraft documentation][rocks-security]. 
 

--- a/docs/src/explanation/security.md
+++ b/docs/src/explanation/security.md
@@ -34,7 +34,7 @@ The Kubernetes cluster deployed by Canonical Kubernetes can be secured using
 any of the methods and options described by the upstream
 [Kubernetes Security Documentation][].
 
-Canonical Kubernetes enables RBAC(Rules Based Access Control)by default.
+Canonical Kubernetes enables RBAC (Rules Based Access Control) by default.
 
 ## Cloud security
 

--- a/docs/src/reference/roadmap.md
+++ b/docs/src/reference/roadmap.md
@@ -5,7 +5,9 @@ roadmap, letting everyone know the headline features we are working on and the
 future direction and priorities of the project.
 
 Our roadmap matches the cadence of the Ubuntu release cycle, so `24.10` is the
-same as the release date for Ubuntu 24.10. 
+same as the release date for Ubuntu 24.10. This does not precisely map to the
+release cycle of Kubernetes versions, so please consult the [release notes] for
+specifics of whatfeatures have been delivered.
 
 
 ``` {csv-table} Canonical Kubernetes public roadmap
@@ -13,3 +15,8 @@ same as the release date for Ubuntu 24.10.
    :widths: 30, 30
    :header-rows: 1
 ```
+
+
+<!-- LINKS -->
+
+[release notes]: ./releases


### PR DESCRIPTION
Adds the security explainer and adjusts a few other pages accordingly.