### PR TITLE
POST k8sd/cluster endpoint to bootstrap a cluster

### DIFF
--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -8,7 +8,7 @@ type GetClusterStatusResponse struct {
 	ClusterStatus ClusterStatus `json:"status"`
 }
 
-// PostClusterBootstrapRequest is used to bootstrap the cluster.
+// PostClusterBootstrapRequest is used to bootstrap the cluster by using the endpoint "POST 1.0/k8sd/cluster".
 type PostClusterBootstrapRequest struct {
 	Name    string          `json:"name"`
 	Address string          `json:"address"`

--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -10,10 +10,9 @@ type GetClusterStatusResponse struct {
 
 // PostClusterBootstrapRequest is used to bootstrap the cluster.
 type PostClusterBootstrapRequest struct {
-	Bootstrap bool            `json:"bootstrap"`
-	Name      string          `json:"name"`
-	Address   string          `json:"address"`
-	Config    BootstrapConfig `json:"config"`
+	Name    string          `json:"name"`
+	Address string          `json:"address"`
+	Config  BootstrapConfig `json:"config"`
 }
 
 // GetKubeConfigRequest is used to ask for the admin kubeconfig

--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -8,6 +8,14 @@ type GetClusterStatusResponse struct {
 	ClusterStatus ClusterStatus `json:"status"`
 }
 
+// PostClusterBootstrapRequest is used to bootstrap the cluster.
+type PostClusterBootstrapRequest struct {
+	Bootstrap bool            `json:"bootstrap"`
+	Name      string          `json:"name"`
+	Address   string          `json:"address"`
+	Config    BootstrapConfig `json:"config"`
+}
+
 // GetKubeConfigRequest is used to ask for the admin kubeconfig
 type GetKubeConfigRequest struct {
 	Server string `json:"server"`

--- a/src/k8s/api/v1/cluster_node.go
+++ b/src/k8s/api/v1/cluster_node.go
@@ -7,10 +7,6 @@ type JoinClusterRequest struct {
 	Token   string `json:"token"`
 }
 
-type ClusterBootstrapRequest struct {
-	BootstrapConfig BootstrapConfig `json:"BootstrapConfig"`
-}
-
 // RemoveNodeRequest is used to request to remove a node from the cluster.
 type RemoveNodeRequest struct {
 	Name  string `json:"name"`

--- a/src/k8s/api/v1/cluster_node.go
+++ b/src/k8s/api/v1/cluster_node.go
@@ -7,6 +7,10 @@ type JoinClusterRequest struct {
 	Token   string `json:"token"`
 }
 
+type ClusterBootstrapRequest struct {
+	BootstrapConfig BootstrapConfig `json:"BootstrapConfig"`
+}
+
 // RemoveNodeRequest is used to request to remove a node from the cluster.
 type RemoveNodeRequest struct {
 	Name  string `json:"name"`

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -96,7 +96,15 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 
 			cmd.PrintErrln("Bootstrapping the cluster. This may take a few seconds, please wait.")
-			node, err := client.Bootstrap(cmd.Context(), opts.name, opts.address, bootstrapConfig)
+
+			request := apiv1.PostClusterBootstrapRequest{
+				Bootstrap: true,
+				Name:      opts.name,
+				Address:   opts.address,
+				Config:    bootstrapConfig,
+			}
+
+			node, err := client.Bootstrap(cmd.Context(), request)
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to bootstrap the cluster.\n\nThe error was: %v\n", err)
 				env.Exit(1)

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -98,10 +98,9 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			cmd.PrintErrln("Bootstrapping the cluster. This may take a few seconds, please wait.")
 
 			request := apiv1.PostClusterBootstrapRequest{
-				Bootstrap: true,
-				Name:      opts.name,
-				Address:   opts.address,
-				Config:    bootstrapConfig,
+				Name:    opts.name,
+				Address: opts.address,
+				Config:  bootstrapConfig,
 			}
 
 			node, err := client.Bootstrap(cmd.Context(), request)

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -18,10 +19,7 @@ func (c *k8sdClient) IsBootstrapped(ctx context.Context) bool {
 
 // Bootstrap bootstraps the k8s cluster
 func (c *k8sdClient) Bootstrap(ctx context.Context, request apiv1.PostClusterBootstrapRequest) (apiv1.NodeStatus, error) {
-	timeout := 30 * time.Second
-	if deadline, set := ctx.Deadline(); set {
-		timeout = time.Until(deadline)
-	}
+	timeout := utils.TimeoutFromCtx(ctx)
 
 	if err := c.m.Ready(int(timeout / time.Second)); err != nil {
 		return apiv1.NodeStatus{}, fmt.Errorf("k8sd API is not ready: %w", err)

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
@@ -18,7 +17,7 @@ func (c *k8sdClient) IsBootstrapped(ctx context.Context) bool {
 }
 
 // Bootstrap bootstraps the k8s cluster
-func (c *k8sdClient) Bootstrap(ctx context.Context, hostname string, address string, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error) {
+func (c *k8sdClient) Bootstrap(ctx context.Context, request apiv1.PostClusterBootstrapRequest) (apiv1.NodeStatus, error) {
 	timeout := 30 * time.Second
 	if deadline, set := ctx.Deadline(); set {
 		timeout = time.Until(deadline)
@@ -27,22 +26,14 @@ func (c *k8sdClient) Bootstrap(ctx context.Context, hostname string, address str
 	if err := c.m.Ready(int(timeout / time.Second)); err != nil {
 		return apiv1.NodeStatus{}, fmt.Errorf("k8sd API is not ready: %w", err)
 	}
-	config, err := bootstrapConfig.ToMap()
-	if err != nil {
-		return apiv1.NodeStatus{}, fmt.Errorf("failed to convert bootstrap config to map: %w", err)
-	}
-	if err := c.m.NewCluster(hostname, address, config, timeout); err != nil {
-		// TODO(neoaggelos): only return error that bootstrap failed
-		fmt.Fprintln(os.Stderr, "Failed with error:", err)
-		c.CleanupNode(ctx, hostname)
-		return apiv1.NodeStatus{}, fmt.Errorf("failed to bootstrap new cluster: %w", err)
+	response := apiv1.NodeStatus{}
+
+	if err := c.mc.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster"), request, &response); err != nil {
+		c.CleanupNode(ctx, request.Name)
+		return response, fmt.Errorf("failed to bootstrap new cluster using POST /k8sd/cluster: %w", err)
 	}
 
-	// TODO(neoaggelos): retrieve hostname and address from the cluster, do not guess
-	return apiv1.NodeStatus{
-		Name:    hostname,
-		Address: address,
-	}, nil
+	return response, nil
 }
 
 // ClusterStatus returns the current status of the cluster.

--- a/src/k8s/pkg/k8s/client/cluster.go
+++ b/src/k8s/pkg/k8s/client/cluster.go
@@ -19,7 +19,7 @@ func (c *k8sdClient) IsBootstrapped(ctx context.Context) bool {
 
 // Bootstrap bootstraps the k8s cluster
 func (c *k8sdClient) Bootstrap(ctx context.Context, request apiv1.PostClusterBootstrapRequest) (apiv1.NodeStatus, error) {
-	timeout := utils.TimeoutFromCtx(ctx)
+	timeout := utils.TimeoutFromCtx(ctx, 30*time.Second)
 
 	if err := c.m.Ready(int(timeout / time.Second)); err != nil {
 		return apiv1.NodeStatus{}, fmt.Errorf("k8sd API is not ready: %w", err)
@@ -27,6 +27,7 @@ func (c *k8sdClient) Bootstrap(ctx context.Context, request apiv1.PostClusterBoo
 	response := apiv1.NodeStatus{}
 
 	if err := c.mc.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster"), request, &response); err != nil {
+
 		c.CleanupNode(ctx, request.Name)
 		return response, fmt.Errorf("failed to bootstrap new cluster using POST /k8sd/cluster: %w", err)
 	}

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (c *k8sdClient) JoinCluster(ctx context.Context, request apiv1.JoinClusterRequest) error {
-	timeout := utils.TimeoutFromCtx(ctx)
+	timeout := utils.TimeoutFromCtx(ctx, 30*time.Second)
 
 	if err := c.m.Ready(int(timeout / time.Second)); err != nil {
 		return fmt.Errorf("k8sd API is not ready: %w", err)

--- a/src/k8s/pkg/k8s/client/cluster_node.go
+++ b/src/k8s/pkg/k8s/client/cluster_node.go
@@ -8,15 +8,13 @@ import (
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/lxd/shared/api"
 )
 
 func (c *k8sdClient) JoinCluster(ctx context.Context, request apiv1.JoinClusterRequest) error {
-	timeout := 30 * time.Second
-	if deadline, set := ctx.Deadline(); set {
-		timeout = time.Until(deadline)
-	}
+	timeout := utils.TimeoutFromCtx(ctx)
 
 	if err := c.m.Ready(int(timeout / time.Second)); err != nil {
 		return fmt.Errorf("k8sd API is not ready: %w", err)

--- a/src/k8s/pkg/k8s/client/interface.go
+++ b/src/k8s/pkg/k8s/client/interface.go
@@ -9,7 +9,7 @@ import (
 // Client defines the interface for interacting with a k8s cluster.
 type Client interface {
 	// Bootstrap initializes a new cluster member using the provided bootstrap configuration.
-	Bootstrap(ctx context.Context, name string, address string, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error)
+	Bootstrap(ctx context.Context, request apiv1.PostClusterBootstrapRequest) (apiv1.NodeStatus, error)
 	// IsBootstrapped checks whether the current node is already bootstrapped.
 	IsBootstrapped(ctx context.Context) bool
 	// CleanupNode performs cleanup operations for a specific node in the cluster.

--- a/src/k8s/pkg/k8s/client/mock/mock.go
+++ b/src/k8s/pkg/k8s/client/mock/mock.go
@@ -10,10 +10,8 @@ import (
 // Client is a mock implementation for k8s Client.
 type Client struct {
 	BootstrapCalledWith struct {
-		Ctx             context.Context
-		Name            string
-		Address         string
-		BootstrapConfig apiv1.BootstrapConfig
+		Ctx     context.Context
+		request apiv1.PostClusterBootstrapRequest
 	}
 	BootstrapClusterMember apiv1.NodeStatus
 	BootstrapErr           error
@@ -53,11 +51,9 @@ type Client struct {
 	UpdateClusterConfigErr        error
 }
 
-func (c *Client) Bootstrap(ctx context.Context, name string, address string, bootstrapConfig apiv1.BootstrapConfig) (apiv1.NodeStatus, error) {
+func (c *Client) Bootstrap(ctx context.Context, request apiv1.PostClusterBootstrapRequest) (apiv1.NodeStatus, error) {
 	c.BootstrapCalledWith.Ctx = ctx
-	c.BootstrapCalledWith.Name = name
-	c.BootstrapCalledWith.Address = address
-	c.BootstrapCalledWith.BootstrapConfig = bootstrapConfig
+	c.BootstrapCalledWith.request = request
 	return c.BootstrapClusterMember, c.BootstrapErr
 }
 

--- a/src/k8s/pkg/k8s/client/mock/mock.go
+++ b/src/k8s/pkg/k8s/client/mock/mock.go
@@ -11,7 +11,7 @@ import (
 type Client struct {
 	BootstrapCalledWith struct {
 		Ctx     context.Context
-		request apiv1.PostClusterBootstrapRequest
+		Request apiv1.PostClusterBootstrapRequest
 	}
 	BootstrapClusterMember apiv1.NodeStatus
 	BootstrapErr           error
@@ -53,7 +53,7 @@ type Client struct {
 
 func (c *Client) Bootstrap(ctx context.Context, request apiv1.PostClusterBootstrapRequest) (apiv1.NodeStatus, error) {
 	c.BootstrapCalledWith.Ctx = ctx
-	c.BootstrapCalledWith.request = request
+	c.BootstrapCalledWith.Request = request
 	return c.BootstrapClusterMember, c.BootstrapErr
 }
 

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -44,17 +44,15 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 	}
 
 	// Check if the cluster is already bootstrapped
-	// TODO Return 471 Already bootstrapped A cluster is already bootstrapped on this node.
 	_, err = m.Status()
 	if err == nil {
 		return response.BadRequest(fmt.Errorf("cluster is already bootstrapped"))
 	}
 
 	// Bootstrap the cluster
-	// TODO where do we grab the address from?
 	address := util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), req.BootstrapConfig.K8sDqlitePort)
 	if err := m.NewCluster(hostname, address, config, timeout); err != nil {
-		// c.CleanupNode(ctx, hostname)
+		// TODO move node cleanup here
 		return response.BadRequest(fmt.Errorf("failed to bootstrap new cluster: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/utils"
@@ -39,7 +40,7 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 	}
 
 	// Set timeout
-	timeout := utils.TimeoutFromCtx(s.Context)
+	timeout := utils.TimeoutFromCtx(s.Context, 30*time.Second)
 
 	// Bootstrap the cluster
 	if err := m.NewCluster(hostname, req.Address, config, timeout); err != nil {

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/utils"
@@ -31,16 +30,6 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 	hostname, err := utils.CleanHostname(s.Name())
 	if err != nil {
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", s.Name(), err))
-	}
-
-	// Set timeout
-	timeout := 30 * time.Second
-	if deadline, set := s.Context.Deadline(); set {
-		timeout = time.Until(deadline)
-	}
-
-	if err := m.Ready(int(timeout / time.Second)); err != nil {
-		return response.InternalError(fmt.Errorf("cluster did not come up in time: %w", err))
 	}
 
 	// Check if the cluster is already bootstrapped

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/utils"
@@ -30,6 +31,12 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 	hostname, err := utils.CleanHostname(s.Name())
 	if err != nil {
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", s.Name(), err))
+	}
+
+	// Set timeout
+	timeout := 30 * time.Second
+	if deadline, set := s.Context.Deadline(); set {
+		timeout = time.Until(deadline)
 	}
 
 	// Check if the cluster is already bootstrapped

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -33,16 +33,16 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", s.Name(), err))
 	}
 
-	// Set timeout
-	timeout := 30 * time.Second
-	if deadline, set := s.Context.Deadline(); set {
-		timeout = time.Until(deadline)
-	}
-
 	// Check if the cluster is already bootstrapped
 	_, err = m.Status()
 	if err == nil {
 		return response.BadRequest(fmt.Errorf("cluster is already bootstrapped"))
+	}
+
+	// Set timeout
+	timeout := 30 * time.Second
+	if deadline, set := s.Context.Deadline(); set {
+		timeout = time.Until(deadline)
 	}
 
 	// Bootstrap the cluster

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -9,28 +9,28 @@ import (
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/canonical/microcluster/state"
 )
 
 func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.Request) response.Response {
-	req := apiv1.ClusterBootstrapRequest{}
-	req.BootstrapConfig.SetDefaults()
+	req := apiv1.PostClusterBootstrapRequest{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 
+	req.Config.SetDefaults()
+
 	//Convert Bootstrap config to map
-	config, err := req.BootstrapConfig.ToMap()
+	config, err := req.Config.ToMap()
 	if err != nil {
 		return response.BadRequest(fmt.Errorf("failed to convert bootstrap config to map: %w", err))
 	}
 
 	// Clean hostname
-	hostname, err := utils.CleanHostname(s.Name())
+	hostname, err := utils.CleanHostname(req.Name)
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", s.Name(), err))
+		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", req.Name, err))
 	}
 
 	// Check if the cluster is already bootstrapped
@@ -46,11 +46,15 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 	}
 
 	// Bootstrap the cluster
-	address := util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), req.BootstrapConfig.K8sDqlitePort)
-	if err := m.NewCluster(hostname, address, config, timeout); err != nil {
+	if err := m.NewCluster(hostname, req.Address, config, timeout); err != nil {
 		// TODO move node cleanup here
 		return response.BadRequest(fmt.Errorf("failed to bootstrap new cluster: %w", err))
 	}
 
-	return response.SyncResponse(true, nil)
+	result := apiv1.NodeStatus{
+		Name:    hostname,
+		Address: req.Address,
+	}
+
+	return response.SyncResponse(true, &result)
 }

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -16,11 +16,8 @@ import (
 )
 
 func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.Request) response.Response {
-	// TODO: set bootstrap config defaults?
-	// bootstrapConfig := apiv1.BootstrapConfig{}
-	// bootstrapConfig.SetDefaults()
-
 	req := apiv1.ClusterBootstrapRequest{}
+	req.BootstrapConfig.SetDefaults()
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
@@ -51,10 +48,12 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 	// TODO Check if already Bootstrapped
 
 	// Bootstrap the cluster
-	address := util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), config.DefaultPort)
+	// TODO where do we grab the address from?
+	address := util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), req.BootstrapConfig.K8sDqlitePort)
 	if err := m.NewCluster(hostname, address, config, timeout); err != nil {
 		// TODO(neoaggelos): only return error that bootstrap failed
 		fmt.Fprintln(os.Stderr, "Failed with error:", err)
+
 		// c.CleanupNode(ctx, hostname)
 		return response.BadRequest(fmt.Errorf("failed to bootstrap new cluster: %w", err))
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/canonical/microcluster/state"
+)
+
+func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.Request) response.Response {
+	// TODO: set bootstrap config defaults?
+	// bootstrapConfig := apiv1.BootstrapConfig{}
+	// bootstrapConfig.SetDefaults()
+
+	req := apiv1.ClusterBootstrapRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
+	}
+
+	//Convert Bootstrap config to map
+	config, err := req.BootstrapConfig.ToMap()
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("failed to convert bootstrap config to map: %w", err))
+	}
+
+	// Clean hostname
+	// TODO: Move this to the server side
+	hostname, err := utils.CleanHostname(s.Name())
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", s.Name(), err))
+	}
+
+	// Set timeout
+	timeout := 30 * time.Second
+	if deadline, set := s.Context.Deadline(); set {
+		timeout = time.Until(deadline)
+	}
+
+	if err := m.Ready(int(timeout / time.Second)); err != nil {
+		return response.BadRequest(fmt.Errorf("cluster did not come up in time: %w", err))
+	}
+
+	// TODO Check if already Bootstrapped
+
+	// Bootstrap the cluster
+	address := util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), config.DefaultPort)
+	if err := m.NewCluster(hostname, address, config, timeout); err != nil {
+		// TODO(neoaggelos): only return error that bootstrap failed
+		fmt.Fprintln(os.Stderr, "Failed with error:", err)
+		// c.CleanupNode(ctx, hostname)
+		return response.BadRequest(fmt.Errorf("failed to bootstrap new cluster: %w", err))
+	}
+
+	return response.SyncResponse(true, nil)
+}

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/utils"
@@ -40,10 +39,7 @@ func postClusterBootstrap(m *microcluster.MicroCluster, s *state.State, r *http.
 	}
 
 	// Set timeout
-	timeout := 30 * time.Second
-	if deadline, set := s.Context.Deadline(); set {
-		timeout = time.Until(deadline)
-	}
+	timeout := utils.TimeoutFromCtx(s.Context)
 
 	// Bootstrap the cluster
 	if err := m.NewCluster(hostname, req.Address, config, timeout); err != nil {

--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -24,7 +25,7 @@ func postClusterJoin(m *microcluster.MicroCluster, s *state.State, r *http.Reque
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", req.Name, err))
 	}
 
-	timeout := utils.TimeoutFromCtx(s.Context)
+	timeout := utils.TimeoutFromCtx(s.Context, 30*time.Second)
 
 	internalToken := types.InternalWorkerNodeToken{}
 	// Check if token is worker token

--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -25,10 +24,7 @@ func postClusterJoin(m *microcluster.MicroCluster, s *state.State, r *http.Reque
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", req.Name, err))
 	}
 
-	timeout := 30 * time.Second
-	if deadline, set := s.Context.Deadline(); set {
-		timeout = time.Until(deadline)
-	}
+	timeout := utils.TimeoutFromCtx(s.Context)
 
 	internalToken := types.InternalWorkerNodeToken{}
 	// Check if token is worker token

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -9,16 +9,11 @@ import (
 // Endpoints returns the list of endpoints for a given microcluster app.
 func Endpoints(app *microcluster.MicroCluster) []rest.Endpoint {
 	return []rest.Endpoint{
-		// Cluster status
+		// Cluster status and bootstrap
 		{
-			Name: "ClusterStatus",
-			Path: "k8sd/cluster",
-			Get:  rest.EndpointAction{Handler: getClusterStatus, AccessHandler: RestrictWorkers},
-		},
-		// Cluster Bootstrap
-		{
-			Name:              "ClusterBootstrap",
+			Name:              "Cluster",
 			Path:              "k8sd/cluster",
+			Get:               rest.EndpointAction{Handler: getClusterStatus, AccessHandler: RestrictWorkers},
 			Post:              rest.EndpointAction{Handler: wrapHandlerWithMicroCluster(app, postClusterBootstrap)},
 			AllowedBeforeInit: true,
 		},

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -15,6 +15,13 @@ func Endpoints(app *microcluster.MicroCluster) []rest.Endpoint {
 			Path: "k8sd/cluster",
 			Get:  rest.EndpointAction{Handler: getClusterStatus, AccessHandler: RestrictWorkers},
 		},
+		// Cluster Bootstrap
+		{
+			Name:              "ClusterBootstrap",
+			Path:              "k8sd/cluster",
+			Post:              rest.EndpointAction{Handler: wrapHandlerWithMicroCluster(app, postClusterBootstrap)},
+			AllowedBeforeInit: true,
+		},
 		// Node
 		// Returns the status (e.g. current role) of the local node (control-plane, worker or unknown).
 		{

--- a/src/k8s/pkg/utils/timeout.go
+++ b/src/k8s/pkg/utils/timeout.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"context"
+	"time"
+)
+
+func TimeoutFromCtx(ctx context.Context) time.Duration {
+	timeout := 30 * time.Second
+	if deadline, set := ctx.Deadline(); set {
+		timeout = time.Until(deadline)
+	}
+	return timeout
+}

--- a/src/k8s/pkg/utils/timeout.go
+++ b/src/k8s/pkg/utils/timeout.go
@@ -5,8 +5,9 @@ import (
 	"time"
 )
 
-func TimeoutFromCtx(ctx context.Context) time.Duration {
-	timeout := 30 * time.Second
+func TimeoutFromCtx(ctx context.Context, defaultTimeout time.Duration) time.Duration {
+	timeout := defaultTimeout
+
 	if deadline, set := ctx.Deadline(); set {
 		timeout = time.Until(deadline)
 	}


### PR DESCRIPTION
## Description 
This PR adds the  `POST k8sd/cluster` endpoint to the k8s-snap.

The endpoints calls `postClusterBootstrap` which then calls the `cluster/control` endpoint in microcluster in order to create a new cluster.
