### PR TITLE
Use strict json decoder for API requests

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -13,7 +12,7 @@ import (
 
 func (e *Endpoints) postClusterBootstrap(s *state.State, r *http.Request) response.Response {
 	req := apiv1.PostClusterBootstrapRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -22,7 +21,7 @@ func (e *Endpoints) putClusterConfig(s *state.State, r *http.Request) response.R
 	var req api.UpdateClusterConfigRequest
 	snap := e.provider.Snap()
 
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to decode request: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -14,7 +13,7 @@ import (
 
 func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Response {
 	req := apiv1.JoinClusterRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -16,7 +15,7 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 	snap := e.provider.Snap()
 
 	req := apiv1.RemoveNodeRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/cluster_tokens.go
+++ b/src/k8s/pkg/k8sd/api/cluster_tokens.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -18,7 +17,7 @@ import (
 
 func (e *Endpoints) postClusterJoinTokens(s *state.State, r *http.Request) response.Response {
 	req := apiv1.GetJoinTokenRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/kubeconfig.go
+++ b/src/k8s/pkg/k8sd/api/kubeconfig.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -15,7 +14,7 @@ import (
 
 func (e *Endpoints) getKubeconfig(s *state.State, r *http.Request) response.Response {
 	req := apiv1.GetKubeConfigRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -21,7 +20,7 @@ func (e *Endpoints) postWorkerInfo(s *state.State, r *http.Request) response.Res
 	snap := e.provider.Snap()
 
 	req := apiv1.WorkerNodeInfoRequest{}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 

--- a/src/k8s/pkg/utils/json.go
+++ b/src/k8s/pkg/utils/json.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// NewStrictJSONDecoder creates a new JSON decoder that disallows unknown fields.
+func NewStrictJSONDecoder(r io.Reader) *json.Decoder {
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+	return decoder
+}

--- a/src/k8s/pkg/utils/json_test.go
+++ b/src/k8s/pkg/utils/json_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewStrictJSONDecoder(t *testing.T) {
+	RegisterTestingT(t)
+
+	type TestData struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+
+	tests := []struct {
+		name      string
+		input     string
+		expectErr bool
+	}{
+		{
+			name:      "Valid JSON",
+			input:     `{"name": "John Doe", "age": 30}`,
+			expectErr: false,
+		},
+		{
+			name:      "JSON with unknown fields",
+			input:     `{"name": "Jane Doe", "age": 25, "occupation": "Engineer"}`,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := strings.NewReader(tt.input)
+			decoder := NewStrictJSONDecoder(r)
+
+			var data TestData
+			err := decoder.Decode(&data)
+
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current `json.NewDecoder()` parses unknown fields and invalid json which might cause silent failures. With `DisallowUnknownFields` we now only allow valid json with known fields.