### PR TITLE
Update RTD build conditions

### DIFF
--- a/docs/tools/.readthedocs.yaml
+++ b/docs/tools/.readthedocs.yaml
@@ -14,6 +14,7 @@ build:
     post_checkout:
       # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
       #
+      # https://docs.readthedocs.io/en/latest/build-customization.html#cancel-build-based-on-a-condition
       # If there are no changes (git diff exits with 0) we force the command to return with 183.
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       - |

--- a/docs/tools/.readthedocs.yaml
+++ b/docs/tools/.readthedocs.yaml
@@ -9,10 +9,21 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     pre_build:
-      - cp -r docs/src/* docs/tools/
+      - cp -r docs/src/* docs/tools/    
+    post_checkout:
+      # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
+      #
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/ .readthedocs.yaml;
+        then
+          exit 183;
+        fi
+  
       
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/tools/.readthedocs.yaml
+++ b/docs/tools/.readthedocs.yaml
@@ -22,7 +22,7 @@ build:
           exit 183;
         fi
     pre_build:
-      - cp -r docs/src/* docs/tools/    
+      - cp -r docs/src/* docs/tools/
       
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/tools/.readthedocs.yaml
+++ b/docs/tools/.readthedocs.yaml
@@ -11,8 +11,6 @@ build:
   tools:
     python: "3.12"
   jobs:
-    pre_build:
-      - cp -r docs/src/* docs/tools/    
     post_checkout:
       # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
       #
@@ -23,7 +21,8 @@ build:
         then
           exit 183;
         fi
-  
+    pre_build:
+      - cp -r docs/src/* docs/tools/    
       
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Updating the RTD build script to auto-cancel creating docs for PRs with no doc changes

N.B., the webhook will still run, it will just finish quickly without building any docs and saving some server power.