### PR TITLE
Bump cilium cli to 0.16.0

### DIFF
--- a/tests/e2e/tests/test_cilium_e2e.py
+++ b/tests/e2e/tests/test_cilium_e2e.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 
 ARCH = platform.machine()
 CILIUM_CLI_ARCH_MAP = {"aarch64": "arm64", "x86_64": "amd64"}
-CILIUM_CLI_VERSION = "v0.15.19"
+CILIUM_CLI_VERSION = "v0.16.0"
 CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CILIUM_CLI_VERSION}/cilium-linux-{CILIUM_CLI_ARCH_MAP.get(ARCH)}.tar.gz"  # noqa
 
 


### PR DESCRIPTION
### Summary

Update the cilium cli version to 0.16.0 for e2e tests