### PR TITLE
Use the admin client for updating the configmap

### DIFF
--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -89,7 +89,7 @@ func New(ctx context.Context, cfg Config) (*App, error) {
 		cfg.Snap,
 		app.readyWg.Wait,
 		func() (*k8s.Client, error) {
-			return k8s.NewClient(cfg.Snap.KubernetesNodeRESTClientGetter(""))
+			return k8s.NewClient(cfg.Snap.KubernetesRESTClientGetter("kube-system"))
 		},
 	)
 


### PR DESCRIPTION
### Summary

Follow up fix for #339, use the admin client, as the node config cannot update the configmap:

```
Apr 18 17:49:12 u1 k8s.k8sd[1482]: 2024/04/18 17:49:12 failed to reconcile cluster configuration: failed to update node config: failed to update configmap, namespace: kube-system name: k8sd-config: configmaps "k8sd-config" is forbidden: User "system:node:u1" cannot patch resource "configmaps" in API group "" in the namespace "kube-system": can only read resources of this type
```