### PR TITLE
Request enabled should be treated as true if not set in request

### DIFF
--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -143,7 +143,7 @@ func DisableDNSComponent(ctx context.Context, s snap.Snap) error {
 }
 
 func ReconcileDNSComponent(ctx context.Context, s snap.Snap, alreadyEnabled *bool, requestEnabled *bool, clusterConfig types.ClusterConfig) (string, string, error) {
-	if vals.OptionalBool(requestEnabled, false) && vals.OptionalBool(alreadyEnabled, false) {
+	if vals.OptionalBool(requestEnabled, true) && vals.OptionalBool(alreadyEnabled, false) {
 		// If already enabled, and request does not contain `enabled` key
 		// or if already enabled and request contains `enabled=true`
 		dnsIP, clusterDomain, err := UpdateDNSComponent(ctx, s, true, clusterConfig.Kubelet.ClusterDomain, clusterConfig.Kubelet.ClusterDNS, clusterConfig.DNS.UpstreamNameservers)

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -82,7 +82,7 @@ func DisableGatewayComponent(s snap.Snap) error {
 }
 
 func ReconcileGatewayComponent(ctx context.Context, s snap.Snap, alreadyEnabled *bool, requestEnabled *bool, clusterConfig types.ClusterConfig) error {
-	if vals.OptionalBool(requestEnabled, false) && vals.OptionalBool(alreadyEnabled, false) {
+	if vals.OptionalBool(requestEnabled, true) && vals.OptionalBool(alreadyEnabled, false) {
 		// If already enabled, and request does not contain `enabled` key
 		// or if already enabled and request contains `enabled=true`
 		err := UpdateGatewayComponent(ctx, s, true)

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -77,7 +77,7 @@ func ReconcileIngressComponent(ctx context.Context, s snap.Snap, alreadyEnabled 
 		enableProxyProtocol = *clusterConfig.Ingress.EnableProxyProtocol
 	}
 
-	if vals.OptionalBool(requestEnabled, false) && vals.OptionalBool(alreadyEnabled, false) {
+	if vals.OptionalBool(requestEnabled, true) && vals.OptionalBool(alreadyEnabled, false) {
 		// If already enabled, and request does not contain `enabled` key
 		// or if already enabled and request contains `enabled=true`
 		err := UpdateIngressComponent(ctx, s, true, clusterConfig.Ingress.DefaultTLSSecret, enableProxyProtocol)

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -140,7 +140,7 @@ func ReconcileLoadBalancerComponent(ctx context.Context, s snap.Snap, alreadyEna
 		l2Enabled = *clusterConfig.LoadBalancer.L2Enabled
 	}
 
-	if vals.OptionalBool(requestEnabled, false) && vals.OptionalBool(alreadyEnabled, false) {
+	if vals.OptionalBool(requestEnabled, true) && vals.OptionalBool(alreadyEnabled, false) {
 		// If already enabled, and request does not contain `enabled` key
 		// or if already enabled and request contains `enabled=true`
 		err := UpdateLoadBalancerComponent(ctx, s, true, clusterConfig.LoadBalancer.CIDRs, l2Enabled, clusterConfig.LoadBalancer.L2Interfaces, bgpEnabled, clusterConfig.LoadBalancer.BGPLocalASN, clusterConfig.LoadBalancer.BGPPeerAddress, clusterConfig.LoadBalancer.BGPPeerASN, clusterConfig.LoadBalancer.BGPPeerPort)

--- a/src/k8s/pkg/component/metrics_server.go
+++ b/src/k8s/pkg/component/metrics_server.go
@@ -53,7 +53,7 @@ func DisableMetricsServerComponent(s snap.Snap) error {
 }
 
 func ReconcileMetricsServerComponent(ctx context.Context, s snap.Snap, alreadyEnabled *bool, requestEnabled *bool, clusterConfig types.ClusterConfig) error {
-	if vals.OptionalBool(requestEnabled, false) && vals.OptionalBool(alreadyEnabled, false) {
+	if vals.OptionalBool(requestEnabled, true) && vals.OptionalBool(alreadyEnabled, false) {
 		// If already enabled, and request does not contain `enabled` key
 		// or if already enabled and request contains `enabled=true`
 		err := UpdateMetricsServerComponent(ctx, s, true)

--- a/src/k8s/pkg/component/network.go
+++ b/src/k8s/pkg/component/network.go
@@ -139,7 +139,7 @@ func DisableNetworkComponent(s snap.Snap) error {
 }
 
 func ReconcileNetworkComponent(ctx context.Context, s snap.Snap, alreadyEnabled *bool, requestEnabled *bool, clusterConfig types.ClusterConfig) error {
-	if vals.OptionalBool(requestEnabled, false) && vals.OptionalBool(alreadyEnabled, false) {
+	if vals.OptionalBool(requestEnabled, true) && vals.OptionalBool(alreadyEnabled, false) {
 		// If already enabled, and request does not contain `enabled` key
 		// or if already enabled and request contains `enabled=true`
 		err := UpdateNetworkComponent(ctx, s, true, clusterConfig.Network.PodCIDR)

--- a/src/k8s/pkg/component/storage.go
+++ b/src/k8s/pkg/component/storage.go
@@ -75,7 +75,7 @@ func ReconcileLocalStorageComponent(ctx context.Context, s snap.Snap, alreadyEna
 		setDefault = *clusterConfig.LocalStorage.SetDefault
 	}
 
-	if vals.OptionalBool(requestEnabled, false) && vals.OptionalBool(alreadyEnabled, false) {
+	if vals.OptionalBool(requestEnabled, true) && vals.OptionalBool(alreadyEnabled, false) {
 		// If already enabled, and request does not contain `enabled` key
 		// or if already enabled and request contains `enabled=true`
 		err := UpdateStorageComponent(ctx, s, true, clusterConfig.LocalStorage.LocalPath, clusterConfig.LocalStorage.ReclaimPolicy, setDefault)


### PR DESCRIPTION
Request enabled should be treated as true if not set in request, otherwise the functionality won't be refreshed with new settings.