### PR TITLE
[1.30] read configs from stdin on '-' (#407)

### DIFF
--- a/docs/src/_parts/commands/k8s_bootstrap.md
+++ b/docs/src/_parts/commands/k8s_bootstrap.md
@@ -14,7 +14,7 @@ k8s bootstrap [flags]
 
 ```
       --address string         microcluster address, defaults to the node IP address
-      --file string            path to the YAML file containing your custom cluster bootstrap configuration.
+      --file string            path to the YAML file containing your custom cluster bootstrap configuration. Use '-' to read from stdin.
   -h, --help                   help for bootstrap
       --interactive            interactively configure the most important cluster options
       --name string            node name, defaults to hostname

--- a/docs/src/_parts/commands/k8s_join-cluster.md
+++ b/docs/src/_parts/commands/k8s_join-cluster.md
@@ -10,7 +10,7 @@ k8s join-cluster <join-token> [flags]
 
 ```
       --address string         microcluster address, defaults to the node IP address
-      --file string            path to the YAML file containing your custom cluster join configuration
+      --file string            path to the YAML file containing your custom cluster join configuration. Use '-' to read from stdin.
   -h, --help                   help for join-cluster
       --name string            node name, defaults to hostname
       --output-format string   set the output format to one of plain, json or yaml (default "plain")

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -88,7 +88,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			case opts.interactive:
 				bootstrapConfig = getConfigInteractively(env.Stdin, env.Stdout, env.Stderr)
 			case opts.configFile != "":
-				bootstrapConfig, err = getConfigFromYaml(opts.configFile)
+				bootstrapConfig, err = getConfigFromYaml(env, opts.configFile)
 				if err != nil {
 					cmd.PrintErrf("Error: Failed to read bootstrap configuration from %q.\n\nThe error was: %v\n", opts.configFile, err)
 					env.Exit(1)
@@ -134,7 +134,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.interactive, "interactive", false, "interactively configure the most important cluster options")
-	cmd.Flags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster bootstrap configuration.")
+	cmd.Flags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster bootstrap configuration. Use '-' to read from stdin.")
 	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")
 	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address, defaults to the node IP address")
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
@@ -142,10 +142,20 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	return cmd
 }
 
-func getConfigFromYaml(filePath string) (apiv1.BootstrapConfig, error) {
-	b, err := os.ReadFile(filePath)
-	if err != nil {
-		return apiv1.BootstrapConfig{}, fmt.Errorf("failed to read file: %w", err)
+func getConfigFromYaml(env cmdutil.ExecutionEnvironment, filePath string) (apiv1.BootstrapConfig, error) {
+	var b []byte
+	var err error
+
+	if filePath == "-" {
+		b, err = io.ReadAll(env.Stdin)
+		if err != nil {
+			return apiv1.BootstrapConfig{}, fmt.Errorf("failed to read config from stdin: %w", err)
+		}
+	} else {
+		b, err = os.ReadFile(filePath)
+		if err != nil {
+			return apiv1.BootstrapConfig{}, fmt.Errorf("failed to read file: %w", err)
+		}
 	}
 
 	var config apiv1.BootstrapConfig

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
@@ -66,11 +67,23 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 			var joinClusterConfig string
 			if opts.configFile != "" {
-				b, err := os.ReadFile(opts.configFile)
-				if err != nil {
-					cmd.PrintErrf("Error: Failed to read join configuration from %q.\n\nThe error was: %v\n", opts.configFile, err)
-					env.Exit(1)
-					return
+				var b []byte
+				var err error
+
+				if opts.configFile == "-" {
+					b, err = io.ReadAll(os.Stdin)
+					if err != nil {
+						cmd.PrintErrf("Error: Failed to read join configuration from stdin. \n\nThe error was: %v\n", err)
+						env.Exit(1)
+						return
+					}
+				} else {
+					b, err = os.ReadFile(opts.configFile)
+					if err != nil {
+						cmd.PrintErrf("Error: Failed to read join configuration from %q.\n\nThe error was: %v\n", opts.configFile, err)
+						env.Exit(1)
+						return
+					}
 				}
 				joinClusterConfig = string(b)
 			}
@@ -87,7 +100,7 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")
 	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address, defaults to the node IP address")
-	cmd.Flags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster join configuration")
+	cmd.Flags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster join configuration. Use '-' to read from stdin.")
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 	return cmd
 }

--- a/tests/integration/templates/bootstrap-all.yaml
+++ b/tests/integration/templates/bootstrap-all.yaml
@@ -1,0 +1,15 @@
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  ingress:
+    enabled: true
+  load-balancer:
+    enabled: true
+  local-storage:
+    enabled: true
+  gateway:
+    enabled: true
+  metrics-server:
+    enabled: true

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -2,19 +2,14 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from typing import List
 
 from test_util import harness, util
 
 LOG = logging.getLogger(__name__)
 
 
-def test_dns(instances: List[harness.Instance]):
-    instance = instances[0]
-    util.wait_for_dns(instance)
-    util.wait_for_network(instance)
-
-    instance.exec(
+def test_dns(session_instance: harness.Instance):
+    session_instance.exec(
         [
             "k8s",
             "kubectl",
@@ -28,7 +23,7 @@ def test_dns(instances: List[harness.Instance]):
         ],
     )
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -42,14 +37,14 @@ def test_dns(instances: List[harness.Instance]):
         ]
     )
 
-    result = instance.exec(
+    result = session_instance.exec(
         ["k8s", "kubectl", "exec", "busybox", "--", "nslookup", "kubernetes.default"],
         capture_output=True,
     )
 
     assert "10.152.183.1 kubernetes.default.svc.cluster.local" in result.stdout.decode()
 
-    result = instance.exec(
+    result = session_instance.exec(
         ["k8s", "kubectl", "exec", "busybox", "--", "nslookup", "canonical.com"],
         capture_output=True,
         check=False,

--- a/tests/integration/tests/test_metrics_server.py
+++ b/tests/integration/tests/test_metrics_server.py
@@ -2,29 +2,20 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from typing import List
 
-import pytest
-from test_util import config, harness, util
+from test_util import harness, util
 
 LOG = logging.getLogger(__name__)
 
 
-def test_metrics_server(instances: List[harness.Instance]):
-    if not config.SNAP:
-        pytest.fail("Set TEST_SNAP to the path where the snap is")
-
-    instance = instances[0]
-    util.wait_for_dns(instance)
-    util.wait_for_network(instance)
-
+def test_metrics_server(session_instance: harness.Instance):
     LOG.info("Waiting for metrics-server pod to show up...")
-    util.stubbornly(retries=15, delay_s=5).on(instance).until(
+    util.stubbornly(retries=15, delay_s=5).on(session_instance).until(
         lambda p: "metrics-server" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"])
     LOG.info("Metrics-server pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -40,6 +31,6 @@ def test_metrics_server(instances: List[harness.Instance]):
         ]
     )
 
-    util.stubbornly(retries=15, delay_s=5).on(instance).until(
-        lambda p: instance.id in p.stdout.decode()
+    util.stubbornly(retries=15, delay_s=5).on(session_instance).until(
+        lambda p: session_instance.id in p.stdout.decode()
     ).exec(["k8s", "kubectl", "top", "node"])

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -4,7 +4,6 @@
 import json
 import logging
 from pathlib import Path
-from typing import List
 
 from test_util import harness, util
 from test_util.config import MANIFESTS_DIR
@@ -12,12 +11,8 @@ from test_util.config import MANIFESTS_DIR
 LOG = logging.getLogger(__name__)
 
 
-def test_network(instances: List[harness.Instance]):
-    instance = instances[0]
-    util.wait_for_dns(instance)
-    util.wait_for_network(instance)
-
-    p = instance.exec(
+def test_network(session_instance: harness.Instance):
+    p = session_instance.exec(
         [
             "k8s",
             "kubectl",
@@ -38,7 +33,7 @@ def test_network(instances: List[harness.Instance]):
 
     cilium_pod = out["items"][0]
 
-    p = instance.exec(
+    p = session_instance.exec(
         [
             "k8s",
             "kubectl",
@@ -60,12 +55,12 @@ def test_network(instances: List[harness.Instance]):
     assert p.stdout.decode().strip() == "OK"
 
     manifest = MANIFESTS_DIR / "nginx-pod.yaml"
-    p = instance.exec(
+    p = session_instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
         input=Path(manifest).read_bytes(),
     )
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=1).on(session_instance).exec(
         [
             "k8s",
             "kubectl",
@@ -79,7 +74,7 @@ def test_network(instances: List[harness.Instance]):
         ]
     )
 
-    p = instance.exec(
+    p = session_instance.exec(
         [
             "k8s",
             "kubectl",

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -2,21 +2,16 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
-from typing import List
 
-from test_util import harness, util
+from test_util import harness
 
 LOG = logging.getLogger(__name__)
 
 
-def test_smoke(instances: List[harness.Instance]):
-    instance = instances[0]
-
-    util.wait_until_k8s_ready(instance, instances)
-
+def test_smoke(session_instance: harness.Instance):
     # Verify the functionality of the k8s config command during the smoke test.
     # It would be excessive to deploy a cluster solely for this purpose.
-    result = instance.exec(
+    result = session_instance.exec(
         "k8s config --server 192.168.210.41".split(), capture_output=True
     )
     config = result.stdout.decode()


### PR DESCRIPTION
Backport #407 and #396 to release-1.30 branch

* read configs from stdin on '-'
* Reuse k8s instance across feature tests (#392)