### PR TITLE
Adjust systemd service definitions

### DIFF
--- a/build-scripts/patches/strict/0001-Strict-patch.patch
+++ b/build-scripts/patches/strict/0001-Strict-patch.patch
@@ -1,34 +1,34 @@
-From 37c1acf06d05404d89f42202aa19e18871495822 Mon Sep 17 00:00:00 2001
+From 8b2ddb158fa7a1b864648594e12c01a9d62d2bcb Mon Sep 17 00:00:00 2001
 From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
-Date: Sun, 4 Feb 2024 17:39:41 +0200
+Date: Wed, 17 Apr 2024 00:35:00 +0300
 Subject: [PATCH] Strict patch
 
 ---
  build-scripts/print-patches-for.py |   2 +-
  k8s/hack/init.sh                   |   6 +-
- snap/snapcraft.yaml                | 169 ++++++++++++++++++++++++++++-
- 3 files changed, 174 insertions(+), 3 deletions(-)
+ snap/snapcraft.yaml                | 168 ++++++++++++++++++++++++++++-
+ 3 files changed, 173 insertions(+), 3 deletions(-)
 
 diff --git a/build-scripts/print-patches-for.py b/build-scripts/print-patches-for.py
 index 2c65083..13ea57c 100755
 --- a/build-scripts/print-patches-for.py
 +++ b/build-scripts/print-patches-for.py
 @@ -5,7 +5,7 @@ from pathlib import Path
-
+ 
  DIR = Path(__file__).absolute().parent
-
+ 
 -PATCH_DIRS = ["patches"]
 +PATCH_DIRS = ["patches", "strict-patches"]
-
-
+ 
+ 
  class Version:
 diff --git a/k8s/hack/init.sh b/k8s/hack/init.sh
-index a0b57c7..1507db4 100755
+index a0b57c7..d53b528 100755
 --- a/k8s/hack/init.sh
 +++ b/k8s/hack/init.sh
 @@ -1,3 +1,7 @@
  #!/usr/bin/env bash
-
+ 
 -# no-op for classic confinement
 +DIR=`realpath $(dirname "${0}")`
 +
@@ -36,7 +36,7 @@ index a0b57c7..1507db4 100755
 +"${DIR}/connect-interfaces.sh"
 +"${DIR}/network-requirements.sh"
 diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
-index 2d157e2..ceb9e33 100644
+index 53347a0..339ca8a 100644
 --- a/snap/snapcraft.yaml
 +++ b/snap/snapcraft.yaml
 @@ -7,7 +7,7 @@ description: |-
@@ -48,7 +48,7 @@ index 2d157e2..ceb9e33 100644
  base: core20
  environment:
    REAL_PATH: $PATH
-@@ -191,6 +191,20 @@ parts:
+@@ -216,6 +216,20 @@ parts:
  apps:
    k8s:
      command: k8s/wrappers/commands/k8s
@@ -69,10 +69,10 @@ index 2d157e2..ceb9e33 100644
    containerd:
      command: k8s/wrappers/services/containerd
      daemon: notify
-@@ -200,35 +214,188 @@ apps:
-     stop-mode: sigterm
+@@ -226,43 +240,195 @@ apps:
      restart-condition: always
      start-timeout: 5m
+     before: [kubelet]
 +    plugs:
 +      - network-bind
 +      - docker-privileged
@@ -89,6 +89,7 @@ index 2d157e2..ceb9e33 100644
      command: k8s/wrappers/services/k8s-dqlite
      install-mode: disable
      daemon: simple
+     before: [kube-apiserver]
 +    plugs:
 +      - network-bind
    k8sd:
@@ -105,7 +106,7 @@ index 2d157e2..ceb9e33 100644
      install-mode: disable
      command: k8s/wrappers/services/kubelet
      daemon: simple
-+    after: [containerd]
+     after: [containerd]
 +    plugs:
 +      - docker-privileged
 +      - firewall-control
@@ -123,6 +124,8 @@ index 2d157e2..ceb9e33 100644
      install-mode: disable
      command: k8s/wrappers/services/kube-apiserver
      daemon: simple
+     before: [kubelet, kube-controller-manager, kube-proxy, kube-scheduler]
+     stop-timeout: 5s
 +    plugs:
 +      - docker-privileged
 +      - firewall-control
@@ -140,6 +143,7 @@ index 2d157e2..ceb9e33 100644
      install-mode: disable
      command: k8s/wrappers/services/kube-controller-manager
      daemon: simple
+     after: [kube-apiserver]
 +    plugs:
 +      - docker-privileged
 +      - firewall-control
@@ -157,6 +161,7 @@ index 2d157e2..ceb9e33 100644
      install-mode: disable
      command: k8s/wrappers/services/kube-proxy
      daemon: simple
+     after: [kube-apiserver]
 +    plugs:
 +      - docker-privileged
 +      - firewall-control
@@ -174,6 +179,7 @@ index 2d157e2..ceb9e33 100644
      install-mode: disable
      command: k8s/wrappers/services/kube-scheduler
      daemon: simple
+     after: [kube-apiserver]
 +    plugs:
 +      - docker-privileged
 +      - firewall-control
@@ -191,6 +197,7 @@ index 2d157e2..ceb9e33 100644
      install-mode: disable
      command: k8s/wrappers/services/k8s-apiserver-proxy
      daemon: simple
+     before: [kubelet, kube-proxy]
 +    plugs:
 +      - network-bind
 +
@@ -258,5 +265,6 @@ index 2d157e2..ceb9e33 100644
 +      - process-control
 +      - network-control
 +      - firewall-control
---
-2.25.1
+-- 
+2.34.1
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -225,10 +225,12 @@ apps:
     stop-mode: sigterm
     restart-condition: always
     start-timeout: 5m
+    before: [kubelet]
   k8s-dqlite:
     command: k8s/wrappers/services/k8s-dqlite
     install-mode: disable
     daemon: simple
+    before: [kube-apiserver]
   k8sd:
     command: k8s/wrappers/services/k8sd
     install-mode: enable
@@ -237,23 +239,30 @@ apps:
     install-mode: disable
     command: k8s/wrappers/services/kubelet
     daemon: simple
+    after: [containerd]
   kube-apiserver:
     install-mode: disable
     command: k8s/wrappers/services/kube-apiserver
     daemon: simple
+    before: [kubelet, kube-controller-manager, kube-proxy, kube-scheduler]
+    stop-timeout: 5s
   kube-controller-manager:
     install-mode: disable
     command: k8s/wrappers/services/kube-controller-manager
     daemon: simple
+    after: [kube-apiserver]
   kube-proxy:
     install-mode: disable
     command: k8s/wrappers/services/kube-proxy
     daemon: simple
+    after: [kube-apiserver]
   kube-scheduler:
     install-mode: disable
     command: k8s/wrappers/services/kube-scheduler
     daemon: simple
+    after: [kube-apiserver]
   k8s-apiserver-proxy:
     install-mode: disable
     command: k8s/wrappers/services/k8s-apiserver-proxy
     daemon: simple
+    before: [kubelet, kube-proxy]


### PR DESCRIPTION
### Summary

Adjust systemd service definitions in `snapcraft.yaml`:

- Add `before` and `after` to note the order in which to start the services
- Adjust the strict patch for the updates to `snap/snapcraft.yaml`
- Add a 5s timeout to apiserver restarts