### PR TITLE
Only run code actions on code changes

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,8 +7,12 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'release-[0-9]+.[0-9]+-strict'
+    paths:
+      - '**/*.go'
 
   pull_request:
+    paths:
+      - '**/*.go'
 
 jobs:
   test:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,10 +7,20 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'release-[0-9]+.[0-9]+-strict'
+    paths:
+      - 'build-scripts/**'
+      - 'k8s/**'
+      - 'src/**'
+      - 'snap/**'
   pull_request:
     branches:
       - main
       - 'release-[0-9].[0-9]+'
+    paths:
+      - 'build-scripts/**''
+      - 'k8s/**'
+      - 'src/**'
+      - 'snap/**'
 
 jobs:
   build:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -7,10 +7,14 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'release-[0-9]+.[0-9]+-strict'
+    paths:
+      - '**/*.py'
   pull_request:
     branches:
       - main
       - 'release-[0-9]+.[0-9]+'
+    paths:
+      - '**/*.py'
 
 jobs:
   lint:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -7,10 +7,20 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'release-[0-9]+.[0-9]+-strict'
+    paths:
+      - 'build-scripts/**'
+      - 'k8s/**'
+      - 'src/**'
+      - 'snap/**'
   pull_request:
     branches:
       - main
       - 'release-[0-9]+.[0-9]+'
+    paths:
+      - 'build-scripts/**'
+      - 'k8s/**'
+      - 'src/**'
+      - 'snap/**'
 
 jobs:
   build:

--- a/.github/workflows/strict-integration.yaml
+++ b/.github/workflows/strict-integration.yaml
@@ -5,10 +5,20 @@ on:
     branches:
       - main
       - 'release-[0-9]+.[0-9]+'
+    paths:
+      - 'build-scripts/**'
+      - 'k8s/**'
+      - 'src/**'
+      - 'snap/**'
   pull_request:
     branches:
       - main
       - 'release-[0-9]+.[0-9]+'
+    paths:
+      - 'build-scripts/**'
+      - 'k8s/**'
+      - 'src/**'
+      - 'snap/**'
 
 jobs:
   build:

--- a/.github/workflows/strict.yaml
+++ b/.github/workflows/strict.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - 'release-[0-9]+.[0-9]+'
+    paths:
+      - 'build-scripts/**'
+      - 'k8s/**'
+      - 'src/**'
+      - 'snap/**'
 
 jobs:
   prepare:


### PR DESCRIPTION
This gets the ball rolling... can probably be improved. Any ideas?

Rationale is that right now integration tests, unit tests, builds occur on documentation updates. Also, go code coverage bot comments on PR's that don't contain go code.