### PR TITLE
add pprof debug endpoints (disabled by default)

### DIFF
--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -19,10 +19,11 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short: "Canonical Kubernetes orchestrator and clustering daemon",
 		Run: func(cmd *cobra.Command, args []string) {
 			app, err := app.New(cmd.Context(), app.Config{
-				Debug:    rootCmdOpts.logDebug,
-				Verbose:  rootCmdOpts.logVerbose,
-				StateDir: rootCmdOpts.stateDir,
-				Snap:     env.Snap,
+				Debug:        rootCmdOpts.logDebug,
+				Verbose:      rootCmdOpts.logVerbose,
+				StateDir:     rootCmdOpts.stateDir,
+				Snap:         env.Snap,
+				PprofAddress: rootCmdOpts.pprofAddress,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd: %v", err)

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -7,9 +7,10 @@ import (
 )
 
 var rootCmdOpts struct {
-	logDebug   bool
-	logVerbose bool
-	stateDir   string
+	logDebug     bool
+	logVerbose   bool
+	stateDir     string
+	pprofAddress string
 }
 
 func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
@@ -44,6 +45,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&rootCmdOpts.logDebug, "debug", "d", false, "Show all debug messages")
 	cmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
+	cmd.PersistentFlags().StringVar(&rootCmdOpts.pprofAddress, "pprof-address", "", "Listen address for pprof endpoints, e.g. \"127.0.0.1:4217\"")
 
 	cmd.Flags().Uint("port", 0, "Default port for the HTTP API")
 	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -3,6 +3,9 @@ package app
 import (
 	"context"
 	"fmt"
+	"log"
+	"net/http"
+	"net/http/pprof"
 	"sync"
 	"time"
 
@@ -26,12 +29,17 @@ type Config struct {
 	StateDir string
 	// Snap is the snap instance to use.
 	Snap snap.Snap
+	// ProfilingAddress is the address to listen for pprof debug endpoints. Empty to disable.
+	ProfilingAddress string
 }
 
 // App is the k8sd microcluster instance.
 type App struct {
 	microCluster *microcluster.MicroCluster
 	snap         snap.Snap
+
+	// profilingAddress
+	profilingAddress string
 
 	// readyWg is used to denote that the microcluster node is now running
 	readyWg sync.WaitGroup
@@ -56,8 +64,9 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	}
 
 	app := &App{
-		microCluster: cluster,
-		snap:         cfg.Snap,
+		microCluster:     cluster,
+		snap:             cfg.Snap,
+		profilingAddress: cfg.ProfilingAddress,
 	}
 	app.readyWg.Add(1)
 
@@ -102,6 +111,25 @@ func (a *App) Run(customHooks *config.Hooks) error {
 			hooks.OnStart = customHooks.OnStart
 		}
 	}
+
+	// start profiling server
+	if a.profilingAddress != "" {
+		log.Printf("Enable pprof endpoint at http://%s", a.profilingAddress)
+
+		go func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/debug/pprof/", pprof.Index)
+			mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+			if err := http.ListenAndServe(a.profilingAddress, mux); err != nil {
+				log.Printf("ERROR: Failed to serve pprof endpoint: %v", err)
+			}
+		}()
+	}
+
 	err := a.microCluster.Start(api.New(a).Endpoints(), database.SchemaExtensions, hooks)
 	if err != nil {
 		return fmt.Errorf("failed to run microcluster: %w", err)

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -29,8 +29,8 @@ type Config struct {
 	StateDir string
 	// Snap is the snap instance to use.
 	Snap snap.Snap
-	// ProfilingAddress is the address to listen for pprof debug endpoints. Empty to disable.
-	ProfilingAddress string
+	// PprofAddress is the address to listen for pprof debug endpoints. Empty to disable.
+	PprofAddress string
 }
 
 // App is the k8sd microcluster instance.
@@ -66,7 +66,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 	app := &App{
 		microCluster:     cluster,
 		snap:             cfg.Snap,
-		profilingAddress: cfg.ProfilingAddress,
+		profilingAddress: cfg.PprofAddress,
 	}
 	app.readyWg.Add(1)
 


### PR DESCRIPTION
To enable, `--pprof-address` needs to be specified in k8sd arguments.