### PR TITLE
Add fingerprint check when worker joins cluster

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -39,6 +39,8 @@ func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Re
 			return response.BadRequest(fmt.Errorf("server authentication failed: join token fingerprint does not match that of the cluster member"))
 		}
 
+		// TODO: add certificate to trusted certificates
+
 		// valid worker node token - let's join the cluster
 		// The validation of the token is done when fetching the cluster information.
 		if err := e.provider.MicroCluster().NewCluster(hostname, req.Address, map[string]string{"workerToken": req.Token}, 0); err != nil {

--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -26,21 +26,6 @@ func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Re
 	internalToken := types.InternalWorkerNodeToken{}
 	// Check if token is worker token
 	if internalToken.Decode(req.Token) == nil {
-		// Check Server Auth
-		// Get remote certificate from the cluster member
-		cert, err := utils.GetRemoteCertificate(req.Address)
-		if err != nil {
-			return response.InternalError(fmt.Errorf("failed to get certificate of cluster member: %w", err))
-		}
-
-		// verify that the fingerprint of the certificate matches the fingerprint of the token
-		fingerprint := utils.CertFingerprint(cert)
-		if fingerprint != internalToken.Fingerprint {
-			return response.BadRequest(fmt.Errorf("server authentication failed: join token fingerprint does not match that of the cluster member"))
-		}
-
-		// TODO: add certificate to trusted certificates
-
 		// valid worker node token - let's join the cluster
 		// The validation of the token is done when fetching the cluster information.
 		if err := e.provider.MicroCluster().NewCluster(hostname, req.Address, map[string]string{"workerToken": req.Token}, 0); err != nil {

--- a/src/k8s/pkg/k8sd/api/cluster_tokens.go
+++ b/src/k8s/pkg/k8sd/api/cluster_tokens.go
@@ -81,12 +81,18 @@ func getOrCreateWorkerToken(s *state.State, nodeName string) (string, error) {
 		addresses = append(addresses, addrPort.String())
 	}
 
+	cert, err := s.ClusterCert().PublicKeyX509()
+	if err != nil {
+		return "", fmt.Errorf("failed to get cluster certificate: %w", err)
+	}
+
 	info := &types.InternalWorkerNodeToken{
 		Secret:        token,
 		JoinAddresses: addresses,
-		Fingerprint:   utils.CertFingerprint(s.ServerCert().CA()),
+		Fingerprint:   utils.CertFingerprint(cert),
 	}
-	token, err := info.Encode()
+
+	token, err = info.Encode()
 	if err != nil {
 		return "", fmt.Errorf("failed to encode join token: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_tokens.go
+++ b/src/k8s/pkg/k8sd/api/cluster_tokens.go
@@ -84,6 +84,7 @@ func getOrCreateWorkerToken(s *state.State, nodeName string) (string, error) {
 	info := &types.InternalWorkerNodeToken{
 		Secret:        token,
 		JoinAddresses: addresses,
+		Fingerprint:   utils.CertFingerprint(s.ServerCert().CA()),
 	}
 	token, err := info.Encode()
 	if err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
@@ -50,9 +51,12 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	}
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
 
-	url := "https://" + token.JoinAddresses[0]
+	url, err := url.Parse("https://" + token.JoinAddresses[0])
+	if err != nil {
+		return fmt.Errorf("failed to parse control plane address: %w", err)
+	}
 	// Get remote certificate from the cluster member
-	cert, err := utils.GetRemoteCertificate(url)
+	cert, err := utils.GetRemoteCertificate(url.String())
 	if err != nil {
 		return fmt.Errorf("failed to get certificate of cluster member: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -51,7 +51,7 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
 
 	// Get remote certificate from the cluster member
-	cert, err := utils.GetRemoteCertificate(nodeIP.String())
+	cert, err := utils.GetRemoteCertificate(token.JoinAddresses[0])
 	if err != nil {
 		return fmt.Errorf("failed to get certificate of cluster member: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -63,7 +63,7 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 		return fmt.Errorf("server authentication failed: join token fingerprint does not match that of the cluster member")
 	}
 
-	httpClient, err := utils.CreateHTTPClientWithCert(cert, key)
+	httpClient, err := utils.CreateHTTPClientWithCert(cert)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP client with certificate: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -50,7 +50,6 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	}
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
 
-	// Check Server Auth
 	// Get remote certificate from the cluster member
 	cert, err := utils.GetRemoteCertificate(nodeIP.String())
 	if err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -50,8 +50,9 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	}
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
 
+	url := "https://" + token.JoinAddresses[0]
 	// Get remote certificate from the cluster member
-	cert, err := utils.GetRemoteCertificate(token.JoinAddresses[0])
+	cert, err := utils.GetRemoteCertificate(url)
 	if err != nil {
 		return fmt.Errorf("failed to get certificate of cluster member: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -3,7 +3,6 @@ package app
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -49,7 +48,6 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	if nodeIP == nil {
 		return fmt.Errorf("failed to parse node IP address %s", s.Address().Hostname())
 	}
-
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
 
 	// Check Server Auth
@@ -65,15 +63,12 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 		return fmt.Errorf("server authentication failed: join token fingerprint does not match that of the cluster member")
 	}
 
-	// TODO: add certificate to trusted certificates
+	// TODO: figure out where to get this key from
+	key := "what's my key"
 
-	// create an HTTP client that ignores https
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				Certificates: cert,
-			},
-		},
+	httpClient, err := utils.CreateHTTPClientWithCert(cert, key)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP client with certificate: %w", err)
 	}
 
 	type wrappedResponse struct {

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -63,7 +64,7 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	}
 
 	// Create the http client with trusted certificate
-	tlsConfig, err := utils.TLSClientConfigWithTrustedCertificate(cert)
+	tlsConfig, err := utils.TLSClientConfigWithTrustedCertificate(cert, x509.NewCertPool())
 	if err != nil {
 		return fmt.Errorf("failed to get TLS configuration for trusted certificate: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"path"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
@@ -51,12 +50,8 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 	}
 	// TODO(neoaggelos): figure out how to use the microcluster client instead
 
-	url, err := url.Parse("https://" + token.JoinAddresses[0])
-	if err != nil {
-		return fmt.Errorf("failed to parse control plane address: %w", err)
-	}
 	// Get remote certificate from the cluster member
-	cert, err := utils.GetRemoteCertificate(url.String())
+	cert, err := utils.GetRemoteCertificate(token.JoinAddresses[0])
 	if err != nil {
 		return fmt.Errorf("failed to get certificate of cluster member: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -63,9 +63,6 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string) error {
 		return fmt.Errorf("server authentication failed: join token fingerprint does not match that of the cluster member")
 	}
 
-	// TODO: figure out where to get this key from
-	key := "what's my key"
-
 	httpClient, err := utils.CreateHTTPClientWithCert(cert, key)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP client with certificate: %w", err)

--- a/src/k8s/pkg/k8sd/types/worker.go
+++ b/src/k8s/pkg/k8sd/types/worker.go
@@ -14,6 +14,8 @@ type InternalWorkerNodeToken struct {
 	Secret string `json:"secret"`
 	// JoinAddresses is a list of control-plane addresses that exist in the cluster.
 	JoinAddresses []string `json:"join_addresses"`
+	// Fingerprint is used for server Auth
+	Fingerprint string `json:"fingerprint"`
 }
 
 // internalWorkerNodeTokenSerializeMagicString is used to validate serialized worker node tokens.

--- a/src/k8s/pkg/k8sd/types/worker.go
+++ b/src/k8s/pkg/k8sd/types/worker.go
@@ -14,7 +14,7 @@ type InternalWorkerNodeToken struct {
 	Secret string `json:"secret"`
 	// JoinAddresses is a list of control-plane addresses that exist in the cluster.
 	JoinAddresses []string `json:"join_addresses"`
-	// Fingerprint is used for server Auth
+	// Fingerprint is used for verification of the control-plane certificate.
 	Fingerprint string `json:"fingerprint"`
 }
 

--- a/src/k8s/pkg/k8sd/types/worker_test.go
+++ b/src/k8s/pkg/k8sd/types/worker_test.go
@@ -12,6 +12,7 @@ func TestWorkerTokenEncode(t *testing.T) {
 		Token:         "token1",
 		Secret:        "mysecret",
 		JoinAddresses: []string{"addr1:1010", "addr2:1212"},
+		Fingerprint:   "fingerprint",
 	}
 
 	g := NewWithT(t)

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -41,6 +41,10 @@ func TLSClientConfigWithTrustedCertificate(remoteCert *x509.Certificate, rootCAs
 		return nil, fmt.Errorf("invalid remote public key")
 	}
 
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
 	config.RootCAs = rootCAs
 	remoteCert.IsCA = true
 	config.RootCAs.AddCert(remoteCert)

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -32,6 +32,9 @@ func SplitIPAndDNSSANs(extraSANs []string) ([]net.IP, []string) {
 	return ipSANs, dnsSANs
 }
 
+// TLSClientConfig returns a TLS configuration that trusts a remote server
+// The remoteCert is the public key of the server we are connecting to.
+// The rootCAs is the list of trusted CAs, allowing you to pass the clients existing trusted CAs.
 func TLSClientConfigWithTrustedCertificate(remoteCert *x509.Certificate, rootCAs *x509.CertPool) (*tls.Config, error) {
 	config := &tls.Config{}
 	if remoteCert == nil {

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -39,7 +39,6 @@ func CreateHTTPClientWithCert(cert *x509.Certificate, key crypto.PrivateKey) (*h
 		Certificates: []tls.Certificate{
 			{
 				Certificate: [][]byte{cert.Raw},
-				PrivateKey:  key,
 			},
 		},
 	}

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -49,7 +49,7 @@ func CreateHTTPClientWithCert(cert *x509.Certificate) (*http.Client, error) {
 	}, nil
 }
 
-func GetRemoteCertificate(address string) (*x509.Certificate, error) {
+func GetRemoteCertificate(url string) (*x509.Certificate, error) {
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -59,7 +59,7 @@ func GetRemoteCertificate(address string) (*x509.Certificate, error) {
 	}
 
 	// Connect
-	req, err := http.NewRequest("GET", address, nil)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 )
 
 // SplitIPAndDNSSANs splits a list of SANs into IP and DNS SANs
@@ -34,7 +35,7 @@ func SplitIPAndDNSSANs(extraSANs []string) ([]net.IP, []string) {
 
 func TLSClientConfig(remoteCert *x509.Certificate) (*tls.Config, error) {
 	if remoteCert == nil {
-		return nil, fmt.Errorf("Invalid remote public key")
+		return nil, fmt.Errorf("invalid remote public key")
 	}
 
 	config := &tls.Config{}
@@ -67,7 +68,7 @@ func CreateHTTPClientWithCert(cert *x509.Certificate) (*http.Client, error) {
 	}, nil
 }
 
-func GetRemoteCertificate(url string) (*x509.Certificate, error) {
+func GetRemoteCertificate(address string) (*x509.Certificate, error) {
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -76,8 +77,13 @@ func GetRemoteCertificate(url string) (*x509.Certificate, error) {
 		},
 	}
 
+	url, err := url.Parse("https://" + address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse address: %w", err)
+	}
+
 	// Connect
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"crypto"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -33,7 +32,7 @@ func SplitIPAndDNSSANs(extraSANs []string) ([]net.IP, []string) {
 	return ipSANs, dnsSANs
 }
 
-func CreateHTTPClientWithCert(cert *x509.Certificate, key crypto.PrivateKey) (*http.Client, error) {
+func CreateHTTPClientWithCert(cert *x509.Certificate) (*http.Client, error) {
 	// Create the client
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -30,6 +31,24 @@ func SplitIPAndDNSSANs(extraSANs []string) ([]net.IP, []string) {
 	}
 
 	return ipSANs, dnsSANs
+}
+
+func CreateHTTPClientWithCert(cert *x509.Certificate, key crypto.PrivateKey) (*http.Client, error) {
+	// Create the client
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{
+			{
+				Certificate: [][]byte{cert.Raw},
+				PrivateKey:  key,
+			},
+		},
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
 }
 
 func GetRemoteCertificate(address string) (*x509.Certificate, error) {

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -57,6 +57,9 @@ func TLSClientConfigWithTrustedCertificate(remoteCert *x509.Certificate, rootCAs
 	return config, nil
 }
 
+// GetRemoteCertificate retrieves the remote certificate from a given address
+// The address should be in the format of "hostname:port"
+// Returns the remote certificate or an error
 func GetRemoteCertificate(address string) (*x509.Certificate, error) {
 	// validate address
 	_, _, err := net.SplitHostPort(address)
@@ -93,6 +96,7 @@ func GetRemoteCertificate(address string) (*x509.Certificate, error) {
 	return resp.TLS.PeerCertificates[0], nil
 }
 
+// CertFingerprint returns the SHA256 fingerprint of a certificate
 func CertFingerprint(cert *x509.Certificate) string {
 	return fmt.Sprintf("%x", sha256.Sum256(cert.Raw))
 }

--- a/src/k8s/pkg/utils/certificate.go
+++ b/src/k8s/pkg/utils/certificate.go
@@ -39,7 +39,6 @@ func TLSClientConfigWithTrustedCertificate(remoteCert *x509.Certificate) (*tls.C
 
 	config := &tls.Config{}
 
-	// Add the public key to the CA pool to make it trusted.
 	remoteCert.IsCA = true
 	config.RootCAs.AddCert(remoteCert)
 

--- a/src/k8s/pkg/utils/certificate_test.go
+++ b/src/k8s/pkg/utils/certificate_test.go
@@ -1,7 +1,12 @@
 package utils_test
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/utils"
@@ -49,4 +54,52 @@ func TestTLSClientConfigWithTrustedCertificate(t *testing.T) {
 	// Test with nil root CAs
 	_, err = utils.TLSClientConfigWithTrustedCertificate(remoteCert, nil)
 	g.Expect(err).To(BeNil())
+}
+
+func TestCertFingerprint(t *testing.T) {
+	g := NewWithT(t)
+	// Create a mock certificate for testing
+	mockCert := &x509.Certificate{
+		Raw: []byte("ChocolateChipCookieDough"),
+	}
+
+	// Calculate the expected SHA256 fingerprint of the mock certificate
+	expectedFingerprint := sha256.Sum256(mockCert.Raw)
+	expectedFingerprintStr := hex.EncodeToString(expectedFingerprint[:])
+
+	// Call the CertFingerprint function
+	actualFingerprint := utils.CertFingerprint(mockCert)
+
+	// Check if the returned fingerprint matches the expected fingerprint
+	g.Expect(actualFingerprint).To(Equal(expectedFingerprintStr))
+}
+
+func TestGetRemoteCertificate(t *testing.T) {
+	g := NewWithT(t)
+	// Create a mock HTTP server that returns a mock certificate
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Test with a valid address
+	remoteCert, err := utils.GetRemoteCertificate(server.Listener.Addr().String())
+	g.Expect(err).To(BeNil())
+	g.Expect(remoteCert).To(Equal(server.Certificate()))
+
+	// Test with an invalid address (missing port)
+	invalidAddr := "candy.canes"
+	expectedErr := fmt.Sprintf("failed to validate the cluster member address: address %s: missing port in address", invalidAddr)
+
+	remoteCert, err = utils.GetRemoteCertificate(invalidAddr)
+	g.Expect(err.Error()).To(ContainSubstring(expectedErr))
+	g.Expect(remoteCert).To(BeNil())
+
+	// Test with a non-existent address
+	nonExistentAddr := "jellybeans:9999"
+	expectedErr = fmt.Sprintf("Get \"https://%s\": dial tcp: lookup jellybeans on", nonExistentAddr)
+
+	remoteCert, err = utils.GetRemoteCertificate(nonExistentAddr)
+	g.Expect(err.Error()).To(ContainSubstring(expectedErr))
+	g.Expect(remoteCert).To(BeNil())
 }

--- a/src/k8s/pkg/utils/certificate_test.go
+++ b/src/k8s/pkg/utils/certificate_test.go
@@ -40,4 +40,13 @@ func TestTLSClientConfigWithTrustedCertificate(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(tlsConfig.ServerName).To(Equal("bubblegum.com"))
 	g.Expect(tlsConfig.RootCAs.Subjects()).To(ContainElement(remoteCert.RawSubject))
+
+	// Test with invalid remote certificate
+	tlsConfig, err = utils.TLSClientConfigWithTrustedCertificate(nil, rootCAs)
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(tlsConfig).To(BeNil())
+
+	// Test with nil root CAs
+	_, err = utils.TLSClientConfigWithTrustedCertificate(remoteCert, nil)
+	g.Expect(err).To(BeNil())
 }


### PR DESCRIPTION
## Description
This PR addresses Mitm vulnerabilities for joining worker nodes by validating the server. 

A joining node validates the server (cluster member) by checking the servers certificate against the fingerprint of the join token. The joining node adds the certificate to its trusted certificates and the TLS connection is established, the joining node may now join the cluster.