### PR TITLE
Increase timeout for etcd and apiserver to come up during tests

### DIFF
--- a/tests/integration/tests/test_etcd.py
+++ b/tests/integration/tests/test_etcd.py
@@ -72,7 +72,7 @@ def test_etcd(instances: List[harness.Instance], etcd_cluster: EtcdCluster):
     )
 
     # check that we can still connect to the kubernetes cluster
-    util.stubbornly(retries=3, delay_s=1).on(k8s_instance).exec(
+    util.stubbornly(retries=10, delay_s=2).on(k8s_instance).exec(
         ["k8s", "kubectl", "get", "pods", "-A"]
     )
 


### PR DESCRIPTION
Addresses flake https://github.com/canonical/k8s-snap/actions/runs/8848200925/job/24298083455#step:7:1473