### PR TITLE
add datastore to k8s status

### DIFF
--- a/src/k8s/api/v1/cluster_config.go
+++ b/src/k8s/api/v1/cluster_config.go
@@ -27,6 +27,7 @@ type UserFacingClusterConfig struct {
 	LocalStorage  *LocalStorageConfig  `json:"local-storage,omitempty" yaml:"local-storage,omitempty"`
 	Gateway       *GatewayConfig       `json:"gateway,omitempty" yaml:"gateway,omitempty"`
 	MetricsServer *MetricsServerConfig `json:"metrics-server,omitempty" yaml:"metrics-server,omitempty"`
+	APIServer     *APIServerConfig     `json:"apiserver,omitempty" yaml:"apiserver,omitempty"`
 }
 
 type DNSConfig struct {
@@ -65,6 +66,11 @@ type NetworkConfig struct {
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
 }
 
+type APIServerConfig struct {
+	Datastore    string `json:"datastore,omitempty" yaml:"datastore"`
+	DatastoreURL string `json:"datastore-url,omitempty" yaml:"datastore-url"`
+}
+
 type GatewayConfig struct {
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled"`
 }
@@ -82,6 +88,14 @@ func (c UserFacingClusterConfig) String() string {
 }
 
 func (c NetworkConfig) String() string {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Sprintf("%#v\n", c)
+	}
+	return string(b)
+}
+
+func (c APIServerConfig) String() string {
 	b, err := yaml.Marshal(c)
 	if err != nil {
 		return fmt.Sprintf("%#v\n", c)

--- a/src/k8s/api/v1/types_test.go
+++ b/src/k8s/api/v1/types_test.go
@@ -114,19 +114,49 @@ func TestString(t *testing.T) {
 					{Name: "node3", DatastoreRole: DatastoreRoleVoter, Address: "192.168.0.3"},
 				},
 				Config: UserFacingClusterConfig{
-					Network: &NetworkConfig{Enabled: vals.Pointer(true)},
-					DNS:     &DNSConfig{Enabled: vals.Pointer(true)},
+					Network:   &NetworkConfig{Enabled: vals.Pointer(true)},
+					DNS:       &DNSConfig{Enabled: vals.Pointer(true)},
+					APIServer: &APIServerConfig{Datastore: "k8s-dqlite", DatastoreURL: ""},
 				},
 			},
 			expectedOutput: `status: ready
 high-availability: yes
 datastore:
+  datastore: k8s-dqlite
   voter-nodes:
     - 192.168.0.1
     - 192.168.0.2
     - 192.168.0.3
   standby-nodes: none
   spare-nodes: none
+
+network:
+  enabled: true
+dns:
+  enabled: true
+  cluster-domain: ""
+  service-ip: ""
+  upstream-nameservers: []
+`,
+		},
+		{
+			name: "External Datastore",
+			clusterStatus: ClusterStatus{
+				Ready: true,
+				Members: []NodeStatus{
+					{Name: "node1", DatastoreRole: DatastoreRoleVoter, Address: "192.168.0.1"},
+				},
+				Config: UserFacingClusterConfig{
+					Network:   &NetworkConfig{Enabled: vals.Pointer(true)},
+					DNS:       &DNSConfig{Enabled: vals.Pointer(true)},
+					APIServer: &APIServerConfig{Datastore: "external", DatastoreURL: "I-am-a-postgres-url"},
+				},
+			},
+			expectedOutput: `status: ready
+high-availability: no
+datastore:
+  datastore: external
+  datastore-url: I-am-a-postgres-url
 
 network:
   enabled: true

--- a/src/k8s/pkg/utils/database.go
+++ b/src/k8s/pkg/utils/database.go
@@ -75,6 +75,10 @@ func GetUserFacingClusterConfig(ctx context.Context, state *state.State) (apiv1.
 		MetricsServer: &apiv1.MetricsServerConfig{
 			Enabled: vals.Pointer(false),
 		},
+		APIServer: &apiv1.APIServerConfig{
+			Datastore:    cfg.APIServer.Datastore,
+			DatastoreURL: cfg.APIServer.DatastoreURL,
+		},
 	}
 
 	if cfg.Network.Enabled != nil {


### PR DESCRIPTION
This PR grabs the datastore type and the datastore-url from the cluster config to display them in the 'k8s status' command.

For external we now have (relevant snippet of the output):
```
status: ready
high-availability: no
datastore:
  datastore: external
  datastore-url: I-am-a-postgres-url
```
For internal we get:
```
status: ready
high-availability: yes
datastore:
  datastore: k8s-dqlite
  voter-nodes:
    - 192.168.0.1
    - 192.168.0.2
    - 192.168.0.3
  standby-nodes: none
  spare-nodes: none
```