### PR TITLE
Wait for microcluster to be running before starting node config controller

### DIFF
--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -125,8 +125,8 @@ func TestConfigPropagation(t *testing.T) {
 	watcher := watch.NewFake()
 	clientset.PrependWatchReactor("configmaps", k8stesting.DefaultWatchReactor(watcher, nil))
 
-	configController := NewNodeConfigurationController(s, func(ctx context.Context) *k8s.Client {
-		return &k8s.Client{Interface: clientset}
+	configController := NewNodeConfigurationController(s, func() {}, func() (*k8s.Client, error) {
+		return &k8s.Client{Interface: clientset}, nil
 	})
 
 	go configController.Run(ctx)


### PR DESCRIPTION
### Summary

Do not start the node config controller before the microcluster node is running (i.e. the database is open, see https://github.com/canonical/microcluster/blob/5043bc984c83e9ecfdba1de731ec05678b166f13/internal/rest/rest.go#L188

### Changes

- Add a `sync.WaitGroup` in `*app.App`, which is marked as complete once the database is open.
- Move the node config controller creation to `*app.App`, and accept the `waitReady` func for the wait group
- Move the node config controller create k8s client inside the package, to simplify how dependencies are passed.