### PR TITLE
add support for ip range in load-balancer.cidrs

### DIFF
--- a/docs/src/howto/networking/default-loadbalancer.md
+++ b/docs/src/howto/networking/default-loadbalancer.md
@@ -31,7 +31,7 @@ sudo k8s get load-balancer
 This should output a list of values like this:
 
 
-- `cidrs` - a list containing [cidr] definitions of the pool of IP addresses to use
+- `cidrs` - a list containing [cidr] or ip address range definitions of the pool of IP addresses to use
 - `l2-mode` - whether L2 mode (failover) is turned on
 - `l2-interfaces` - optional list of interfaces to announce services over (defaults to all)
 - `bgp-mode` - whether BGP mode is active.

--- a/src/k8s/api/v1/bootstrap_config_test.go
+++ b/src/k8s/api/v1/bootstrap_config_test.go
@@ -26,7 +26,7 @@ func TestBootstrapConfigToMicrocluster(t *testing.T) {
 			LoadBalancer: apiv1.LoadBalancerConfig{
 				Enabled: vals.Pointer(true),
 				L2Mode:  vals.Pointer(true),
-				CIDRs:   vals.Pointer([]string{"10.0.0.0/24"}),
+				CIDRs:   vals.Pointer([]string{"10.0.0.0/24", "10.1.0.10-10.1.0.20"}),
 			},
 			LocalStorage: apiv1.LocalStorageConfig{
 				Enabled:    vals.Pointer(true),

--- a/src/k8s/cmd/k8s/k8s_bootstrap_test.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap_test.go
@@ -46,7 +46,7 @@ var testCases = []testCase{
 				LoadBalancer: apiv1.LoadBalancerConfig{
 					Enabled: vals.Pointer(true),
 					L2Mode:  vals.Pointer(true),
-					CIDRs:   vals.Pointer([]string{"10.0.0.0/24"}),
+					CIDRs:   vals.Pointer([]string{"10.0.0.0/24", "10.1.0.10-10.1.0.20"}),
 				},
 				LocalStorage: apiv1.LocalStorageConfig{
 					Enabled:    vals.Pointer(true),

--- a/src/k8s/cmd/k8s/testdata/bootstrap-config-full.yaml
+++ b/src/k8s/cmd/k8s/testdata/bootstrap-config-full.yaml
@@ -10,6 +10,7 @@ cluster-config:
     enabled: true
     cidrs:
     - 10.0.0.0/24
+    - 10.1.0.10-10.1.0.20
     l2-mode: true
   local-storage:
     enabled: true

--- a/src/k8s/pkg/component/loadbalancer.go
+++ b/src/k8s/pkg/component/loadbalancer.go
@@ -3,6 +3,7 @@ package component
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
@@ -72,7 +73,14 @@ func UpdateLoadBalancerComponent(ctx context.Context, s snap.Snap, isRefresh boo
 	formattedCidrs := []map[string]any{}
 
 	for _, cidr := range config.GetCIDRs() {
-		formattedCidrs = append(formattedCidrs, map[string]any{"cidr": cidr})
+		// Handle IP range
+		if strings.Contains(cidr, "-") {
+			ipRange := strings.Split(cidr, "-")
+			formattedCidrs = append(formattedCidrs, map[string]any{"start": ipRange[0], "stop": ipRange[1]})
+		} else {
+			// Handle CIDRs
+			formattedCidrs = append(formattedCidrs, map[string]any{"cidr": cidr})
+		}
 	}
 
 	values := map[string]any{

--- a/src/k8s/pkg/k8sd/types/cluster_config_convert_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_convert_test.go
@@ -93,7 +93,7 @@ func TestClusterConfigFromBootstrapConfig(t *testing.T) {
 					LoadBalancer: apiv1.LoadBalancerConfig{
 						Enabled: vals.Pointer(true),
 						L2Mode:  vals.Pointer(true),
-						CIDRs:   vals.Pointer([]string{"10.0.0.0/24"}),
+						CIDRs:   vals.Pointer([]string{"10.0.0.0/24", "10.1.0.10-10.1.0.20"}),
 					},
 					LocalStorage: apiv1.LocalStorageConfig{
 						Enabled:    vals.Pointer(true),
@@ -143,7 +143,7 @@ func TestClusterConfigFromBootstrapConfig(t *testing.T) {
 				LoadBalancer: types.LoadBalancer{
 					Enabled: vals.Pointer(true),
 					L2Mode:  vals.Pointer(true),
-					CIDRs:   vals.Pointer([]string{"10.0.0.0/24"}),
+					CIDRs:   vals.Pointer([]string{"10.0.0.0/24", "10.1.0.10-10.1.0.20"}),
 				},
 				LocalStorage: types.LocalStorage{
 					Enabled:    vals.Pointer(true),

--- a/src/k8s/pkg/k8sd/types/cluster_config_merge_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_merge_test.go
@@ -133,7 +133,7 @@ func TestMergeClusterConfig(t *testing.T) {
 			c.Network.Enabled = vals.Pointer(true)
 			c.LoadBalancer.Enabled = vals.Pointer(v.(bool))
 		}),
-		generateMergeClusterConfigTestCases("LoadBalancer/CIDRs", true, []string{"172.16.101.0/24"}, []string{"172.16.100.0/24"}, func(c *types.ClusterConfig, v any) {
+		generateMergeClusterConfigTestCases("LoadBalancer/CIDRs", true, []string{"172.16.101.0/24"}, []string{"172.16.100.0-172.16.100.254"}, func(c *types.ClusterConfig, v any) {
 			c.LoadBalancer.CIDRs = vals.Pointer(v.([]string))
 		}),
 		generateMergeClusterConfigTestCases("LoadBalancer/L2Mode/Enable", true, true, false, func(c *types.ClusterConfig, v any) { c.LoadBalancer.L2Mode = vals.Pointer(v.(bool)) }),

--- a/src/k8s/pkg/k8sd/types/cluster_config_validate_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_validate_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -49,6 +50,52 @@ func TestValidateCIDR(t *testing.T) {
 					g.Expect(err).To(HaveOccurred())
 				} else {
 					g.Expect(err).To(BeNil())
+				}
+			})
+		})
+	}
+}
+
+func TestValidateLoadbalancer(t *testing.T) {
+	for _, tc := range []struct {
+		cidr      []string
+		expectErr bool
+	}{
+		{cidr: []string{"10.3.0.0/16"}},
+		{cidr: []string{"2001:0db8::/32"}},
+		{cidr: []string{"10.3.0.0/16", "2001:0db8::/32"}},
+		{cidr: []string{"10.3.0.10-10.3.0.20"}},
+		{cidr: []string{"10.3.0.32/28", "10.3.0.10-10.3.0.20"}},
+		{cidr: []string{"2001:0db8::0-2001:0db8::10"}},
+		{cidr: []string{"10.3.0.32/28", "2001:0db8::0-2001:0db8::10"}},
+		{cidr: []string{""}, expectErr: true},
+		{cidr: []string{"bananas"}, expectErr: true},
+		{cidr: []string{"fd01::/64,fd02::/64,fd03::/64"}, expectErr: true},
+		{cidr: []string{"10.3.0.10-10.3.0.300"}, expectErr: true},
+		{cidr: []string{"10.3.0.10-10.3.0.7"}, expectErr: true},
+		{cidr: []string{"2001:0db8::0-2001:0db8::gg"}, expectErr: true},
+		{cidr: []string{"", "10.3.0.10-10.3.0.300"}, expectErr: true},
+		{cidr: []string{"10.3.0.10-10.3.0.12-10.3.0.15"}, expectErr: true},
+	} {
+		t.Run(strings.Join(tc.cidr, ","), func(t *testing.T) {
+			t.Run("LoadBalancer", func(t *testing.T) {
+				g := NewWithT(t)
+				config := types.ClusterConfig{
+					Network: types.Network{
+						Enabled:     vals.Pointer(true),
+						PodCIDR:     vals.Pointer("10.2.0.0/16"),
+						ServiceCIDR: vals.Pointer("10.1.0.0/16"),
+					},
+					LoadBalancer: types.LoadBalancer{
+						Enabled: vals.Pointer(true),
+						CIDRs:   vals.Pointer(tc.cidr),
+					},
+				}
+				err := config.Validate()
+				if tc.expectErr {
+					g.Expect(err).Should(HaveOccurred())
+				} else {
+					g.Expect(err).ShouldNot(HaveOccurred())
 				}
 			})
 		})


### PR DESCRIPTION
Currently only CIDRs can be specified for load-balancer.cidrs.

Accept IP range as well to the load-balaner.cidrs.
Example to set IP range:
```
sudo k8s set load-balancer.cidrs="10.1.0.0/16,10.2.0.100-10.2.0.200"
```

Fixes: #311 