### PR TITLE
add missing k8s-dqlite entry in the bom.json

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -203,6 +203,7 @@ parts:
       - cni
       - containerd
       - helm
+      - k8s-dqlite
       - kubernetes
       - runc
     plugin: nil


### PR DESCRIPTION
### Summary

`k8s-dqlite` is missing from the `bom.json` on the snap, fix that.