### PR TITLE
Use gomega NewWithT instead of deprecated NewGomegaWithT

### DIFF
--- a/src/k8s/api/v1/types_test.go
+++ b/src/k8s/api/v1/types_test.go
@@ -51,7 +51,7 @@ func TestBootstrapConfigFromMap(t *testing.T) {
 }
 
 func TestHaClusterFormed(t *testing.T) {
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	testCases := []struct {
 		name           string

--- a/src/k8s/pkg/k8sd/pki/k8sdqlite_test.go
+++ b/src/k8s/pkg/k8sd/pki/k8sdqlite_test.go
@@ -120,7 +120,7 @@ m5cIDhPBuZSCs7ZnhWCHF0WMztl6fqNVp2GuFGbDM+LjAZT2YOdP0Ts=
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			err := tt.pki.CompleteCertificates()
 
 			if tt.expectedError {
@@ -170,7 +170,7 @@ func TestNewK8sDqlitePKI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 
 			pki := NewK8sDqlitePKI(tt.opts)
 			g.Expect(pki).To(Equal(tt.expectedPki), "Unexpected K8sDqlitePKI")

--- a/src/k8s/pkg/snap/util/node_test.go
+++ b/src/k8s/pkg/snap/util/node_test.go
@@ -18,7 +18,7 @@ func TestIsWorker(t *testing.T) {
 	}
 
 	t.Run("WorkerFileExists", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 
 		fname := path.Join(mock.LockFilesDir(), "worker")
 		lock, err := os.Create(fname)
@@ -32,7 +32,7 @@ func TestIsWorker(t *testing.T) {
 
 	t.Run("WorkerFileNotExists", func(t *testing.T) {
 		mock.Mock.LockFilesDir = "/non-existent"
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		exists, err := snaputil.IsWorker(mock)
 		g.Expect(err).To(BeNil())
 		g.Expect(exists).To(BeFalse())
@@ -50,7 +50,7 @@ func TestMarkAsWorkerNode(t *testing.T) {
 	}
 
 	t.Run("MarkWorker", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		err := snaputil.MarkAsWorkerNode(mock, true)
 		g.Expect(err).To(BeNil())
 
@@ -63,7 +63,7 @@ func TestMarkAsWorkerNode(t *testing.T) {
 	})
 
 	t.Run("UnmarkWorker", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		workerFile := path.Join(mock.LockFilesDir(), "worker")
 		_, err := os.Create(workerFile)
 		g.Expect(err).To(BeNil())
@@ -86,28 +86,28 @@ func TestMarkAsWorkerNode_ErrorCases(t *testing.T) {
 
 	t.Run("FailedToCreateWorkerFile", func(t *testing.T) {
 		mock.Mock.LockFilesDir = "/non-existent"
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		err := snaputil.MarkAsWorkerNode(mock, true)
 		g.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("FailedToRemoveWorkerFile", func(t *testing.T) {
 		mock.Mock.LockFilesDir = "/non-existent"
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		err := snaputil.MarkAsWorkerNode(mock, false)
 		g.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("FailedToChownWorkerFile", func(t *testing.T) {
 		mock.Mock.UID = -1 // Invalid UID to cause chown failure
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		err := snaputil.MarkAsWorkerNode(mock, true)
 		g.Expect(err).To(HaveOccurred())
 	})
 
 	t.Run("FailedToChmodWorkerFile", func(t *testing.T) {
 		mock.Mock.LockFilesDir = "/non-existent"
-		g := NewGomegaWithT(t)
+		g := NewWithT(t)
 		err := snaputil.MarkAsWorkerNode(mock, true)
 		g.Expect(err).To(HaveOccurred())
 	})

--- a/src/k8s/pkg/snap/util/services_test.go
+++ b/src/k8s/pkg/snap/util/services_test.go
@@ -13,7 +13,7 @@ func TestStartWorkerServices(t *testing.T) {
 	mock := &mock.Snap{
 		Mock: mock.Mock{},
 	}
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mock.StartServiceErr = fmt.Errorf("service start failed")
 
@@ -33,7 +33,7 @@ func TestStartControlPlaneServices(t *testing.T) {
 	mock := &mock.Snap{
 		Mock: mock.Mock{},
 	}
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mock.StartServiceErr = fmt.Errorf("service start failed")
 
@@ -53,7 +53,7 @@ func TestStartK8sDqliteServices(t *testing.T) {
 	mock := &mock.Snap{
 		Mock: mock.Mock{},
 	}
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mock.StartServiceErr = fmt.Errorf("service start failed")
 
@@ -73,7 +73,7 @@ func TestStopControlPlaneServices(t *testing.T) {
 	mock := &mock.Snap{
 		Mock: mock.Mock{},
 	}
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mock.StopServiceErr = fmt.Errorf("service stop failed")
 
@@ -93,7 +93,7 @@ func TestStopK8sDqliteServices(t *testing.T) {
 	mock := &mock.Snap{
 		Mock: mock.Mock{},
 	}
-	g := NewGomegaWithT(t)
+	g := NewWithT(t)
 
 	mock.StopServiceErr = fmt.Errorf("service stop failed")
 

--- a/src/k8s/pkg/utils/errors/errors_test.go
+++ b/src/k8s/pkg/utils/errors/errors_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDeeplyUnwrapError(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	t.Run("when error is not wrapped", func(t *testing.T) {
 		err := errors.New("test error")

--- a/src/k8s/pkg/utils/k8s/node_test.go
+++ b/src/k8s/pkg/utils/k8s/node_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestDeleteNode(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	t.Run("node deletion is successful", func(t *testing.T) {
 		clientset := fake.NewSimpleClientset()


### PR DESCRIPTION
Minor PR

```
NewGomegaWithT is deprecated in favor of gomega.NewWithT, which does not stutter.
```
