### PR TITLE
Fix GitHub actions update components CI for release branches

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,7 +7,7 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
-      - 'autoupdate/sync/+'
+      - 'autoupdate/sync/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,7 +7,7 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
-      - 'autoupdate/sync/+'
+      - 'autoupdate/sync/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -7,7 +7,7 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
-      - 'autoupdate/sync/+'
+      - 'autoupdate/sync/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -7,7 +7,7 @@ on:
       - autoupdate/strict
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
-      - 'autoupdate/sync/+'
+      - 'autoupdate/sync/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/strict-integration.yaml
+++ b/.github/workflows/strict-integration.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - 'release-[0-9]+.[0-9]+'
-      - 'autoupdate/sync/+'
+      - 'autoupdate/sync/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
+          git-token: ${{ secrets.DEPLOY_KEY_TO_UPDATE_STRICT_BRANCH }}
           commit-message: "[${{ matrix.branch }}] Update component versions"
           title: "[${{ matrix.branch }}] Update component versions"
           body: "[${{ matrix.branch }}] Update component versions"


### PR DESCRIPTION
### Summary

Resolves the following issue https://github.com/canonical/k8s-snap/actions/runs/9125937201/job/25093148460#step:6:105

With this change, CI runs properly on PRs: https://github.com/canonical/k8s-snap/pull/432