### PR TITLE
Support signed kubelet configmap

### DIFF
--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -67,7 +67,7 @@ func (c *NodeConfigurationController) Run(ctx context.Context) {
 }
 
 func (c *NodeConfigurationController) reconcile(ctx context.Context, configMap *v1.ConfigMap) error {
-	config, err := types.KubeletFromConfigMap(configMap.Data)
+	config, err := types.KubeletFromConfigMap(configMap.Data, nil)
 	if err != nil {
 		return fmt.Errorf("failed to parse configmap data to kubelet config: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
@@ -95,7 +95,7 @@ func (c *UpdateNodeConfigurationController) Run(ctx context.Context, getClusterC
 }
 
 func (c *UpdateNodeConfigurationController) reconcile(ctx context.Context, client *k8s.Client, config types.ClusterConfig) error {
-	cmData, err := config.Kubelet.ToConfigMap()
+	cmData, err := config.Kubelet.ToConfigMap(nil)
 	if err != nil {
 		return fmt.Errorf("failed to format kubelet configmap data: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
@@ -64,7 +64,7 @@ func TestUpdateNodeConfigurationController(t *testing.T) {
 			defer cancel()
 
 			configProvider := &configProvider{config: tc.expectedConfig}
-			kubeletConfigMap, err := tc.initialConfig.Kubelet.ToConfigMap()
+			kubeletConfigMap, err := tc.initialConfig.Kubelet.ToConfigMap(nil)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			configMap := &corev1.ConfigMap{
@@ -95,7 +95,7 @@ func TestUpdateNodeConfigurationController(t *testing.T) {
 
 			result, err := clientset.CoreV1().ConfigMaps("kube-system").Get(ctx, "k8sd-config", metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
-			expectedConfigMap, err := tc.expectedConfig.Kubelet.ToConfigMap()
+			expectedConfigMap, err := tc.expectedConfig.Kubelet.ToConfigMap(nil)
 			g.Expect(err).ToNot(HaveOccurred())
 			if tc.expectedFailure {
 				g.Expect(result.Data).ToNot(Equal(expectedConfigMap))

--- a/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
@@ -1,6 +1,9 @@
 package types_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -69,7 +72,7 @@ func TestKubelet(t *testing.T) {
 			t.Run("ToConfigMap", func(t *testing.T) {
 				g := NewWithT(t)
 
-				cm, err := tc.kubelet.ToConfigMap()
+				cm, err := tc.kubelet.ToConfigMap(nil)
 				g.Expect(err).To(BeNil())
 				g.Expect(cm).To(Equal(tc.configmap))
 			})
@@ -77,11 +80,121 @@ func TestKubelet(t *testing.T) {
 			t.Run("FromConfigMap", func(t *testing.T) {
 				g := NewWithT(t)
 
-				k, err := types.KubeletFromConfigMap(tc.configmap)
+				k, err := types.KubeletFromConfigMap(tc.configmap, nil)
 				g.Expect(err).To(BeNil())
 				g.Expect(k).To(Equal(tc.kubelet))
 			})
 		})
 	}
+}
 
+func TestKubeletSign(t *testing.T) {
+	g := NewWithT(t)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	g.Expect(err).To(BeNil())
+
+	kubelet := types.Kubelet{
+		CloudProvider: vals.Pointer("external"),
+		ClusterDNS:    vals.Pointer("10.0.0.1"),
+		ClusterDomain: vals.Pointer("cluster.local"),
+	}
+
+	configmap, err := kubelet.ToConfigMap(key)
+	g.Expect(err).To(BeNil())
+	g.Expect(configmap).To(HaveKeyWithValue("k8sd-mac", Not(BeEmpty())))
+
+	t.Run("NoSign", func(t *testing.T) {
+		g := NewWithT(t)
+
+		configmap, err := kubelet.ToConfigMap(nil)
+		g.Expect(err).To(BeNil())
+		g.Expect(configmap).To(Not(HaveKey("k8sd-mac")))
+	})
+
+	t.Run("SignAndVerify", func(t *testing.T) {
+		g := NewWithT(t)
+
+		fromKubelet, err := types.KubeletFromConfigMap(configmap, &key.PublicKey)
+		g.Expect(err).To(BeNil())
+		g.Expect(fromKubelet).To(Equal(kubelet))
+	})
+
+	t.Run("WrongKey", func(t *testing.T) {
+		g := NewWithT(t)
+
+		wrongKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		g.Expect(err).To(BeNil())
+
+		cm, err := types.KubeletFromConfigMap(configmap, &wrongKey.PublicKey)
+		g.Expect(cm).To(BeZero())
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("SmallCurve", func(t *testing.T) {
+		g := NewWithT(t)
+
+		key, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		g.Expect(err).To(BeNil())
+
+		_, err = kubelet.ToConfigMap(key)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("InvalidSignature", func(t *testing.T) {
+		g := NewWithT(t)
+
+		configmap, err := kubelet.ToConfigMap(key)
+		g.Expect(err).To(BeNil())
+		g.Expect(configmap).To(HaveKeyWithValue("k8sd-mac", Not(BeEmpty())))
+
+		t.Run("Manipulated", func(t *testing.T) {
+			configmap["k8sd-mac"] = "MEUCIQCwOI42A5DRYI7ssh3sz+EpRgPNRM13sYLbWeMIvCAt5AIgZW0M49yZD5pGMk/Kb2f8DlUaPCbCDHFHrkmtYHzse6w="
+
+			k, err := types.KubeletFromConfigMap(configmap, &key.PublicKey)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(k).To(BeZero())
+		})
+
+		t.Run("Deleted", func(t *testing.T) {
+			delete(configmap, "k8sd-mac")
+
+			k, err := types.KubeletFromConfigMap(configmap, &key.PublicKey)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(k).To(BeZero())
+		})
+	})
+
+	t.Run("BadSignature", func(t *testing.T) {
+		keys := make([]string, len(configmap))
+		for cmKey := range configmap {
+			keys = append(keys, cmKey)
+		}
+		for _, editKey := range keys {
+			t.Run(editKey, func(t *testing.T) {
+				g := NewWithT(t)
+				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				g.Expect(err).To(BeNil())
+
+				c, err := kubelet.ToConfigMap(key)
+				g.Expect(err).To(BeNil())
+				g.Expect(c).To(HaveKeyWithValue("k8sd-mac", Not(BeEmpty())))
+
+				t.Run("Manipulated", func(t *testing.T) {
+					c[editKey] = "attack"
+
+					k, err := types.KubeletFromConfigMap(c, &key.PublicKey)
+					g.Expect(err).To(Not(BeNil()))
+					g.Expect(k).To(BeZero())
+				})
+
+				t.Run("Deleted", func(t *testing.T) {
+					delete(c, editKey)
+
+					k, err := types.KubeletFromConfigMap(c, &key.PublicKey)
+					g.Expect(err).To(Not(BeNil()))
+					g.Expect(k).To(BeZero())
+				})
+			})
+		}
+	})
 }

--- a/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
@@ -167,11 +167,7 @@ func TestKubeletSign(t *testing.T) {
 	})
 
 	t.Run("BadSignature", func(t *testing.T) {
-		keys := make([]string, len(configmap))
-		for cmKey := range configmap {
-			keys = append(keys, cmKey)
-		}
-		for _, editKey := range keys {
+		for editKey := range configmap {
 			t.Run(editKey, func(t *testing.T) {
 				g := NewWithT(t)
 				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
@@ -182,7 +182,7 @@ func TestKubeletSign(t *testing.T) {
 					c[editKey] = "attack"
 
 					k, err := types.KubeletFromConfigMap(c, &key.PublicKey)
-					g.Expect(err).To(Not(BeNil()))
+					g.Expect(err).To(HaveOccurred())
 					g.Expect(k).To(BeZero())
 				})
 
@@ -191,7 +191,7 @@ func TestKubeletSign(t *testing.T) {
 					delete(c, editKey)
 
 					k, err := types.KubeletFromConfigMap(c, &key.PublicKey)
-					g.Expect(err).To(Not(BeNil()))
+					g.Expect(err).To(HaveOccurred())
 					g.Expect(k).To(BeZero())
 				})
 			})

--- a/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_kubelet_test.go
@@ -148,6 +148,7 @@ func TestKubeletSign(t *testing.T) {
 		g.Expect(configmap).To(HaveKeyWithValue("k8sd-mac", Not(BeEmpty())))
 
 		t.Run("Manipulated", func(t *testing.T) {
+			g := NewWithT(t)
 			configmap["k8sd-mac"] = "MEUCIQCwOI42A5DRYI7ssh3sz+EpRgPNRM13sYLbWeMIvCAt5AIgZW0M49yZD5pGMk/Kb2f8DlUaPCbCDHFHrkmtYHzse6w="
 
 			k, err := types.KubeletFromConfigMap(configmap, &key.PublicKey)
@@ -156,6 +157,7 @@ func TestKubeletSign(t *testing.T) {
 		})
 
 		t.Run("Deleted", func(t *testing.T) {
+			g := NewWithT(t)
 			delete(configmap, "k8sd-mac")
 
 			k, err := types.KubeletFromConfigMap(configmap, &key.PublicKey)
@@ -180,6 +182,7 @@ func TestKubeletSign(t *testing.T) {
 				g.Expect(c).To(HaveKeyWithValue("k8sd-mac", Not(BeEmpty())))
 
 				t.Run("Manipulated", func(t *testing.T) {
+					g := NewWithT(t)
 					c[editKey] = "attack"
 
 					k, err := types.KubeletFromConfigMap(c, &key.PublicKey)
@@ -188,6 +191,7 @@ func TestKubeletSign(t *testing.T) {
 				})
 
 				t.Run("Deleted", func(t *testing.T) {
+					g := NewWithT(t)
 					delete(c, editKey)
 
 					k, err := types.KubeletFromConfigMap(c, &key.PublicKey)


### PR DESCRIPTION
### Summary

Add machinery to sign and verify the kubelet configmap contents. We currently specify `nil` keys everywhere for now.

### Changes

Extend `types.KubeletFromConfigMap()` and `types.Kubelet.ToConfigMap()` to accept an optional ECDSA public and private key respectively.

If a non-nil key is passed:

- We hash the configuration contents (using `Kubelet.hash()`)
- In `Kubelet.ToConfigMap()` we use the private key and include it in the configmap as `k8sd-mac`
- In `types.KubeletFromConfigMap()` we use the public key to verify the hash and return an error otherwise.

### Notes

- `ecdsa.SignASN1` will only sign `hash[:curveBitsize/8]`. We ensure that we don't verify mismatching signatures by ensuring that the key is large enough. The hash is a sha256 sum (32 bytes long), therefore we need at least `elliptic.P256()`
- Added multiple tests to verify that any mutations to the configmap will result in it not being verified.