### PR TITLE
fix `k8s enable network` not working

### DIFF
--- a/src/k8s/pkg/k8sd/types/cluster_config_network.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_network.go
@@ -9,4 +9,4 @@ type Network struct {
 func (c Network) GetEnabled() bool       { return getField(c.Enabled) }
 func (c Network) GetPodCIDR() string     { return getField(c.PodCIDR) }
 func (c Network) GetServiceCIDR() string { return getField(c.ServiceCIDR) }
-func (c Network) Empty() bool            { return c.PodCIDR == nil && c.ServiceCIDR == nil }
+func (c Network) Empty() bool            { return c.Enabled == nil && c.PodCIDR == nil && c.ServiceCIDR == nil }


### PR DESCRIPTION
### Summary

Fix `k8s enable network` and `k8s disable network` not updating the network feature. The missing check caused https://github.com/canonical/k8s-snap/blob/e6227daf6e17a426eb8088dfc3e5af1ed4f33236/src/k8s/pkg/k8sd/api/cluster_config.go#L49 to fail