### PR TITLE
Allow specifying extra SANs when joining control plane nodes

### DIFF
--- a/src/k8s/api/v1/join_config.go
+++ b/src/k8s/api/v1/join_config.go
@@ -7,6 +7,8 @@ import (
 )
 
 type ControlPlaneNodeJoinConfig struct {
+	ExtraSANS []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`
+
 	APIServerCert *string `json:"apiserver-crt,omitempty" yaml:"apiserver-crt,omitempty"`
 	APIServerKey  *string `json:"apiserver-key,omitempty" yaml:"apiserver-key,omitempty"`
 	KubeletCert   *string `json:"kubelet-crt,omitempty" yaml:"kubelet-crt,omitempty"`

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -237,14 +237,11 @@ func (a *App) onBootstrapControlPlane(s *state.State, bootstrapConfig apiv1.Boot
 		return fmt.Errorf("unsupported datastore %s, must be one of %v", cfg.Datastore.GetType(), setup.SupportedDatastores)
 	}
 
-	extraIPs, extraNames := utils.SplitIPAndDNSSANs(bootstrapConfig.ExtraSANs)
-
-	IPSANs := append(append([]net.IP{nodeIP}, serviceIPs...), extraIPs...)
-
 	// Certificates
+	extraIPs, extraNames := utils.SplitIPAndDNSSANs(bootstrapConfig.ExtraSANs)
 	certificates := pki.NewControlPlanePKI(pki.ControlPlanePKIOpts{
 		Hostname:                  s.Name(),
-		IPSANs:                    IPSANs,
+		IPSANs:                    append(append([]net.IP{nodeIP}, serviceIPs...), extraIPs...),
 		DNSSANs:                   extraNames,
 		Years:                     20,
 		AllowSelfSignedCA:         true,


### PR DESCRIPTION
### Summary

Allow specifying extra SANs when joining control plane nodes.