### PR TITLE
CLI UX fixes

### DIFF
--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -31,8 +31,8 @@ func newDisableCmd() *cobra.Command {
 			}
 
 			config := api.UserFacingClusterConfig{}
-
-			switch args[0] {
+			functionality := args[0]
+			switch functionality {
 			case "network":
 				config.Network = &api.NetworkConfig{
 					Enabled: vals.Pointer(false),
@@ -68,9 +68,11 @@ func newDisableCmd() *cobra.Command {
 				Config: config,
 			}
 
+			fmt.Printf("Disabling %s. This may take some time, please wait.\n", functionality)
 			if err := k8sdClient.UpdateClusterConfig(cmd.Context(), request); err != nil {
 				return fmt.Errorf("failed to update cluster configuration: %w", err)
 			}
+			fmt.Printf("%s disabled.\n", functionality)
 
 			return nil
 		},

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -35,7 +35,8 @@ func newEnableCmd() *cobra.Command {
 			}
 
 			config := api.UserFacingClusterConfig{}
-			switch args[0] {
+			functionality := args[0]
+			switch functionality {
 			case "network":
 				config.Network = &api.NetworkConfig{
 					Enabled: vals.Pointer(true),
@@ -70,9 +71,11 @@ func newEnableCmd() *cobra.Command {
 				Config: config,
 			}
 
+			fmt.Printf("Enabling %s. This may take some time, please wait.\n", functionality)
 			if err := k8sdClient.UpdateClusterConfig(cmd.Context(), request); err != nil {
 				return fmt.Errorf("failed to update cluster configuration: %w", err)
 			}
+			fmt.Printf("%s enabled.\n", functionality)
 
 			return nil
 		},

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -16,6 +16,7 @@ func newSetCmd() *cobra.Command {
 	setCmd := &cobra.Command{
 		Use:     "set <functionality.key=value>...",
 		Short:   "Set functionality configuration",
+		Long:    fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
 		PreRunE: chainPreRunHooks(hookSetupClient),
 		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -8,6 +8,7 @@ import (
 
 	api "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/cmd/k8s/errors"
+	"github.com/canonical/k8s/pkg/utils/vals"
 	"github.com/spf13/cobra"
 )
 
@@ -205,6 +206,34 @@ func newSetCmd() *cobra.Command {
 				default:
 					return fmt.Errorf("invalid config key: %s", key)
 				}
+			}
+
+			// Fetching current config to check where an already enabled functionality is updated.
+			currentConfig, err := k8sdClient.GetClusterConfig(cmd.Context(), api.GetClusterConfigRequest{})
+			if err != nil {
+				return fmt.Errorf("failed to get current cluster config: %w", err)
+			}
+
+			if vals.OptionalBool(currentConfig.Network.Enabled, false) && config.Network != nil && config.Network.Enabled == nil {
+				fmt.Println("Reapplying configuration for network")
+			}
+			if vals.OptionalBool(currentConfig.DNS.Enabled, false) && config.DNS != nil && config.DNS.Enabled == nil {
+				fmt.Println("Reapplying configuration for dns")
+			}
+			if vals.OptionalBool(currentConfig.Gateway.Enabled, false) && config.Gateway != nil && config.Gateway.Enabled == nil {
+				fmt.Println("Reapplying configuration for gateway")
+			}
+			if vals.OptionalBool(currentConfig.Ingress.Enabled, false) && config.Ingress != nil && config.Ingress.Enabled == nil {
+				fmt.Println("Reapplying configuration for ingress")
+			}
+			if vals.OptionalBool(currentConfig.LocalStorage.Enabled, false) && config.LocalStorage != nil && config.LocalStorage.Enabled == nil {
+				fmt.Println("Reapplying configuration for local-storage")
+			}
+			if vals.OptionalBool(currentConfig.LoadBalancer.Enabled, false) && config.LoadBalancer != nil && config.LoadBalancer.Enabled == nil {
+				fmt.Println("Reapplying configuration for load-balancer")
+			}
+			if vals.OptionalBool(currentConfig.MetricsServer.Enabled, false) && config.MetricsServer != nil && config.MetricsServer.Enabled == nil {
+				fmt.Println("Reapplying configuration for metrics-server")
 			}
 
 			request := api.UpdateClusterConfigRequest{


### PR DESCRIPTION
## Changes

* if `k8s get` is called without functionality it returns the full configuration
```
ubuntu@bob:~/k8s$ sudo k8s get
network:
  enabled: true
dns:
  enabled: true
  cluster-domain: cluster.local
  service-ip: 10.152.183.149
  upstream-nameservers:
  - /etc/resolv.conf
...
```

* `k8s kubectl` gives a meaningful error msg if cluster is not bootstrapped
```
ubuntu@bob:~/k8s$ sudo k8s kubectl get nodes -A
The cluster has not been initialized yet. Please call:

 sudo k8s bootstrap
```

`k8s set --help` gives a hint how to find configurations.
```
ubuntu@bob:~/k8s$ sudo k8s set --help
Configure one of network, dns, gateway, ingress, local-storage, load-balancer, metrics-server.
Use `k8s get` to explore configuration options.
```

`k8s enable/disable` print feedback (`Enabling ingress...`)
```
ubuntu@bob:~/k8s$ sudo k8s enable gateway
Enabling gateway. This may take some time, please wait.
gateway enabled.

ubuntu@bob:~/k8s$ sudo k8s disable gateway
Disabling gateway. This may take some time, please wait.
gateway disabled.
```

`k8s set` should give feedback `Reapplying configuration ...` if executed on an already enabled functionality.
```
ubuntu@bob:~/k8s$ sudo k8s set dns.cluster-domain=test.local ingress.enable-proxy-protocol=true
Reapplying configuration for dns
Reapplying configuration for ingress
```