### PR TITLE
Fix `k8s bootstrap` interactive mode

### DIFF
--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -153,7 +153,7 @@ func askQuestion(stdin io.Reader, stdout io.Writer, stderr io.Writer, question s
 				break
 			}
 		}
-		s = strings.ReplaceAll(strings.ToLower(s), " ", "")
+		s = strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(s), " ", ""), "\n", "")
 
 		if s == "" {
 			return defaultVal


### PR DESCRIPTION
The options checker was too exact and also took the newline into account. The options validation therefore never passed.