### PR TITLE
Set k8s-dqlite branch to bump-grpc

### DIFF
--- a/build-scripts/components/k8s-dqlite/version.sh
+++ b/build-scripts/components/k8s-dqlite/version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo "master"
+echo "bump-grpc"


### PR DESCRIPTION
Just creating this PR for the e2e test results of setting the k8s-dqlite branch to "bump-grpc". Goal is to bump grpc in k8s-dqlite.
https://github.com/canonical/k8s-dqlite/pull/96