### PR TITLE
Configure External Datastore

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -136,6 +136,7 @@ func onPostJoin(s *state.State, initConfig map[string]string) error {
 		if err := setup.K8sDqlite(snap, address, cluster); err != nil {
 			return fmt.Errorf("failed to configure k8s-dqlite with address=%s cluster=%v: %w", address, cluster, err)
 		}
+	case "external":
 	default:
 		return fmt.Errorf("unsupported datastore %s, must be one of %v", cfg.APIServer.Datastore, setup.SupportedDatastores)
 	}
@@ -209,6 +210,7 @@ func onPreRemove(s *state.State, force bool) error {
 		if err := client.RemoveNodeByAddress(s.Context, nodeAddress); err != nil {
 			return fmt.Errorf("failed to remove node with address %s from k8s-dqlite cluster: %w", nodeAddress, err)
 		}
+	case "external":
 	default:
 	}
 


### PR DESCRIPTION
## Overview
We are missing some checks for external datastores. Therefore, while attempting to join other control plane units, these fail to join the cluster. This pull request aims to fix that issue