### PR TITLE
Reuse k8s instance across feature tests

### DIFF
--- a/tests/integration/templates/bootstrap-all.yaml
+++ b/tests/integration/templates/bootstrap-all.yaml
@@ -1,0 +1,15 @@
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  ingress:
+    enabled: true
+  load-balancer:
+    enabled: true
+  local-storage:
+    enabled: true
+  gateway:
+    enabled: true
+  metrics-server:
+    enabled: true

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -86,7 +86,7 @@ def instances(
     snap_path = (tmp_path / "k8s.snap").as_posix()
 
     LOG.info(f"Creating {node_count} instances")
-    instances: List[util.Instance] = []
+    instances: List[harness.Instance] = []
 
     for _ in range(node_count):
         # Create <node_count> instances and setup the k8s snap in each.
@@ -100,7 +100,38 @@ def instances(
 
     yield instances
 
-    _harness_clean(h)
+    if not config.SKIP_CLEANUP:
+        for instance in instances:
+            h.delete_instance(instance.id)
+
+
+@pytest.fixture(scope="session")
+def instance(
+    h: harness.Harness, tmp_path_factory: pytest.TempPathFactory
+) -> Generator[harness.Instance, None, None]:
+    """Constructs and bootstraps an instance that persists over a test session.
+
+    Bootstraps the instance with all k8sd features enabled to reduce testing time.
+    """
+    LOG.info("Setup node and enable all features")
+
+    snap_path = str(tmp_path_factory.mktemp("data") / "k8s.snap")
+    instance = h.new_instance()
+    util.setup_k8s_snap(instance, snap_path)
+
+    bootstrap_config_path = (
+        tmp_path_factory.mktemp("data") / "bootstrap-all-features.yaml"
+    ).as_posix()
+    instance.send_file(
+        (config.MANIFESTS_DIR / "bootstrap-all.yaml").as_posix(), bootstrap_config_path
+    )
+
+    instance.exec(["k8s", "bootstrap", "--file", bootstrap_config_path])
+    util.wait_until_k8s_ready(instance, [instance])
+    util.wait_for_network(instance)
+    util.wait_for_dns(instance)
+
+    yield instance
 
 
 @pytest.fixture(scope="function")
@@ -122,5 +153,3 @@ def etcd_cluster(
     cluster = EtcdCluster(h, initial_node_count=etcd_count)
 
     yield cluster
-
-    _harness_clean(h)

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -102,7 +102,7 @@ def instances(
 
     if not config.SKIP_CLEANUP:
         # Cleanup after each test.
-        # We cannot execute _harness_clean() here as this would also 
+        # We cannot execute _harness_clean() here as this would also
         # remove the session_instance. The harness ensures that everything is cleaned up
         # at the end of the test session.
         for instance in instances:

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -101,12 +101,16 @@ def instances(
     yield instances
 
     if not config.SKIP_CLEANUP:
+        # Cleanup after each test.
+        # We cannot execute _harness_clean() here as this would also 
+        # remove the session_instance. The harness ensures that everything is cleaned up
+        # at the end of the test session.
         for instance in instances:
             h.delete_instance(instance.id)
 
 
 @pytest.fixture(scope="session")
-def instance(
+def session_instance(
     h: harness.Harness, tmp_path_factory: pytest.TempPathFactory
 ) -> Generator[harness.Instance, None, None]:
     """Constructs and bootstraps an instance that persists over a test session.
@@ -119,9 +123,7 @@ def instance(
     instance = h.new_instance()
     util.setup_k8s_snap(instance, snap_path)
 
-    bootstrap_config_path = (
-        tmp_path_factory.mktemp("data") / "bootstrap-all-features.yaml"
-    ).as_posix()
+    bootstrap_config_path = "/home/ubuntu/bootstrap-all-features.yaml"
     instance.send_file(
         (config.MANIFESTS_DIR / "bootstrap-all.yaml").as_posix(), bootstrap_config_path
     )

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -100,13 +100,16 @@ def instances(
 
     yield instances
 
-    if not config.SKIP_CLEANUP:
-        # Cleanup after each test.
-        # We cannot execute _harness_clean() here as this would also
-        # remove the session_instance. The harness ensures that everything is cleaned up
-        # at the end of the test session.
-        for instance in instances:
-            h.delete_instance(instance.id)
+    if config.SKIP_CLEANUP:
+        LOG.warning("Skipping clean-up of instances, delete them on your own")
+        return
+
+    # Cleanup after each test.
+    # We cannot execute _harness_clean() here as this would also
+    # remove the session_instance. The harness ensures that everything is cleaned up
+    # at the end of the test session.
+    for instance in instances:
+        h.delete_instance(instance.id)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -8,8 +8,8 @@ from test_util import harness, util
 LOG = logging.getLogger(__name__)
 
 
-def test_dns(instance: harness.Instance):
-    instance.exec(
+def test_dns(session_instance: harness.Instance):
+    session_instance.exec(
         [
             "k8s",
             "kubectl",
@@ -23,7 +23,7 @@ def test_dns(instance: harness.Instance):
         ],
     )
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -37,14 +37,14 @@ def test_dns(instance: harness.Instance):
         ]
     )
 
-    result = instance.exec(
+    result = session_instance.exec(
         ["k8s", "kubectl", "exec", "busybox", "--", "nslookup", "kubernetes.default"],
         capture_output=True,
     )
 
     assert "10.152.183.1 kubernetes.default.svc.cluster.local" in result.stdout.decode()
 
-    result = instance.exec(
+    result = session_instance.exec(
         ["k8s", "kubectl", "exec", "busybox", "--", "nslookup", "canonical.com"],
         capture_output=True,
         check=False,

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -2,18 +2,13 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from typing import List
 
 from test_util import harness, util
 
 LOG = logging.getLogger(__name__)
 
 
-def test_dns(instances: List[harness.Instance]):
-    instance = instances[0]
-    util.wait_for_dns(instance)
-    util.wait_for_network(instance)
-
+def test_dns(instance: harness.Instance):
     instance.exec(
         [
             "k8s",

--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -3,7 +3,6 @@
 #
 import logging
 from pathlib import Path
-from typing import List
 
 from test_util import harness, util
 from test_util.config import MANIFESTS_DIR
@@ -11,11 +10,7 @@ from test_util.config import MANIFESTS_DIR
 LOG = logging.getLogger(__name__)
 
 
-def test_gateway(instances: List[harness.Instance]):
-    instance = instances[0]
-    util.wait_for_network(instance)
-    util.wait_for_dns(instance)
-
+def test_gateway(instance: harness.Instance):
     manifest = MANIFESTS_DIR / "gateway-test.yaml"
     instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -11,12 +11,7 @@ from test_util.config import MANIFESTS_DIR
 LOG = logging.getLogger(__name__)
 
 
-def test_ingress(instances: List[harness.Instance]):
-    instance = instances[0]
-    util.wait_for_network(instance)
-    util.wait_for_dns(instance)
-
-    instance.exec(["k8s", "enable", "ingress"])
+def test_ingress(instance: List[harness.Instance]):
 
     util.stubbornly(retries=5, delay_s=2).on(instance).until(
         lambda p: "cilium-ingress" in p.stdout.decode()

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -11,13 +11,13 @@ from test_util.config import MANIFESTS_DIR
 LOG = logging.getLogger(__name__)
 
 
-def test_ingress(instance: List[harness.Instance]):
+def test_ingress(session_instance: List[harness.Instance]):
 
-    util.stubbornly(retries=5, delay_s=2).on(instance).until(
+    util.stubbornly(retries=5, delay_s=2).on(session_instance).until(
         lambda p: "cilium-ingress" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "service", "-n", "kube-system", "-o", "json"])
 
-    p = instance.exec(
+    p = session_instance.exec(
         [
             "k8s",
             "kubectl",
@@ -33,18 +33,18 @@ def test_ingress(instance: List[harness.Instance]):
     ingress_http_port = p.stdout.decode().replace("'", "")
 
     manifest = MANIFESTS_DIR / "ingress-test.yaml"
-    instance.exec(
+    session_instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
         input=Path(manifest).read_bytes(),
     )
 
     LOG.info("Waiting for nginx pod to show up...")
-    util.stubbornly(retries=5, delay_s=10).on(instance).until(
+    util.stubbornly(retries=5, delay_s=10).on(session_instance).until(
         lambda p: "my-nginx" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
     LOG.info("Nginx pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -58,6 +58,6 @@ def test_ingress(instance: List[harness.Instance]):
         ]
     )
 
-    util.stubbornly(retries=5, delay_s=5).on(instance).until(
+    util.stubbornly(retries=5, delay_s=5).on(session_instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"localhost:{ingress_http_port}", "-H", "Host: foo.bar.com"])

--- a/tests/integration/tests/test_metrics_server.py
+++ b/tests/integration/tests/test_metrics_server.py
@@ -8,14 +8,14 @@ from test_util import harness, util
 LOG = logging.getLogger(__name__)
 
 
-def test_metrics_server(instance: harness.Instance):
+def test_metrics_server(session_instance: harness.Instance):
     LOG.info("Waiting for metrics-server pod to show up...")
-    util.stubbornly(retries=15, delay_s=5).on(instance).until(
+    util.stubbornly(retries=15, delay_s=5).on(session_instance).until(
         lambda p: "metrics-server" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"])
     LOG.info("Metrics-server pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -31,6 +31,6 @@ def test_metrics_server(instance: harness.Instance):
         ]
     )
 
-    util.stubbornly(retries=15, delay_s=5).on(instance).until(
-        lambda p: instance.id in p.stdout.decode()
+    util.stubbornly(retries=15, delay_s=5).on(session_instance).until(
+        lambda p: session_instance.id in p.stdout.decode()
     ).exec(["k8s", "kubectl", "top", "node"])

--- a/tests/integration/tests/test_metrics_server.py
+++ b/tests/integration/tests/test_metrics_server.py
@@ -2,22 +2,13 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from typing import List
 
-import pytest
-from test_util import config, harness, util
+from test_util import harness, util
 
 LOG = logging.getLogger(__name__)
 
 
-def test_metrics_server(instances: List[harness.Instance]):
-    if not config.SNAP:
-        pytest.fail("Set TEST_SNAP to the path where the snap is")
-
-    instance = instances[0]
-    util.wait_for_dns(instance)
-    util.wait_for_network(instance)
-
+def test_metrics_server(instance: harness.Instance):
     LOG.info("Waiting for metrics-server pod to show up...")
     util.stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "metrics-server" in p.stdout.decode()

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -4,7 +4,6 @@
 import json
 import logging
 from pathlib import Path
-from typing import List
 
 from test_util import harness, util
 from test_util.config import MANIFESTS_DIR
@@ -12,11 +11,7 @@ from test_util.config import MANIFESTS_DIR
 LOG = logging.getLogger(__name__)
 
 
-def test_network(instances: List[harness.Instance]):
-    instance = instances[0]
-    util.wait_for_dns(instance)
-    util.wait_for_network(instance)
-
+def test_network(instance: harness.Instance):
     p = instance.exec(
         [
             "k8s",

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -11,8 +11,8 @@ from test_util.config import MANIFESTS_DIR
 LOG = logging.getLogger(__name__)
 
 
-def test_network(instance: harness.Instance):
-    p = instance.exec(
+def test_network(session_instance: harness.Instance):
+    p = session_instance.exec(
         [
             "k8s",
             "kubectl",
@@ -33,7 +33,7 @@ def test_network(instance: harness.Instance):
 
     cilium_pod = out["items"][0]
 
-    p = instance.exec(
+    p = session_instance.exec(
         [
             "k8s",
             "kubectl",
@@ -55,12 +55,12 @@ def test_network(instance: harness.Instance):
     assert p.stdout.decode().strip() == "OK"
 
     manifest = MANIFESTS_DIR / "nginx-pod.yaml"
-    p = instance.exec(
+    p = session_instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
         input=Path(manifest).read_bytes(),
     )
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -74,7 +74,7 @@ def test_network(instance: harness.Instance):
         ]
     )
 
-    p = instance.exec(
+    p = session_instance.exec(
         [
             "k8s",
             "kubectl",

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -2,18 +2,13 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from typing import List
 
-from test_util import harness, util
+from test_util import harness
 
 LOG = logging.getLogger(__name__)
 
 
-def test_smoke(instances: List[harness.Instance]):
-    instance = instances[0]
-
-    util.wait_until_k8s_ready(instance, instances)
-
+def test_smoke(instance: harness.Instance):
     # Verify the functionality of the k8s config command during the smoke test.
     # It would be excessive to deploy a cluster solely for this purpose.
     result = instance.exec(

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -8,10 +8,10 @@ from test_util import harness
 LOG = logging.getLogger(__name__)
 
 
-def test_smoke(instance: harness.Instance):
+def test_smoke(session_instance: harness.Instance):
     # Verify the functionality of the k8s config command during the smoke test.
     # It would be excessive to deploy a cluster solely for this purpose.
-    result = instance.exec(
+    result = session_instance.exec(
         "k8s config --server 192.168.210.41".split(), capture_output=True
     )
     config = result.stdout.decode()

--- a/tests/integration/tests/test_storage.py
+++ b/tests/integration/tests/test_storage.py
@@ -5,10 +5,8 @@ import json
 import logging
 import subprocess
 from pathlib import Path
-from typing import List
 
-import pytest
-from test_util import config, harness, util
+from test_util import harness, util
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
@@ -22,13 +20,7 @@ def check_pvc_bound(p: subprocess.CompletedProcess) -> bool:
     return False
 
 
-def test_storage(instances: List[harness.Instance]):
-    if not config.SNAP:
-        pytest.fail("Set TEST_SNAP to the path where the snap is")
-
-    instance = instances[0]
-    instance.exec(["k8s", "enable", "local-storage"])
-
+def test_storage(instance: harness.Instance):
     LOG.info("Waiting for storage provisioner pod to show up...")
     util.stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "ck-storage" in p.stdout.decode()

--- a/tests/integration/tests/test_storage.py
+++ b/tests/integration/tests/test_storage.py
@@ -20,14 +20,14 @@ def check_pvc_bound(p: subprocess.CompletedProcess) -> bool:
     return False
 
 
-def test_storage(instance: harness.Instance):
+def test_storage(session_instance: harness.Instance):
     LOG.info("Waiting for storage provisioner pod to show up...")
-    util.stubbornly(retries=15, delay_s=5).on(instance).until(
+    util.stubbornly(retries=15, delay_s=5).on(session_instance).until(
         lambda p: "ck-storage" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"])
     LOG.info("Storage provisioner pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -44,18 +44,18 @@ def test_storage(instance: harness.Instance):
     )
 
     manifest = MANIFESTS_DIR / "storage-setup.yaml"
-    instance.exec(
+    session_instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
         input=Path(manifest).read_bytes(),
     )
 
     LOG.info("Waiting for storage writer pod to show up...")
-    util.stubbornly(retries=3, delay_s=10).on(instance).until(
+    util.stubbornly(retries=3, delay_s=10).on(session_instance).until(
         lambda p: "storage-writer-pod" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
     LOG.info("Storage writer pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -70,16 +70,16 @@ def test_storage(instance: harness.Instance):
     )
 
     LOG.info("Waiting for storage to get provisioned...")
-    util.stubbornly(retries=3, delay_s=1).on(instance).until(check_pvc_bound).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).until(check_pvc_bound).exec(
         ["k8s", "kubectl", "get", "pvc", "-o", "json"]
     )
     LOG.info("Storage got provisioned and pvc is bound.")
 
-    util.stubbornly(retries=5, delay_s=10).on(instance).until(
+    util.stubbornly(retries=5, delay_s=10).on(session_instance).until(
         lambda p: "LOREM IPSUM" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "logs", "storage-writer-pod"])
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -92,18 +92,18 @@ def test_storage(instance: harness.Instance):
     )
 
     manifest = MANIFESTS_DIR / "storage-test.yaml"
-    instance.exec(
+    session_instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
         input=Path(manifest).read_bytes(),
     )
 
     LOG.info("Waiting for storage reader pod to show up...")
-    util.stubbornly(retries=3, delay_s=10).on(instance).until(
+    util.stubbornly(retries=3, delay_s=10).on(session_instance).until(
         lambda p: "storage-reader-pod" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
     LOG.info("Storage reader pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -117,7 +117,7 @@ def test_storage(instance: harness.Instance):
         ]
     )
 
-    util.stubbornly(retries=5, delay_s=10).on(instance).until(
+    util.stubbornly(retries=5, delay_s=10).on(session_instance).until(
         lambda p: "LOREM IPSUM" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "logs", "storage-reader-pod"])
 

--- a/tests/integration/tests/test_storage.py
+++ b/tests/integration/tests/test_storage.py
@@ -70,9 +70,9 @@ def test_storage(session_instance: harness.Instance):
     )
 
     LOG.info("Waiting for storage to get provisioned...")
-    util.stubbornly(retries=3, delay_s=1).on(session_instance).until(check_pvc_bound).exec(
-        ["k8s", "kubectl", "get", "pvc", "-o", "json"]
-    )
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).until(
+        check_pvc_bound
+    ).exec(["k8s", "kubectl", "get", "pvc", "-o", "json"])
     LOG.info("Storage got provisioned and pvc is bound.")
 
     util.stubbornly(retries=5, delay_s=10).on(session_instance).until(


### PR DESCRIPTION
Sets up an instance that enables all features and persists over the test session. All features (dns, gateway, ...) run against this instance to reduce setup/teardown time.

This reduces the integration test time by around ~18 min (58min -> 30min)