### PR TITLE
transfer leadership before removing the leader node

### DIFF
--- a/src/k8s/pkg/client/dqlite/remove.go
+++ b/src/k8s/pkg/client/dqlite/remove.go
@@ -3,6 +3,9 @@ package dqlite
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/canonical/k8s/pkg/utils/control"
 )
 
 func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error {
@@ -18,6 +21,7 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 	var (
 		memberExists, clusterHasOtherVoters bool
 		memberToRemove                      NodeInfo
+		failOverMemberID                    *uint64
 	)
 	for _, member := range members {
 		switch {
@@ -27,6 +31,12 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 
 		case member.Address != address && member.Role == Voter:
 			clusterHasOtherVoters = true
+
+		case member.Address != address && member.Role == Spare:
+			// Mark as fail-over node. This is only used in a two node setup,
+			// where the leader node is removed. The fail-over node will be
+			// promoted to leader before the existing leader is removed.
+			failOverMemberID = &member.ID
 		}
 	}
 
@@ -34,14 +44,36 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 		return fmt.Errorf("cluster does not have a node with address %v", address)
 	}
 
-	// TODO: consider using client.Transfer() for a different node to become leader
 	if !clusterHasOtherVoters {
-		return fmt.Errorf("not removing node because there are no other voter members")
+		if failOverMemberID == nil {
+			// This normally should not happen. There should always be a backup node, except
+			// if one tries to remove the last node in the cluster.
+			return fmt.Errorf("cannot transfer dqlite leadership as there is no remaining spare node")
+		}
+
+		// Leadership can only be transfered to a voter or standby node.
+		// Therefore the remaining node in the cluster needs to be promoted first.
+		if err := client.Assign(ctx, *failOverMemberID, Voter); err != nil {
+			return fmt.Errorf("failed to assign voter role to %d: %w", *failOverMemberID, err)
+		}
+		// Transfer leadership to remaining node in cluster.
+		if err := client.Transfer(ctx, *failOverMemberID); err != nil {
+			return fmt.Errorf("failed to transfer leadership to %d: %w", *failOverMemberID, err)
+		}
+		// Recreate client to point to the new leader.
+		client, err = c.clientGetter(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create dqlite client: %w", err)
+		}
 	}
 
-	if err := client.Remove(ctx, memberToRemove.ID); err != nil {
-		return fmt.Errorf("failed to remove node %#v from dqlite cluster: %w", memberToRemove, err)
-	}
-
-	return nil
+	// Remove the node from the cluster. Retry as the leadership transfer might still be in progress.
+	// For a large database this might take some time.
+	return control.RetryFor(10, func() error {
+		if err := client.Remove(ctx, memberToRemove.ID); err != nil {
+			time.Sleep(5 * time.Second)
+			return fmt.Errorf("failed to remove node %#v from dqlite cluster: %w", memberToRemove, err)
+		}
+		return nil
+	})
 }

--- a/src/k8s/pkg/client/dqlite/remove.go
+++ b/src/k8s/pkg/client/dqlite/remove.go
@@ -21,7 +21,7 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 	var (
 		memberExists, clusterHasOtherVoters bool
 		memberToRemove                      NodeInfo
-		failOverMemberID                    *uint64
+		freeSpareNode                       *NodeInfo
 	)
 	for _, member := range members {
 		switch {
@@ -33,10 +33,9 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 			clusterHasOtherVoters = true
 
 		case member.Address != address && member.Role == Spare:
-			// Mark as fail-over node. This is only used in a two node setup,
-			// where the leader node is removed. The fail-over node will be
-			// promoted to leader before the existing leader is removed.
-			failOverMemberID = &member.ID
+			// This is only used in a two node setup, where the leader node is removed.
+			// The free spare node will be promoted to leader before the existing leader is removed.
+			freeSpareNode = &member
 		}
 	}
 
@@ -45,7 +44,7 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 	}
 
 	if !clusterHasOtherVoters {
-		if failOverMemberID == nil {
+		if freeSpareNode == nil {
 			// This normally should not happen. There should always be a backup node, except
 			// if one tries to remove the last node in the cluster.
 			return fmt.Errorf("cannot transfer dqlite leadership as there is no remaining spare node")
@@ -53,12 +52,12 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 
 		// Leadership can only be transfered to a voter or standby node.
 		// Therefore the remaining node in the cluster needs to be promoted first.
-		if err := client.Assign(ctx, *failOverMemberID, Voter); err != nil {
-			return fmt.Errorf("failed to assign voter role to %d: %w", *failOverMemberID, err)
+		if err := client.Assign(ctx, freeSpareNode.ID, Voter); err != nil {
+			return fmt.Errorf("failed to assign voter role to %d: %w", freeSpareNode.ID, err)
 		}
 		// Transfer leadership to remaining node in cluster.
-		if err := client.Transfer(ctx, *failOverMemberID); err != nil {
-			return fmt.Errorf("failed to transfer leadership to %d: %w", *failOverMemberID, err)
+		if err := client.Transfer(ctx, freeSpareNode.ID); err != nil {
+			return fmt.Errorf("failed to transfer leadership to %d: %w", freeSpareNode.ID, err)
 		}
 		// Recreate client to point to the new leader.
 		client, err = c.clientGetter(ctx)
@@ -72,7 +71,7 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 	return control.RetryFor(ctx, 10, func() error {
 		if err := client.Remove(ctx, memberToRemove.ID); err != nil {
 			time.Sleep(5 * time.Second)
-			return fmt.Errorf("failed to remove node %#v from dqlite cluster: %w", memberToRemove, err)
+			return fmt.Errorf("failed to remove node %v from dqlite cluster: %w", memberToRemove, err)
 		}
 		return nil
 	})

--- a/src/k8s/pkg/client/dqlite/remove.go
+++ b/src/k8s/pkg/client/dqlite/remove.go
@@ -69,7 +69,7 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 
 	// Remove the node from the cluster. Retry as the leadership transfer might still be in progress.
 	// For a large database this might take some time.
-	return control.RetryFor(10, func() error {
+	return control.RetryFor(ctx, 10, func() error {
 		if err := client.Remove(ctx, memberToRemove.ID); err != nil {
 			time.Sleep(5 * time.Second)
 			return fmt.Errorf("failed to remove node %#v from dqlite cluster: %w", memberToRemove, err)

--- a/src/k8s/pkg/client/dqlite/remove.go
+++ b/src/k8s/pkg/client/dqlite/remove.go
@@ -68,9 +68,8 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 
 	// Remove the node from the cluster. Retry as the leadership transfer might still be in progress.
 	// For a large database this might take some time.
-	return control.RetryFor(ctx, 10, func() error {
+	return control.RetryFor(ctx, 10, 5*time.Second, func() error {
 		if err := client.Remove(ctx, memberToRemove.ID); err != nil {
-			time.Sleep(5 * time.Second)
 			return fmt.Errorf("failed to remove node %v from dqlite cluster: %w", memberToRemove, err)
 		}
 		return nil

--- a/src/k8s/pkg/client/dqlite/remove_test.go
+++ b/src/k8s/pkg/client/dqlite/remove_test.go
@@ -65,6 +65,8 @@ func TestRemoveNodeByAddress(t *testing.T) {
 			g.Expect(members).To(HaveLen(1))
 			g.Expect(members[0].Role == dqlite.Voter)
 			g.Expect(members[0].Address).ToNot(Equal(memberToRemove.Address))
+
+			g.Expect(client.RemoveNodeByAddress(ctx, remainingNode.Address)).ToNot(Succeed())
 		})
 	})
 }

--- a/src/k8s/pkg/client/dqlite/remove_test.go
+++ b/src/k8s/pkg/client/dqlite/remove_test.go
@@ -35,7 +35,7 @@ func TestRemoveNodeByAddress(t *testing.T) {
 		})
 	})
 
-	t.Run("LastVoterFails", func(t *testing.T) {
+	t.Run("LastVoter", func(t *testing.T) {
 		withDqliteCluster(t, 2, func(ctx context.Context, dirs []string) {
 			g := NewWithT(t)
 			client, err := dqlite.NewClient(ctx, dqlite.ClientOpts{
@@ -48,17 +48,23 @@ func TestRemoveNodeByAddress(t *testing.T) {
 			g.Expect(err).To(BeNil())
 			g.Expect(members).To(HaveLen(2))
 
-			memberToRemove := members[0].Address
+			memberToRemove := members[0]
+			remainingNode := members[1]
 			if members[0].Role != dqlite.Voter {
-				memberToRemove = members[1].Address
+				memberToRemove = members[1]
+				remainingNode = members[0]
 			}
+			g.Expect(memberToRemove.Role).To(Equal(dqlite.Voter))
+			g.Expect(remainingNode.Role).To(Equal(dqlite.Spare))
 
-			// Removing the last Voter should fail
-			g.Expect(client.RemoveNodeByAddress(ctx, memberToRemove)).ToNot(BeNil())
+			// Removing the last voter should succeed and leadership should be transfered.
+			g.Expect(client.RemoveNodeByAddress(ctx, memberToRemove.Address)).To(Succeed())
 
 			members, err = client.ListMembers(ctx)
 			g.Expect(err).To(BeNil())
-			g.Expect(members).To(HaveLen(2))
+			g.Expect(members).To(HaveLen(1))
+			g.Expect(members[0].Role == dqlite.Voter)
+			g.Expect(members[0].Address).ToNot(Equal(memberToRemove.Address))
 		})
 	})
 }

--- a/src/k8s/pkg/client/dqlite/types.go
+++ b/src/k8s/pkg/client/dqlite/types.go
@@ -9,3 +9,9 @@ type NodeInfo = client.NodeInfo
 
 // Voter is the role for nodes that participate in the Raft quorum.
 var Voter = client.Voter
+
+// StandBy is the role for nodes that do not participate in quroum but replicate the database.
+var StandBy = client.StandBy
+
+// Spare is the role for nodes that do not participate in quroum and do not replicate the database.
+var Spare = client.Spare

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -48,7 +48,7 @@ func UpdateGatewayComponent(ctx context.Context, s snap.Snap, isRefresh bool) er
 	// while we try to restart them, which fails with:
 	// the object has been modified; please apply your changes to the latest version and try again
 	attempts := 3
-	if err := control.RetryFor(ctx, attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, 0, func() error {
 		if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 		}
@@ -57,7 +57,7 @@ func UpdateGatewayComponent(ctx context.Context, s snap.Snap, isRefresh bool) er
 		return fmt.Errorf("failed to restart cilium-operator deployment after %d attempts: %w", attempts, err)
 	}
 
-	if err := control.RetryFor(ctx, attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, 0, func() error {
 		if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 		}

--- a/src/k8s/pkg/component/gateway.go
+++ b/src/k8s/pkg/component/gateway.go
@@ -48,7 +48,7 @@ func UpdateGatewayComponent(ctx context.Context, s snap.Snap, isRefresh bool) er
 	// while we try to restart them, which fails with:
 	// the object has been modified; please apply your changes to the latest version and try again
 	attempts := 3
-	if err := control.RetryFor(attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, func() error {
 		if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 		}
@@ -57,7 +57,7 @@ func UpdateGatewayComponent(ctx context.Context, s snap.Snap, isRefresh bool) er
 		return fmt.Errorf("failed to restart cilium-operator deployment after %d attempts: %w", attempts, err)
 	}
 
-	if err := control.RetryFor(attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, func() error {
 		if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 		}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -37,7 +37,7 @@ func UpdateIngressComponent(ctx context.Context, s snap.Snap, isRefresh bool, de
 	}
 
 	attempts := 3
-	if err := control.RetryFor(ctx, attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, 0, func() error {
 		if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 		}
@@ -46,7 +46,7 @@ func UpdateIngressComponent(ctx context.Context, s snap.Snap, isRefresh bool, de
 		return fmt.Errorf("failed to restart cilium-operator deployment after %d attempts: %w", attempts, err)
 	}
 
-	if err := control.RetryFor(ctx, attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, 0, func() error {
 		if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 		}

--- a/src/k8s/pkg/component/ingress.go
+++ b/src/k8s/pkg/component/ingress.go
@@ -37,7 +37,7 @@ func UpdateIngressComponent(ctx context.Context, s snap.Snap, isRefresh bool, de
 	}
 
 	attempts := 3
-	if err := control.RetryFor(attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, func() error {
 		if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 		}
@@ -46,7 +46,7 @@ func UpdateIngressComponent(ctx context.Context, s snap.Snap, isRefresh bool, de
 		return fmt.Errorf("failed to restart cilium-operator deployment after %d attempts: %w", attempts, err)
 	}
 
-	if err := control.RetryFor(attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, func() error {
 		if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 		}

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -110,7 +110,7 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 	}
 
 	attempts := 3
-	if err := control.RetryFor(ctx, attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, 0, func() error {
 		if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 		}
@@ -119,7 +119,7 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 		return fmt.Errorf("failed to restart cilium-operator deployment after %d attempts: %w", attempts, err)
 	}
 
-	if err := control.RetryFor(ctx, attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, 0, func() error {
 		if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 		}

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -110,7 +110,7 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 	}
 
 	attempts := 3
-	if err := control.RetryFor(attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, func() error {
 		if err := client.RestartDeployment(ctx, "cilium-operator", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium-operator deployment: %w", err)
 		}
@@ -119,7 +119,7 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 		return fmt.Errorf("failed to restart cilium-operator deployment after %d attempts: %w", attempts, err)
 	}
 
-	if err := control.RetryFor(attempts, func() error {
+	if err := control.RetryFor(ctx, attempts, func() error {
 		if err := client.RestartDaemonset(ctx, "cilium", "kube-system"); err != nil {
 			return fmt.Errorf("failed to restart cilium daemonset: %w", err)
 		}

--- a/src/k8s/pkg/utils/control/retry.go
+++ b/src/k8s/pkg/utils/control/retry.go
@@ -1,17 +1,20 @@
 package control
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // RetryFor will retry a given function for the given amount of times.
-// RetryFor will not wait between retries. This is up to the retryFunc to handle.
-func RetryFor(ctx context.Context, retryCount int, retryFunc func() error) error {
+// RetryFor will wait for delayBetweenRetry between retries.
+func RetryFor(ctx context.Context, retryCount int, delayBetweenRetry time.Duration, retryFunc func() error) error {
 	var err error = nil
 	for i := 0; i < retryCount; i++ {
 		if err = retryFunc(); err != nil {
 			select {
 			case <-ctx.Done():
 				return context.Canceled
-			default:
+			case <-time.After(delayBetweenRetry):
 				continue
 			}
 		}

--- a/src/k8s/pkg/utils/control/retry.go
+++ b/src/k8s/pkg/utils/control/retry.go
@@ -6,7 +6,7 @@ import (
 )
 
 // RetryFor will retry a given function for the given amount of times.
-// RetryFor will wait for delayBetweenRetry between retries.
+// RetryFor will wait for backoff between retries.
 func RetryFor(ctx context.Context, retryCount int, delayBetweenRetry time.Duration, retryFunc func() error) error {
 	var err error = nil
 	for i := 0; i < retryCount; i++ {

--- a/src/k8s/pkg/utils/control/retry.go
+++ b/src/k8s/pkg/utils/control/retry.go
@@ -1,5 +1,7 @@
 package control
 
+// RetryFor will retry a given function for the given amount of times.
+// RetryFor will not wait between retries. This is up to the retryFunc to handle.
 func RetryFor(retryCount int, retryFunc func() error) error {
 	var err error = nil
 	for i := 0; i < retryCount; i++ {

--- a/src/k8s/pkg/utils/control/retry.go
+++ b/src/k8s/pkg/utils/control/retry.go
@@ -1,12 +1,19 @@
 package control
 
+import "context"
+
 // RetryFor will retry a given function for the given amount of times.
 // RetryFor will not wait between retries. This is up to the retryFunc to handle.
-func RetryFor(retryCount int, retryFunc func() error) error {
+func RetryFor(ctx context.Context, retryCount int, retryFunc func() error) error {
 	var err error = nil
 	for i := 0; i < retryCount; i++ {
 		if err = retryFunc(); err != nil {
-			continue
+			select {
+			case <-ctx.Done():
+				return context.Canceled
+			default:
+				continue
+			}
 		}
 		break
 	}

--- a/src/k8s/pkg/utils/control/retry_test.go
+++ b/src/k8s/pkg/utils/control/retry_test.go
@@ -15,7 +15,7 @@ func TestRetryFor(t *testing.T) {
 		retryCount := 3
 		count := 0
 
-		err := RetryFor(ctx, retryCount, func() error {
+		err := RetryFor(ctx, retryCount, 50*time.Millisecond, func() error {
 			count++
 			if count < retryCount {
 				return errors.New("failed")
@@ -37,7 +37,7 @@ func TestRetryFor(t *testing.T) {
 
 		retryCount := 3
 
-		err := RetryFor(ctx, retryCount, func() error {
+		err := RetryFor(ctx, retryCount, time.Second, func() error {
 			time.Sleep(200 * time.Millisecond)
 			return errors.New("failed")
 		})
@@ -53,7 +53,7 @@ func TestRetryFor(t *testing.T) {
 
 		retryCount := 3
 
-		err := RetryFor(ctx, retryCount, func() error {
+		err := RetryFor(ctx, retryCount, 100*time.Millisecond, func() error {
 			return errors.New("failed")
 		})
 

--- a/src/k8s/pkg/utils/control/retry_test.go
+++ b/src/k8s/pkg/utils/control/retry_test.go
@@ -1,0 +1,64 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryFor(t *testing.T) {
+	t.Run("Retry succeeds", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		retryCount := 3
+		count := 0
+
+		err := RetryFor(ctx, retryCount, func() error {
+			count++
+			if count < retryCount {
+				return errors.New("failed")
+			}
+			return nil
+		})
+
+		if err != nil {
+			t.Errorf("Expected nil error, got: %v", err)
+		}
+		if count != retryCount {
+			t.Errorf("Expected retry count %d, got: %d", retryCount, count)
+		}
+	})
+
+	t.Run("Retry fails with context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		retryCount := 3
+
+		err := RetryFor(ctx, retryCount, func() error {
+			time.Sleep(200 * time.Millisecond)
+			return errors.New("failed")
+		})
+
+		if err != context.Canceled {
+			t.Errorf("Expected context.Canceled error, got: %v", err)
+		}
+	})
+
+	t.Run("Retry exhausts without success", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		retryCount := 3
+
+		err := RetryFor(ctx, retryCount, func() error {
+			return errors.New("failed")
+		})
+
+		if err == nil {
+			t.Error("Expected non-nil error, got nil")
+		}
+	})
+}


### PR DESCRIPTION
In a two node dqlite cluster, one is leader/voter and one is a spare node.
If the leader node should be removed, the leadership needs to be transferred to the remaining node first. 
The `go-dqlite` client provides a Transfer function that transfers the leadership to another node. However, this requires the other node to either be a voter or standby, not spare.
To work around this limitation, this PR:

1. assign the spare node the standby role
1. transfer leadership to the new standby node
1. create a new client to the new leader
1. remove the old leader node from the cluster

This approach is a bit problematic for several reasons. If a spare node is promoted to standby it needs to copy the whole database. For large dbs this might take significant amount of time. 

So, this implementation serves as a workaround. A proper fix - have the non-leader node as standby by default - will be delivered by in https://github.com/canonical/go-dqlite/issues/293