### PR TITLE
Adjustments so launchpad builders pick up arm64 requirement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,8 +15,8 @@ environment:
   SNAPCRAFT_ARCH_TRIPLET: $SNAPCRAFT_ARCH_TRIPLET
 
 architectures:
-  - amd64
-  - arm64
+  - build-on: [amd64]
+  - build-on: [arm64]
 
 parts:
   build-deps:


### PR DESCRIPTION
According to [snapcraft io docs](https://snapcraft.io/docs/architectures#core20-4) the `architectures` tag for `core20` snaps, this replacement is identical.  Launchpad builds however seem to be having difficulty seeing that this snap should be built for multiple architectures without this change