### PR TITLE
Do not fail-fast when updating components

### DIFF
--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -9,6 +9,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         branch:
           # Keep main branch up to date


### PR DESCRIPTION
### Summary

Possible failures should not affect other matrix items. Relates to https://github.com/canonical/k8s-snap/actions/runs/9113429433/job/25054910350 (which rightly fails because `release-1.30` does not yet have #419 merged)