### PR TITLE
Support single-node deployments

### DIFF
--- a/docs/src/_parts/commands/k8s_bootstrap.md
+++ b/docs/src/_parts/commands/k8s_bootstrap.md
@@ -13,9 +13,11 @@ k8s bootstrap [flags]
 ### Options
 
 ```
-      --config string   path to the YAML file containing your custom cluster bootstrap configuration.
-  -h, --help            help for bootstrap
-      --interactive     interactively configure the most important cluster options
+      --address string   microcluster address, defaults to the node IP address
+      --config string    path to the YAML file containing your custom cluster bootstrap configuration.
+  -h, --help             help for bootstrap
+      --interactive      interactively configure the most important cluster options
+      --name string      node name, defaults to hostname
 ```
 
 ### Options inherited from parent commands

--- a/docs/src/_parts/commands/k8s_join-cluster.md
+++ b/docs/src/_parts/commands/k8s_join-cluster.md
@@ -9,9 +9,9 @@ k8s join-cluster <join-token> [flags]
 ### Options
 
 ```
-      --address string   the address (IP:Port) on which the nodes REST API should be available
+      --address string   microcluster address, defaults to the node IP address
   -h, --help             help for join-cluster
-      --name string      the name of the joining node. defaults to hostname
+      --name string      node name, defaults to hostname
 ```
 
 ### Options inherited from parent commands

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -59,7 +59,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				}
 				opts.name, err = utils.CleanHostname(hostname)
 				if err != nil {
-					cmd.PrintErrf("Error: --name is not set and default hostname %q is not valid.\n\nThe error was: %v\n", err)
+					cmd.PrintErrf("Error: --name is not set and default hostname %q is not valid.\n\nThe error was: %v\n", hostname, err)
 				}
 			}
 

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -11,7 +11,9 @@ import (
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	cmdutil "github.com/canonical/k8s/cmd/util"
+	"github.com/canonical/k8s/pkg/config"
 	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -32,6 +34,8 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
 		interactive bool
 		configFile  string
+		name        string
+		address     string
 	}
 	cmd := &cobra.Command{
 		Use:    "bootstrap",
@@ -43,6 +47,24 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				cmd.PrintErrln("Error: --interactive and --config flags cannot be set at the same time.")
 				env.Exit(1)
 				return
+			}
+
+			// Use hostname as default node name
+			if opts.name == "" {
+				hostname, err := os.Hostname()
+				if err != nil {
+					cmd.PrintErrf("Error: --name is not set and could not determine the current node name.\n\nThe error was: %v\n", err)
+					env.Exit(1)
+					return
+				}
+				opts.name, err = utils.CleanHostname(hostname)
+				if err != nil {
+					cmd.PrintErrf("Error: --name is not set and default hostname %q is not valid.\n\nThe error was: %v\n", err)
+				}
+			}
+
+			if opts.address == "" {
+				opts.address = util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), config.DefaultPort)
 			}
 
 			client, err := env.Client(cmd.Context())
@@ -74,7 +96,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 
 			cmd.PrintErrln("Bootstrapping the cluster. This may take a few seconds, please wait.")
-			node, err := client.Bootstrap(cmd.Context(), bootstrapConfig)
+			node, err := client.Bootstrap(cmd.Context(), opts.name, opts.address, bootstrapConfig)
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to bootstrap the cluster.\n\nThe error was: %v\n", err)
 				env.Exit(1)
@@ -89,6 +111,8 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&opts.interactive, "interactive", false, "interactively configure the most important cluster options")
 	cmd.PersistentFlags().StringVar(&opts.configFile, "config", "", "path to the YAML file containing your custom cluster bootstrap configuration.")
+	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")
+	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address, defaults to the node IP address")
 	return cmd
 }
 

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -72,7 +72,7 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 		},
 	}
-	cmd.Flags().StringVar(&opts.name, "name", "", "the name of the joining node. defaults to hostname")
-	cmd.Flags().StringVar(&opts.address, "address", "", "the address (IP:Port) on which the nodes REST API should be available")
+	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")
+	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address, defaults to the node IP address")
 	return cmd
 }

--- a/src/k8s/pkg/k8s/client/interface.go
+++ b/src/k8s/pkg/k8s/client/interface.go
@@ -9,7 +9,7 @@ import (
 // Client defines the interface for interacting with a k8s cluster.
 type Client interface {
 	// Bootstrap initializes a new cluster member using the provided bootstrap configuration.
-	Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error)
+	Bootstrap(ctx context.Context, name string, address string, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error)
 	// IsKubernetesAPIServerReady checks if kube-apiserver is reachable.
 	IsKubernetesAPIServerReady(ctx context.Context) bool
 	// IsBootstrapped checks whether the current node is already bootstrapped.

--- a/src/k8s/pkg/k8s/client/mock/mock.go
+++ b/src/k8s/pkg/k8s/client/mock/mock.go
@@ -8,7 +8,12 @@ import (
 
 // Client is a mock implementation for k8s Client.
 type Client struct {
-	BootstrapCalledWith              apiv1.BootstrapConfig
+	BootstrapCalledWith struct {
+		Ctx             context.Context
+		Name            string
+		Address         string
+		BootstrapConfig apiv1.BootstrapConfig
+	}
 	BootstrapClusterMember           apiv1.NodeStatus
 	BootstrapErr                     error
 	IsBootstrappedReturn             bool
@@ -54,8 +59,11 @@ type Client struct {
 	UpdateClusterConfigErr        error
 }
 
-func (c *Client) Bootstrap(ctx context.Context, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error) {
-	c.BootstrapCalledWith = bootstrapConfig
+func (c *Client) Bootstrap(ctx context.Context, name string, address string, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error) {
+	c.BootstrapCalledWith.Ctx = ctx
+	c.BootstrapCalledWith.Name = name
+	c.BootstrapCalledWith.Address = address
+	c.BootstrapCalledWith.BootstrapConfig = bootstrapConfig
 	return c.BootstrapClusterMember, c.BootstrapErr
 }
 

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -182,8 +182,8 @@ func onBootstrapControlPlane(s *state.State, initConfig map[string]string) error
 	case "k8s-dqlite":
 		certificates := pki.NewK8sDqlitePKI(pki.K8sDqlitePKIOpts{
 			Hostname:          s.Name(),
-			IPSANs:            append([]net.IP{nodeIP}, serviceIPs...),
-			Years:             10,
+			IPSANs:            []net.IP{{127, 0, 0, 1}},
+			Years:             20,
 			AllowSelfSignedCA: true,
 		})
 		if err := certificates.CompleteCertificates(); err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -213,10 +213,11 @@ func onBootstrapControlPlane(s *state.State, initConfig map[string]string) error
 
 	// Certificates
 	certificates := pki.NewControlPlanePKI(pki.ControlPlanePKIOpts{
-		Hostname:          s.Name(),
-		IPSANs:            append([]net.IP{nodeIP}, serviceIPs...),
-		Years:             10,
-		AllowSelfSignedCA: true,
+		Hostname:                  s.Name(),
+		IPSANs:                    append([]net.IP{nodeIP}, serviceIPs...),
+		Years:                     20,
+		AllowSelfSignedCA:         true,
+		IncludeMachineAddressSANs: true,
 	})
 	if err := certificates.CompleteCertificates(); err != nil {
 		return fmt.Errorf("failed to initialize cluster certificates: %w", err)

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -73,9 +73,10 @@ func onPostJoin(s *state.State, initConfig map[string]string) error {
 
 	// Certificates
 	certificates := pki.NewControlPlanePKI(pki.ControlPlanePKIOpts{
-		Hostname: s.Name(),
-		IPSANs:   append([]net.IP{nodeIP}, serviceIPs...),
-		Years:    10,
+		Hostname:                  s.Name(),
+		IPSANs:                    append([]net.IP{nodeIP}, serviceIPs...),
+		Years:                     20,
+		IncludeMachineAddressSANs: true,
 	})
 
 	// load existing certificates, then generate certificates for the node

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -44,8 +44,8 @@ func onPostJoin(s *state.State, initConfig map[string]string) error {
 	case "k8s-dqlite":
 		certificates := pki.NewK8sDqlitePKI(pki.K8sDqlitePKIOpts{
 			Hostname: s.Name(),
-			IPSANs:   append([]net.IP{nodeIP}, serviceIPs...),
-			Years:    10,
+			IPSANs:   []net.IP{{127, 0, 0, 1}},
+			Years:    20,
 		})
 		certificates.K8sDqliteCert = cfg.Certificates.K8sDqliteCert
 		certificates.K8sDqliteKey = cfg.Certificates.K8sDqliteKey

--- a/src/k8s/pkg/k8sd/pki/control_plane.go
+++ b/src/k8s/pkg/k8sd/pki/control_plane.go
@@ -66,13 +66,12 @@ func (c *ControlPlanePKI) CompleteCertificates() error {
 
 	var machineIPs []net.IP
 	if c.includeMachineAddressSANs {
-		// Find machine IP addresses if needed
 		addresses, err := net.InterfaceAddrs()
 		if err != nil {
 			return fmt.Errorf("failed to retrieve machine addresses: %w", err)
 		}
 		for _, addr := range addresses {
-			if ip := net.ParseIP(addr.String()); ip != nil {
+			if ip, _, err := net.ParseCIDR(addr.String()); err == nil && ip != nil {
 				machineIPs = append(machineIPs, ip)
 			}
 		}

--- a/src/k8s/pkg/k8sd/setup/kubelet.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet.go
@@ -68,7 +68,7 @@ func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, 
 	if clusterDomain != "" {
 		args["--cluster-domain"] = clusterDomain
 	}
-	if nodeIP != nil {
+	if nodeIP != nil && !nodeIP.IsLoopback() {
 		args["--node-ip"] = nodeIP.String()
 	}
 	if _, err := snaputil.UpdateServiceArguments(snap, "kubelet", args, nil); err != nil {


### PR DESCRIPTION
### Summary

Small improvements to make the single-node cluster for development UX better.

### Changes

- Configurable `hostname` and `address` in the `k8s bootstrap` command.
- Always include machine IP addresses as SANs to the generated self-signed certificates.
- Do not set the kubelet `--node-ip` if a loopback address is used.

### Testing

You can bootstrap a cluster using the loopback address and get a functional cluster

```bash
k8s bootstrap --address 127.0.0.1:6400
```
