### PR TITLE
Propagate node configuration through kubernetes api

### DIFF
--- a/build-scripts/components/kubernetes/patches/default/0001-allow-all-nodes-to-get-k8sd-config.patch
+++ b/build-scripts/components/kubernetes/patches/default/0001-allow-all-nodes-to-get-k8sd-config.patch
@@ -1,0 +1,25 @@
+From 3ef3359a350e72687599f44906ecf2cc236347ee Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Tue, 12 Mar 2024 16:53:02 +0200
+Subject: [PATCH] allow all nodes to get k8sd-config
+
+---
+ plugin/pkg/auth/authorizer/node/node_authorizer.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/plugin/pkg/auth/authorizer/node/node_authorizer.go b/plugin/pkg/auth/authorizer/node/node_authorizer.go
+index b03467ffd73..686d292b151 100644
+--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
++++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
+@@ -112,6 +112,9 @@ func (r *NodeAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attribu
+ 		case secretResource:
+ 			return r.authorizeReadNamespacedObject(nodeName, secretVertexType, attrs)
+ 		case configMapResource:
++			if (attrs.GetVerb() == "get" || attrs.GetVerb() == "watch") && attrs.GetName() == "k8sd-config" && attrs.GetNamespace() == "kube-system" {
++				return authorizer.DecisionAllow, "", nil
++			}
+ 			return r.authorizeReadNamespacedObject(nodeName, configMapVertexType, attrs)
+ 		case pvcResource:
+ 			if attrs.GetSubresource() == "status" {
+--
+2.34.1

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231002162033-38796399c135
 	github.com/canonical/microcluster v0.0.0-20240122235408-1525f8ea8d7a
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/sys/mountinfo v0.7.1
 	github.com/onsi/gomega v1.30.0
 	github.com/pelletier/go-toml v1.9.5

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -464,6 +464,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/src/k8s/pkg/component/dns.go
+++ b/src/k8s/pkg/component/dns.go
@@ -81,7 +81,7 @@ func UpdateDNSComponent(ctx context.Context, s snap.Snap, isRefresh bool, cluste
 		}
 	}
 
-	client, err := k8s.NewClient(s)
+	client, err := k8s.NewClient(s.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -38,7 +38,7 @@ func UpdateGatewayComponent(ctx context.Context, s snap.Snap, isRefresh bool) er
 		return fmt.Errorf("failed to enable gateway component: %w", err)
 	}
 
-	client, err := k8s.NewClient(s)
+	client, err := k8s.NewClient(s.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -30,7 +30,7 @@ func UpdateIngressComponent(ctx context.Context, s snap.Snap, isRefresh bool, de
 		return fmt.Errorf("failed to enable ingress component: %w", err)
 	}
 
-	client, err := k8s.NewClient(s)
+	client, err := k8s.NewClient(s.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -40,7 +40,7 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 	}
 
 	// Wait for cilium CRDs to be available.
-	k8sClient, err := k8s.NewClient(s)
+	k8sClient, err := k8s.NewClient(s.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client: %w", err)
 	}
@@ -104,7 +104,7 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 		}
 	}
 
-	client, err := k8s.NewClient(s)
+	client, err := k8s.NewClient(s.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -44,7 +44,7 @@ func postClusterRemove(m *microcluster.MicroCluster, s *state.State, r *http.Req
 	}
 	if isWorker {
 		// For worker nodes, we need to manually cleanup the kubernetes node and db entry.
-		c, err := k8s.NewClient(snap)
+		c, err := k8s.NewClient(snap.KubernetesRESTClientGetter(""))
 		if err != nil {
 			return response.InternalError(fmt.Errorf("failed to create k8s client: %w", err))
 		}

--- a/src/k8s/pkg/k8sd/api/impl/k8sd.go
+++ b/src/k8s/pkg/k8sd/api/impl/k8sd.go
@@ -27,7 +27,7 @@ func GetClusterStatus(ctx context.Context, s *state.State) (apiv1.ClusterStatus,
 		return apiv1.ClusterStatus{}, fmt.Errorf("failed to get user-facing cluster config: %w", err)
 	}
 
-	client, err := k8s.NewClient(snap)
+	client, err := k8s.NewClient(snap.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return apiv1.ClusterStatus{}, fmt.Errorf("failed to create k8s client: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -45,7 +45,7 @@ func postWorkerInfo(s *state.State, r *http.Request) response.Response {
 	}
 
 	snap := snap.SnapFromContext(s.Context)
-	client, err := k8s.NewClient(snap)
+	client, err := k8s.NewClient(snap.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to create kubernetes client: %w", err))
 	}

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -61,6 +61,7 @@ func (a *App) Run(customHooks *config.Hooks) error {
 		OnBootstrap: onBootstrap,
 		PostJoin:    onPostJoin,
 		PreRemove:   onPreRemove,
+		OnStart:     onStart,
 	}
 	if customHooks != nil {
 		if customHooks.OnBootstrap != nil {
@@ -71,6 +72,9 @@ func (a *App) Run(customHooks *config.Hooks) error {
 		}
 		if customHooks.PreRemove != nil {
 			hooks.PreRemove = customHooks.PreRemove
+		}
+		if customHooks.OnStart != nil {
+			hooks.OnStart = customHooks.OnStart
 		}
 	}
 	err := a.MicroCluster.Start(api.Endpoints(a.MicroCluster), database.SchemaExtensions, hooks)

--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -84,7 +84,7 @@ func startControlPlaneServices(ctx context.Context, snap snap.Snap, datastore st
 func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 
 	// Wait for API server to come up
-	client, err := k8s.NewClient(snap)
+	client, err := k8s.NewClient(snap.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -164,7 +164,7 @@ func onPreRemove(s *state.State, force bool) error {
 	default:
 	}
 
-	c, err := k8s.NewClient(snap)
+	c, err := k8s.NewClient(snap.KubernetesRESTClientGetter(""))
 	if err != nil {
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -9,8 +9,8 @@ import (
 func onStart(s *state.State) error {
 	snap := snap.SnapFromContext(s.Context)
 
-	configController := controllers.NewNodeConfigurationController()
-	go configController.Run(s.Context, snap)
+	configController := controllers.NewNodeConfigurationController(snap)
+	go configController.Run(s.Context)
 
 	return nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -1,15 +1,20 @@
 package app
 
 import (
+	"context"
+
 	"github.com/canonical/k8s/pkg/k8sd/controllers"
 	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils/k8s"
 	"github.com/canonical/microcluster/state"
 )
 
 func onStart(s *state.State) error {
 	snap := snap.SnapFromContext(s.Context)
 
-	configController := controllers.NewNodeConfigurationController(snap)
+	configController := controllers.NewNodeConfigurationController(snap, func(ctx context.Context) *k8s.Client {
+		return k8s.RetryNewClient(ctx, snap.KubernetesNodeRESTClientGetter("kube-system"))
+	})
 	go configController.Run(s.Context)
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	"github.com/canonical/k8s/pkg/k8sd/controllers"
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/microcluster/state"
+)
+
+func onStart(s *state.State) error {
+	snap := snap.SnapFromContext(s.Context)
+
+	configController := controllers.NewNodeConfigurationController()
+	go configController.Run(s.Context, snap)
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -1,0 +1,79 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils/k8s"
+	"github.com/mitchellh/mapstructure"
+	v1 "k8s.io/api/core/v1"
+)
+
+type NodeConfigurationController struct {
+}
+
+func NewNodeConfigurationController() *NodeConfigurationController {
+	return &NodeConfigurationController{}
+}
+
+func (c *NodeConfigurationController) Run(ctx context.Context, snap snap.Snap) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(3 * time.Second):
+		default:
+		}
+
+		client, err := k8s.NewClient(snap.KubernetesNodeRESTClientGetter("kube-system"))
+		if err != nil {
+			// This fails when the node is not bootstrapped or joined
+			log.Println(fmt.Errorf("failed to create kubernetes node client: %w", err))
+			continue
+		}
+
+		if err := client.WatchConfigMap(ctx, "kube-system", "k8sd-config", func(configMap *v1.ConfigMap) error { return c.reconcile(ctx, snap, configMap) }); err != nil {
+			// This also can fail during bootstrapping/start up when api-server is not ready
+			// So the watch requests get connection refused replies
+			log.Println(fmt.Errorf("error while watching configmap: %w", err))
+		}
+	}
+}
+
+func (c *NodeConfigurationController) reconcile(ctx context.Context, snap snap.Snap, configMap *v1.ConfigMap) error {
+	var nodeConfig types.NodeConfig
+	if err := mapstructure.Decode(configMap.Data, &nodeConfig); err != nil {
+		return fmt.Errorf("failed to decode node config: %w", err)
+	}
+
+	var kubeletUpdateMap map[string]string = make(map[string]string)
+	var kubeletDeleteList []string
+
+	if nodeConfig.ClusterDNS != "" {
+		kubeletUpdateMap["--cluster-dns"] = nodeConfig.ClusterDNS
+	} else {
+		kubeletDeleteList = append(kubeletDeleteList, "--cluster-dns")
+	}
+
+	if nodeConfig.ClusterDomain != "" {
+		kubeletUpdateMap["--cluster-domain"] = nodeConfig.ClusterDomain
+	}
+
+	mustRestartKubelet, err := snaputil.UpdateServiceArguments(snap, "kubelet", kubeletUpdateMap, kubeletDeleteList)
+	if err != nil {
+		return fmt.Errorf("failed to update kubelet arguments: %w", err)
+	}
+
+	if mustRestartKubelet {
+		if err := snap.RestartService(ctx, "kubelet"); err != nil {
+			return fmt.Errorf("failed to restart kubelet to apply node configuration: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -51,7 +51,7 @@ func (c *NodeConfigurationController) reconcile(ctx context.Context, snap snap.S
 		return fmt.Errorf("failed to decode node config: %w", err)
 	}
 
-	var kubeletUpdateMap map[string]string = make(map[string]string)
+	kubeletUpdateMap := make(map[string]string)
 	var kubeletDeleteList []string
 
 	if nodeConfig.ClusterDNS != "" {

--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -15,30 +15,14 @@ import (
 )
 
 type NodeConfigurationController struct {
-	snap snap.Snap
+	snap            snap.Snap
+	createK8sClient func(ctx context.Context) *k8s.Client
 }
 
-func NewNodeConfigurationController(snap snap.Snap) *NodeConfigurationController {
+func NewNodeConfigurationController(snap snap.Snap, createK8sClient func(ctx context.Context) *k8s.Client) *NodeConfigurationController {
 	return &NodeConfigurationController{
-		snap: snap,
-	}
-}
-
-func (c *NodeConfigurationController) createK8sClient(ctx context.Context) *k8s.Client {
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-time.After(3 * time.Second):
-		default:
-		}
-
-		client, err := k8s.NewClient(c.snap.KubernetesNodeRESTClientGetter("kube-system"))
-		if err != nil {
-			// This fails when node is neither bootstrapped or joined
-			continue
-		}
-		return client
+		snap:            snap,
+		createK8sClient: createK8sClient,
 	}
 }
 

--- a/src/k8s/pkg/k8sd/database/util_test.go
+++ b/src/k8s/pkg/k8sd/database/util_test.go
@@ -70,6 +70,9 @@ func WithDB(t *testing.T, f func(context.Context, DB)) {
 				databaseCh <- s.Database
 				return nil
 			},
+			OnStart: func(s *state.State) error {
+				return nil
+			},
 		})
 	}()
 

--- a/src/k8s/pkg/k8sd/types/node_config.go
+++ b/src/k8s/pkg/k8sd/types/node_config.go
@@ -1,0 +1,7 @@
+package types
+
+type NodeConfig struct {
+	CloudProvider string `mapstructure:"cloud-provider,omitempty"`
+	ClusterDNS    string `mapstructure:"cluster-dns,omitempty"`
+	ClusterDomain string `mapstructure:"cluster-domain,omitempty"`
+}

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -47,7 +47,8 @@ type Snap interface {
 
 	Components() map[string]types.Component // available components
 
-	KubernetesRESTClientGetter(namespace string) genericclioptions.RESTClientGetter // admin kubernetes client
+	KubernetesRESTClientGetter(namespace string) genericclioptions.RESTClientGetter     // admin kubernetes client
+	KubernetesNodeRESTClientGetter(namespace string) genericclioptions.RESTClientGetter // node kubernetes client
 
 	K8sDqliteClient(ctx context.Context) (*dqlite.Client, error) // go-dqlite client for k8s-dqlite
 }

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -10,33 +10,34 @@ import (
 )
 
 type Mock struct {
-	Strict                      bool
-	OnLXD                       bool
-	OnLXDErr                    error
-	UID                         int
-	GID                         int
-	KubernetesConfigDir         string
-	KubernetesPKIDir            string
-	EtcdPKIDir                  string
-	KubeletRootDir              string
-	CNIConfDir                  string
-	CNIBinDir                   string
-	CNIPlugins                  []string
-	CNIPluginsBinary            string
-	ContainerdConfigDir         string
-	ContainerdExtraConfigDir    string
-	ContainerdRegistryConfigDir string
-	ContainerdRootDir           string
-	ContainerdSocketDir         string
-	ContainerdStateDir          string
-	K8sdStateDir                string
-	K8sDqliteStateDir           string
-	ServiceArgumentsDir         string
-	ServiceExtraConfigDir       string
-	LockFilesDir                string
-	Components                  map[string]types.Component
-	KubernetesRESTClientGetter  genericclioptions.RESTClientGetter
-	K8sDqliteClient             *dqlite.Client
+	Strict                         bool
+	OnLXD                          bool
+	OnLXDErr                       error
+	UID                            int
+	GID                            int
+	KubernetesConfigDir            string
+	KubernetesPKIDir               string
+	EtcdPKIDir                     string
+	KubeletRootDir                 string
+	CNIConfDir                     string
+	CNIBinDir                      string
+	CNIPlugins                     []string
+	CNIPluginsBinary               string
+	ContainerdConfigDir            string
+	ContainerdExtraConfigDir       string
+	ContainerdRegistryConfigDir    string
+	ContainerdRootDir              string
+	ContainerdSocketDir            string
+	ContainerdStateDir             string
+	K8sdStateDir                   string
+	K8sDqliteStateDir              string
+	ServiceArgumentsDir            string
+	ServiceExtraConfigDir          string
+	LockFilesDir                   string
+	Components                     map[string]types.Component
+	KubernetesRESTClientGetter     genericclioptions.RESTClientGetter
+	KubernetesNodeRESTClientGetter genericclioptions.RESTClientGetter
+	K8sDqliteClient                *dqlite.Client
 }
 
 // Snap is a mock implementation for snap.Snap.
@@ -150,6 +151,9 @@ func (s *Snap) Components() map[string]types.Component {
 }
 func (s *Snap) KubernetesRESTClientGetter(namespace string) genericclioptions.RESTClientGetter {
 	return s.Mock.KubernetesRESTClientGetter
+}
+func (s *Snap) KubernetesNodeRESTClientGetter(namespace string) genericclioptions.RESTClientGetter {
+	return s.Mock.KubernetesNodeRESTClientGetter
 }
 func (s *Snap) K8sDqliteClient(context.Context) (*dqlite.Client, error) {
 	return s.Mock.K8sDqliteClient, nil

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/k8s/pkg/client/dqlite"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/k8s/pkg/utils/vals"
 	"github.com/moby/sys/mountinfo"
 	"gopkg.in/yaml.v2"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -231,6 +232,16 @@ func (s *snap) Components() map[string]types.Component {
 func (s *snap) KubernetesRESTClientGetter(namespace string) genericclioptions.RESTClientGetter {
 	flags := &genericclioptions.ConfigFlags{
 		KubeConfig: &[]string{"/etc/kubernetes/admin.conf"}[0],
+	}
+	if namespace != "" {
+		flags.Namespace = &namespace
+	}
+	return flags
+}
+
+func (s *snap) KubernetesNodeRESTClientGetter(namespace string) genericclioptions.RESTClientGetter {
+	flags := &genericclioptions.ConfigFlags{
+		KubeConfig: vals.Pointer(path.Join(s.KubernetesConfigDir(), "kubelet.conf")),
 	}
 	if namespace != "" {
 		flags.Namespace = &namespace

--- a/src/k8s/pkg/utils/k8s/client.go
+++ b/src/k8s/pkg/utils/k8s/client.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
@@ -22,4 +24,21 @@ func NewClient(restClientGetter genericclioptions.RESTClientGetter) (*Client, er
 		return nil, fmt.Errorf("failed to create Kubernetes clientset: %w", err)
 	}
 	return &Client{clientset}, nil
+}
+
+func RetryNewClient(ctx context.Context, restClientGetter genericclioptions.RESTClientGetter) *Client {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(3 * time.Second):
+		default:
+		}
+
+		client, err := NewClient(restClientGetter)
+		if err != nil {
+			continue
+		}
+		return client
+	}
 }

--- a/src/k8s/pkg/utils/k8s/client.go
+++ b/src/k8s/pkg/utils/k8s/client.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"fmt"
 
-	"github.com/canonical/k8s/pkg/snap"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -12,8 +12,8 @@ type Client struct {
 	kubernetes.Interface
 }
 
-func NewClient(snap snap.Snap) (*Client, error) {
-	config, err := snap.KubernetesRESTClientGetter("").ToRESTConfig()
+func NewClient(restClientGetter genericclioptions.RESTClientGetter) (*Client, error) {
+	config, err := restClientGetter.ToRESTConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build Kubernetes REST config: %w", err)
 	}

--- a/src/k8s/pkg/utils/k8s/configmap.go
+++ b/src/k8s/pkg/utils/k8s/configmap.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+func (c *Client) WatchConfigMap(ctx context.Context, namespace string, name string, reconcile func(configMap *v1.ConfigMap) error) error {
+	w, err := c.CoreV1().ConfigMaps(namespace).Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{Name: name}))
+	if err != nil {
+		return fmt.Errorf("failed to watch configmap, namespace: %s name: %s: %w", namespace, name, err)
+	}
+	defer w.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt := <-w.ResultChan():
+			if evt.Object != nil {
+				configMap := evt.Object.(*v1.ConfigMap)
+
+				if err := reconcile(configMap); err != nil {
+					log.Println(fmt.Errorf("failed to reconcile configmap, namespace: %s name: %s: %w", namespace, name, err))
+				}
+			}
+		}
+	}
+}
+
+func (c *Client) UpdateConfigMap(ctx context.Context, namespace string, name string, data map[string]string) (*v1.ConfigMap, error) {
+	opts := applyv1.ConfigMap(name, namespace).WithData(data)
+	configmap, err := c.CoreV1().ConfigMaps(namespace).Apply(ctx, opts, metav1.ApplyOptions{FieldManager: "ck-k8s-client"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update configmap, namespace: %s name: %s: %w", namespace, name, err)
+	}
+	return configmap, nil
+}


### PR DESCRIPTION
Added `NodeConfigurationController` that handles watching and reconciling arguments on services. 
Restructured components(functionalities) to reduce code duplication and help with updating node config(`k8sd-config` configmap)