### PR TITLE
Properly handle LoadBalancer IPRanges in the internal state

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -31,7 +31,7 @@ func (e *Endpoints) putClusterConfig(s *state.State, r *http.Request) response.R
 	if err != nil {
 		return response.BadRequest(fmt.Errorf("invalid configuration: %w", err))
 	}
-````
+
 	oldConfig, err := utils.GetClusterConfig(r.Context(), s)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to retrieve cluster configuration: %w", err))

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -27,12 +27,16 @@ func (e *Endpoints) putClusterConfig(s *state.State, r *http.Request) response.R
 		return response.BadRequest(fmt.Errorf("failed to decode request: %w", err))
 	}
 
+	requestedConfig, err := types.ClusterConfigFromUserFacing(req.Config)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("invalid configuration: %w", err))
+	}
+````
 	oldConfig, err := utils.GetClusterConfig(r.Context(), s)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to retrieve cluster configuration: %w", err))
 	}
 
-	requestedConfig := types.ClusterConfigFromUserFacing(req.Config)
 	var mergedConfig types.ClusterConfig
 	if err := s.Database.Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error

--- a/src/k8s/pkg/k8sd/types/cluster_config_convert_loadbalancer.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_convert_loadbalancer.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// loadBalancerCIDRsFromAPI splits a list of CIDRs from API and returns the parsed list of CIDRs and IP ranges.
+// loadBalancerCIDRsFromAPI returns nil lists for nil input, but empty lists for a valid empty list.
+// loadBalancerCIDRsFromAPI returns an error if the input is not valid.
+func loadBalancerCIDRsFromAPI(inCIDRs *[]string) (*[]string, *[]LoadBalancer_IPRange, error) {
+	if inCIDRs == nil {
+		return nil, nil, nil
+	}
+	outCIDRs := []string{}
+	outRanges := []LoadBalancer_IPRange{}
+	if len(*inCIDRs) == 0 {
+		return &outCIDRs, &outRanges, nil
+	}
+
+	for _, cidr := range *inCIDRs {
+		// Handle IP Range
+		if strings.Contains(cidr, "-") {
+			ipRange := strings.Split(cidr, "-")
+			if len(ipRange) != 2 {
+				return nil, nil, fmt.Errorf("load-balancer.cidrs contains an IP range (%q) not in $START-$END format", cidr)
+			}
+
+			start, err := netip.ParseAddr(ipRange[0])
+			if err != nil {
+				return nil, nil, fmt.Errorf("load-balancer.cidrs contains an IP range (%q) with an invalid start IP (%q): %w", cidr, ipRange[0], err)
+			}
+			stop, err := netip.ParseAddr(ipRange[1])
+			if err != nil {
+				return nil, nil, fmt.Errorf("load-balancer.cidrs contains an IP range (%q) with an invalid stop IP (%q): %w", cidr, ipRange[1], err)
+			}
+			if stop.Less(start) {
+				return nil, nil, fmt.Errorf("load-balancer.cidrs contains an IP range (%q) with start IP (%q) greater than the stop IP (%q)", cidr, ipRange[0], ipRange[1])
+			}
+
+			outRanges = append(outRanges, LoadBalancer_IPRange{Start: ipRange[0], Stop: ipRange[1]})
+		} else {
+			// Handle CIDR
+			if _, _, err := net.ParseCIDR(cidr); err != nil {
+				return nil, nil, fmt.Errorf("load-balancer.cidrs contains an invalid CIDR %q: %w", cidr, err)
+			}
+
+			outCIDRs = append(outCIDRs, cidr)
+		}
+	}
+
+	return &outCIDRs, &outRanges, nil
+}
+
+// loadBalancerCIDRsToAPI encodes internal CIDR and IP ranges for the LoadBalancer.CIDRs API field.
+// loadBalancerCIDRsToAPI returns a nil list of CIDRs if both inputs are nil, otherwise an empty list.
+func loadBalancerCIDRsToAPI(inCIDRs *[]string, inRanges *[]LoadBalancer_IPRange) *[]string {
+	if inCIDRs == nil && inRanges == nil {
+		return nil
+	}
+
+	outCIDRs := []string{}
+
+	if inCIDRs != nil {
+		outCIDRs = append(outCIDRs, *inCIDRs...)
+	}
+
+	if inRanges != nil {
+		for _, ipRange := range *inRanges {
+			outCIDRs = append(outCIDRs, fmt.Sprintf("%s-%s", ipRange.Start, ipRange.Stop))
+		}
+	}
+
+	return &outCIDRs
+}

--- a/src/k8s/pkg/k8sd/types/cluster_config_convert_loadbalancer_internal_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_convert_loadbalancer_internal_test.go
@@ -3,31 +3,119 @@ package types
 import (
 	"testing"
 
+	"github.com/canonical/k8s/pkg/utils/vals"
 	. "github.com/onsi/gomega"
 )
 
+var loadBalancerCIDRTestCases = []struct {
+	name           string
+	apiCIDRs       []string
+	internalCIDRs  []string
+	internalRanges []LoadBalancer_IPRange
+	expectErr      bool
+}{
+	{
+		name:           "IPv4CIDR",
+		apiCIDRs:       []string{"10.3.0.0/16"},
+		internalCIDRs:  []string{"10.3.0.0/16"},
+		internalRanges: []LoadBalancer_IPRange{},
+	},
+	{
+		name:           "IPv6CIDR",
+		apiCIDRs:       []string{"2001:0db8::/32"},
+		internalCIDRs:  []string{"2001:0db8::/32"},
+		internalRanges: []LoadBalancer_IPRange{},
+	},
+	{
+		name:           "IPv4AndIPv6CIDRs",
+		apiCIDRs:       []string{"10.3.0.0/16", "2001:0db8::/32"},
+		internalCIDRs:  []string{"10.3.0.0/16", "2001:0db8::/32"},
+		internalRanges: []LoadBalancer_IPRange{},
+	},
+	{
+		name:           "IPv4Range",
+		apiCIDRs:       []string{"10.3.0.10-10.3.0.20"},
+		internalCIDRs:  []string{},
+		internalRanges: []LoadBalancer_IPRange{{Start: "10.3.0.10", Stop: "10.3.0.20"}},
+	},
+	{
+		name:           "IPv4CIDRAndRange",
+		apiCIDRs:       []string{"10.3.0.32/28", "10.3.0.10-10.3.0.20"},
+		internalCIDRs:  []string{"10.3.0.32/28"},
+		internalRanges: []LoadBalancer_IPRange{{Start: "10.3.0.10", Stop: "10.3.0.20"}},
+	},
+	{
+		name:           "IPv6Range",
+		apiCIDRs:       []string{"2001:0db8::0-2001:0db8::10"},
+		internalCIDRs:  []string{},
+		internalRanges: []LoadBalancer_IPRange{{Start: "2001:0db8::0", Stop: "2001:0db8::10"}},
+	},
+	{
+		name:           "IPv4CIDRAndIPv6Range",
+		apiCIDRs:       []string{"10.3.0.32/28", "2001:0db8::0-2001:0db8::10"},
+		internalCIDRs:  []string{"10.3.0.32/28"},
+		internalRanges: []LoadBalancer_IPRange{{Start: "2001:0db8::0", Stop: "2001:0db8::10"}},
+	},
+	{name: "Empty", apiCIDRs: []string{""}, expectErr: true},
+	{name: "Invalid", apiCIDRs: []string{"bananas"}, expectErr: true},
+	{name: "CommaSeparated", apiCIDRs: []string{"fd01::/64,fd02::/64,fd03::/64"}, expectErr: true},
+	{name: "InvalidStartIPv4", apiCIDRs: []string{"10.3.0.1000-10.3.0.1001"}, expectErr: true},
+	{name: "InvalidStopIPv4", apiCIDRs: []string{"10.3.0.10-10.3.0.300"}, expectErr: true},
+	{name: "Order", apiCIDRs: []string{"10.3.0.10-10.3.0.7"}, expectErr: true},
+	{name: "InvalidStopIPv6", apiCIDRs: []string{"2001:0db8::0-2001:0db8::gg"}, expectErr: true},
+	{name: "AnyFail", apiCIDRs: []string{"", "10.3.0.7-10.3.0.10"}, expectErr: true},
+	{name: "InvalidRange", apiCIDRs: []string{"", "10.3.0.10-10.3.0.12-10.3.0.15"}, expectErr: true},
+}
+
 func Test_loadBalancerCIDRsFromAPI(t *testing.T) {
-	for _, tc := range []struct {
-		name         string
-		cidrs        []string
-		expectCIDRs  []string
-		expectRanges []LoadBalancer_IPRange
-		expectErr    bool
-	}{
-		{},
-	} {
+	t.Run("Nil", func(t *testing.T) {
+		g := NewWithT(t)
+		cidrs, ranges, err := loadBalancerCIDRsFromAPI(nil)
+		g.Expect(err).To(BeNil())
+		g.Expect(cidrs).To(BeNil())
+		g.Expect(ranges).To(BeNil())
+	})
+
+	for _, tc := range loadBalancerCIDRTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			cidrs, ranges, err := loadBalancerCIDRsFromAPI(tc.cidrs)
+			cidrs, ranges, err := loadBalancerCIDRsFromAPI(&tc.apiCIDRs)
 			if tc.expectErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
 				g.Expect(err).To(BeNil())
-				g.Expect(cidrs).To(Equal(tc.expectCIDRs))
-				g.Expect(ranges).To(Equal(tc.expectRanges))
+				g.Expect(*cidrs).To(Equal(tc.internalCIDRs))
+				g.Expect(*ranges).To(Equal(tc.internalRanges))
 			}
 		})
 	}
+}
 
+func Test_loadBalancerCIDRsToAPI(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		t.Run("All", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(loadBalancerCIDRsToAPI(nil, nil)).To(BeNil())
+		})
+		t.Run("CIDRsOnly", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(loadBalancerCIDRsToAPI(nil, vals.Pointer([]LoadBalancer_IPRange{}))).To(Equal(vals.Pointer([]string{})))
+		})
+		t.Run("RangesOnly", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(loadBalancerCIDRsToAPI(vals.Pointer([]string{}), nil)).To(Equal(vals.Pointer([]string{})))
+		})
+	})
+
+	for _, tc := range loadBalancerCIDRTestCases {
+		if !tc.expectErr {
+			t.Run(tc.name, func(t *testing.T) {
+				g := NewWithT(t)
+
+				cidrs := loadBalancerCIDRsToAPI(&tc.internalCIDRs, &tc.internalRanges)
+				g.Expect(*cidrs).To(Equal(tc.apiCIDRs))
+			})
+		}
+	}
 }

--- a/src/k8s/pkg/k8sd/types/cluster_config_convert_loadbalancer_internal_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_convert_loadbalancer_internal_test.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_loadBalancerCIDRsFromAPI(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		cidrs        []string
+		expectCIDRs  []string
+		expectRanges []LoadBalancer_IPRange
+		expectErr    bool
+	}{
+		{},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cidrs, ranges, err := loadBalancerCIDRsFromAPI(tc.cidrs)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(cidrs).To(Equal(tc.expectCIDRs))
+				g.Expect(ranges).To(Equal(tc.expectRanges))
+			}
+		})
+	}
+
+}

--- a/src/k8s/pkg/k8sd/types/cluster_config_convert_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_convert_test.go
@@ -141,9 +141,10 @@ func TestClusterConfigFromBootstrapConfig(t *testing.T) {
 					Enabled: vals.Pointer(true),
 				},
 				LoadBalancer: types.LoadBalancer{
-					Enabled: vals.Pointer(true),
-					L2Mode:  vals.Pointer(true),
-					CIDRs:   vals.Pointer([]string{"10.0.0.0/24", "10.1.0.10-10.1.0.20"}),
+					Enabled:  vals.Pointer(true),
+					L2Mode:   vals.Pointer(true),
+					CIDRs:    vals.Pointer([]string{"10.0.0.0/24"}),
+					IPRanges: vals.Pointer([]types.LoadBalancer_IPRange{{Start: "10.1.0.10", Stop: "10.1.0.20"}}),
 				},
 				LocalStorage: types.LocalStorage{
 					Enabled:   vals.Pointer(true),

--- a/src/k8s/pkg/k8sd/types/cluster_config_features.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_features.go
@@ -12,15 +12,21 @@ type Ingress struct {
 }
 
 type LoadBalancer struct {
-	Enabled        *bool     `json:"enabled,omitempty"`
-	CIDRs          *[]string `json:"cidrs,omitempty"`
-	L2Mode         *bool     `json:"l2-mode,omitempty"`
-	L2Interfaces   *[]string `json:"l2-interfaces,omitempty"`
-	BGPMode        *bool     `json:"bgp-mode,omitempty"`
-	BGPLocalASN    *int      `json:"bgp-local-asn,omitempty"`
-	BGPPeerAddress *string   `json:"bgp-peer-address,omitempty"`
-	BGPPeerASN     *int      `json:"bgp-peer-asn,omitempty"`
-	BGPPeerPort    *int      `json:"bgp-peer-port,omitempty"`
+	Enabled        *bool                   `json:"enabled,omitempty"`
+	CIDRs          *[]string               `json:"cidrs,omitempty"`
+	IPRanges       *[]LoadBalancer_IPRange `json:"ranges,omitempty"`
+	L2Mode         *bool                   `json:"l2-mode,omitempty"`
+	L2Interfaces   *[]string               `json:"l2-interfaces,omitempty"`
+	BGPMode        *bool                   `json:"bgp-mode,omitempty"`
+	BGPLocalASN    *int                    `json:"bgp-local-asn,omitempty"`
+	BGPPeerAddress *string                 `json:"bgp-peer-address,omitempty"`
+	BGPPeerASN     *int                    `json:"bgp-peer-asn,omitempty"`
+	BGPPeerPort    *int                    `json:"bgp-peer-port,omitempty"`
+}
+
+type LoadBalancer_IPRange struct {
+	Start string `json:"start"`
+	Stop  string `json:"stop"`
 }
 
 type Gateway struct {
@@ -52,15 +58,16 @@ func (c Ingress) Empty() bool {
 func (c Gateway) GetEnabled() bool { return getField(c.Enabled) }
 func (c Gateway) Empty() bool      { return c.Enabled == nil }
 
-func (c LoadBalancer) GetEnabled() bool          { return getField(c.Enabled) }
-func (c LoadBalancer) GetCIDRs() []string        { return getField(c.CIDRs) }
-func (c LoadBalancer) GetL2Mode() bool           { return getField(c.L2Mode) }
-func (c LoadBalancer) GetL2Interfaces() []string { return getField(c.L2Interfaces) }
-func (c LoadBalancer) GetBGPMode() bool          { return getField(c.BGPMode) }
-func (c LoadBalancer) GetBGPLocalASN() int       { return getField(c.BGPLocalASN) }
-func (c LoadBalancer) GetBGPPeerAddress() string { return getField(c.BGPPeerAddress) }
-func (c LoadBalancer) GetBGPPeerASN() int        { return getField(c.BGPPeerASN) }
-func (c LoadBalancer) GetBGPPeerPort() int       { return getField(c.BGPPeerPort) }
+func (c LoadBalancer) GetEnabled() bool                    { return getField(c.Enabled) }
+func (c LoadBalancer) GetCIDRs() []string                  { return getField(c.CIDRs) }
+func (c LoadBalancer) GetIPRanges() []LoadBalancer_IPRange { return getField(c.IPRanges) }
+func (c LoadBalancer) GetL2Mode() bool                     { return getField(c.L2Mode) }
+func (c LoadBalancer) GetL2Interfaces() []string           { return getField(c.L2Interfaces) }
+func (c LoadBalancer) GetBGPMode() bool                    { return getField(c.BGPMode) }
+func (c LoadBalancer) GetBGPLocalASN() int                 { return getField(c.BGPLocalASN) }
+func (c LoadBalancer) GetBGPPeerAddress() string           { return getField(c.BGPPeerAddress) }
+func (c LoadBalancer) GetBGPPeerASN() int                  { return getField(c.BGPPeerASN) }
+func (c LoadBalancer) GetBGPPeerPort() int                 { return getField(c.BGPPeerPort) }
 func (c LoadBalancer) Empty() bool {
 	return c.Enabled == nil && c.CIDRs == nil && c.L2Mode == nil && c.L2Interfaces == nil && c.BGPMode == nil && c.BGPLocalASN == nil && c.BGPPeerAddress == nil && c.BGPPeerASN == nil && c.BGPPeerPort == nil
 }

--- a/src/k8s/pkg/k8sd/types/cluster_config_merge.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_merge.go
@@ -79,7 +79,7 @@ func MergeClusterConfig(existing ClusterConfig, new ClusterConfig) (ClusterConfi
 
 	// update LoadBalancer_IPRange fields
 	if config.LoadBalancer.IPRanges, err = mergeSliceField(existing.LoadBalancer.IPRanges, new.LoadBalancer.IPRanges, true); err != nil {
-		return ClusterConfig{}, fmt.Errorf("prevent update of load balancer IP ranges: %w", err)
+		return ClusterConfig{}, fmt.Errorf("prevented update of load balancer IP ranges: %w", err)
 	}
 
 	// update int fields

--- a/src/k8s/pkg/k8sd/types/cluster_config_merge.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_merge.go
@@ -77,6 +77,11 @@ func MergeClusterConfig(existing ClusterConfig, new ClusterConfig) (ClusterConfi
 		}
 	}
 
+	// update LoadBalancer_IPRange fields
+	if config.LoadBalancer.IPRanges, err = mergeSliceField(existing.LoadBalancer.IPRanges, new.LoadBalancer.IPRanges, true); err != nil {
+		return ClusterConfig{}, fmt.Errorf("prevent update of load balancer IP ranges: %w", err)
+	}
+
 	// update int fields
 	for _, i := range []struct {
 		name        string

--- a/src/k8s/pkg/k8sd/types/cluster_config_merge_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_merge_test.go
@@ -133,8 +133,11 @@ func TestMergeClusterConfig(t *testing.T) {
 			c.Network.Enabled = vals.Pointer(true)
 			c.LoadBalancer.Enabled = vals.Pointer(v.(bool))
 		}),
-		generateMergeClusterConfigTestCases("LoadBalancer/CIDRs", true, []string{"172.16.101.0/24"}, []string{"172.16.100.0-172.16.100.254"}, func(c *types.ClusterConfig, v any) {
+		generateMergeClusterConfigTestCases("LoadBalancer/CIDRs", true, []string{"172.16.101.0/24"}, []string{"172.16.102.0/24"}, func(c *types.ClusterConfig, v any) {
 			c.LoadBalancer.CIDRs = vals.Pointer(v.([]string))
+		}),
+		generateMergeClusterConfigTestCases("LoadBalancer/IPRanges", true, []types.LoadBalancer_IPRange{{Start: "10.0.0.10", Stop: "10.0.0.20"}}, []types.LoadBalancer_IPRange{{Start: "10.1.0.10", Stop: "10.1.0.20"}}, func(c *types.ClusterConfig, v any) {
+			c.LoadBalancer.IPRanges = vals.Pointer(v.([]types.LoadBalancer_IPRange))
 		}),
 		generateMergeClusterConfigTestCases("LoadBalancer/L2Mode/Enable", true, true, false, func(c *types.ClusterConfig, v any) { c.LoadBalancer.L2Mode = vals.Pointer(v.(bool)) }),
 		generateMergeClusterConfigTestCases("LoadBalancer/L2Mode/Disable", true, false, true, func(c *types.ClusterConfig, v any) { c.LoadBalancer.L2Mode = vals.Pointer(v.(bool)) }),

--- a/src/k8s/pkg/k8sd/types/cluster_config_validate.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_validate.go
@@ -45,31 +45,25 @@ func (c *ClusterConfig) Validate() error {
 
 	// check: load-balancer CIDRs
 	for _, cidr := range c.LoadBalancer.GetCIDRs() {
-		// Handle IP Range
-		if strings.Contains(cidr, "-") {
-			ipRange := strings.Split(cidr, "-")
-			if len(ipRange) != 2 {
-				return fmt.Errorf("load-balancer.cidrs contains an invalid IP Range %q", cidr)
-			}
+		// Handle CIDR
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("load-balancer configuration contains an invalid CIDR %q: %w", cidr, err)
+		}
+	}
 
-			start, err := netip.ParseAddr(ipRange[0])
-			if err != nil {
-				return fmt.Errorf("load-balancer.cidrs contains an invalid IP Range %q", cidr)
-			}
-			stop, err := netip.ParseAddr(ipRange[1])
-			if err != nil {
-				return fmt.Errorf("load-balancer.cidrs contains an invalid IP Range %q", cidr)
-			}
+	for _, ipRange := range c.LoadBalancer.GetIPRanges() {
+		start, err := netip.ParseAddr(ipRange.Start)
+		if err != nil {
+			return fmt.Errorf("load-balancer configuration contains an IP range (%#v) with an invalid start IP: %w", ipRange, err)
+		}
+		stop, err := netip.ParseAddr(ipRange.Stop)
+		if err != nil {
+			return fmt.Errorf("load-balancer configuration contains an IP range (%#v) with an invalid stop IP: %w", ipRange, err)
+		}
 
-			// Check if stop is greater than start
-			if stop.Less(start) {
-				return fmt.Errorf("load-balancer.cidrs contains an invalid IP Range %q", cidr)
-			}
-		} else {
-			// Handle CIDR
-			if _, _, err := net.ParseCIDR(cidr); err != nil {
-				return fmt.Errorf("load-balancer.cidrs contains an invalid CIDR %q: %w", cidr, err)
-			}
+		// Check if stop is greater than start
+		if stop.Less(start) {
+			return fmt.Errorf("load-balancer configuration contains an IP range (%#v) with start IP greater than the stop IP", ipRange)
 		}
 	}
 

--- a/src/k8s/pkg/k8sd/types/cluster_config_validate_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_validate_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -50,52 +49,6 @@ func TestValidateCIDR(t *testing.T) {
 					g.Expect(err).To(HaveOccurred())
 				} else {
 					g.Expect(err).To(BeNil())
-				}
-			})
-		})
-	}
-}
-
-func TestValidateLoadbalancer(t *testing.T) {
-	for _, tc := range []struct {
-		cidr      []string
-		expectErr bool
-	}{
-		{cidr: []string{"10.3.0.0/16"}},
-		{cidr: []string{"2001:0db8::/32"}},
-		{cidr: []string{"10.3.0.0/16", "2001:0db8::/32"}},
-		{cidr: []string{"10.3.0.10-10.3.0.20"}},
-		{cidr: []string{"10.3.0.32/28", "10.3.0.10-10.3.0.20"}},
-		{cidr: []string{"2001:0db8::0-2001:0db8::10"}},
-		{cidr: []string{"10.3.0.32/28", "2001:0db8::0-2001:0db8::10"}},
-		{cidr: []string{""}, expectErr: true},
-		{cidr: []string{"bananas"}, expectErr: true},
-		{cidr: []string{"fd01::/64,fd02::/64,fd03::/64"}, expectErr: true},
-		{cidr: []string{"10.3.0.10-10.3.0.300"}, expectErr: true},
-		{cidr: []string{"10.3.0.10-10.3.0.7"}, expectErr: true},
-		{cidr: []string{"2001:0db8::0-2001:0db8::gg"}, expectErr: true},
-		{cidr: []string{"", "10.3.0.10-10.3.0.300"}, expectErr: true},
-		{cidr: []string{"10.3.0.10-10.3.0.12-10.3.0.15"}, expectErr: true},
-	} {
-		t.Run(strings.Join(tc.cidr, ","), func(t *testing.T) {
-			t.Run("LoadBalancer", func(t *testing.T) {
-				g := NewWithT(t)
-				config := types.ClusterConfig{
-					Network: types.Network{
-						Enabled:     vals.Pointer(true),
-						PodCIDR:     vals.Pointer("10.2.0.0/16"),
-						ServiceCIDR: vals.Pointer("10.1.0.0/16"),
-					},
-					LoadBalancer: types.LoadBalancer{
-						Enabled: vals.Pointer(true),
-						CIDRs:   vals.Pointer(tc.cidr),
-					},
-				}
-				err := config.Validate()
-				if tc.expectErr {
-					g.Expect(err).Should(HaveOccurred())
-				} else {
-					g.Expect(err).ShouldNot(HaveOccurred())
 				}
 			})
 		})


### PR DESCRIPTION
### Summary

Follow up PR on #324. Make sure the internal state separates CIDRs and IP ranges.

