### PR TITLE
Use unique worker tokens

### DIFF
--- a/src/k8s/api/v1/tokens.go
+++ b/src/k8s/api/v1/tokens.go
@@ -6,7 +6,6 @@ type TokenRequest struct {
 	// If false, a token for joining a control plane node is created.
 	Worker bool `json:"worker"`
 	// Name of the node that should join.
-	// Only required for control plane nodes as all workers share the same token.
 	Name string `json:"name"`
 }
 

--- a/src/k8s/api/v1/worker.go
+++ b/src/k8s/api/v1/worker.go
@@ -3,8 +3,6 @@ package v1
 // WorkerNodeInfoRequest is used by a worker node to retrieve the required credentials
 // to join a cluster.
 type WorkerNodeInfoRequest struct {
-	// Hostname is the name of the worker node.
-	Hostname string `json:"hostname"`
 	// Address is the address of the worker node.
 	Address string `json:"address"`
 }

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -46,9 +46,8 @@ func Endpoints(app *microcluster.MicroCluster) []rest.Endpoint {
 		{
 			Name: "WorkerInfo",
 			Path: "k8sd/worker/info",
-			// This endpoint is used by worker nodes that are not part of the microcluster.
-			// We authenticate by passing a token through an HTTP header instead.
-			Post: rest.EndpointAction{Handler: postWorkerInfo, AllowUntrusted: true},
+			// AllowUntrusted disabled the microcluster authorization check. Authorization is done via custom token.
+			Post: rest.EndpointAction{Handler: postWorkerInfo, AllowUntrusted: true, AccessHandler: TokenAuthentication},
 		},
 		// Kubeconfig
 		{

--- a/src/k8s/pkg/k8sd/api/worker_access_handler.go
+++ b/src/k8s/pkg/k8sd/api/worker_access_handler.go
@@ -1,11 +1,15 @@
 package api
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 
+	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/state"
 )
@@ -20,6 +24,41 @@ func RestrictWorkers(s *state.State, r *http.Request) response.Response {
 
 	if isWorker {
 		return response.Forbidden(fmt.Errorf("this action is restricted on workers"))
+	}
+
+	return response.EmptySyncResponse
+}
+
+// TokenAuthentication access handler checks if the worker is allowed to access this endpoint with the provided token.
+// TokenAuthentication expects the "worker-name" and "worker-secret" fields to be set in the request header.
+func TokenAuthentication(s *state.State, r *http.Request) response.Response {
+	name := r.Header.Get("worker-name")
+	if name == "" {
+		return response.Unauthorized(fmt.Errorf("missing 'worker-name'"))
+	}
+	hostname, err := utils.CleanHostname(name)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", hostname, err))
+	}
+
+	token := r.Header.Get("worker-secret")
+	if token == "" {
+		return response.Unauthorized(fmt.Errorf("invalid token"))
+	}
+
+	var tokenIsValid bool
+	if err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
+		var err error
+		tokenIsValid, err = database.CheckWorkerNodeToken(ctx, tx, hostname, token)
+		if err != nil {
+			return fmt.Errorf("failed to check worker node token: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return response.InternalError(fmt.Errorf("check token database transaction failed: %w", err))
+	}
+	if !tokenIsValid {
+		return response.Unauthorized(fmt.Errorf("invalid token"))
 	}
 
 	return response.EmptySyncResponse

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -68,7 +68,7 @@ func onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 		Metadata apiv1.WorkerNodeInfoResponse `json:"metadata"`
 	}
 
-	requestBody, err := json.Marshal(apiv1.WorkerNodeInfoRequest{Hostname: s.Name(), Address: nodeIP.String()})
+	requestBody, err := json.Marshal(apiv1.WorkerNodeInfoRequest{Address: nodeIP.String()})
 	if err != nil {
 		return fmt.Errorf("failed to prepare worker info request: %w", err)
 	}
@@ -77,7 +77,8 @@ func onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	if err != nil {
 		return fmt.Errorf("failed to prepare HTTP request: %w", err)
 	}
-	httpRequest.Header.Add("k8sd-token", token.Token)
+	httpRequest.Header.Add("worker-name", s.Name())
+	httpRequest.Header.Add("worker-secret", token.Secret)
 
 	httpResponse, err := httpClient.Do(httpRequest)
 	if err != nil {

--- a/src/k8s/pkg/k8sd/database/sql/queries/cluster-configs/delete-worker-token.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/cluster-configs/delete-worker-token.sql
@@ -1,4 +1,4 @@
 DELETE FROM
     cluster_configs AS c
 WHERE
-    c.key = "worker-token"
+    c.key = "worker-token::" || ?

--- a/src/k8s/pkg/k8sd/database/sql/queries/cluster-configs/insert-worker-token.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/cluster-configs/insert-worker-token.sql
@@ -1,6 +1,6 @@
 INSERT INTO
     cluster_configs(key, value)
 VALUES
-    ("worker-token", ?)
+    ( "worker-token::" || ?, ? )
 ON CONFLICT(key) DO
     UPDATE SET value = EXCLUDED.value;

--- a/src/k8s/pkg/k8sd/database/sql/queries/cluster-configs/select-worker-token.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/cluster-configs/select-worker-token.sql
@@ -3,4 +3,4 @@ SELECT
 FROM
     cluster_configs AS c
 WHERE
-    ( c.key = "worker-token" )
+    ( c.key = "worker-token::" || ? ) 

--- a/src/k8s/pkg/k8sd/types/worker.go
+++ b/src/k8s/pkg/k8sd/types/worker.go
@@ -8,23 +8,18 @@ import (
 
 // InternalWorkerNodeToken encodes information required to join a cluster as a worker node.
 type InternalWorkerNodeToken struct {
-	Token         string   `json:"token"`
+	// Secret is used to verify the join request.
+	// Secret is only valid for a specified worker that was specified upon creation.
+	Secret string `json:"secret"`
+	// JoinAddresses is a list of control-plane addresses that exist in the cluster.
 	JoinAddresses []string `json:"join_addresses"`
 }
 
-// internalWorkerNodeTokenSerializeMagicString is used to validate serialized worker node tokens.
-const internalWorkerNodeTokenSerializeMagicString = "m!!"
-
 var encoding = base64.RawStdEncoding
-
-type serializableWorkerNodeInfo struct {
-	InternalWorkerNodeToken
-	Magic string `json:"_"`
-}
 
 // Encode a worker node token to a base64-encoded string.
 func (t *InternalWorkerNodeToken) Encode() (string, error) {
-	b, err := json.Marshal(serializableWorkerNodeInfo{InternalWorkerNodeToken: *t, Magic: internalWorkerNodeTokenSerializeMagicString})
+	b, err := json.Marshal(t)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal token: %w", err)
 	}
@@ -32,20 +27,13 @@ func (t *InternalWorkerNodeToken) Encode() (string, error) {
 }
 
 // Decode parses the base64-encoded string into the token.
-// Decode returns an error if the token is not valid.
 func (t *InternalWorkerNodeToken) Decode(encoded string) error {
 	raw, err := encoding.DecodeString(encoded)
 	if err != nil {
 		return fmt.Errorf("failed to deserialize token: %w", err)
 	}
-	var st serializableWorkerNodeInfo
-	if err := json.Unmarshal(raw, &st); err != nil {
+	if err := json.Unmarshal(raw, &t); err != nil {
 		return fmt.Errorf("failed to unmarshal token: %w", err)
 	}
-	if st.Magic != internalWorkerNodeTokenSerializeMagicString {
-		return fmt.Errorf("magic string mismatch")
-	}
-
-	*t = st.InternalWorkerNodeToken
 	return nil
 }

--- a/src/k8s/pkg/k8sd/types/worker_test.go
+++ b/src/k8s/pkg/k8sd/types/worker_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestWorkerTokenEncode(t *testing.T) {
 	token := &types.InternalWorkerNodeToken{
-		Token:         "token1",
+		Secret:        "mysecret",
 		JoinAddresses: []string{"addr1:1010", "addr2:1212"},
 	}
 
@@ -21,6 +21,5 @@ func TestWorkerTokenEncode(t *testing.T) {
 	decoded := &types.InternalWorkerNodeToken{}
 	err = decoded.Decode(s)
 	g.Expect(err).To(BeNil())
-
 	g.Expect(decoded).To(Equal(token))
 }

--- a/src/k8s/pkg/utils/database.go
+++ b/src/k8s/pkg/utils/database.go
@@ -175,3 +175,20 @@ func DeleteWorkerNodeEntry(ctx context.Context, state *state.State, name string)
 
 	return nil
 }
+
+// CheckWorkerNodeToken is a convenience wrapper around the database call to check if a worker token is valid.
+func CheckWorkerNodeToken(ctx context.Context, state *state.State, name string, token string) (bool, error) {
+	var exists bool
+	var err error
+	if err := state.Database.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		exists, err = database.CheckWorkerNodeToken(ctx, tx, name, token)
+		if err != nil {
+			return fmt.Errorf("failed to get worker node token from database: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("failed to perform check worker node token transaction request: %w", err)
+	}
+
+	return exists, nil
+}


### PR DESCRIPTION
Create a unique token for each worker. Previously, all workers shared the same token.

This increases security and allows workers to authenticate on endpoints on a per-node basis. 