### PR TITLE
Docs: unlist page for now

### DIFF
--- a/docs/src/howto/index.md
+++ b/docs/src/howto/index.md
@@ -19,7 +19,6 @@ install/index
 networking/index
 /howto/storage
 /howto/contribute
-/howto/support
 ```
 
 ---


### PR DESCRIPTION
removes the dedicated support page for now (support is covered in community)