### PR TITLE
Node address port fixes

### DIFF
--- a/k8s/args/k8sd
+++ b/k8s/args/k8sd
@@ -1,2 +1,1 @@
---port=6400
 --state-dir=${SNAP_COMMON}/var/lib/k8sd/state

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -64,8 +64,9 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 
 			if opts.address == "" {
-				opts.address = util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), config.DefaultPort)
+				opts.address = util.NetworkInterfaceAddress()
 			}
+			opts.address = util.CanonicalNetworkAddress(opts.address, config.DefaultPort)
 
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -45,8 +45,9 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 
 			if opts.address == "" {
-				opts.address = util.CanonicalNetworkAddress(util.NetworkInterfaceAddress(), config.DefaultPort)
+				opts.address = util.NetworkInterfaceAddress()
 			}
+			opts.address = util.CanonicalNetworkAddress(opts.address, config.DefaultPort)
 
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -2,7 +2,6 @@ package k8sd
 
 import (
 	cmdutil "github.com/canonical/k8s/cmd/util"
-	"github.com/canonical/k8s/pkg/config"
 	"github.com/canonical/k8s/pkg/k8sd/app"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +10,6 @@ var rootCmdOpts struct {
 	logDebug   bool
 	logVerbose bool
 	stateDir   string
-	port       uint
 }
 
 func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
@@ -20,11 +18,10 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short: "Canonical Kubernetes orchestrator and clustering daemon",
 		Run: func(cmd *cobra.Command, args []string) {
 			app, err := app.New(cmd.Context(), app.Config{
-				Debug:      rootCmdOpts.logDebug,
-				Verbose:    rootCmdOpts.logVerbose,
-				StateDir:   rootCmdOpts.stateDir,
-				ListenPort: rootCmdOpts.port,
-				Snap:       env.Snap,
+				Debug:    rootCmdOpts.logDebug,
+				Verbose:  rootCmdOpts.logVerbose,
+				StateDir: rootCmdOpts.stateDir,
+				Snap:     env.Snap,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd: %v", err)
@@ -46,7 +43,6 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVarP(&rootCmdOpts.logDebug, "debug", "d", false, "Show all debug messages")
 	cmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
-	cmd.PersistentFlags().UintVar(&rootCmdOpts.port, "port", config.DefaultPort, "Port on which the REST API is exposed")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
 
 	cmd.AddCommand(newSqlCmd(env))

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -45,6 +45,9 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
 
+	cmd.Flags().Uint("port", 0, "Default port for the HTTP API")
+	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")
+
 	cmd.AddCommand(newSqlCmd(env))
 
 	return cmd

--- a/src/k8s/cmd/k8sd/k8sd_sql.go
+++ b/src/k8s/cmd/k8sd/k8sd_sql.go
@@ -13,10 +13,9 @@ func newSqlCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Hidden: true,
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
-			cluster, err := app.New(cmd.Context(), app.Config{
-				StateDir:   rootCmdOpts.stateDir,
-				ListenPort: rootCmdOpts.port,
-				Snap:       env.Snap,
+			app, err := app.New(cmd.Context(), app.Config{
+				StateDir: rootCmdOpts.stateDir,
+				Snap:     env.Snap,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd app.\n\nThe error was: %v\n", err)
@@ -24,7 +23,7 @@ func newSqlCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			_, batch, err := cluster.MicroCluster.SQL(args[0])
+			_, batch, err := app.MicroCluster.SQL(args[0])
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to execute the SQL query.\n\nThe error was: %v\n", err)
 				env.Exit(1)

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -17,8 +17,6 @@ type Config struct {
 	Debug bool
 	// Verbose increases log message verbosity.
 	Verbose bool
-	// ListenPort is the network port to bind for connections.
-	ListenPort uint
 	// StateDir is the local directory to store the state of the node.
 	StateDir string
 	// Snap is the snap instance to use.
@@ -38,10 +36,9 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		cfg.StateDir = cfg.Snap.K8sdStateDir()
 	}
 	cluster, err := microcluster.App(ctx, microcluster.Args{
-		Verbose:    cfg.Verbose,
-		Debug:      cfg.Debug,
-		ListenPort: fmt.Sprintf("%d", cfg.ListenPort),
-		StateDir:   cfg.StateDir,
+		Verbose:  cfg.Verbose,
+		Debug:    cfg.Debug,
+		StateDir: cfg.StateDir,
 	})
 
 	if err != nil {


### PR DESCRIPTION
### Summary

Fixes around the node microcluster address and port

### Changes

- Remove `ListenPort` config from the microcluster app configuration, and deprecate the `--port` k8sd argument. This port is the default HTTPS port for the microcluster app, before the node is bootstrapped. After bootstrapping, this is unused, and the node address specified is used instead.
- Automatically add the default port (6400), if only the node address is specified during bootstrap (e.g. via `k8s bootstrap --address 1.1.1.1`)

