### PR TITLE
Remove timeout contexts

### DIFF
--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
@@ -87,10 +86,7 @@ func UpdateDNSComponent(ctx context.Context, s snap.Snap, isRefresh bool, cluste
 		return "", "", fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	dnsIP, err := client.GetServiceClusterIP(timeoutCtx, "coredns", "kube-system")
+	dnsIP, err := client.GetServiceClusterIP(ctx, "coredns", "kube-system")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get dns service: %w", err)
 	}
@@ -105,10 +101,7 @@ func UpdateDNSComponent(ctx context.Context, s snap.Snap, isRefresh bool, cluste
 	}
 
 	if changed {
-		timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-
-		if err := s.RestartService(timeoutCtx, "kubelet"); err != nil {
+		if err := s.RestartService(ctx, "kubelet"); err != nil {
 			return "", "", fmt.Errorf("failed to restart kubelet to apply new dns configuration: %w", err)
 		}
 	}
@@ -131,10 +124,7 @@ func DisableDNSComponent(ctx context.Context, s snap.Snap) error {
 	}
 
 	if changed {
-		timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-
-		if err := s.RestartService(timeoutCtx, "kubelet"); err != nil {
+		if err := s.RestartService(ctx, "kubelet"); err != nil {
 			return fmt.Errorf("failed to restart service 'kubelet': %w", err)
 		}
 	}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
@@ -44,14 +43,11 @@ func UpdateGatewayComponent(ctx context.Context, s snap.Snap, isRefresh bool) er
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	if err := client.RestartDeployment(timeoutCtx, "cilium-operator", "kube-system"); err != nil {
+	if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 	}
 
-	if err := client.RestartDaemonset(timeoutCtx, "cilium", "kube-system"); err != nil {
+	if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 	}
 

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
@@ -36,13 +35,10 @@ func UpdateIngressComponent(ctx context.Context, s snap.Snap, isRefresh bool, de
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	if err := client.RestartDeployment(timeoutCtx, "cilium-operator", "kube-system"); err != nil {
+	if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 	}
-	if err := client.RestartDaemonset(timeoutCtx, "cilium", "kube-system"); err != nil {
+	if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 	}
 

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
@@ -81,13 +80,10 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	if err := client.RestartDeployment(timeoutCtx, "cilium-operator", "kube-system"); err != nil {
+	if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 	}
-	if err := client.RestartDaemonset(timeoutCtx, "cilium", "kube-system"); err != nil {
+	if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 		return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 	}
 

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -78,13 +78,10 @@ func (c *k8sdClient) ClusterStatus(ctx context.Context, waitReady bool) (apiv1.C
 
 // KubeConfig returns admin kubeconfig to connect to the cluster.
 func (c *k8sdClient) KubeConfig(ctx context.Context, server string) (string, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
-	defer cancel()
-
 	request := apiv1.GetKubeConfigRequest{Server: server}
 	response := apiv1.GetKubeConfigResponse{}
 
-	err := c.Query(queryCtx, "GET", api.NewURL().Path("k8sd", "kubeconfig"), request, &response)
+	err := c.Query(ctx, "GET", api.NewURL().Path("k8sd", "kubeconfig"), request, &response)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return "", fmt.Errorf("failed to query endpoint GET /k8sd/kubeconfig on %q: %w", clientURL.String(), err)

--- a/src/k8s/pkg/k8s/client/cluster_config.go
+++ b/src/k8s/pkg/k8s/client/cluster_config.go
@@ -3,18 +3,14 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
 	api "github.com/canonical/k8s/api/v1"
 	lxdApi "github.com/canonical/lxd/shared/api"
 )
 
 func (c *k8sdClient) UpdateClusterConfig(ctx context.Context, request api.UpdateClusterConfigRequest) error {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
-	defer cancel()
-
 	var response api.UpdateClusterConfigResponse
-	err := c.Query(queryCtx, "PUT", lxdApi.NewURL().Path("k8sd", "cluster", "config"), request, &response)
+	err := c.Query(ctx, "PUT", lxdApi.NewURL().Path("k8sd", "cluster", "config"), request, &response)
 	if err != nil {
 		return fmt.Errorf("failed to update cluster configuration: %w", err)
 	}
@@ -22,12 +18,9 @@ func (c *k8sdClient) UpdateClusterConfig(ctx context.Context, request api.Update
 }
 
 func (c *k8sdClient) GetClusterConfig(ctx context.Context, request api.GetClusterConfigRequest) (api.UserFacingClusterConfig, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
-	defer cancel()
-
 	var response api.GetClusterConfigResponse
 
-	err := c.Query(queryCtx, "GET", lxdApi.NewURL().Path("k8sd", "cluster", "config"), nil, &response)
+	err := c.Query(ctx, "GET", lxdApi.NewURL().Path("k8sd", "cluster", "config"), nil, &response)
 	if err != nil {
 		return api.UserFacingClusterConfig{}, err
 	}

--- a/src/k8s/pkg/k8s/client/component.go
+++ b/src/k8s/pkg/k8s/client/component.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
 	api "github.com/canonical/k8s/api/v1"
 	lxdApi "github.com/canonical/lxd/shared/api"
@@ -11,11 +10,8 @@ import (
 
 // ListComponents returns the k8s components.
 func (c *k8sdClient) ListComponents(ctx context.Context) ([]api.Component, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
-	defer cancel()
-
 	var response api.GetComponentsResponse
-	err := c.Query(queryCtx, "GET", lxdApi.NewURL().Path("k8sd", "components"), nil, &response)
+	err := c.Query(ctx, "GET", lxdApi.NewURL().Path("k8sd", "components"), nil, &response)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return nil, fmt.Errorf("failed to query endpoint GET /k8sd/components on %q: %w", clientURL.String(), err)

--- a/src/k8s/pkg/k8s/client/kubernetes_auth_tokens.go
+++ b/src/k8s/pkg/k8s/client/kubernetes_auth_tokens.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/lxd/shared/api"
@@ -11,13 +10,10 @@ import (
 
 // GenerateAuthToken calls "POST 1.0/kubernetes/auth/tokens".
 func (c *k8sdClient) GenerateAuthToken(ctx context.Context, username string, groups []string) (string, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
-	defer cancel()
-
 	request := apiv1.CreateKubernetesAuthTokenRequest{Username: username, Groups: groups}
 	response := apiv1.CreateKubernetesAuthTokenResponse{}
 
-	err := c.Query(queryCtx, "POST", api.NewURL().Path("kubernetes", "auth", "tokens"), request, &response)
+	err := c.Query(ctx, "POST", api.NewURL().Path("kubernetes", "auth", "tokens"), request, &response)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return "", fmt.Errorf("failed to query endpoint POST /kubernetes/auth/tokens on %q: %w", clientURL.String(), err)
@@ -28,12 +24,9 @@ func (c *k8sdClient) GenerateAuthToken(ctx context.Context, username string, gro
 
 // RevokeAuthToken calls "DELETE 1.0/kubernetes/auth/tokens".
 func (c *k8sdClient) RevokeAuthToken(ctx context.Context, token string) error {
-	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
-	defer cancel()
-
 	request := apiv1.RevokeKubernetesAuthTokenRequest{Token: token}
 
-	err := c.Query(queryCtx, "DELETE", api.NewURL().Path("kubernetes", "auth", "tokens"), request, nil)
+	err := c.Query(ctx, "DELETE", api.NewURL().Path("kubernetes", "auth", "tokens"), request, nil)
 	if err != nil {
 		clientURL := c.mc.URL()
 		return fmt.Errorf("failed to query endpoint DELETE /kubernetes/auth/tokens on %q: %w", clientURL.String(), err)


### PR DESCRIPTION
The timeout should only be set via CLI. Introducing hard-coded timeouts in the code may randomly break.