### PR TITLE
Use `load-balancer.l2-mode` and `load-balancer.bgp-mode` consistently

### DIFF
--- a/src/k8s/api/v1/cluster_config.go
+++ b/src/k8s/api/v1/cluster_config.go
@@ -45,9 +45,9 @@ type IngressConfig struct {
 type LoadBalancerConfig struct {
 	Enabled        *bool    `json:"enabled,omitempty" yaml:"enabled"`
 	CIDRs          []string `json:"cidrs,omitempty" yaml:"cidrs"`
-	L2Enabled      *bool    `json:"l2-enabled,omitempty" yaml:"l2-enabled"`
+	L2Enabled      *bool    `json:"l2-mode,omitempty" yaml:"l2-mode"`
 	L2Interfaces   []string `json:"l2-interfaces,omitempty" yaml:"l2-interfaces"`
-	BGPEnabled     *bool    `json:"bgp-enabled,omitempty" yaml:"bgp-enabled"`
+	BGPEnabled     *bool    `json:"bgp-mode,omitempty" yaml:"bgp-mode"`
 	BGPLocalASN    int      `json:"bgp-local-asn,omitempty" yaml:"bgp-local-asn"`
 	BGPPeerAddress string   `json:"bgp-peer-address,omitempty" yaml:"bgp-peer-address"`
 	BGPPeerASN     int      `json:"bgp-peer-asn,omitempty" yaml:"bgp-peer-asn"`

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -49,7 +49,7 @@ func validateConfig(oldConfig types.ClusterConfig, newConfig types.ClusterConfig
 		}
 	}
 
-	// load-balancer.bgp-enabled=true should fail if any of the bgp config is empty
+	// load-balancer.bgp-mode=true should fail if any of the bgp config is empty
 	if vals.OptionalBool(newConfig.LoadBalancer.BGPEnabled, false) {
 		if newConfig.LoadBalancer.BGPLocalASN == 0 {
 			return fmt.Errorf("load-balancer.bgp-local-asn must be set when load-balancer.bgp-mode is enabled")

--- a/src/k8s/pkg/k8sd/types/cluster_config.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config.go
@@ -78,9 +78,9 @@ type Ingress struct {
 type LoadBalancer struct {
 	Enabled        *bool    `yaml:"enabled,omitempty"`
 	CIDRs          []string `yaml:"cidrs,omitempty"`
-	L2Enabled      *bool    `yaml:"l2-enabled,omitempty"`
+	L2Enabled      *bool    `yaml:"l2-mode,omitempty"`
 	L2Interfaces   []string `yaml:"l2-interfaces,omitempty"`
-	BGPEnabled     *bool    `yaml:"bgp-enabled,omitempty"`
+	BGPEnabled     *bool    `yaml:"bgp-mode,omitempty"`
 	BGPLocalASN    int      `yaml:"bgp-local-asn,omitempty"`
 	BGPPeerAddress string   `yaml:"bgp-peer-address,omitempty"`
 	BGPPeerASN     int      `yaml:"bgp-peer-asn,omitempty"`


### PR DESCRIPTION
### Summary

Use `load-balancer.l2-mode` and `load-balancer.bgp-mode` consistently in the code base