### PR TITLE
use `autoupdate/release-1.xx-strict` branches for strict

### DIFF
--- a/.github/ISSUE_TEMPLATE/create_release_branch.md
+++ b/.github/ISSUE_TEMPLATE/create_release_branch.md
@@ -42,11 +42,6 @@ The steps are to be followed in-order, each task must be completed by the person
 
       Thank you, $name
 
-- [ ] **Owner**: Create `release-1.xx-strict` branch from latest `autoupdate/strict`
-  - `git switch autoupdate/strict`
-  - `git pull`
-  - `git checkout -b release-1.xx-strict`
-  - `git push origin release-1.xx-strict`
 - [ ] **Owner**: Create `release-1.xx` branch from latest `main`
   - `git switch main`
   - `git pull`
@@ -98,7 +93,6 @@ The steps are to be followed in-order, each task must be completed by the person
   - `popd`
   - `rm -rf ~/tmp/release-1.xx`
 - [ ] **Reviewer**: Ensure `release-1.xx` branch is based on latest changes on `main` at the time of the release cut.
-- [ ] **Reviewer**: Ensure `release-1.xx-strict` branch is based on latest changes on `autoupdate/strict` at the time of the release cut.
 - [ ] **Owner**: Create PR to initialize `release-1.xx` branch:
   - [ ] Update `KUBE_TRACK` to `1.xx` in [/build-scripts/components/kubernetes/version.sh][]
   - [ ] Update `master` to `release-1.xx` in [/build-scripts/components/k8s-dqlite/version.sh][]
@@ -106,7 +100,7 @@ The steps are to be followed in-order, each task must be completed by the person
   - [ ] `git commit -m 'Release 1.xx'`
   - [ ] Create PR with the changes and request review from **Reviewer**. Make sure to update the issue `Information` section with a link to the PR.
 - [ ] **Reviewer**: Review and merge PR to initialize branch.
-- [ ] **Reviewer**: On merge, confirm [Auto-update strict branch] action runs to completion
+- [ ] **Reviewer**: On merge, confirm [Auto-update strict branch] action runs to completion and that the `autoupdate/release-1.xx-strict` branch is created.
 - [ ] **Owner**: Create launchpad builders for `release-1.xx`
   - [ ] Go to [lp:k8s][] and do **Import now** to pick up all latest changes.
   - [ ] Under **Branches**, select `release-1.xx`, then **Create snap package**
@@ -122,7 +116,7 @@ The steps are to be followed in-order, each task must be completed by the person
   - [ ] Click **Create snap package** at the bottom of the page.
 - [ ] **Owner**: Create launchpad builders for `release-1.xx-strict`
   - [ ] Return to [lp:k8s][].
-  - [ ] Under **Branches**, select `release-1.xx-strict`, then **Create snap package**
+  - [ ] Under **Branches**, select `autoupdate/release-1.xx-strict`, then **Create snap package**
   - [ ] Set **Snap recipe name** to `k8s-snap-1.xx-strict`
   - [ ] Set **Owner** to `Canonical Kubernetes (containers)`
   - [ ] Set **The project that this Snap is associated with** to `k8s`

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,8 +6,7 @@ on:
       - main
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+-strict'
-
+      - 'autoupdate/release-[0-9]+.[0-9]+-strict'
   pull_request:
 
 jobs:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -6,11 +6,8 @@ on:
       - main
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+-strict'
+      - 'autoupdate/release-[0-9]+.[0-9]+-strict'
   pull_request:
-    branches:
-      - main
-      - 'release-[0-9].[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -6,11 +6,8 @@ on:
       - main
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+-strict'
+      - 'autoupdate/release-[0-9]+.[0-9]+-strict'
   pull_request:
-    branches:
-      - main
-      - 'release-[0-9]+.[0-9]+'
 
 jobs:
   lint:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -6,11 +6,8 @@ on:
       - main
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
-      - 'release-[0-9]+.[0-9]+-strict'
+      - 'autoupdate/release-[0-9]+.[0-9]+-strict'
   pull_request:
-    branches:
-      - main
-      - 'release-[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/strict-integration.yaml
+++ b/.github/workflows/strict-integration.yaml
@@ -6,9 +6,6 @@ on:
       - main
       - 'release-[0-9]+.[0-9]+'
   pull_request:
-    branches:
-      - main
-      - 'release-[0-9]+.[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/strict.yaml
+++ b/.github/workflows/strict.yaml
@@ -22,7 +22,7 @@ jobs:
           if [[ "${BRANCH}" == "main" ]]; then
             echo "strict=autoupdate/strict" >> "$GITHUB_OUTPUT"
           elif [[ "${BRANCH}" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
-            echo "strict=${BRANCH}-strict" >> "$GITHUB_OUTPUT"
+            echo "strict=autoupdate/${BRANCH}-strict" >> "$GITHUB_OUTPUT"
           else
             echo "Failed to determine matching strict branch for ${BRANCH}"
             echo "strict=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary

Use `autoupdate/release-1.xx-strict` for strict release branches, to avoid having the auto promotion jobs failing due to branch protection rules

This also makes the strict branches fall in line with `autoupdate/strict`, to make it clear that these branches are not to be interacted with.