### PR TITLE
Fix wrong context for joining cluster

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -25,19 +24,17 @@ func postClusterJoin(m *microcluster.MicroCluster, s *state.State, r *http.Reque
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", req.Name, err))
 	}
 
-	timeout := utils.TimeoutFromCtx(r.Context(), 30*time.Second)
-
 	internalToken := types.InternalWorkerNodeToken{}
 	// Check if token is worker token
 	if internalToken.Decode(req.Token) == nil {
 		// valid worker node token - let's join the cluster
 		// The validation of the token is done when fetching the cluster information.
-		if err := m.NewCluster(hostname, req.Address, map[string]string{"workerToken": req.Token}, timeout); err != nil {
+		if err := m.NewCluster(hostname, req.Address, map[string]string{"workerToken": req.Token}, 0); err != nil {
 			return response.InternalError(fmt.Errorf("failed to join k8sd cluster as worker: %w", err))
 		}
 	} else {
 		// Is not a worker token. let microcluster check if it is a valid control-plane token.
-		if err := m.JoinCluster(hostname, req.Address, req.Token, nil, timeout); err != nil {
+		if err := m.JoinCluster(hostname, req.Address, req.Token, nil, 0); err != nil {
 			return response.InternalError(fmt.Errorf("failed to join k8sd cluster as control plane: %w", err))
 		}
 	}


### PR DESCRIPTION
The server-side context does not get the deadline from the client. Instead it will just be cancelled when the client context is cancelled. So, instead of querying the context from the context we do not set a deadline at all on the server-side and let't the client handle this.