### PR TITLE
Parse k8s set with mapstructure

### DIFF
--- a/src/k8s/cmd/k8s/k8s_set_test.go
+++ b/src/k8s/cmd/k8s/k8s_set_test.go
@@ -1,0 +1,158 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	apiv1 "github.com/canonical/k8s/api/v1"
+	"github.com/canonical/k8s/pkg/utils"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+type mapstructureTestCase struct {
+	name       string
+	val        string
+	expectErr  bool
+	assertions []types.GomegaMatcher
+}
+
+func generateMapstructureTestCasesBool(keyName string, fieldName string) []mapstructureTestCase {
+	return []mapstructureTestCase{
+		{
+			val:        fmt.Sprintf("%s=true", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer(true))},
+		},
+		{
+			val:        fmt.Sprintf("%s=false", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer(false))},
+		},
+		{
+			val:        fmt.Sprintf("%s=", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer(false))},
+		},
+		{
+			val:       fmt.Sprintf("%s=yes", keyName),
+			expectErr: true,
+		},
+	}
+}
+
+func generateMapstructureTestCasesStringSlice(keyName string, fieldName string) []mapstructureTestCase {
+	return []mapstructureTestCase{
+		{
+			val:        fmt.Sprintf("%s=", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{}))},
+		},
+		{
+			val:        fmt.Sprintf("%s=[]", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{}))},
+		},
+		{
+			val:        fmt.Sprintf("%s=100", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{"100"}))},
+		},
+		{
+			val:        fmt.Sprintf("%s=t1", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{"t1"}))},
+		},
+		{
+			val:        fmt.Sprintf(`%s=["t1"]`, keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{"t1"}))},
+		},
+		{
+			val:        fmt.Sprintf("%s=[t1]", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{"t1"}))},
+		},
+		{
+			val:        fmt.Sprintf("%s=t1, t2", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{"t1", "t2"}))},
+		},
+		{
+			val:        fmt.Sprintf(`%s=["t1", "t2"]`, keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{"t1", "t2"}))},
+		},
+		{
+			val:        fmt.Sprintf(`%s=[t1, t2]`, keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer([]string{"t1", "t2"}))},
+		},
+	}
+}
+
+func generateMapstructureTestCasesString(keyName string, fieldName string) []mapstructureTestCase {
+	return []mapstructureTestCase{
+		{
+			val:        fmt.Sprintf("%s=", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer(""))},
+		},
+		{
+			val:        fmt.Sprintf("%s=t1", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer("t1"))},
+		},
+	}
+}
+
+func generateMapstructureTestCasesInt(keyName string, fieldName string) []mapstructureTestCase {
+	return []mapstructureTestCase{
+		{
+			val:        fmt.Sprintf("%s=", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer(0))},
+		},
+		{
+			val:        fmt.Sprintf("%s=100", keyName),
+			assertions: []types.GomegaMatcher{HaveField(fieldName, utils.Pointer(100))},
+		},
+		{
+			val:       fmt.Sprintf("%s=notanumber", keyName),
+			expectErr: true,
+		},
+	}
+}
+
+func Test_updateConfigMapstructure(t *testing.T) {
+	for _, tcs := range [][]mapstructureTestCase{
+		generateMapstructureTestCasesBool("dns.enabled", "DNS.Enabled"),
+		generateMapstructureTestCasesBool("gateway.enabled", "Gateway.Enabled"),
+		generateMapstructureTestCasesBool("ingress.enable-proxy-protocol", "Ingress.EnableProxyProtocol"),
+		generateMapstructureTestCasesBool("ingress.enabled", "Ingress.Enabled"),
+		generateMapstructureTestCasesBool("load-balancer.bgp-mode", "LoadBalancer.BGPMode"),
+		generateMapstructureTestCasesBool("load-balancer.l2-mode", "LoadBalancer.L2Mode"),
+		generateMapstructureTestCasesBool("load-balancer.enabled", "LoadBalancer.Enabled"),
+		generateMapstructureTestCasesBool("load-balancer.enabled", "LoadBalancer.Enabled"),
+		generateMapstructureTestCasesBool("local-storage.default", "LocalStorage.Default"),
+		generateMapstructureTestCasesBool("local-storage.enabled", "LocalStorage.Enabled"),
+		generateMapstructureTestCasesBool("metrics-server.enabled", "MetricsServer.Enabled"),
+		generateMapstructureTestCasesBool("network.enabled", "Network.Enabled"),
+
+		generateMapstructureTestCasesString("cloud-provider", "CloudProvider"),
+		generateMapstructureTestCasesString("dns.cluster-domain", "DNS.ClusterDomain"),
+		generateMapstructureTestCasesString("dns.service-ip", "DNS.ServiceIP"),
+		generateMapstructureTestCasesString("ingress.default-tls-secret", "Ingress.DefaultTLSSecret"),
+		generateMapstructureTestCasesString("load-balancer.bgp-peer-address", "LoadBalancer.BGPPeerAddress"),
+		generateMapstructureTestCasesString("local-storage.local-path", "LocalStorage.LocalPath"),
+		generateMapstructureTestCasesString("local-storage.reclaim-policy", "LocalStorage.ReclaimPolicy"),
+
+		generateMapstructureTestCasesStringSlice("dns.upstream-nameservers", "DNS.UpstreamNameservers"),
+		generateMapstructureTestCasesStringSlice("load-balancer.cidrs", "LoadBalancer.CIDRs"),
+		generateMapstructureTestCasesStringSlice("load-balancer.l2-interfaces", "LoadBalancer.L2Interfaces"),
+
+		generateMapstructureTestCasesInt("load-balancer.bgp-local-asn", "LoadBalancer.BGPLocalASN"),
+		generateMapstructureTestCasesInt("load-balancer.bgp-peer-asn", "LoadBalancer.BGPPeerASN"),
+		generateMapstructureTestCasesInt("load-balancer.bgp-peer-port", "LoadBalancer.BGPPeerPort"),
+	} {
+		for _, tc := range tcs {
+			t.Run(tc.val, func(t *testing.T) {
+				g := NewWithT(t)
+
+				var cfg apiv1.UserFacingClusterConfig
+				err := updateConfigMapstructure(&cfg, tc.val)
+				if tc.expectErr {
+					g.Expect(err).To(HaveOccurred())
+				} else {
+					g.Expect(err).To(BeNil())
+					g.Expect(cfg).To(SatisfyAll(tc.assertions...))
+				}
+			})
+		}
+	}
+}

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20240403135607-df45915ce961
 	github.com/canonical/microcluster v0.0.0-20240418162032-e0f837527e02
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/sys/mountinfo v0.7.1
 	github.com/onsi/gomega v1.30.0
 	github.com/pelletier/go-toml v1.9.5

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -443,6 +443,8 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/src/k8s/pkg/utils/mapstructure.go
+++ b/src/k8s/pkg/utils/mapstructure.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"reflect"
+	"strings"
+	"unicode"
+
+	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v2"
+)
+
+// YAMLToStringSliceHookFunc returns a mapstructure.DecodeHookFunc that converts string to []string by parsing YAML.
+func YAMLToStringSliceHookFunc(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
+	if f != reflect.String || t != reflect.Slice {
+		return data, nil
+	}
+
+	if data.(string) == "" {
+		return data, nil
+	}
+
+	var result []string
+	if err := yaml.Unmarshal([]byte(data.(string)), &result); err != nil {
+		return data, nil
+	}
+
+	return result, nil
+}
+
+// StringToFieldsSliceHookFunc is like mapstructure.StringToSliceHookFunc() but uses strings.Fields() and filters whitespace.
+func StringToFieldsSliceHookFunc(r rune) mapstructure.DecodeHookFunc {
+	return func(f reflect.Kind, t reflect.Kind, data interface{}) (interface{}, error) {
+		if f != reflect.String || t != reflect.Slice {
+			return data, nil
+		}
+
+		raw := data.(string)
+		if raw == "" {
+			return []string{}, nil
+		}
+
+		return strings.FieldsFunc(raw, func(this rune) bool { return this == r || unicode.IsSpace(this) }), nil
+	}
+}


### PR DESCRIPTION
### Summary

Use `mapstructure` to parse `k8s set` command arguments

### Changes

- Allows parsing string slice inputs as `val1,val2` or YAML (or JSON) formatted strings
- Add unit tests for `k8s set` arguments

### Notes

- If `mapstructure.NewDecoder` fails we panic, as all errors are programming bugs (see implementation of `NewDecoder`)
- We check for the list of known keys such that we present a meaningful user error, rather than a mapstructure error that the field is unknown.