### PR TITLE
Update k8s --help message

### DIFF
--- a/docs/src/_parts/commands/k8s.md
+++ b/docs/src/_parts/commands/k8s.md
@@ -14,7 +14,6 @@ Canonical Kubernetes CLI
 
 * [k8s bootstrap](k8s_bootstrap.md)	 - Bootstrap a new Kubernetes cluster
 * [k8s completion](k8s_completion.md)	 - Generate the autocompletion script for the specified shell
-* [k8s config](k8s_config.md)	 - Generate an admin kubeconfig that can be used to access the Kubernetes cluster
 * [k8s disable](k8s_disable.md)	 - Disable core cluster features
 * [k8s enable](k8s_enable.md)	 - Enable core cluster features
 * [k8s get](k8s_get.md)	 - Get cluster configuration

--- a/docs/src/_parts/commands/k8s.md
+++ b/docs/src/_parts/commands/k8s.md
@@ -5,8 +5,7 @@ Canonical Kubernetes CLI
 ### Options
 
 ```
-  -h, --help                   help for k8s
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
+  -h, --help   help for k8s
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s.md
+++ b/docs/src/_parts/commands/k8s.md
@@ -14,10 +14,10 @@ Canonical Kubernetes CLI
 
 * [k8s bootstrap](k8s_bootstrap.md)	 - Bootstrap a new Kubernetes cluster
 * [k8s completion](k8s_completion.md)	 - Generate the autocompletion script for the specified shell
-* [k8s config](k8s_config.md)	 - Generate a kubeconfig that can be used to access the Kubernetes cluster
+* [k8s config](k8s_config.md)	 - Generate an admin kubeconfig that can be used to access the Kubernetes cluster
 * [k8s disable](k8s_disable.md)	 - Disable core cluster features
 * [k8s enable](k8s_enable.md)	 - Enable core cluster features
-* [k8s get](k8s_get.md)	 - get cluster configuration
+* [k8s get](k8s_get.md)	 - Get cluster configuration
 * [k8s get-join-token](k8s_get-join-token.md)	 - Create a token for a node to join the cluster
 * [k8s join-cluster](k8s_join-cluster.md)	 - Join a cluster using the provided token
 * [k8s kubectl](k8s_kubectl.md)	 - Integrated Kubernetes kubectl client

--- a/docs/src/_parts/commands/k8s.md
+++ b/docs/src/_parts/commands/k8s.md
@@ -7,7 +7,6 @@ Canonical Kubernetes CLI
 ```
   -h, --help                   help for k8s
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_bootstrap.md
+++ b/docs/src/_parts/commands/k8s_bootstrap.md
@@ -24,7 +24,6 @@ k8s bootstrap [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_bootstrap.md
+++ b/docs/src/_parts/commands/k8s_bootstrap.md
@@ -13,16 +13,11 @@ k8s bootstrap [flags]
 ### Options
 
 ```
-      --address string   microcluster address, defaults to the node IP address
-      --file string      path to the YAML file containing your custom cluster bootstrap configuration.
-  -h, --help             help for bootstrap
-      --interactive      interactively configure the most important cluster options
-      --name string      node name, defaults to hostname
-```
-
-### Options inherited from parent commands
-
-```
+      --address string         microcluster address, defaults to the node IP address
+      --file string            path to the YAML file containing your custom cluster bootstrap configuration.
+  -h, --help                   help for bootstrap
+      --interactive            interactively configure the most important cluster options
+      --name string            node name, defaults to hostname
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
 ```
 

--- a/docs/src/_parts/commands/k8s_completion.md
+++ b/docs/src/_parts/commands/k8s_completion.md
@@ -14,12 +14,6 @@ See each sub-command's help for details on how to use the generated script.
   -h, --help   help for completion
 ```
 
-### Options inherited from parent commands
-
-```
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-```
-
 ### SEE ALSO
 
 * [k8s](k8s.md)	 - Canonical Kubernetes CLI

--- a/docs/src/_parts/commands/k8s_completion.md
+++ b/docs/src/_parts/commands/k8s_completion.md
@@ -18,7 +18,6 @@ See each sub-command's help for details on how to use the generated script.
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_completion_bash.md
+++ b/docs/src/_parts/commands/k8s_completion_bash.md
@@ -41,7 +41,6 @@ k8s completion bash
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_completion_bash.md
+++ b/docs/src/_parts/commands/k8s_completion_bash.md
@@ -37,12 +37,6 @@ k8s completion bash
       --no-descriptions   disable completion descriptions
 ```
 
-### Options inherited from parent commands
-
-```
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-```
-
 ### SEE ALSO
 
 * [k8s completion](k8s_completion.md)	 - Generate the autocompletion script for the specified shell

--- a/docs/src/_parts/commands/k8s_completion_fish.md
+++ b/docs/src/_parts/commands/k8s_completion_fish.md
@@ -32,7 +32,6 @@ k8s completion fish [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_completion_fish.md
+++ b/docs/src/_parts/commands/k8s_completion_fish.md
@@ -28,12 +28,6 @@ k8s completion fish [flags]
       --no-descriptions   disable completion descriptions
 ```
 
-### Options inherited from parent commands
-
-```
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-```
-
 ### SEE ALSO
 
 * [k8s completion](k8s_completion.md)	 - Generate the autocompletion script for the specified shell

--- a/docs/src/_parts/commands/k8s_completion_powershell.md
+++ b/docs/src/_parts/commands/k8s_completion_powershell.md
@@ -25,12 +25,6 @@ k8s completion powershell [flags]
       --no-descriptions   disable completion descriptions
 ```
 
-### Options inherited from parent commands
-
-```
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-```
-
 ### SEE ALSO
 
 * [k8s completion](k8s_completion.md)	 - Generate the autocompletion script for the specified shell

--- a/docs/src/_parts/commands/k8s_completion_powershell.md
+++ b/docs/src/_parts/commands/k8s_completion_powershell.md
@@ -29,7 +29,6 @@ k8s completion powershell [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_completion_zsh.md
+++ b/docs/src/_parts/commands/k8s_completion_zsh.md
@@ -43,7 +43,6 @@ k8s completion zsh [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_completion_zsh.md
+++ b/docs/src/_parts/commands/k8s_completion_zsh.md
@@ -39,12 +39,6 @@ k8s completion zsh [flags]
       --no-descriptions   disable completion descriptions
 ```
 
-### Options inherited from parent commands
-
-```
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-```
-
 ### SEE ALSO
 
 * [k8s completion](k8s_completion.md)	 - Generate the autocompletion script for the specified shell

--- a/docs/src/_parts/commands/k8s_config.md
+++ b/docs/src/_parts/commands/k8s_config.md
@@ -1,6 +1,6 @@
 ## k8s config
 
-Generate a kubeconfig that can be used to access the Kubernetes cluster
+Generate an admin kubeconfig that can be used to access the Kubernetes cluster
 
 ```
 k8s config [flags]

--- a/docs/src/_parts/commands/k8s_disable.md
+++ b/docs/src/_parts/commands/k8s_disable.md
@@ -13,12 +13,7 @@ k8s disable <feature> ... [flags]
 ### Options
 
 ```
-  -h, --help   help for disable
-```
-
-### Options inherited from parent commands
-
-```
+  -h, --help                   help for disable
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
 ```
 

--- a/docs/src/_parts/commands/k8s_disable.md
+++ b/docs/src/_parts/commands/k8s_disable.md
@@ -20,7 +20,6 @@ k8s disable <feature> ... [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_enable.md
+++ b/docs/src/_parts/commands/k8s_enable.md
@@ -13,12 +13,7 @@ k8s enable <feature> ... [flags]
 ### Options
 
 ```
-  -h, --help   help for enable
-```
-
-### Options inherited from parent commands
-
-```
+  -h, --help                   help for enable
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
 ```
 

--- a/docs/src/_parts/commands/k8s_enable.md
+++ b/docs/src/_parts/commands/k8s_enable.md
@@ -20,7 +20,6 @@ k8s enable <feature> ... [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_get-join-token.md
+++ b/docs/src/_parts/commands/k8s_get-join-token.md
@@ -9,8 +9,9 @@ k8s get-join-token <node-name> [flags]
 ### Options
 
 ```
-  -h, --help     help for get-join-token
-      --worker   generate a join token for a worker node
+  -h, --help                   help for get-join-token
+      --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --worker                 generate a join token for a worker node
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_get-join-token.md
+++ b/docs/src/_parts/commands/k8s_get-join-token.md
@@ -17,7 +17,6 @@ k8s get-join-token <node-name> [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_get-join-token.md
+++ b/docs/src/_parts/commands/k8s_get-join-token.md
@@ -13,12 +13,6 @@ k8s get-join-token <node-name> [flags]
       --worker   generate a join token for a worker node
 ```
 
-### Options inherited from parent commands
-
-```
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-```
-
 ### SEE ALSO
 
 * [k8s](k8s.md)	 - Canonical Kubernetes CLI

--- a/docs/src/_parts/commands/k8s_get.md
+++ b/docs/src/_parts/commands/k8s_get.md
@@ -13,12 +13,7 @@ k8s get <feature.key> [flags]
 ### Options
 
 ```
-  -h, --help   help for get
-```
-
-### Options inherited from parent commands
-
-```
+  -h, --help                   help for get
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
 ```
 

--- a/docs/src/_parts/commands/k8s_get.md
+++ b/docs/src/_parts/commands/k8s_get.md
@@ -20,7 +20,6 @@ k8s get <feature.key> [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_get.md
+++ b/docs/src/_parts/commands/k8s_get.md
@@ -1,6 +1,6 @@
 ## k8s get
 
-get cluster configuration
+Get cluster configuration
 
 ### Synopsis
 

--- a/docs/src/_parts/commands/k8s_join-cluster.md
+++ b/docs/src/_parts/commands/k8s_join-cluster.md
@@ -19,7 +19,6 @@ k8s join-cluster <join-token> [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_join-cluster.md
+++ b/docs/src/_parts/commands/k8s_join-cluster.md
@@ -9,15 +9,10 @@ k8s join-cluster <join-token> [flags]
 ### Options
 
 ```
-      --address string   microcluster address, defaults to the node IP address
-      --file string      path to the YAML file containing your custom cluster join configuration
-  -h, --help             help for join-cluster
-      --name string      node name, defaults to hostname
-```
-
-### Options inherited from parent commands
-
-```
+      --address string         microcluster address, defaults to the node IP address
+      --file string            path to the YAML file containing your custom cluster join configuration
+  -h, --help                   help for join-cluster
+      --name string            node name, defaults to hostname
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
 ```
 

--- a/docs/src/_parts/commands/k8s_kubectl.md
+++ b/docs/src/_parts/commands/k8s_kubectl.md
@@ -16,7 +16,6 @@ k8s kubectl [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_kubectl.md
+++ b/docs/src/_parts/commands/k8s_kubectl.md
@@ -12,12 +12,6 @@ k8s kubectl [flags]
   -h, --help   help for kubectl
 ```
 
-### Options inherited from parent commands
-
-```
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-```
-
 ### SEE ALSO
 
 * [k8s](k8s.md)	 - Canonical Kubernetes CLI

--- a/docs/src/_parts/commands/k8s_remove-node.md
+++ b/docs/src/_parts/commands/k8s_remove-node.md
@@ -9,13 +9,8 @@ k8s remove-node <node-name> [flags]
 ### Options
 
 ```
-      --force   forcibly remove the cluster member
-  -h, --help    help for remove-node
-```
-
-### Options inherited from parent commands
-
-```
+      --force                  forcibly remove the cluster member
+  -h, --help                   help for remove-node
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
 ```
 

--- a/docs/src/_parts/commands/k8s_remove-node.md
+++ b/docs/src/_parts/commands/k8s_remove-node.md
@@ -17,7 +17,6 @@ k8s remove-node <node-name> [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_set.md
+++ b/docs/src/_parts/commands/k8s_set.md
@@ -21,7 +21,6 @@ k8s set <feature.key=value> ... [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_set.md
+++ b/docs/src/_parts/commands/k8s_set.md
@@ -14,12 +14,7 @@ k8s set <feature.key=value> ... [flags]
 ### Options
 
 ```
-  -h, --help   help for set
-```
-
-### Options inherited from parent commands
-
-```
+  -h, --help                   help for set
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
 ```
 

--- a/docs/src/_parts/commands/k8s_status.md
+++ b/docs/src/_parts/commands/k8s_status.md
@@ -17,7 +17,6 @@ k8s status [flags]
 
 ```
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_status.md
+++ b/docs/src/_parts/commands/k8s_status.md
@@ -9,14 +9,9 @@ k8s status [flags]
 ### Options
 
 ```
-  -h, --help         help for status
-      --wait-ready   wait until at least one cluster node is ready
-```
-
-### Options inherited from parent commands
-
-```
+  -h, --help                   help for status
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --wait-ready             wait until at least one cluster node is ready
 ```
 
 ### SEE ALSO

--- a/src/k8s/cmd/k8s/hooks.go
+++ b/src/k8s/cmd/k8s/hooks.go
@@ -21,3 +21,16 @@ func hookRequireRoot(env cmdutil.ExecutionEnvironment) func(*cobra.Command, []st
 		}
 	}
 }
+
+func hookInitializeFormatter(env cmdutil.ExecutionEnvironment, format string) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, args []string) {
+		// initialize formatter
+		var err error
+		globalFormatter, err = cmdutil.NewFormatter(format, cmd.OutOrStdout())
+		if err != nil {
+			cmd.PrintErrf("Error: Unknown --output-format %q. It must be one of %q (default), %q or %q.", format, "plain", "json", "yaml")
+			env.Exit(1)
+			return
+		}
+	}
+}

--- a/src/k8s/cmd/k8s/hooks.go
+++ b/src/k8s/cmd/k8s/hooks.go
@@ -22,13 +22,13 @@ func hookRequireRoot(env cmdutil.ExecutionEnvironment) func(*cobra.Command, []st
 	}
 }
 
-func hookInitializeFormatter(env cmdutil.ExecutionEnvironment, format string) func(*cobra.Command, []string) {
+func hookInitializeFormatter(env cmdutil.ExecutionEnvironment, format *string) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		// initialize formatter
 		var err error
-		globalFormatter, err = cmdutil.NewFormatter(format, cmd.OutOrStdout())
+		outputFormatter, err = cmdutil.NewFormatter(*format, cmd.OutOrStdout())
 		if err != nil {
-			cmd.PrintErrf("Error: Unknown --output-format %q. It must be one of %q (default), %q or %q.", format, "plain", "json", "yaml")
+			cmd.PrintErrf("Error: Unknown --output-format %q. It must be one of %q (default), %q or %q.", *format, "plain", "json", "yaml")
 			env.Exit(1)
 			return
 		}

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -80,6 +80,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().MarkHidden("state-dir")
 	cmd.PersistentFlags().MarkHidden("debug")
 	cmd.PersistentFlags().MarkHidden("verbose")
+	cmd.PersistentFlags().MarkHidden("timeout")
 
 	// General
 	addCommands(

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -10,6 +10,8 @@ import (
 
 var (
 	componentList = []string{"network", "dns", "gateway", "ingress", "local-storage", "load-balancer", "metrics-server"}
+
+	globalFormatter cmdutil.Formatter
 )
 
 func addCommands(root *cobra.Command, group *cobra.Group, commands ...*cobra.Command) {
@@ -40,16 +42,6 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			// initialize context
 			ctx := cmd.Context()
 
-			// initialize formatter
-			var err error
-			formatter, err := cmdutil.NewFormatter(opts.outputFormat, cmd.OutOrStdout())
-			if err != nil {
-				cmd.PrintErrf("Error: Unknown --output-format %q. It must be one of %q (default), %q or %q.", opts.outputFormat, "plain", "json", "yaml")
-				env.Exit(1)
-				return
-			}
-			ctx = cmdutil.ContextWithFormatter(ctx, formatter)
-
 			// configure command context timeout
 			const minTimeout = 3 * time.Second
 			if opts.timeout < minTimeout {
@@ -72,7 +64,6 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.stateDir, "state-dir", "", "directory with the dqlite datastore")
 	cmd.PersistentFlags().BoolVarP(&opts.logDebug, "debug", "d", false, "show all debug messages")
 	cmd.PersistentFlags().BoolVarP(&opts.logVerbose, "verbose", "v", true, "show all information messages")
-	cmd.PersistentFlags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 	cmd.PersistentFlags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 
 	// By default, the state dir is set to a fixed directory in the snap.

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -11,7 +11,7 @@ import (
 var (
 	componentList = []string{"network", "dns", "gateway", "ingress", "local-storage", "load-balancer", "metrics-server"}
 
-	globalFormatter cmdutil.Formatter
+	outputFormatter cmdutil.Formatter
 )
 
 func addCommands(root *cobra.Command, group *cobra.Group, commands ...*cobra.Command) {
@@ -28,11 +28,10 @@ func addCommands(root *cobra.Command, group *cobra.Group, commands ...*cobra.Com
 func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var (
 		opts struct {
-			logDebug     bool
-			logVerbose   bool
-			outputFormat string
-			stateDir     string
-			timeout      time.Duration
+			logDebug   bool
+			logVerbose bool
+			stateDir   string
+			timeout    time.Duration
 		}
 	)
 	cmd := &cobra.Command{

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -40,10 +40,11 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		address     string
 	}
 	cmd := &cobra.Command{
-		Use:    "bootstrap",
-		Short:  "Bootstrap a new Kubernetes cluster",
-		Long:   "Generate certificates, configure service arguments and start the Kubernetes services.",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Use:     "bootstrap",
+		GroupID: "cluster",
+		Short:   "Bootstrap a new Kubernetes cluster",
+		Long:    "Generate certificates, configure service arguments and start the Kubernetes services.",
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			if opts.interactive && opts.configFile != "" {
 				cmd.PrintErrln("Error: --interactive and --file flags cannot be set at the same time.")

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -40,11 +40,10 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		address     string
 	}
 	cmd := &cobra.Command{
-		Use:     "bootstrap",
-		GroupID: "cluster",
-		Short:   "Bootstrap a new Kubernetes cluster",
-		Long:    "Generate certificates, configure service arguments and start the Kubernetes services.",
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Use:    "bootstrap",
+		Short:  "Bootstrap a new Kubernetes cluster",
+		Long:   "Generate certificates, configure service arguments and start the Kubernetes services.",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			if opts.interactive && opts.configFile != "" {
 				cmd.PrintErrln("Error: --interactive and --file flags cannot be set at the same time.")

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -34,16 +34,17 @@ func (b BootstrapResult) String() string {
 
 func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
-		interactive bool
-		configFile  string
-		name        string
-		address     string
+		interactive  bool
+		configFile   string
+		name         string
+		address      string
+		outputFormat string
 	}
 	cmd := &cobra.Command{
 		Use:    "bootstrap",
 		Short:  "Bootstrap a new Kubernetes cluster",
 		Long:   "Generate certificates, configure service arguments and start the Kubernetes services.",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			if opts.interactive && opts.configFile != "" {
 				cmd.PrintErrln("Error: --interactive and --file flags cannot be set at the same time.")
@@ -129,16 +130,15 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(BootstrapResult{Node: node}); err != nil {
-				cmd.PrintErrf("WARNING: Failed to print the cluster bootstrap result.\n\nThe error was: %v\n", err)
-			}
+			globalFormatter.Print(BootstrapResult{Node: node})
 		},
 	}
 
-	cmd.PersistentFlags().BoolVar(&opts.interactive, "interactive", false, "interactively configure the most important cluster options")
-	cmd.PersistentFlags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster bootstrap configuration.")
+	cmd.Flags().BoolVar(&opts.interactive, "interactive", false, "interactively configure the most important cluster options")
+	cmd.Flags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster bootstrap configuration.")
 	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")
 	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address, defaults to the node IP address")
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -44,7 +44,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Use:    "bootstrap",
 		Short:  "Bootstrap a new Kubernetes cluster",
 		Long:   "Generate certificates, configure service arguments and start the Kubernetes services.",
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			if opts.interactive && opts.configFile != "" {
 				cmd.PrintErrln("Error: --interactive and --file flags cannot be set at the same time.")
@@ -130,7 +130,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(BootstrapResult{Node: node})
+			outputFormatter.Print(BootstrapResult{Node: node})
 		},
 	}
 

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -11,9 +11,10 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		server string
 	}
 	cmd := &cobra.Command{
-		Use:    "config",
-		Short:  "Generate a kubeconfig that can be used to access the Kubernetes cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Use:     "config",
+		GroupID: "general",
+		Short:   "Generate an admin kubeconfig that can be used to access the Kubernetes cluster",
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -39,6 +39,6 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			cmd.Println(config)
 		},
 	}
-	cmd.PersistentFlags().StringVar(&opts.server, "server", "", "custom cluster server address")
+	cmd.Flags().StringVar(&opts.server, "server", "", "custom cluster server address")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -12,6 +12,7 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:    "config",
+		Hidden: true,
 		Short:  "Generate an admin kubeconfig that can be used to access the Kubernetes cluster",
 		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -11,10 +11,9 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		server string
 	}
 	cmd := &cobra.Command{
-		Use:     "config",
-		GroupID: "general",
-		Short:   "Generate an admin kubeconfig that can be used to access the Kubernetes cluster",
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Use:    "config",
+		Short:  "Generate an admin kubeconfig that can be used to access the Kubernetes cluster",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -28,7 +28,7 @@ func newDisableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short:  "Disable core cluster features",
 		Long:   fmt.Sprintf("Disable one of %s.", strings.Join(componentList, ", ")),
 		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args
@@ -88,7 +88,7 @@ func newDisableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(DisableResult{Features: features})
+			outputFormatter.Print(DisableResult{Features: features})
 		},
 	}
 

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -21,12 +21,11 @@ func (d DisableResult) String() string {
 
 func newDisableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "disable <feature> ...",
-		GroupID: "management",
-		Short:   "Disable core cluster features",
-		Long:    fmt.Sprintf("Disable one of %s.", strings.Join(componentList, ", ")),
-		Args:    cmdutil.MinimumNArgs(env, 1),
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Use:    "disable <feature> ...",
+		Short:  "Disable core cluster features",
+		Long:   fmt.Sprintf("Disable one of %s.", strings.Join(componentList, ", ")),
+		Args:   cmdutil.MinimumNArgs(env, 1),
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -20,12 +20,15 @@ func (d DisableResult) String() string {
 }
 
 func newDisableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+	var opts struct {
+		outputFormat string
+	}
 	cmd := &cobra.Command{
 		Use:    "disable <feature> ...",
 		Short:  "Disable core cluster features",
 		Long:   fmt.Sprintf("Disable one of %s.", strings.Join(componentList, ", ")),
 		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args
@@ -85,14 +88,11 @@ func newDisableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(DisableResult{Features: features}); err != nil {
-				cmd.PrintErrf("WARNING: Failed to print the disable result.\n\nThe error was: %v\n", err)
-			}
+			globalFormatter.Print(DisableResult{Features: features})
 		},
 	}
 
-	cmd.PersistentFlags().SetOutput(env.Stderr)
-	cmd.Flags().SetOutput(env.Stderr)
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -21,11 +21,12 @@ func (d DisableResult) String() string {
 
 func newDisableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "disable <feature> ...",
-		Short:  "Disable core cluster features",
-		Long:   fmt.Sprintf("Disable one of %s.", strings.Join(componentList, ", ")),
-		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Use:     "disable <feature> ...",
+		GroupID: "management",
+		Short:   "Disable core cluster features",
+		Long:    fmt.Sprintf("Disable one of %s.", strings.Join(componentList, ", ")),
+		Args:    cmdutil.MinimumNArgs(env, 1),
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -21,11 +21,12 @@ func (e EnableResult) String() string {
 
 func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "enable <feature> ...",
-		Short:  "Enable core cluster features",
-		Long:   fmt.Sprintf("Enable one of %s.", strings.Join(componentList, ", ")),
-		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Use:     "enable <feature> ...",
+		GroupID: "management",
+		Short:   "Enable core cluster features",
+		Long:    fmt.Sprintf("Enable one of %s.", strings.Join(componentList, ", ")),
+		Args:    cmdutil.MinimumNArgs(env, 1),
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -21,12 +21,11 @@ func (e EnableResult) String() string {
 
 func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "enable <feature> ...",
-		GroupID: "management",
-		Short:   "Enable core cluster features",
-		Long:    fmt.Sprintf("Enable one of %s.", strings.Join(componentList, ", ")),
-		Args:    cmdutil.MinimumNArgs(env, 1),
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Use:    "enable <feature> ...",
+		Short:  "Enable core cluster features",
+		Long:   fmt.Sprintf("Enable one of %s.", strings.Join(componentList, ", ")),
+		Args:   cmdutil.MinimumNArgs(env, 1),
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -28,7 +28,7 @@ func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short:  "Enable core cluster features",
 		Long:   fmt.Sprintf("Enable one of %s.", strings.Join(componentList, ", ")),
 		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args
@@ -88,7 +88,7 @@ func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(EnableResult{Features: features})
+			outputFormatter.Print(EnableResult{Features: features})
 		},
 	}
 

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -20,12 +20,15 @@ func (e EnableResult) String() string {
 }
 
 func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+	var opts struct {
+		outputFormat string
+	}
 	cmd := &cobra.Command{
 		Use:    "enable <feature> ...",
 		Short:  "Enable core cluster features",
 		Long:   fmt.Sprintf("Enable one of %s.", strings.Join(componentList, ", ")),
 		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
 			features := args
@@ -85,11 +88,11 @@ func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(EnableResult{Features: features}); err != nil {
-				cmd.PrintErrf("WARNING: Failed to print the enable result.\n\nThe error was: %v\n", err)
-			}
+			globalFormatter.Print(EnableResult{Features: features})
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_get.go
+++ b/src/k8s/cmd/k8s/k8s_get.go
@@ -11,11 +11,12 @@ import (
 
 func newGetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	getCmd := &cobra.Command{
-		Use:    "get <feature.key>",
-		Short:  "get cluster configuration",
-		Long:   fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
-		Args:   cmdutil.MaximumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Use:     "get <feature.key>",
+		GroupID: "management",
+		Short:   "Get cluster configuration",
+		Long:    fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
+		Args:    cmdutil.MaximumNArgs(env, 1),
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_get.go
+++ b/src/k8s/cmd/k8s/k8s_get.go
@@ -11,12 +11,11 @@ import (
 
 func newGetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	getCmd := &cobra.Command{
-		Use:     "get <feature.key>",
-		GroupID: "management",
-		Short:   "Get cluster configuration",
-		Long:    fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
-		Args:    cmdutil.MaximumNArgs(env, 1),
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Use:    "get <feature.key>",
+		Short:  "Get cluster configuration",
+		Long:   fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
+		Args:   cmdutil.MaximumNArgs(env, 1),
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_get.go
+++ b/src/k8s/cmd/k8s/k8s_get.go
@@ -18,7 +18,7 @@ func newGetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short:  "Get cluster configuration",
 		Long:   fmt.Sprintf("Show configuration of one of %s.", strings.Join(componentList, ", ")),
 		Args:   cmdutil.MaximumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {
@@ -109,7 +109,7 @@ func newGetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(output)
+			outputFormatter.Print(output)
 		},
 	}
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -18,12 +18,13 @@ func (g GetJoinTokenResult) String() string {
 
 func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
-		worker bool
+		worker       bool
+		outputFormat string
 	}
 	cmd := &cobra.Command{
 		Use:    "get-join-token <node-name>",
 		Short:  "Create a token for a node to join the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
@@ -42,14 +43,10 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(GetJoinTokenResult{JoinToken: token}); err != nil {
-				cmd.PrintErrf("Error: Failed to print the join token.\n\nThe error was: %v\n", err)
-				env.Exit(1)
-				return
-			}
+			globalFormatter.Print(GetJoinTokenResult{JoinToken: token})
 		},
 	}
 
-	cmd.PersistentFlags().BoolVar(&opts.worker, "worker", false, "generate a join token for a worker node")
+	cmd.Flags().BoolVar(&opts.worker, "worker", false, "generate a join token for a worker node")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -21,10 +21,11 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		worker bool
 	}
 	cmd := &cobra.Command{
-		Use:    "get-join-token <node-name>",
-		Short:  "Create a token for a node to join the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
-		Args:   cmdutil.ExactArgs(env, 1),
+		Use:     "get-join-token <node-name>",
+		GroupID: "cluster",
+		Short:   "Create a token for a node to join the cluster",
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Args:    cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -21,11 +21,10 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		worker bool
 	}
 	cmd := &cobra.Command{
-		Use:     "get-join-token <node-name>",
-		GroupID: "cluster",
-		Short:   "Create a token for a node to join the cluster",
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
-		Args:    cmdutil.ExactArgs(env, 1),
+		Use:    "get-join-token <node-name>",
+		Short:  "Create a token for a node to join the cluster",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -24,7 +24,7 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "get-join-token <node-name>",
 		Short:  "Create a token for a node to join the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
@@ -43,10 +43,11 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(GetJoinTokenResult{JoinToken: token})
+			outputFormatter.Print(GetJoinTokenResult{JoinToken: token})
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.worker, "worker", false, "generate a join token for a worker node")
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -29,7 +29,7 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "join-cluster <join-token>",
 		Short:  "Join a cluster using the provided token",
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			token := args[0]
@@ -82,7 +82,7 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(JoinClusterResult{Name: opts.name})
+			outputFormatter.Print(JoinClusterResult{Name: opts.name})
 		},
 	}
 	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -21,14 +21,15 @@ func (b JoinClusterResult) String() string {
 
 func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
-		name       string
-		address    string
-		configFile string
+		name         string
+		address      string
+		configFile   string
+		outputFormat string
 	}
 	cmd := &cobra.Command{
 		Use:    "join-cluster <join-token>",
 		Short:  "Join a cluster using the provided token",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			token := args[0]
@@ -81,13 +82,12 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(JoinClusterResult{Name: opts.name}); err != nil {
-				cmd.PrintErrf("WARNING: Failed to print the join cluster result.\n\nThe error was: %v\n", err)
-			}
+			globalFormatter.Print(JoinClusterResult{Name: opts.name})
 		},
 	}
 	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")
 	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address, defaults to the node IP address")
 	cmd.Flags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster join configuration")
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -26,11 +26,10 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		configFile string
 	}
 	cmd := &cobra.Command{
-		Use:     "join-cluster <join-token>",
-		GroupID: "cluster",
-		Short:   "Join a cluster using the provided token",
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
-		Args:    cmdutil.ExactArgs(env, 1),
+		Use:    "join-cluster <join-token>",
+		Short:  "Join a cluster using the provided token",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			token := args[0]
 

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -26,10 +26,11 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		configFile string
 	}
 	cmd := &cobra.Command{
-		Use:    "join-cluster <join-token>",
-		Short:  "Join a cluster using the provided token",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
-		Args:   cmdutil.ExactArgs(env, 1),
+		Use:     "join-cluster <join-token>",
+		GroupID: "cluster",
+		Short:   "Join a cluster using the provided token",
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Args:    cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			token := args[0]
 

--- a/src/k8s/cmd/k8s/k8s_kubectl.go
+++ b/src/k8s/cmd/k8s/k8s_kubectl.go
@@ -13,6 +13,7 @@ import (
 func newKubectlCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	return &cobra.Command{
 		Use:                "kubectl",
+		GroupID:            "general",
 		Short:              "Integrated Kubernetes kubectl client",
 		DisableFlagParsing: true,
 		PreRun:             chainPreRunHooks(hookRequireRoot(env)),

--- a/src/k8s/cmd/k8s/k8s_kubectl.go
+++ b/src/k8s/cmd/k8s/k8s_kubectl.go
@@ -13,7 +13,6 @@ import (
 func newKubectlCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	return &cobra.Command{
 		Use:                "kubectl",
-		GroupID:            "general",
 		Short:              "Integrated Kubernetes kubectl client",
 		DisableFlagParsing: true,
 		PreRun:             chainPreRunHooks(hookRequireRoot(env)),

--- a/src/k8s/cmd/k8s/k8s_local_node_status.go
+++ b/src/k8s/cmd/k8s/k8s_local_node_status.go
@@ -6,13 +6,15 @@ import (
 )
 
 func newLocalNodeStatusCommand(env cmdutil.ExecutionEnvironment) *cobra.Command {
-	localNodeStatusCmd := &cobra.Command{
+	var opts struct {
+		outputFormat string
+	}
+	cmd := &cobra.Command{
 		Use:    "local-node-status",
 		Short:  "Retrieve the current status of the local node",
 		Hidden: true,
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
-
 			client, err := env.Client(cmd.Context())
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
@@ -27,12 +29,10 @@ func newLocalNodeStatusCommand(env cmdutil.ExecutionEnvironment) *cobra.Command 
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(status); err != nil {
-				cmd.PrintErrf("Error: Failed to print the status of the local node.\n\nThe error was: %v\n", err)
-				env.Exit(1)
-				return
-			}
+			globalFormatter.Print(status)
 		},
 	}
-	return localNodeStatusCmd
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
+
+	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_local_node_status.go
+++ b/src/k8s/cmd/k8s/k8s_local_node_status.go
@@ -13,7 +13,7 @@ func newLocalNodeStatusCommand(env cmdutil.ExecutionEnvironment) *cobra.Command 
 		Use:    "local-node-status",
 		Short:  "Retrieve the current status of the local node",
 		Hidden: true,
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {
@@ -29,7 +29,7 @@ func newLocalNodeStatusCommand(env cmdutil.ExecutionEnvironment) *cobra.Command 
 				return
 			}
 
-			globalFormatter.Print(status)
+			outputFormatter.Print(status)
 		},
 	}
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -21,10 +21,11 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		force bool
 	}
 	cmd := &cobra.Command{
-		Use:    "remove-node <node-name>",
-		Short:  "Remove a node from the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
-		Args:   cmdutil.ExactArgs(env, 1),
+		Use:     "remove-node <node-name>",
+		GroupID: "cluster",
+		Short:   "Remove a node from the cluster",
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Args:    cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -21,11 +21,10 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		force bool
 	}
 	cmd := &cobra.Command{
-		Use:     "remove-node <node-name>",
-		GroupID: "cluster",
-		Short:   "Remove a node from the cluster",
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
-		Args:    cmdutil.ExactArgs(env, 1),
+		Use:    "remove-node <node-name>",
+		Short:  "Remove a node from the cluster",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -18,12 +18,13 @@ func (r RemoveNodeResult) String() string {
 
 func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
-		force bool
+		force        bool
+		outputFormat string
 	}
 	cmd := &cobra.Command{
 		Use:    "remove-node <node-name>",
 		Short:  "Remove a node from the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
@@ -42,12 +43,11 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(RemoveNodeResult{Name: name}); err != nil {
-				cmd.PrintErrf("WARNING: Failed to print remove node result.\n\nThe error was: %v\n", err)
-			}
+			globalFormatter.Print(RemoveNodeResult{Name: name})
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.force, "force", false, "forcibly remove the cluster member")
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -24,7 +24,7 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "remove-node <node-name>",
 		Short:  "Remove a node from the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
@@ -43,7 +43,7 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(RemoveNodeResult{Name: name})
+			outputFormatter.Print(RemoveNodeResult{Name: name})
 		},
 	}
 

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -57,7 +57,7 @@ func newSetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(SetResult{ClusterConfig: config})
+			outputFormatter.Print(SetResult{ClusterConfig: config})
 		},
 	}
 

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -29,7 +29,7 @@ func newSetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short:  "Set cluster configuration",
 		Long:   fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
 		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := apiv1.UserFacingClusterConfig{}
 

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -22,11 +22,12 @@ func (s SetResult) String() string {
 
 func newSetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	return &cobra.Command{
-		Use:    "set <feature.key=value> ...",
-		Short:  "Set cluster configuration",
-		Long:   fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
-		Args:   cmdutil.MinimumNArgs(env, 1),
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Use:     "set <feature.key=value> ...",
+		GroupID: "management",
+		Short:   "Set cluster configuration",
+		Long:    fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
+		Args:    cmdutil.MinimumNArgs(env, 1),
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := apiv1.UserFacingClusterConfig{}
 

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -21,7 +21,10 @@ func (s SetResult) String() string {
 }
 
 func newSetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
-	return &cobra.Command{
+	var opts struct {
+		outputFormat string
+	}
+	cmd := &cobra.Command{
 		Use:    "set <feature.key=value> ...",
 		Short:  "Set cluster configuration",
 		Long:   fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
@@ -54,11 +57,13 @@ func newSetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if err := cmdutil.FormatterFromContext(cmd.Context()).Print(SetResult{ClusterConfig: config}); err != nil {
-				cmd.PrintErrf("WARNING: Failed to print the cluster configuration result.\n\nThe error was: %v\n", err)
-			}
+			globalFormatter.Print(SetResult{ClusterConfig: config})
 		},
 	}
+
+	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
+
+	return cmd
 }
 
 func updateConfig(config *apiv1.UserFacingClusterConfig, arg string) error {

--- a/src/k8s/cmd/k8s/k8s_set.go
+++ b/src/k8s/cmd/k8s/k8s_set.go
@@ -22,12 +22,11 @@ func (s SetResult) String() string {
 
 func newSetCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	return &cobra.Command{
-		Use:     "set <feature.key=value> ...",
-		GroupID: "management",
-		Short:   "Set cluster configuration",
-		Long:    fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
-		Args:    cmdutil.MinimumNArgs(env, 1),
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		Use:    "set <feature.key=value> ...",
+		Short:  "Set cluster configuration",
+		Long:   fmt.Sprintf("Configure one of %s.\nUse `k8s get` to explore configuration options.", strings.Join(componentList, ", ")),
+		Args:   cmdutil.MinimumNArgs(env, 1),
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := apiv1.UserFacingClusterConfig{}
 

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -13,7 +13,7 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "status",
 		Short:  "Retrieve the current status of the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {
@@ -35,7 +35,7 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			globalFormatter.Print(status)
+			outputFormatter.Print(status)
 		},
 	}
 

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -10,10 +10,9 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		waitReady bool
 	}
 	cmd := &cobra.Command{
-		Use:     "status",
-		Short:   "Retrieve the current status of the cluster",
-		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
-		GroupID: "general",
+		Use:    "status",
+		Short:  "Retrieve the current status of the cluster",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -10,9 +10,10 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		waitReady bool
 	}
 	cmd := &cobra.Command{
-		Use:    "status",
-		Short:  "Retrieve the current status of the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Use:     "status",
+		Short:   "Retrieve the current status of the cluster",
+		PreRun:  chainPreRunHooks(hookRequireRoot(env)),
+		GroupID: "general",
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Client(cmd.Context())
 			if err != nil {

--- a/src/k8s/cmd/util/formatter.go
+++ b/src/k8s/cmd/util/formatter.go
@@ -35,7 +35,7 @@ type plainFormatter struct {
 
 func (p plainFormatter) Print(data any) {
 	if _, err := fmt.Fprint(p.writer, data, "\n"); err != nil {
-		log.Println("Failed to format output: %v", err)
+		log.Printf("Failed to format output: %v", err)
 	}
 }
 
@@ -47,7 +47,7 @@ func (j jsonFormatter) Print(data any) {
 	encoder := json.NewEncoder(j.writer)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(data); err != nil {
-		log.Println("Failed to format JSON output: %v", err)
+		log.Printf("Failed to format JSON output: %v", err)
 	}
 }
 
@@ -57,6 +57,6 @@ type yamlFormatter struct {
 
 func (y yamlFormatter) Print(data any) {
 	if err := yaml.NewEncoder(y.writer).Encode(data); err != nil {
-		log.Println("Failed to format YAML output: %v", err)
+		log.Printf("Failed to format YAML output: %v", err)
 	}
 }

--- a/src/k8s/cmd/util/formatter.go
+++ b/src/k8s/cmd/util/formatter.go
@@ -1,24 +1,24 @@
 package cmdutil
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 
 	"gopkg.in/yaml.v2"
 )
 
 type Formatter interface {
 	// Print formattes the output.
-	Print(any) error
+	Print(any)
 }
 
 // New creates a new formatter based on passed type
 // Can be "plain", "json", "yaml".
 func NewFormatter(formatterType string, writer io.Writer) (Formatter, error) {
 	switch formatterType {
-	case "plain":
+	case "", "plain":
 		return plainFormatter{writer: writer}, nil
 	case "json":
 		return jsonFormatter{writer: writer}, nil
@@ -33,42 +33,30 @@ type plainFormatter struct {
 	writer io.Writer
 }
 
-func (p plainFormatter) Print(data any) error {
-	_, err := fmt.Fprint(p.writer, data, "\n")
-	return err
+func (p plainFormatter) Print(data any) {
+	if _, err := fmt.Fprint(p.writer, data, "\n"); err != nil {
+		log.Println("Failed to format output: %v", err)
+	}
 }
 
 type jsonFormatter struct {
 	writer io.Writer
 }
 
-func (j jsonFormatter) Print(data any) error {
+func (j jsonFormatter) Print(data any) {
 	encoder := json.NewEncoder(j.writer)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(data)
+	if err := encoder.Encode(data); err != nil {
+		log.Println("Failed to format JSON output: %v", err)
+	}
 }
 
 type yamlFormatter struct {
 	writer io.Writer
 }
 
-func (y yamlFormatter) Print(data any) error {
-	return yaml.NewEncoder(y.writer).Encode(data)
-}
-
-type formatterContextKey struct{}
-
-// ContextWithFormatter wraps the given context with a Formatter.
-func ContextWithFormatter(ctx context.Context, formatter Formatter) context.Context {
-	return context.WithValue(ctx, formatterContextKey{}, formatter)
-}
-
-// FormatterFromContext retrieves a Formatter from the given context.
-// FormatterFromContext panics in case no formatter is set.
-func FormatterFromContext(ctx context.Context) Formatter {
-	formatter, ok := ctx.Value(formatterContextKey{}).(Formatter)
-	if !ok {
-		panic("There is no formatter value in the given context. Make sure that the context is wrapped with cmdutil.ContextWithFormatter().")
+func (y yamlFormatter) Print(data any) {
+	if err := yaml.NewEncoder(y.writer).Encode(data); err != nil {
+		log.Println("Failed to format YAML output: %v", err)
 	}
-	return formatter
 }


### PR DESCRIPTION
`k8s --help` now prints:

```
Canonical Kubernetes CLI

Usage:
  k8s [command]

General Commands:
  kubectl             Integrated Kubernetes kubectl client
  status              Retrieve the current status of the cluster

Clustering Commands:
  bootstrap           Bootstrap a new Kubernetes cluster
  get-join-token      Create a token for a node to join the cluster
  join-cluster        Join a cluster using the provided token
  remove-node         Remove a node from the cluster

Management Commands:
  disable             Disable core cluster features
  enable              Enable core cluster features
  get                 Get cluster configuration
  set                 Set cluster configuration

Additional Commands:
  completion          Generate the autocompletion script for the specified shell
  help                Help about any command

Flags:
  -h, --help   help for k8s

Use "k8s [command] --help" for more information about a command.
```