### PR TITLE
Add (Datastore).ToKubeAPIServerArguments() helper

### DIFF
--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -57,7 +57,7 @@ func setupControlPlaneServices(snap snap.Snap, s *state.State, cfg types.Cluster
 	if err := setup.KubeScheduler(snap); err != nil {
 		return fmt.Errorf("failed to configure kube-scheduler: %w", err)
 	}
-	if err := setup.KubeAPIServer(snap, cfg.Network.GetServiceCIDR(), s.Address().Path("1.0", "kubernetes", "auth", "webhook").String(), true, cfg.Datastore.GetType(), cfg.Datastore.GetExternalURL(), cfg.APIServer.GetAuthorizationMode()); err != nil {
+	if err := setup.KubeAPIServer(snap, cfg.Network.GetServiceCIDR(), s.Address().Path("1.0", "kubernetes", "auth", "webhook").String(), true, cfg.Datastore, cfg.APIServer.GetAuthorizationMode()); err != nil {
 		return fmt.Errorf("failed to configure kube-apiserver: %w", err)
 	}
 	return nil

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap/mock"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/k8s/pkg/utils/vals"
 	. "github.com/onsi/gomega"
 )
 
@@ -35,7 +37,7 @@ func TestKubeAPIServer(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setKubeAPIServerMock)
 
 		// Call the KubeAPIServer setup function with mock arguments
-		g.Expect(setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", true, "k8s-dqlite", "datastoreurl", "Node,RBAC")).To(BeNil())
+		g.Expect(setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", true, types.Datastore{Type: vals.Pointer("k8s-dqlite")}, "Node,RBAC")).To(BeNil())
 
 		// Ensure the kube-apiserver arguments file has the expected arguments and values
 		tests := []struct {
@@ -90,7 +92,7 @@ func TestKubeAPIServer(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setKubeAPIServerMock)
 
 		// Call the KubeAPIServer setup function with mock arguments
-		g.Expect(setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", false, "k8s-dqlite", "datastoreurl", "Node,RBAC")).To(BeNil())
+		g.Expect(setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", false, types.Datastore{Type: vals.Pointer("k8s-dqlite")}, "Node,RBAC")).To(BeNil())
 
 		// Ensure the kube-apiserver arguments file has the expected arguments and values
 		tests := []struct {
@@ -137,7 +139,7 @@ func TestKubeAPIServer(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setKubeAPIServerMock)
 
 		// Setup without proxy to simplify argument list
-		g.Expect(setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", false, "external", "datastoreurl", "Node,RBAC")).To(BeNil())
+		g.Expect(setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", false, types.Datastore{Type: vals.Pointer("external"), ExternalURL: vals.Pointer("datastoreurl")}, "Node,RBAC")).To(BeNil())
 
 		g.Expect(snaputil.GetServiceArgument(s, "kube-apiserver", "--etcd-servers")).To(Equal("datastoreurl"))
 		_, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
@@ -151,7 +153,7 @@ func TestKubeAPIServer(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setKubeAPIServerMock)
 
 		// Attempt to configure kube-apiserver with an unsupported datastore
-		err := setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", false, "unsupported-datastore", "datastoreurl", "Node,RBAC")
+		err := setup.KubeAPIServer(s, "10.0.0.0/24", "https://auth-webhook.url", false, types.Datastore{Type: vals.Pointer("unsupported")}, "Node,RBAC")
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err).To(MatchError(ContainSubstring("unsupported datastore")))
 	})

--- a/src/k8s/pkg/k8sd/types/cluster_config_datastore.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_datastore.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"fmt"
+	"path"
+)
+
 type Datastore struct {
 	Type *string `json:"type,omitempty"`
 
@@ -23,4 +28,46 @@ func (c Datastore) GetExternalClientCert() string { return getField(c.ExternalCl
 func (c Datastore) GetExternalClientKey() string  { return getField(c.ExternalClientKey) }
 func (c Datastore) Empty() bool {
 	return c.Type == nil && c.K8sDqlitePort == nil && c.K8sDqliteCert == nil && c.K8sDqliteKey == nil && c.ExternalURL == nil && c.ExternalCACert == nil && c.ExternalClientCert == nil && c.ExternalClientKey == nil
+}
+
+// DatastoreSnapProvider is to avoid circular dependency for snap.Snap in Datastore.ToKubeAPIServerArguments()
+type DatastorePathsProvider interface {
+	K8sDqliteStateDir() string
+	EtcdPKIDir() string
+}
+
+// ToKubeAPIServerArguments returns updateArgs, deleteArgs that can be used with snaputil.UpdateServiceArguments() for the kube-apiserver
+// according the datastore configuration.
+func (c Datastore) ToKubeAPIServerArguments(p DatastorePathsProvider) (map[string]string, []string) {
+	var (
+		updateArgs = make(map[string]string)
+		deleteArgs []string
+	)
+
+	switch c.GetType() {
+	case "k8s-dqlite":
+		updateArgs["--etcd-servers"] = fmt.Sprintf("unix://%s", path.Join(p.K8sDqliteStateDir(), "k8s-dqlite.sock"))
+		deleteArgs = []string{"--etcd-cafile", "--etcd-certfile", "--etcd-keyfile"}
+	case "external":
+		updateArgs["--etcd-servers"] = c.GetExternalURL()
+
+		// the certificates will be written by setup.EnsureExtDatastorePKI(), here we only set the paths
+		for _, loop := range []struct {
+			arg  string
+			cert string
+			path string
+		}{
+			{cert: c.GetExternalCACert(), arg: "--etcd-cafile", path: "ca.crt"},
+			{cert: c.GetExternalClientCert(), arg: "--etcd-certfile", path: "client.crt"},
+			{cert: c.GetExternalClientKey(), arg: "--etcd-keyfile", path: "client.key"},
+		} {
+			if loop.cert != "" {
+				updateArgs[loop.arg] = path.Join(p.EtcdPKIDir(), loop.path)
+			} else {
+				deleteArgs = append(deleteArgs, loop.arg)
+			}
+		}
+	}
+
+	return updateArgs, deleteArgs
 }

--- a/src/k8s/pkg/k8sd/types/cluster_config_datastore.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_datastore.go
@@ -30,7 +30,7 @@ func (c Datastore) Empty() bool {
 	return c.Type == nil && c.K8sDqlitePort == nil && c.K8sDqliteCert == nil && c.K8sDqliteKey == nil && c.ExternalURL == nil && c.ExternalCACert == nil && c.ExternalClientCert == nil && c.ExternalClientKey == nil
 }
 
-// DatastoreSnapProvider is to avoid circular dependency for snap.Snap in Datastore.ToKubeAPIServerArguments()
+// DatastorePathsProvider is to avoid circular dependency for snap.Snap in Datastore.ToKubeAPIServerArguments()
 type DatastorePathsProvider interface {
 	K8sDqliteStateDir() string
 	EtcdPKIDir() string

--- a/src/k8s/pkg/k8sd/types/cluster_config_datastore_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_datastore_test.go
@@ -1,0 +1,78 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/k8s/pkg/utils/vals"
+	. "github.com/onsi/gomega"
+)
+
+func TestDatastoreToKubeAPIServerArguments(t *testing.T) {
+	snap := &mock.Snap{
+		Mock: mock.Mock{
+			K8sDqliteStateDir: "/k8s-dqlite",
+			EtcdPKIDir:        "/pki/etcd",
+		},
+	}
+
+	for _, tc := range []struct {
+		name             string
+		config           types.Datastore
+		expectUpdateArgs map[string]string
+		expectDeleteArgs []string
+	}{
+		{
+			name:             "Nil",
+			expectUpdateArgs: map[string]string{},
+		},
+		{
+			name: "K8sDqlite",
+			config: types.Datastore{
+				Type: vals.Pointer("k8s-dqlite"),
+			},
+			expectUpdateArgs: map[string]string{
+				"--etcd-servers": "unix:///k8s-dqlite/k8s-dqlite.sock",
+			},
+			expectDeleteArgs: []string{"--etcd-cafile", "--etcd-certfile", "--etcd-keyfile"},
+		},
+		{
+			name: "ExternalFull",
+			config: types.Datastore{
+				Type:               vals.Pointer("external"),
+				ExternalURL:        vals.Pointer("https://10.0.0.10:2379,https://10.0.0.11:2379"),
+				ExternalCACert:     vals.Pointer("data"),
+				ExternalClientCert: vals.Pointer("data"),
+				ExternalClientKey:  vals.Pointer("data"),
+			},
+			expectUpdateArgs: map[string]string{
+				"--etcd-servers":  "https://10.0.0.10:2379,https://10.0.0.11:2379",
+				"--etcd-cafile":   "/pki/etcd/ca.crt",
+				"--etcd-certfile": "/pki/etcd/client.crt",
+				"--etcd-keyfile":  "/pki/etcd/client.key",
+			},
+		},
+		{
+			name: "ExternalOnlyCA",
+			config: types.Datastore{
+				Type:           vals.Pointer("external"),
+				ExternalURL:    vals.Pointer("https://10.0.0.10:2379,https://10.0.0.11:2379"),
+				ExternalCACert: vals.Pointer("data"),
+			},
+			expectUpdateArgs: map[string]string{
+				"--etcd-servers": "https://10.0.0.10:2379,https://10.0.0.11:2379",
+				"--etcd-cafile":  "/pki/etcd/ca.crt",
+			},
+			expectDeleteArgs: []string{"--etcd-certfile", "--etcd-keyfile"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			update, delete := tc.config.ToKubeAPIServerArguments(snap)
+			g.Expect(update).To(Equal(tc.expectUpdateArgs))
+			g.Expect(delete).To(Equal(tc.expectDeleteArgs))
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Move the generation of kube-apiserver arguments from the datastore configuration into `pkg/k8sd/types`, and add focused unit tests

### Changes

- Add `(Datastore).ToKubeAPIServerArguments()`
- Use it in `setup.KubeAPIServer()`
- Update callers and tests
- Add unit tests for ToKubeAPIServerArguments()