### PR TITLE
Decouple update k8sd-config configmap from k8s set API

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
-	"github.com/canonical/k8s/pkg/utils/k8s"
 	"github.com/canonical/k8s/pkg/utils/vals"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/state"
@@ -53,6 +52,13 @@ func (e *Endpoints) putClusterConfig(s *state.State, r *http.Request) response.R
 		return response.InternalError(fmt.Errorf("database transaction to update cluster configuration failed: %w", err))
 	}
 
+	// Trigger an update of the configuration.
+	// Do not wait if the channel is full. The reconcilation loop will apply the most recent changes
+	select {
+	case e.provider.UpdateNodeConfigurationControllerCh() <- struct{}{}:
+	default:
+	}
+
 	if !requestedConfig.Network.Empty() {
 		if err := component.ReconcileNetworkComponent(r.Context(), snap, oldConfig.Network.Enabled, requestedConfig.Network.Enabled, mergedConfig); err != nil {
 			return response.InternalError(fmt.Errorf("failed to reconcile network: %w", err))
@@ -81,20 +87,6 @@ func (e *Endpoints) putClusterConfig(s *state.State, r *http.Request) response.R
 				return response.InternalError(fmt.Errorf("database transaction to update cluster configuration failed: %w", err))
 			}
 		}
-	}
-
-	cmData, err := mergedConfig.Kubelet.ToConfigMap()
-	if err != nil {
-		return response.InternalError(fmt.Errorf("failed to format kubelet configmap data: %w", err))
-	}
-
-	client, err := k8s.NewClient(snap.KubernetesRESTClientGetter(""))
-	if err != nil {
-		return response.InternalError(fmt.Errorf("failed to create kubernetes client: %w", err))
-	}
-
-	if _, err := client.UpdateConfigMap(r.Context(), "kube-system", "k8sd-config", cmData); err != nil {
-		return response.InternalError(fmt.Errorf("failed to update node config: %w", err))
 	}
 
 	if !requestedConfig.LocalStorage.Empty() {

--- a/src/k8s/pkg/k8sd/api/provider.go
+++ b/src/k8s/pkg/k8sd/api/provider.go
@@ -9,5 +9,5 @@ import (
 type Provider interface {
 	MicroCluster() *microcluster.MicroCluster
 	Snap() snap.Snap
-	UpdateNodeConfigurationControllerCh() chan<- struct{}
+	NotifyUpdateConfigMap()
 }

--- a/src/k8s/pkg/k8sd/api/provider.go
+++ b/src/k8s/pkg/k8sd/api/provider.go
@@ -9,4 +9,5 @@ import (
 type Provider interface {
 	MicroCluster() *microcluster.MicroCluster
 	Snap() snap.Snap
+	UpdateNodeConfigurationControllerCh() chan<- struct{}
 }

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -46,6 +46,7 @@ type App struct {
 
 	nodeConfigController         *controllers.NodeConfigurationController
 	controlPlaneConfigController *controllers.ControlPlaneConfigurationController
+	updateNodeConfigController   *controllers.UpdateNodeConfigurationController
 }
 
 // New initializes a new microcluster instance from configuration.
@@ -82,6 +83,14 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		cfg.Snap,
 		app.readyWg.Wait,
 		time.NewTicker(10*time.Second).C,
+	)
+
+	app.updateNodeConfigController = controllers.NewUpdateNodeConfigurationController(
+		cfg.Snap,
+		app.readyWg.Wait,
+		func() (*k8s.Client, error) {
+			return k8s.NewClient(cfg.Snap.KubernetesNodeRESTClientGetter("kube-system"))
+		},
 	)
 
 	return app, nil

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -89,7 +89,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		cfg.Snap,
 		app.readyWg.Wait,
 		func() (*k8s.Client, error) {
-			return k8s.NewClient(cfg.Snap.KubernetesNodeRESTClientGetter("kube-system"))
+			return k8s.NewClient(cfg.Snap.KubernetesNodeRESTClientGetter(""))
 		},
 	)
 

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -347,13 +347,6 @@ func (a *App) onBootstrapControlPlane(s *state.State, bootstrapConfig apiv1.Boot
 		}
 	}
 
-	// Trigger an update of the configuration.
-	// Do not wait if the channel is full. The reconcilation loop will apply the most recent changes
-	select {
-	case a.updateNodeConfigController.TriggerCh <- struct{}{}:
-	default:
-	}
-
 	if cfg.LocalStorage.GetEnabled() {
 		if err := component.ReconcileLocalStorageComponent(s.Context, snap, vals.Pointer(false), vals.Pointer(true), cfg); err != nil {
 			return fmt.Errorf("failed to reconcile local-storage: %w", err)
@@ -383,6 +376,8 @@ func (a *App) onBootstrapControlPlane(s *state.State, bootstrapConfig apiv1.Boot
 			return fmt.Errorf("failed to reconcile metrics-server: %w", err)
 		}
 	}
+
+	a.NotifyUpdateConfigMap()
 
 	return nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -350,7 +350,7 @@ func (a *App) onBootstrapControlPlane(s *state.State, bootstrapConfig apiv1.Boot
 	// Trigger an update of the configuration.
 	// Do not wait if the channel is full. The reconcilation loop will apply the most recent changes
 	select {
-	case a.updateNodeConfigController.UpdateCh <- struct{}{}:
+	case a.updateNodeConfigController.TriggerCh <- struct{}{}:
 	default:
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -19,7 +19,6 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/k8s/pkg/utils"
-	"github.com/canonical/k8s/pkg/utils/k8s"
 	"github.com/canonical/k8s/pkg/utils/vals"
 	"github.com/canonical/microcluster/state"
 )
@@ -348,18 +347,11 @@ func (a *App) onBootstrapControlPlane(s *state.State, bootstrapConfig apiv1.Boot
 		}
 	}
 
-	cmData, err := cfg.Kubelet.ToConfigMap()
-	if err != nil {
-		return fmt.Errorf("failed to format kubelet configmap data: %w", err)
-	}
-
-	client, err := k8s.NewClient(snap.KubernetesRESTClientGetter(""))
-	if err != nil {
-		return fmt.Errorf("failed to create kubernetes client: %w", err)
-	}
-
-	if _, err := client.UpdateConfigMap(s.Context, "kube-system", "k8sd-config", cmData); err != nil {
-		return fmt.Errorf("failed to update node configs: %w", err)
+	// Trigger an update of the configuration.
+	// Do not wait if the channel is full. The reconcilation loop will apply the most recent changes
+	select {
+	case a.updateNodeConfigController.UpdateCh <- struct{}{}:
+	default:
 	}
 
 	if cfg.LocalStorage.GetEnabled() {

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -24,5 +24,12 @@ func (a *App) onStart(s *state.State) error {
 		})
 	}
 
+	// start update node config controller
+	if a.updateNodeConfigController != nil {
+		go a.updateNodeConfigController.Run(s.Context, func(ctx context.Context) (types.ClusterConfig, error) {
+			return utils.GetClusterConfig(ctx, s)
+		})
+	}
+
 	return nil
 }

--- a/src/k8s/pkg/k8sd/app/provider.go
+++ b/src/k8s/pkg/k8sd/app/provider.go
@@ -14,5 +14,9 @@ func (a *App) Snap() snap.Snap {
 	return a.snap
 }
 
+func (a *App) UpdateNodeConfigurationControllerCh() chan<- struct{} {
+	return a.updateNodeConfigController.UpdateCh
+}
+
 // Ensure App implements api.Provider
 var _ api.Provider = &App{}

--- a/src/k8s/pkg/k8sd/app/provider.go
+++ b/src/k8s/pkg/k8sd/app/provider.go
@@ -15,7 +15,10 @@ func (a *App) Snap() snap.Snap {
 }
 
 func (a *App) NotifyUpdateConfigMap() {
-	a.updateNodeConfigController.TriggerCh <- struct{}{}
+	select {
+	case a.updateNodeConfigController.TriggerCh <- struct{}{}:
+	default:
+	}
 }
 
 // Ensure App implements api.Provider

--- a/src/k8s/pkg/k8sd/app/provider.go
+++ b/src/k8s/pkg/k8sd/app/provider.go
@@ -14,8 +14,8 @@ func (a *App) Snap() snap.Snap {
 	return a.snap
 }
 
-func (a *App) UpdateNodeConfigurationControllerCh() chan<- struct{} {
-	return a.updateNodeConfigController.UpdateCh
+func (a *App) NotifyUpdateConfigMap() {
+	a.updateNodeConfigController.TriggerCh <- struct{}{}
 }
 
 // Ensure App implements api.Provider

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
@@ -1,0 +1,110 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils/k8s"
+)
+
+// UpdateNodeConfigurationController asynchronously performs updates of the cluster config.
+// An updates is triggered by sending the patch to the updateCh.
+type UpdateNodeConfigurationController struct {
+	snap         snap.Snap
+	waitReady    func()
+	newK8sClient func() (*k8s.Client, error)
+	// UpdateCh is used to trigger config updates.
+	UpdateCh chan struct{}
+	// ReconciledCh is used to indicate that a reconcilation loop has finished.
+	ReconciledCh chan struct{}
+}
+
+// NewUpdateNodeConfigurationController creates a new controller.
+func NewUpdateNodeConfigurationController(snap snap.Snap, waitReady func(), newK8sClient func() (*k8s.Client, error)) *UpdateNodeConfigurationController {
+	return &UpdateNodeConfigurationController{
+		snap:         snap,
+		waitReady:    waitReady,
+		newK8sClient: newK8sClient,
+		UpdateCh:     make(chan struct{}, 1),
+		ReconciledCh: make(chan struct{}, 1),
+	}
+}
+
+func (c *UpdateNodeConfigurationController) retryNewK8sClient(ctx context.Context) (*k8s.Client, error) {
+	for {
+		client, err := c.newK8sClient()
+		if err == nil {
+			return client, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+// Run starts the controller.
+// Run accepts a context to manage the lifecycle of the controller.
+// Run accepts a function that retrieves the current cluster configuration.
+// Run will loop everytime a cluster config patch is sent to the UpdateCh.
+func (c *UpdateNodeConfigurationController) Run(ctx context.Context, getClusterConfig func(context.Context) (types.ClusterConfig, error)) {
+	c.waitReady()
+
+	client, err := c.retryNewK8sClient(ctx)
+	if err != nil {
+		log.Println(fmt.Errorf("failed to create a Kubernetes client: %w", err))
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.UpdateCh:
+		}
+
+		if isWorker, err := snaputil.IsWorker(c.snap); err != nil {
+			log.Println(fmt.Errorf("failed to check if this is a worker node: %w", err))
+			continue
+		} else if isWorker {
+			log.Println("Stopping UpdateClusterConfig controller as this is a worker node")
+			return
+		}
+
+		config, err := getClusterConfig(ctx)
+		if err != nil {
+			log.Println(fmt.Errorf("failed to retrieve cluster config: %w", err))
+			continue
+		}
+
+		if err := c.reconcile(ctx, client, config); err != nil {
+			log.Println(fmt.Errorf("failed to reconcile cluster configuration: %w", err))
+		}
+
+		select {
+		case c.ReconciledCh <- struct{}{}:
+		case <-time.After(10 * time.Second):
+			log.Println("failed to reconcile cluster config in time - will fetch latest config and retry.")
+			continue
+		default:
+		}
+	}
+}
+
+func (c *UpdateNodeConfigurationController) reconcile(ctx context.Context, client *k8s.Client, config types.ClusterConfig) error {
+	cmData, err := config.Kubelet.ToConfigMap()
+	if err != nil {
+		return fmt.Errorf("failed to format kubelet configmap data: %w", err)
+	}
+	if _, err := client.UpdateConfigMap(ctx, "kube-system", "k8sd-config", cmData); err != nil {
+		return fmt.Errorf("failed to update node config: %w", err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
@@ -57,12 +57,12 @@ func (c *UpdateNodeConfigurationController) retryNewK8sClient(ctx context.Contex
 func (c *UpdateNodeConfigurationController) Run(ctx context.Context, getClusterConfig func(context.Context) (types.ClusterConfig, error)) {
 	c.waitReady()
 
-	client, err := c.retryNewK8sClient(ctx)
-	if err != nil {
-		log.Println(fmt.Errorf("failed to create a Kubernetes client: %w", err))
-	}
-
 	for {
+		client, err := c.retryNewK8sClient(ctx)
+		if err != nil {
+			log.Println(fmt.Errorf("failed to create a Kubernetes client: %w", err))
+		}
+
 		select {
 		case <-ctx.Done():
 			return

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
@@ -8,41 +8,39 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/controllers"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap/mock"
 	"github.com/canonical/k8s/pkg/utils/k8s"
+	"github.com/canonical/k8s/pkg/utils/vals"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestUpdateNodeConfigurationController(t *testing.T) {
 	testCases := []struct {
 		name            string
-		initialConfig   map[string]string
-		expectedConfig  map[string]string
+		initialConfig   types.ClusterConfig
+		expectedConfig  types.ClusterConfig
 		expectedFailure bool
 	}{
 		{
-			name: "ControlPlane_DefaultConfig",
-			initialConfig: map[string]string{
-				"test": "data",
-			},
-			expectedConfig: map[string]string{
-				"ClusterDNS": "cluster.local",
+			name:          "ControlPlane_DefaultConfig",
+			initialConfig: types.ClusterConfig{},
+			expectedConfig: types.ClusterConfig{
+				Kubelet: types.Kubelet{
+					ClusterDomain: vals.Pointer("cluster.local"),
+				},
 			},
 			expectedFailure: false,
 		},
 		{
-			name: "ControlPlane_EmptyConfig",
-			initialConfig: map[string]string{
-				"test": "data",
-			},
-			expectedConfig:  nil, // Expecting empty ConfigMap data
+			name:            "ControlPlane_EmptyConfig",
+			initialConfig:   types.ClusterConfig{},
+			expectedConfig:  types.ClusterConfig{},
 			expectedFailure: true,
 		},
 	}
@@ -65,23 +63,18 @@ func TestUpdateNodeConfigurationController(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			configProvider := &configProvider{}
+			configProvider := &configProvider{config: tc.expectedConfig}
+			kubeletConfigMap, err := tc.initialConfig.Kubelet.ToConfigMap()
+			g.Expect(err).ToNot(HaveOccurred())
 
 			configMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "k8sd-config",
 					Namespace: "kube-system",
 				},
-				Data: tc.initialConfig,
+				Data: kubeletConfigMap,
 			}
 			clientset := fake.NewSimpleClientset(configMap)
-
-			if !tc.expectedFailure {
-				clientset.PrependReactor("patch", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-					configMap.Data = tc.expectedConfig
-					return true, nil, nil
-				})
-			}
 
 			ctrl := controllers.NewUpdateNodeConfigurationController(s, func() {}, func() (*k8s.Client, error) {
 				return &k8s.Client{Interface: clientset}, nil
@@ -89,16 +82,24 @@ func TestUpdateNodeConfigurationController(t *testing.T) {
 			go ctrl.Run(ctx, configProvider.getConfig)
 
 			select {
-			case ctrl.UpdateCh <- struct{}{}:
+			case ctrl.TriggerCh <- struct{}{}:
 			case <-time.After(channelSendTimeout):
 				g.Fail("Timed out while attempting to trigger controller reconcile loop")
 			}
-			<-ctrl.ReconciledCh
 
+			select {
+			case <-ctrl.ReconciledCh:
+			case <-time.After(channelSendTimeout):
+			}
+
+			result, err := clientset.CoreV1().ConfigMaps("kube-system").Get(ctx, "k8sd-config", metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+			expectedConfigMap, err := tc.expectedConfig.Kubelet.ToConfigMap()
+			g.Expect(err).ToNot(HaveOccurred())
 			if tc.expectedFailure {
-				g.Expect(configMap.Data).ToNot(Equal(tc.expectedConfig))
+				g.Expect(result.Data).ToNot(Equal(expectedConfigMap))
 			} else {
-				g.Expect(configMap.Data).To(Equal(tc.expectedConfig))
+				g.Expect(result.Data).To(Equal(expectedConfigMap))
 			}
 		})
 	}

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
@@ -1,0 +1,105 @@
+package controllers_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/canonical/k8s/pkg/k8sd/controllers"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/k8s/pkg/utils/k8s"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestUpdateNodeConfigurationController(t *testing.T) {
+	testCases := []struct {
+		name            string
+		initialConfig   map[string]string
+		expectedConfig  map[string]string
+		expectedFailure bool
+	}{
+		{
+			name: "ControlPlane_DefaultConfig",
+			initialConfig: map[string]string{
+				"test": "data",
+			},
+			expectedConfig: map[string]string{
+				"ClusterDNS": "cluster.local",
+			},
+			expectedFailure: false,
+		},
+		{
+			name: "ControlPlane_EmptyConfig",
+			initialConfig: map[string]string{
+				"test": "data",
+			},
+			expectedConfig:  nil, // Expecting empty ConfigMap data
+			expectedFailure: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			s := &mock.Snap{
+				Mock: mock.Mock{
+					EtcdPKIDir:                 path.Join(dir, "etcd-pki"),
+					ServiceArgumentsDir:        path.Join(dir, "args"),
+					UID:                        os.Getuid(),
+					GID:                        os.Getgid(),
+					KubernetesRESTClientGetter: genericclioptions.NewTestConfigFlags(),
+				},
+			}
+
+			g := NewWithT(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			configProvider := &configProvider{}
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k8sd-config",
+					Namespace: "kube-system",
+				},
+				Data: tc.initialConfig,
+			}
+			clientset := fake.NewSimpleClientset(configMap)
+
+			if !tc.expectedFailure {
+				clientset.PrependReactor("patch", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					configMap.Data = tc.expectedConfig
+					return true, nil, nil
+				})
+			}
+
+			ctrl := controllers.NewUpdateNodeConfigurationController(s, func() {}, func() (*k8s.Client, error) {
+				return &k8s.Client{Interface: clientset}, nil
+			})
+			go ctrl.Run(ctx, configProvider.getConfig)
+
+			select {
+			case ctrl.UpdateCh <- struct{}{}:
+			case <-time.After(channelSendTimeout):
+				g.Fail("Timed out while attempting to trigger controller reconcile loop")
+			}
+			<-ctrl.ReconciledCh
+
+			if tc.expectedFailure {
+				g.Expect(configMap.Data).ToNot(Equal(tc.expectedConfig))
+			} else {
+				g.Expect(configMap.Data).To(Equal(tc.expectedConfig))
+			}
+		})
+	}
+}

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
@@ -90,6 +90,7 @@ func TestUpdateNodeConfigurationController(t *testing.T) {
 			select {
 			case <-ctrl.ReconciledCh:
 			case <-time.After(channelSendTimeout):
+				g.Fail("Time out while waiting for the reconcile to complete")
 			}
 
 			result, err := clientset.CoreV1().ConfigMaps("kube-system").Get(ctx, "k8sd-config", metav1.GetOptions{})


### PR DESCRIPTION
This PR adds a controller that updates the `k8sd-config` config map of the cluster asynchronously.
It is triggered by the sending `struct{}` to the controllers `UpdateCh` (e.g. by the bootstrap hook or `k8s set`). 

This is a first effort of making commands return fast instead of e.g. waiting for service restarts and apply changes async. Follow-up work will move the component updates to a controller  as well.

Relates and works towards fixing:
#321 and #277 