### PR TITLE
Use TLS when connecting to apiserver

### DIFF
--- a/src/k8s/pkg/k8sd/setup/embed/apiserver/auth-token-webhook.conf
+++ b/src/k8s/pkg/k8sd/setup/embed/apiserver/auth-token-webhook.conf
@@ -3,9 +3,10 @@ kind: Config
 clusters:
   - name: k8s-token-auth-service
     cluster:
-      certificate-authority: /var/snap/k8s/common/var/lib/k8sd/state/cluster.crt
+      certificate-authority: "{{ .CA }}"
+      /var/snap/k8s/common/var/lib/k8sd/state
       tls-server-name: 127.0.0.1
-      server: "https://10.0.0.79:6400/1.0/kubernetes/auth/webhook"
+      server: "{{ .URL }}"
 current-context: webhook
 contexts:
 - context:

--- a/src/k8s/pkg/k8sd/setup/embed/apiserver/auth-token-webhook.conf
+++ b/src/k8s/pkg/k8sd/setup/embed/apiserver/auth-token-webhook.conf
@@ -3,8 +3,7 @@ kind: Config
 clusters:
   - name: k8s-token-auth-service
     cluster:
-      certificate-authority: "{{ .CA }}"
-      /var/snap/k8s/common/var/lib/k8sd/state
+      certificate-authority: "{{ .CAPath }}"
       tls-server-name: 127.0.0.1
       server: "{{ .URL }}"
 current-context: webhook

--- a/src/k8s/pkg/k8sd/setup/embed/apiserver/auth-token-webhook.conf
+++ b/src/k8s/pkg/k8sd/setup/embed/apiserver/auth-token-webhook.conf
@@ -3,8 +3,9 @@ kind: Config
 clusters:
   - name: k8s-token-auth-service
     cluster:
-      insecure-skip-tls-verify: true
-      server: "{{ .URL }}"
+      certificate-authority: /var/snap/k8s/common/var/lib/k8sd/state/cluster.crt
+      tls-server-name: 127.0.0.1
+      server: "https://10.0.0.79:6400/1.0/kubernetes/auth/webhook"
 current-context: webhook
 contexts:
 - context:

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -55,7 +55,7 @@ func KubeAPIServer(snap snap.Snap, serviceCIDR string, authWebhookURL string, en
 		return fmt.Errorf("failed to open auth-token-webhook.conf: %w", err)
 	}
 
-	microclusterCAPath := filepath.Join(snap.K8sDqliteStateDir(), "cert.ca")
+	microclusterCAPath := filepath.Join(snap.K8sdStateDir(), "cert.ca")
 	if err := apiserverAuthTokenWebhookTemplate.Execute(authTokenWebhookFile, apiserverAuthTokenWebhookTemplateConfig{
 		URL: authWebhookURL,
 		CA:  microclusterCAPath,

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -13,8 +12,8 @@ import (
 )
 
 type apiserverAuthTokenWebhookTemplateConfig struct {
-	URL string
-	CA  string
+	URL    string
+	CAPath string
 }
 
 var SupportedDatastores = []string{"k8s-dqlite", "external"}
@@ -55,10 +54,9 @@ func KubeAPIServer(snap snap.Snap, serviceCIDR string, authWebhookURL string, en
 		return fmt.Errorf("failed to open auth-token-webhook.conf: %w", err)
 	}
 
-	microclusterCAPath := filepath.Join(snap.K8sdStateDir(), "cluster.crt")
 	if err := apiserverAuthTokenWebhookTemplate.Execute(authTokenWebhookFile, apiserverAuthTokenWebhookTemplateConfig{
-		URL: authWebhookURL,
-		CA:  microclusterCAPath,
+		URL:    authWebhookURL,
+		CAPath: path.Join(snap.K8sdStateDir(), "cluster.crt"),
 	}); err != nil {
 		return fmt.Errorf("failed to write auth-token-webhook.conf: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -55,7 +55,7 @@ func KubeAPIServer(snap snap.Snap, serviceCIDR string, authWebhookURL string, en
 		return fmt.Errorf("failed to open auth-token-webhook.conf: %w", err)
 	}
 
-	microclusterCAPath := filepath.Join(snap.K8sdStateDir(), "cert.ca")
+	microclusterCAPath := filepath.Join(snap.K8sdStateDir(), "cluster.crt")
 	if err := apiserverAuthTokenWebhookTemplate.Execute(authTokenWebhookFile, apiserverAuthTokenWebhookTemplateConfig{
 		URL: authWebhookURL,
 		CA:  microclusterCAPath,

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -13,6 +14,7 @@ import (
 
 type apiserverAuthTokenWebhookTemplateConfig struct {
 	URL string
+	CA  string
 }
 
 var SupportedDatastores = []string{"k8s-dqlite", "external"}
@@ -52,8 +54,11 @@ func KubeAPIServer(snap snap.Snap, serviceCIDR string, authWebhookURL string, en
 	if err != nil {
 		return fmt.Errorf("failed to open auth-token-webhook.conf: %w", err)
 	}
+
+	microclusterCAPath := filepath.Join(snap.K8sDqliteStateDir(), "cert.ca")
 	if err := apiserverAuthTokenWebhookTemplate.Execute(authTokenWebhookFile, apiserverAuthTokenWebhookTemplateConfig{
 		URL: authWebhookURL,
+		CA:  microclusterCAPath,
 	}); err != nil {
 		return fmt.Errorf("failed to write auth-token-webhook.conf: %w", err)
 	}


### PR DESCRIPTION
## Description
For security reasons we want to connect to the apiserver using tls. We can use microcluster CA.