### PR TITLE
Fix github actions to update strict branches

### DIFF
--- a/.github/workflows/strict-integration.yaml
+++ b/.github/workflows/strict-integration.yaml
@@ -41,8 +41,7 @@ jobs:
           path: k8s-strict.snap
 
   test-integration:
-    needs: [ prepare, build ]
-    if: ${{ needs.prepare.outputs.strict }}
+    needs: [ build ]
     name: Test ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/strict-integration.yaml
+++ b/.github/workflows/strict-integration.yaml
@@ -11,31 +11,9 @@ on:
       - 'release-[0-9]+.[0-9]+'
 
 jobs:
-  prepare:
-    name: Prepare
-    runs-on: ubuntu-latest
-    outputs:
-      strict: ${{ steps.determine.outputs.strict }}
-    steps:
-      - name: Determine Strict branch
-        id: determine
-        env:
-          BRANCH: ${{ github.base_ref || github.ref }}
-        run: |
-          BRANCH=${BRANCH#refs/heads/}  # strip off refs/heads/ if it exists
-          if [[ "${BRANCH}" == "main" ]]; then
-            echo "strict=autoupdate/strict" >> "$GITHUB_OUTPUT"
-          elif [[ "${BRANCH}" =~ "^release-[0-9]+\.[0-9]+$" ]]; then
-            echo "strict=${BRANCH}" >> "$GITHUB_OUTPUT"
-          else
-            echo "Failed to determine matching strict branch for ${BRANCH}"
-            echo "strict=" >> $GITHUB_OUTPUT
-          fi
   build:
     name: Build
     runs-on: ubuntu-20.04
-    needs: [ prepare ]
-    if: ${{ needs.prepare.outputs.strict }}
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
@@ -49,7 +27,6 @@ jobs:
           sudo snap install snapcraft --classic
       - name: Apply strict patch
         run: |
-          git checkout -b ${{ needs.prepare.outputs.strict }}
           git config --global user.email k8s-bot@canonical.com
           git config --global user.name k8s-bot
           git am ./build-scripts/patches/strict/*.patch

--- a/.github/workflows/strict.yaml
+++ b/.github/workflows/strict.yaml
@@ -22,7 +22,7 @@ jobs:
           if [[ "${BRANCH}" == "main" ]]; then
             echo "strict=autoupdate/strict" >> "$GITHUB_OUTPUT"
           elif [[ "${BRANCH}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
-            echo "strict=${BRANCH}" >> "$GITHUB_OUTPUT"
+            echo "strict=${BRANCH}-strict" >> "$GITHUB_OUTPUT"
           else
             echo "Failed to determine matching strict branch for ${BRANCH}"
             echo "strict=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary

- Remove branch checkout during integration tests (we just apply the patch, we don't need to update any branches.
- Strict release branches are `release-1.xx-strict`, see failure in https://github.com/canonical/k8s-snap/actions/runs/8951306335/job/24587484219