### PR TITLE
Wait until kubernetes endpoint becomes available

### DIFF
--- a/src/k8s/pkg/client/kubernetes/status.go
+++ b/src/k8s/pkg/client/kubernetes/status.go
@@ -15,8 +15,8 @@ func (c *Client) WaitKubernetesEndpointAvailable(ctx context.Context) error {
 		// TODO: use the /readyz endpoint instead
 		// We want to retry if an error occurs (=API server not ready)
 		// returning the error would abort, thus checking for nil
-		endpoints, err := c.CoreV1().Endpoints("default").List(ctx, metav1.ListOptions{})
-		return err == nil && len(endpoints.Items) > 0, nil
+		endpoint, err := c.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+		return err == nil && endpoint != nil, nil
 	})
 }
 

--- a/src/k8s/pkg/client/kubernetes/status.go
+++ b/src/k8s/pkg/client/kubernetes/status.go
@@ -9,14 +9,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// WaitApiServerReady waits until the kube-apiserver becomes available.
-func (c *Client) WaitApiServerReady(ctx context.Context) error {
+// WaitKubernetesEndpointAvailable waits until the kubernetes endpoint becomes available.
+func (c *Client) WaitKubernetesEndpointAvailable(ctx context.Context) error {
 	return control.WaitUntilReady(ctx, func() (bool, error) {
 		// TODO: use the /readyz endpoint instead
 		// We want to retry if an error occurs (=API server not ready)
 		// returning the error would abort, thus checking for nil
-		_, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-		return err == nil, nil
+		endpoints, err := c.CoreV1().Endpoints("default").List(ctx, metav1.ListOptions{})
+		return err == nil && len(endpoints.Items) > 0, nil
 	})
 }
 

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -48,7 +48,7 @@ func (e *Endpoints) postWorkerInfo(s *state.State, r *http.Request) response.Res
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to create kubernetes client: %w", err))
 	}
-	if err := client.WaitApiServerReady(s.Context); err != nil {
+	if err := client.WaitKubernetesEndpointAvailable(s.Context); err != nil {
 		return response.InternalError(fmt.Errorf("kube-apiserver did not become ready in time: %w", err))
 	}
 	servers, err := client.GetKubeAPIServerEndpoints(s.Context)

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -49,7 +49,7 @@ func (e *Endpoints) postWorkerInfo(s *state.State, r *http.Request) response.Res
 		return response.InternalError(fmt.Errorf("failed to create kubernetes client: %w", err))
 	}
 	if err := client.WaitKubernetesEndpointAvailable(s.Context); err != nil {
-		return response.InternalError(fmt.Errorf("kube-apiserver did not become ready in time: %w", err))
+		return response.InternalError(fmt.Errorf("kubernetes endpoints not ready yet: %w", err))
 	}
 	servers, err := client.GetKubeAPIServerEndpoints(s.Context)
 	if err != nil {

--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -87,7 +87,7 @@ func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
-	if err := client.WaitApiServerReady(ctx); err != nil {
+	if err := client.WaitKubernetesEndpointAvailable(ctx); err != nil {
 		return fmt.Errorf("kube-apiserver did not become ready in time: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -88,7 +88,7 @@ func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 	}
 
 	if err := client.WaitKubernetesEndpointAvailable(ctx); err != nil {
-		return fmt.Errorf("kube-apiserver did not become ready in time: %w", err)
+		return fmt.Errorf("kubernetes endpoints not ready yet: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
The former implementation just waited for the nodes to become available. This led to some race-conditions where the api-server was not yet ready but the client already queried it.

See e.g. https://github.com/canonical/k8s-snap/actions/runs/8924131359/job/24511724390#step:7:374