### PR TITLE
Create new response API codes for specific Leave/Join failures

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -5,10 +5,8 @@ import (
 	"net/http"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
-	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
-	nodeutil "github.com/canonical/k8s/pkg/utils/node"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/state"
 )
@@ -24,42 +22,26 @@ func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Re
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", req.Name, err))
 	}
 
+	context := r.Context()
+	if _, err := e.provider.MicroCluster().Status(context); err == nil {
+		return NodeInUse(fmt.Errorf("node %q is part of the cluster", hostname))
+	}
+
 	config := map[string]string{}
 	internalToken := types.InternalWorkerNodeToken{}
 	// Check if token is worker token
-
-	workerToken := internalToken.Decode(req.Token) == nil
-
-	if workerToken {
-		isWorker, err := databaseutil.IsWorkerNode(r.Context(), s, hostname)
-		if err != nil {
-			return response.InternalError(fmt.Errorf("failed to check if node is worker: %w", err))
-		}
-		if isWorker {
-			return NodeInUse(fmt.Errorf("node %q is part of the cluster", hostname))
-		}
-	} else {
-		isControlPlane, err := nodeutil.IsControlPlaneNode(r.Context(), s, hostname)
-		if err != nil {
-			return response.InternalError(fmt.Errorf("failed to check if node is control-plane: %w", err))
-		}
-		if isControlPlane {
-			return NodeInUse(fmt.Errorf("node %q is part of the cluster", hostname))
-		}
-	}
-
-	if workerToken {
+	if internalToken.Decode(req.Token) == nil {
 		// valid worker node token - let's join the cluster
 		// The validation of the token is done when fetching the cluster information.
 		config["workerToken"] = req.Token
 		config["workerJoinConfig"] = req.Config
-		if err := e.provider.MicroCluster().NewCluster(r.Context(), hostname, req.Address, config); err != nil {
+		if err := e.provider.MicroCluster().NewCluster(context, hostname, req.Address, config); err != nil {
 			return response.InternalError(fmt.Errorf("failed to join k8sd cluster as worker: %w", err))
 		}
 	} else {
 		// Is not a worker token. let microcluster check if it is a valid control-plane token.
 		config["controlPlaneJoinConfig"] = req.Config
-		if err := e.provider.MicroCluster().JoinCluster(r.Context(), hostname, req.Address, req.Token, config); err != nil {
+		if err := e.provider.MicroCluster().JoinCluster(context, hostname, req.Address, req.Token, config); err != nil {
 			return response.InternalError(fmt.Errorf("failed to join k8sd cluster as control plane: %w", err))
 		}
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -22,8 +22,7 @@ func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Re
 		return response.BadRequest(fmt.Errorf("invalid hostname %q: %w", req.Name, err))
 	}
 
-	context := r.Context()
-	if _, err := e.provider.MicroCluster().Status(context); err == nil {
+	if _, err := e.provider.MicroCluster().Status(r.Context()); err == nil {
 		return NodeInUse(fmt.Errorf("node %q is part of the cluster", hostname))
 	}
 
@@ -35,13 +34,13 @@ func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Re
 		// The validation of the token is done when fetching the cluster information.
 		config["workerToken"] = req.Token
 		config["workerJoinConfig"] = req.Config
-		if err := e.provider.MicroCluster().NewCluster(context, hostname, req.Address, config); err != nil {
+		if err := e.provider.MicroCluster().NewCluster(r.Context(), hostname, req.Address, config); err != nil {
 			return response.InternalError(fmt.Errorf("failed to join k8sd cluster as worker: %w", err))
 		}
 	} else {
 		// Is not a worker token. let microcluster check if it is a valid control-plane token.
 		config["controlPlaneJoinConfig"] = req.Config
-		if err := e.provider.MicroCluster().JoinCluster(context, hostname, req.Address, req.Token, config); err != nil {
+		if err := e.provider.MicroCluster().JoinCluster(r.Context(), hostname, req.Address, req.Token, config); err != nil {
 			return response.InternalError(fmt.Errorf("failed to join k8sd cluster as control plane: %w", err))
 		}
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -36,7 +36,7 @@ func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Re
 			return response.InternalError(fmt.Errorf("failed to check if node is worker: %w", err))
 		}
 		if isWorker {
-			return InvalidNode(fmt.Errorf("node %q is part of the cluster", hostname))
+			return NodeInUse(fmt.Errorf("node %q is part of the cluster", hostname))
 		}
 	} else {
 		isControlPlane, err := nodeutil.IsControlPlaneNode(r.Context(), s, hostname)
@@ -44,7 +44,7 @@ func (e *Endpoints) postClusterJoin(s *state.State, r *http.Request) response.Re
 			return response.InternalError(fmt.Errorf("failed to check if node is control-plane: %w", err))
 		}
 		if isControlPlane {
-			return InvalidNode(fmt.Errorf("node %q is part of the cluster", hostname))
+			return NodeInUse(fmt.Errorf("node %q is part of the cluster", hostname))
 		}
 	}
 

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -38,7 +38,7 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 
 	isWorker, err := databaseutil.IsWorkerNode(r.Context(), s, req.Name)
 	if err != nil {
-		return response.InternalError(fmt.Errorf("failed to check if node is control-plane: %w", err))
+		return response.InternalError(fmt.Errorf("failed to check if node is worker: %w", err))
 	}
 	if isWorker {
 		// For worker nodes, we need to manually clean up the kubernetes node and db entry.
@@ -57,7 +57,7 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 	}
 
 	if !isWorker && !isControlPlane {
-		return response.InternalError(fmt.Errorf("node %q is not part of the cluster", req.Name))
+		return InvalidNode(fmt.Errorf("node %q is not part of the cluster", req.Name))
 	}
 	return response.SyncResponse(true, nil)
 }

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -57,7 +57,7 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 	}
 
 	if !isWorker && !isControlPlane {
-		return NodeUnavalable(fmt.Errorf("node %q is not part of the cluster", req.Name))
+		return NodeUnavailable(fmt.Errorf("node %q is not part of the cluster", req.Name))
 	}
 	return response.SyncResponse(true, nil)
 }

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -57,7 +57,7 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 	}
 
 	if !isWorker && !isControlPlane {
-		return InvalidNode(fmt.Errorf("node %q is not part of the cluster", req.Name))
+		return NodeUnavalable(fmt.Errorf("node %q is not part of the cluster", req.Name))
 	}
 	return response.SyncResponse(true, nil)
 }

--- a/src/k8s/pkg/k8sd/api/response.go
+++ b/src/k8s/pkg/k8sd/api/response.go
@@ -1,0 +1,9 @@
+package api
+
+import (
+	"github.com/canonical/lxd/lxd/response"
+)
+
+func InvalidNode(err error) response.Response {
+	return response.ErrorResponse(517, err.Error())
+}

--- a/src/k8s/pkg/k8sd/api/response.go
+++ b/src/k8s/pkg/k8sd/api/response.go
@@ -5,11 +5,13 @@ import (
 )
 
 const (
-	StatusNodeUnavailable = 520 // Node cannot be removed because it isn't in the cluster
-	StatusNodeInUse       = 521 // Node cannot be joined because it is in the cluster.
+	// StatusNodeUnavailable is the Http status code that the API returns if the node isn't in the cluster
+	StatusNodeUnavailable = 520
+	// StatusNodeInUse is the Http status code that the API returns if the node is already in the cluster
+	StatusNodeInUse = 521
 )
 
-func NodeUnavalable(err error) response.Response {
+func NodeUnavailable(err error) response.Response {
 	return response.ErrorResponse(StatusNodeUnavailable, err.Error())
 }
 

--- a/src/k8s/pkg/k8sd/api/response.go
+++ b/src/k8s/pkg/k8sd/api/response.go
@@ -4,6 +4,15 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 )
 
-func InvalidNode(err error) response.Response {
-	return response.ErrorResponse(517, err.Error())
+const (
+	StatusNodeUnavailable = 520 // Node cannot be removed because it isn't in the cluster
+	StatusNodeInUse       = 521 // Node cannot be joined because it is in the cluster.
+)
+
+func NodeUnavalable(err error) response.Response {
+	return response.ErrorResponse(StatusNodeUnavailable, err.Error())
+}
+
+func NodeInUse(err error) response.Response {
+	return response.ErrorResponse(StatusNodeInUse, err.Error())
 }


### PR DESCRIPTION
`InternalError` doesn't quite describe situations where a client needs to know if a node is already OUT of the cluster, or already IN the cluster. 

This creates unique 521 and 522 HTTP status codes for those events