### PR TITLE
Fix joining under high load

### DIFF
--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -49,6 +49,9 @@ func postWorkerInfo(s *state.State, r *http.Request) response.Response {
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to create kubernetes client: %w", err))
 	}
+	if err := client.WaitApiServerReady(s.Context); err != nil {
+		return response.InternalError(fmt.Errorf("kube-apiserver did not become ready in time: %w", err))
+	}
 	servers, err := client.GetKubeAPIServerEndpoints(s.Context)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to retrieve list of known kube-apiserver endpoints: %w", err))

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -50,10 +50,13 @@ func onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	}
 
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
-
+	timeout := 30 * time.Second
+	if deadline, set := s.Context.Deadline(); set {
+		timeout = time.Until(deadline)
+	}
 	// create an HTTP client that ignores https
 	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"path"
-	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/component"
@@ -50,13 +49,8 @@ func onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	}
 
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
-	timeout := 30 * time.Second
-	if deadline, set := s.Context.Deadline(); set {
-		timeout = time.Until(deadline)
-	}
 	// create an HTTP client that ignores https
 	httpClient := &http.Client{
-		Timeout: timeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -29,7 +29,7 @@ def join_cluster(instance, join_token):
 
 
 @pytest.mark.node_count(2)
-def test_clustering(instances: List[harness.Instance]):
+def test_control_plane_nodes(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_node = instances[1]
 


### PR DESCRIPTION
Makes the k8s-snap joining process more robust and fixes #271 
See integration test runs here: https://github.com/canonical/k8s-operator/pull/54

This PR:
 * Ensures that the `kubernetes API` server is ready
 * Let the worker config request wait for the right context and not a fixed timeout
 * Adds a retry to the k8s endpoint request.