### PR TITLE
Write the External Datastore Certs in the Correct Location

### DIFF
--- a/src/k8s/pkg/k8sd/setup/certificates.go
+++ b/src/k8s/pkg/k8sd/setup/certificates.go
@@ -12,8 +12,8 @@ import (
 func EnsureExtDatastorePKI(snap snap.Snap, certificates *pki.ExternalDatastorePKI) error {
 	toWrite := map[string]string{
 		path.Join(snap.EtcdPKIDir(), "ca.crt"):     certificates.DatastoreCACert,
-		path.Join(snap.EtcdPKIDir(), "client.key"): certificates.DatastoreClientCert,
-		path.Join(snap.EtcdPKIDir(), "client.crt"): certificates.DatastoreClientKey,
+		path.Join(snap.EtcdPKIDir(), "client.key"): certificates.DatastoreClientKey,
+		path.Join(snap.EtcdPKIDir(), "client.crt"): certificates.DatastoreClientCert,
 	}
 
 	for fname, cert := range toWrite {


### PR DESCRIPTION
## Overview
The certificates are being written to different locations, causing the API server to fail to start. This pull request modifies the destination paths of these certificates to the correct ones.