### PR TITLE
Fix issue with finding release branch matches

### DIFF
--- a/.github/workflows/strict.yaml
+++ b/.github/workflows/strict.yaml
@@ -21,7 +21,7 @@ jobs:
           BRANCH=${BRANCH#refs/heads/}  # strip off refs/heads/ if it exists
           if [[ "${BRANCH}" == "main" ]]; then
             echo "strict=autoupdate/strict" >> "$GITHUB_OUTPUT"
-          elif [[ "${BRANCH}" =~ "^release-[0-9]+\.[0-9]+$" ]]; then
+          elif [[ "${BRANCH}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
             echo "strict=${BRANCH}" >> "$GITHUB_OUTPUT"
           else
             echo "Failed to determine matching strict branch for ${BRANCH}"


### PR DESCRIPTION
Don't match exactly with branch, but use bash regex matching

# needs backport to `release-1.30`