### PR TITLE
Update loadbalancer ip pool schema to support ip range

### DIFF
--- a/k8s/components/charts/ck-loadbalancer/values.schema.json
+++ b/k8s/components/charts/ck-loadbalancer/values.schema.json
@@ -29,12 +29,25 @@
               "properties": {
                 "cidr": {
                   "type": "string"
+                },
+                "start": {
+                  "type": "string"
+                },
+                "stop": {
+                  "type": "string"
                 }
-              },
-              "required": ["cidr"]
-            }
-          ]
-        }
+	      },
+	      "anyOf": [
+		{
+		  "required": ["cidr"]
+		},
+		{
+		  "required": ["start", "stop"]
+		}
+	      ]
+	    }
+	  ]
+	}
       },
       "required": ["cidrs"]
     },


### PR DESCRIPTION
Commit 6eb114f1dceac20af3863b30dca8de96e210d274 add support for ip ranges in k8sd config settings. However the helm chart ck-loadbalancer schema validation is not updated. Update ck-loadbalancer schema validation to validate ippool against cidr or start/stop or both.