### PR TITLE
remove --output-format from k8s get-join-token

### DIFF
--- a/docs/src/_parts/commands/k8s_get-join-token.md
+++ b/docs/src/_parts/commands/k8s_get-join-token.md
@@ -9,9 +9,8 @@ k8s get-join-token <node-name> [flags]
 ### Options
 
 ```
-  -h, --help                   help for get-join-token
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --worker                 generate a join token for a worker node
+  -h, --help     help for get-join-token
+      --worker   generate a join token for a worker node
 ```
 
 ### SEE ALSO

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -1,30 +1,19 @@
 package k8s
 
 import (
-	"fmt"
-
 	apiv1 "github.com/canonical/k8s/api/v1"
 	cmdutil "github.com/canonical/k8s/cmd/util"
 	"github.com/spf13/cobra"
 )
 
-type GetJoinTokenResult struct {
-	JoinToken string `json:"join-token" yaml:"join-token"`
-}
-
-func (g GetJoinTokenResult) String() string {
-	return fmt.Sprintf("On the node you want to join call:\n\n  sudo k8s join-cluster %s\n", g.JoinToken)
-}
-
 func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
-		worker       bool
-		outputFormat string
+		worker bool
 	}
 	cmd := &cobra.Command{
 		Use:    "get-join-token <node-name>",
 		Short:  "Create a token for a node to join the cluster",
-		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
@@ -43,11 +32,10 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			outputFormatter.Print(GetJoinTokenResult{JoinToken: token})
+			cmd.PrintErrln(token)
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.worker, "worker", false, "generate a join token for a worker node")
-	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -32,7 +32,7 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			cmd.PrintErrln(token)
+			cmd.Println(token)
 		},
 	}
 

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -261,18 +261,10 @@ def get_join_token(
     initial_node: harness.Instance, joining_cplane_node: harness.Instance, *args: str
 ) -> str:
     out = initial_node.exec(
-        [
-            "k8s",
-            "get-join-token",
-            joining_cplane_node.id,
-            "--output-format",
-            "json",
-            *args,
-        ],
+        ["k8s", "get-join-token", joining_cplane_node.id, *args],
         capture_output=True,
     )
-    result = json.loads(out.stdout.decode())
-    return result["join-token"]
+    return out.stdout.decode().strip()
 
 
 # Join an existing cluster.


### PR DESCRIPTION
### Summary

`k8s get-join-token` simply prints the token in stdout