### PR TITLE
Update global  flags

### DIFF
--- a/src/k8s/cmd/k8s/formatter/formatter.go
+++ b/src/k8s/cmd/k8s/formatter/formatter.go
@@ -42,7 +42,9 @@ type jsonFormatter struct {
 }
 
 func (j jsonFormatter) Print(data any) error {
-	return json.NewEncoder(j.writer).Encode(data)
+	encoder := json.NewEncoder(j.writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(data)
 }
 
 type yamlFormatter struct {

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -10,9 +10,10 @@ import (
 
 var (
 	rootCmdOpts struct {
-		logDebug   bool
-		logVerbose bool
-		stateDir   string
+		logDebug     bool
+		logVerbose   bool
+		outputFormat string
+		stateDir     string
 	}
 	k8sdClient client.Client
 )
@@ -34,10 +35,10 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-
 	rootCmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "directory with the dqlite datastore")
 	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logDebug, "debug", "d", false, "show all debug messages")
 	rootCmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "show all information messages")
+	rootCmd.PersistentFlags().StringVarP(&rootCmdOpts.outputFormat, "output-format", "o", "plain", "set the output format to one of plain, json or yaml")
 
 	// By default, the state dir is set to a fixed directory in the snap.
 	// This shouldn't be overwritten by the user.

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/k8s/cmd/k8s/errors"
+	"github.com/canonical/k8s/cmd/k8s/formatter"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,14 @@ var (
 		server string
 	}
 )
+
+type KubeConfigResult struct {
+	KubeConfig string `json:"kube-config" yaml:"kube-config"`
+}
+
+func (k KubeConfigResult) String() string {
+	return k.KubeConfig
+}
 
 func newKubeConfigCmd() *cobra.Command {
 	kubeConfigCmd := &cobra.Command{
@@ -22,13 +31,18 @@ func newKubeConfigCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 
-			adminConfig, err := k8sdClient.KubeConfig(cmd.Context(), configCmdOpts.server)
+			config, err := k8sdClient.KubeConfig(cmd.Context(), configCmdOpts.server)
 			if err != nil {
 				return fmt.Errorf("failed to get admin config: %w", err)
 			}
 
-			fmt.Println(adminConfig)
-			return nil
+			f, err := formatter.New(rootCmdOpts.outputFormat, cmd.OutOrStdout())
+			if err != nil {
+				return fmt.Errorf("failed to create formatter: %w", err)
+			}
+			return f.Print(KubeConfigResult{
+				KubeConfig: config,
+			})
 		},
 	}
 	kubeConfigCmd.PersistentFlags().StringVar(&configCmdOpts.server, "server", "", "custom cluster server address")

--- a/src/k8s/cmd/k8s/k8s_get.go
+++ b/src/k8s/cmd/k8s/k8s_get.go
@@ -28,7 +28,13 @@ func newGetCmd() *cobra.Command {
 				return fmt.Errorf("failed to get cluster config: %w", err)
 			}
 
-			f, err := formatter.New("yaml", cmd.OutOrStdout())
+			// Use 'yaml' for 'plain' formatting.
+			// TODO: Consider table-based formatting for 'plain' format instead.
+			format := "yaml"
+			if rootCmdOpts.outputFormat == "json" {
+				format = "json"
+			}
+			f, err := formatter.New(format, cmd.OutOrStdout())
 			if err != nil {
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}

--- a/src/k8s/cmd/k8s/k8s_get.go
+++ b/src/k8s/cmd/k8s/k8s_get.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -20,10 +19,7 @@ func newGetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 
-			timeoutCtx, cancel := context.WithTimeout(cmd.Context(), statusCmdOpts.timeout)
-			defer cancel()
-
-			clusterConfig, err := k8sdClient.GetClusterConfig(timeoutCtx, api.GetClusterConfigRequest{})
+			clusterConfig, err := k8sdClient.GetClusterConfig(cmd.Context(), api.GetClusterConfigRequest{})
 			if err != nil {
 				return fmt.Errorf("failed to get cluster config: %w", err)
 			}

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -11,8 +11,7 @@ import (
 
 var (
 	getJoinTokenCmdOpts struct {
-		worker       bool
-		outputFormat string
+		worker bool
 	}
 	getJoinTokenCmdErrorMsgs = map[error]string{
 		apiv1.ErrTokenAlreadyCreated: "A token for this node was already created and the node did not join.",
@@ -52,7 +51,7 @@ func newGetJoinTokenCmd() *cobra.Command {
 			result := GetJoinTokenResult{
 				JoinToken: joinToken,
 			}
-			f, err := formatter.New(getJoinTokenCmdOpts.outputFormat, cmd.OutOrStdout())
+			f, err := formatter.New(rootCmdOpts.outputFormat, cmd.OutOrStdout())
 			if err != nil {
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}
@@ -60,7 +59,6 @@ func newGetJoinTokenCmd() *cobra.Command {
 		},
 	}
 
-	getJoinTokenCmd.PersistentFlags().StringVarP(&getJoinTokenCmdOpts.outputFormat, "output-format", "o", "plain", "set the output format to one of plain, json or yaml")
 	getJoinTokenCmd.PersistentFlags().BoolVar(&getJoinTokenCmdOpts.worker, "worker", false, "generate a join token for a worker node")
 	return getJoinTokenCmd
 }

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -1,9 +1,7 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/canonical/k8s/cmd/k8s/errors"
 	"github.com/canonical/k8s/cmd/k8s/formatter"
@@ -12,8 +10,7 @@ import (
 
 var (
 	removeNodeCmdOpts struct {
-		force   bool
-		timeout time.Duration
+		force bool
 	}
 )
 
@@ -42,18 +39,8 @@ func newRemoveNodeCmd() *cobra.Command {
 
 			name := args[0]
 
-			// TODO: Apply this check for all command where a timeout is required, do not repeat in each command.
-			const minTimeout = 3 * time.Second
-			if removeNodeCmdOpts.timeout < minTimeout {
-				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", removeNodeCmdOpts.timeout, minTimeout, minTimeout)
-				removeNodeCmdOpts.timeout = minTimeout
-			}
-
-			timeoutCtx, cancel := context.WithTimeout(cmd.Context(), removeNodeCmdOpts.timeout)
-			defer cancel()
-
 			fmt.Fprintf(cmd.ErrOrStderr(), "Removing %q from the cluster. This may take some time, please wait.", name)
-			if err := k8sdClient.RemoveNode(timeoutCtx, name, removeNodeCmdOpts.force); err != nil {
+			if err := k8sdClient.RemoveNode(cmd.Context(), name, removeNodeCmdOpts.force); err != nil {
 				return fmt.Errorf("failed to remove node from cluster: %w", err)
 			}
 			f, err := formatter.New(rootCmdOpts.outputFormat, cmd.OutOrStdout())
@@ -66,7 +53,6 @@ func newRemoveNodeCmd() *cobra.Command {
 		},
 	}
 	removeNodeCmd.Flags().BoolVar(&removeNodeCmdOpts.force, "force", false, "forcibly remove the cluster member")
-	removeNodeCmd.PersistentFlags().DurationVar(&removeNodeCmdOpts.timeout, "timeout", 180*time.Second, "the max time to wait for the node to be removed")
 	removeNodeCmd.FlagErrorFunc()
 	return removeNodeCmd
 }

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -6,11 +6,20 @@ import (
 	"strings"
 	"unicode"
 
-	api "github.com/canonical/k8s/api/v1"
+	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/cmd/k8s/errors"
+	"github.com/canonical/k8s/cmd/k8s/formatter"
 	"github.com/canonical/k8s/pkg/utils/vals"
 	"github.com/spf13/cobra"
 )
+
+type SetResult struct {
+	ClusterConfig apiv1.UserFacingClusterConfig `json:"cluster-config" yaml:"cluster-config"`
+}
+
+func (s SetResult) String() string {
+	return "Configuration updated."
+}
 
 func newSetCmd() *cobra.Command {
 	setCmd := &cobra.Command{
@@ -22,7 +31,7 @@ func newSetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			defer errors.Transform(&err, nil)
 
-			config := api.UserFacingClusterConfig{}
+			config := apiv1.UserFacingClusterConfig{}
 
 			for _, arg := range args {
 				parts := strings.SplitN(arg, "=", 2)
@@ -35,7 +44,7 @@ func newSetCmd() *cobra.Command {
 				switch key {
 				case "network.enabled":
 					if config.Network == nil {
-						config.Network = &api.NetworkConfig{}
+						config.Network = &apiv1.NetworkConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -44,7 +53,7 @@ func newSetCmd() *cobra.Command {
 					config.Network.Enabled = &v
 				case "dns.enabled":
 					if config.DNS == nil {
-						config.DNS = &api.DNSConfig{}
+						config.DNS = &apiv1.DNSConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -53,22 +62,22 @@ func newSetCmd() *cobra.Command {
 					config.DNS.Enabled = &v
 				case "dns.upstream-nameservers":
 					if config.DNS == nil {
-						config.DNS = &api.DNSConfig{}
+						config.DNS = &apiv1.DNSConfig{}
 					}
 					config.DNS.UpstreamNameservers = strings.FieldsFunc(value, func(r rune) bool { return unicode.IsSpace(r) || r == ',' })
 				case "dns.cluster-domain":
 					if config.DNS == nil {
-						config.DNS = &api.DNSConfig{}
+						config.DNS = &apiv1.DNSConfig{}
 					}
 					config.DNS.ClusterDomain = value
 				case "dns.service-ip":
 					if config.DNS == nil {
-						config.DNS = &api.DNSConfig{}
+						config.DNS = &apiv1.DNSConfig{}
 					}
 					config.DNS.ServiceIP = value
 				case "gateway.enabled":
 					if config.Gateway == nil {
-						config.Gateway = &api.GatewayConfig{}
+						config.Gateway = &apiv1.GatewayConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -77,7 +86,7 @@ func newSetCmd() *cobra.Command {
 					config.Gateway.Enabled = &v
 				case "ingress.enabled":
 					if config.Ingress == nil {
-						config.Ingress = &api.IngressConfig{}
+						config.Ingress = &apiv1.IngressConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -86,12 +95,12 @@ func newSetCmd() *cobra.Command {
 					config.Ingress.Enabled = &v
 				case "ingress.default-tls-secret":
 					if config.Ingress == nil {
-						config.Ingress = &api.IngressConfig{}
+						config.Ingress = &apiv1.IngressConfig{}
 					}
 					config.Ingress.DefaultTLSSecret = value
 				case "ingress.enable-proxy-protocol":
 					if config.Ingress == nil {
-						config.Ingress = &api.IngressConfig{}
+						config.Ingress = &apiv1.IngressConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -100,7 +109,7 @@ func newSetCmd() *cobra.Command {
 					config.Ingress.EnableProxyProtocol = &v
 				case "local-storage.enabled":
 					if config.LocalStorage == nil {
-						config.LocalStorage = &api.LocalStorageConfig{}
+						config.LocalStorage = &apiv1.LocalStorageConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -109,17 +118,17 @@ func newSetCmd() *cobra.Command {
 					config.LocalStorage.Enabled = &v
 				case "local-storage.local-path":
 					if config.LocalStorage == nil {
-						config.LocalStorage = &api.LocalStorageConfig{}
+						config.LocalStorage = &apiv1.LocalStorageConfig{}
 					}
 					config.LocalStorage.LocalPath = value
 				case "local-storage.reclaim-policy":
 					if config.LocalStorage == nil {
-						config.LocalStorage = &api.LocalStorageConfig{}
+						config.LocalStorage = &apiv1.LocalStorageConfig{}
 					}
 					config.LocalStorage.ReclaimPolicy = value
 				case "local-storage.set-default":
 					if config.LocalStorage == nil {
-						config.LocalStorage = &api.LocalStorageConfig{}
+						config.LocalStorage = &apiv1.LocalStorageConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -128,7 +137,7 @@ func newSetCmd() *cobra.Command {
 					config.LocalStorage.SetDefault = &v
 				case "load-balancer.enabled":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -137,12 +146,12 @@ func newSetCmd() *cobra.Command {
 					config.LoadBalancer.Enabled = &v
 				case "load-balancer.cidrs":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					config.LoadBalancer.CIDRs = strings.FieldsFunc(value, func(r rune) bool { return unicode.IsSpace(r) || r == ',' })
 				case "load-balancer.l2-mode":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -151,12 +160,12 @@ func newSetCmd() *cobra.Command {
 					config.LoadBalancer.L2Enabled = &v
 				case "load-balancer.l2-interfaces":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					config.LoadBalancer.L2Interfaces = strings.FieldsFunc(value, func(r rune) bool { return unicode.IsSpace(r) || r == ',' })
 				case "load-balancer.bgp-mode":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -165,7 +174,7 @@ func newSetCmd() *cobra.Command {
 					config.LoadBalancer.BGPEnabled = &v
 				case "load-balancer.bgp-local-asn":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					v, err := strconv.Atoi(value)
 					if err != nil {
@@ -174,12 +183,12 @@ func newSetCmd() *cobra.Command {
 					config.LoadBalancer.BGPLocalASN = v
 				case "load-balancer.bgp-peer-address":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					config.LoadBalancer.BGPPeerAddress = value
 				case "load-balancer.bgp-peer-port":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					v, err := strconv.Atoi(value)
 					if err != nil {
@@ -188,7 +197,7 @@ func newSetCmd() *cobra.Command {
 					config.LoadBalancer.BGPPeerPort = v
 				case "load-balancer.bgp-peer-asn":
 					if config.LoadBalancer == nil {
-						config.LoadBalancer = &api.LoadBalancerConfig{}
+						config.LoadBalancer = &apiv1.LoadBalancerConfig{}
 					}
 					v, err := strconv.Atoi(value)
 					if err != nil {
@@ -197,7 +206,7 @@ func newSetCmd() *cobra.Command {
 					config.LoadBalancer.BGPPeerASN = v
 				case "metrics-server.enabled":
 					if config.MetricsServer == nil {
-						config.MetricsServer = &api.MetricsServerConfig{}
+						config.MetricsServer = &apiv1.MetricsServerConfig{}
 					}
 					v, err := strconv.ParseBool(value)
 					if err != nil {
@@ -210,41 +219,47 @@ func newSetCmd() *cobra.Command {
 			}
 
 			// Fetching current config to check where an already enabled functionality is updated.
-			currentConfig, err := k8sdClient.GetClusterConfig(cmd.Context(), api.GetClusterConfigRequest{})
+			currentConfig, err := k8sdClient.GetClusterConfig(cmd.Context(), apiv1.GetClusterConfigRequest{})
 			if err != nil {
 				return fmt.Errorf("failed to get current cluster config: %w", err)
 			}
 
 			if vals.OptionalBool(currentConfig.Network.Enabled, false) && config.Network != nil && config.Network.Enabled == nil {
-				fmt.Println("Reapplying configuration for network")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Reapplying configuration for network")
 			}
 			if vals.OptionalBool(currentConfig.DNS.Enabled, false) && config.DNS != nil && config.DNS.Enabled == nil {
-				fmt.Println("Reapplying configuration for dns")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Reapplying configuration for dns")
 			}
 			if vals.OptionalBool(currentConfig.Gateway.Enabled, false) && config.Gateway != nil && config.Gateway.Enabled == nil {
-				fmt.Println("Reapplying configuration for gateway")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Reapplying configuration for gateway")
 			}
 			if vals.OptionalBool(currentConfig.Ingress.Enabled, false) && config.Ingress != nil && config.Ingress.Enabled == nil {
-				fmt.Println("Reapplying configuration for ingress")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Reapplying configuration for ingress")
 			}
 			if vals.OptionalBool(currentConfig.LocalStorage.Enabled, false) && config.LocalStorage != nil && config.LocalStorage.Enabled == nil {
-				fmt.Println("Reapplying configuration for local-storage")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Reapplying configuration for local-storage")
 			}
 			if vals.OptionalBool(currentConfig.LoadBalancer.Enabled, false) && config.LoadBalancer != nil && config.LoadBalancer.Enabled == nil {
-				fmt.Println("Reapplying configuration for load-balancer")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Reapplying configuration for load-balancer")
 			}
 			if vals.OptionalBool(currentConfig.MetricsServer.Enabled, false) && config.MetricsServer != nil && config.MetricsServer.Enabled == nil {
-				fmt.Println("Reapplying configuration for metrics-server")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Reapplying configuration for metrics-server")
 			}
 
-			request := api.UpdateClusterConfigRequest{
+			request := apiv1.UpdateClusterConfigRequest{
 				Config: config,
 			}
 
 			if err := k8sdClient.UpdateClusterConfig(cmd.Context(), request); err != nil {
 				return fmt.Errorf("failed to update cluster configuration: %w", err)
 			}
-			return nil
+			f, err := formatter.New(rootCmdOpts.outputFormat, cmd.OutOrStdout())
+			if err != nil {
+				return fmt.Errorf("failed to create formatter: %w", err)
+			}
+			return f.Print(SetResult{
+				ClusterConfig: config,
+			})
 		},
 	}
 

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -1,9 +1,7 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	v1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/cmd/k8s/errors"
@@ -13,7 +11,6 @@ import (
 
 var (
 	statusCmdOpts struct {
-		timeout   time.Duration
 		waitReady bool
 	}
 )
@@ -38,15 +35,7 @@ func newStatusCmd() *cobra.Command {
 				}
 			}
 
-			const minTimeout = 3 * time.Second
-			if statusCmdOpts.timeout < minTimeout {
-				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", statusCmdOpts.timeout, minTimeout, minTimeout)
-				statusCmdOpts.timeout = minTimeout
-			}
-
-			timeoutCtx, cancel := context.WithTimeout(cmd.Context(), statusCmdOpts.timeout)
-			defer cancel()
-			clusterStatus, err := k8sdClient.ClusterStatus(timeoutCtx, statusCmdOpts.waitReady)
+			clusterStatus, err := k8sdClient.ClusterStatus(cmd.Context(), statusCmdOpts.waitReady)
 			if err != nil {
 				return fmt.Errorf("failed to get cluster status: %w", err)
 			}
@@ -58,7 +47,6 @@ func newStatusCmd() *cobra.Command {
 			return f.Print(clusterStatus)
 		},
 	}
-	statusCmd.PersistentFlags().DurationVar(&statusCmdOpts.timeout, "timeout", 90*time.Second, "the max time to wait for the K8s API server to be ready")
 	statusCmd.PersistentFlags().BoolVar(&statusCmdOpts.waitReady, "wait-ready", false, "wait until at least one cluster node is ready")
 	return statusCmd
 }

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -13,9 +13,8 @@ import (
 
 var (
 	statusCmdOpts struct {
-		outputFormat string
-		timeout      time.Duration
-		waitReady    bool
+		timeout   time.Duration
+		waitReady bool
 	}
 )
 
@@ -52,14 +51,13 @@ func newStatusCmd() *cobra.Command {
 				return fmt.Errorf("failed to get cluster status: %w", err)
 			}
 
-			f, err := formatter.New(statusCmdOpts.outputFormat, cmd.OutOrStdout())
+			f, err := formatter.New(rootCmdOpts.outputFormat, cmd.OutOrStdout())
 			if err != nil {
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}
 			return f.Print(clusterStatus)
 		},
 	}
-	statusCmd.PersistentFlags().StringVar(&statusCmdOpts.outputFormat, "format", "plain", "specify in which format the output should be printed. One of plain, json or yaml")
 	statusCmd.PersistentFlags().DurationVar(&statusCmdOpts.timeout, "timeout", 90*time.Second, "the max time to wait for the K8s API server to be ready")
 	statusCmd.PersistentFlags().BoolVar(&statusCmdOpts.waitReady, "wait-ready", false, "wait until at least one cluster node is ready")
 	return statusCmd


### PR DESCRIPTION
## Changes

* Set global `--output-format/-o` flag for public k8s commands where applicable.
  Feedback/Log messages are printed to `stderr` now, so that the content of `stdout` can be parsed, e.g. if `--output-format=json`
  Example output:
```
ubuntu@peter:~/k8s$ sudo k8s bootstrap -o json
Bootstrapping the cluster. This may take some time, please wait.
{
  "node": {
    "name": "peter",
    "address": "10.84.220.158"
  }
}

ubuntu@peter:~/k8s$ sudo k8s bootstrap -o json 2> /dev/null
{
  "node": {
    "name": "peter",
    "address": "10.84.220.158"
  }
}
```

* Make `--timeout/-t` a global flag. 