### PR TITLE
Explicitly set timeout in each CLI command

### DIFF
--- a/docs/src/_parts/commands/k8s_bootstrap.md
+++ b/docs/src/_parts/commands/k8s_bootstrap.md
@@ -19,6 +19,7 @@ k8s bootstrap [flags]
       --interactive            interactively configure the most important cluster options
       --name string            node name, defaults to hostname
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_disable.md
+++ b/docs/src/_parts/commands/k8s_disable.md
@@ -15,6 +15,7 @@ k8s disable <feature> ... [flags]
 ```
   -h, --help                   help for disable
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_enable.md
+++ b/docs/src/_parts/commands/k8s_enable.md
@@ -15,6 +15,7 @@ k8s enable <feature> ... [flags]
 ```
   -h, --help                   help for enable
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_get-join-token.md
+++ b/docs/src/_parts/commands/k8s_get-join-token.md
@@ -9,8 +9,9 @@ k8s get-join-token <node-name> [flags]
 ### Options
 
 ```
-  -h, --help     help for get-join-token
-      --worker   generate a join token for a worker node
+  -h, --help               help for get-join-token
+      --timeout duration   the max time to wait for the command to execute (default 1m30s)
+      --worker             generate a join token for a worker node
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_get.md
+++ b/docs/src/_parts/commands/k8s_get.md
@@ -15,6 +15,7 @@ k8s get <feature.key> [flags]
 ```
   -h, --help                   help for get
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_join-cluster.md
+++ b/docs/src/_parts/commands/k8s_join-cluster.md
@@ -14,6 +14,7 @@ k8s join-cluster <join-token> [flags]
   -h, --help                   help for join-cluster
       --name string            node name, defaults to hostname
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_remove-node.md
+++ b/docs/src/_parts/commands/k8s_remove-node.md
@@ -12,6 +12,7 @@ k8s remove-node <node-name> [flags]
       --force                  forcibly remove the cluster member
   -h, --help                   help for remove-node
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_set.md
+++ b/docs/src/_parts/commands/k8s_set.md
@@ -16,6 +16,7 @@ k8s set <feature.key=value> ... [flags]
 ```
   -h, --help                   help for set
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_status.md
+++ b/docs/src/_parts/commands/k8s_status.md
@@ -11,6 +11,7 @@ k8s status [flags]
 ```
   -h, --help                   help for status
       --output-format string   set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration       the max time to wait for the command to execute (default 1m30s)
       --wait-ready             wait until at least one cluster node is ready
 ```
 

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -1,6 +1,9 @@
 package k8s
 
 import (
+	"context"
+	"time"
+
 	apiv1 "github.com/canonical/k8s/api/v1"
 	cmdutil "github.com/canonical/k8s/cmd/util"
 	"github.com/spf13/cobra"
@@ -8,7 +11,8 @@ import (
 
 func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
-		server string
+		server  string
+		timeout time.Duration
 	}
 	cmd := &cobra.Command{
 		Use:    "config",
@@ -16,6 +20,11 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short:  "Generate an admin kubeconfig that can be used to access the Kubernetes cluster",
 		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
+			if opts.timeout < minTimeout {
+				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", opts.timeout, minTimeout, minTimeout)
+				opts.timeout = minTimeout
+			}
+
 			client, err := env.Client(cmd.Context())
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
@@ -29,7 +38,10 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			config, err := client.KubeConfig(cmd.Context(), apiv1.GetKubeConfigRequest{Server: opts.server})
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+
+			config, err := client.KubeConfig(ctx, apiv1.GetKubeConfigRequest{Server: opts.server})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to generate an admin kubeconfig for %q.\n\nThe error was: %v\n", opts.server, err)
 				env.Exit(1)
@@ -40,5 +52,6 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&opts.server, "server", "", "custom cluster server address")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -1,9 +1,12 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
-	"github.com/canonical/k8s/pkg/utils"
 	"strings"
+	"time"
+
+	"github.com/canonical/k8s/pkg/utils"
 
 	api "github.com/canonical/k8s/api/v1"
 	cmdutil "github.com/canonical/k8s/cmd/util"
@@ -21,6 +24,7 @@ func (e EnableResult) String() string {
 func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
 		outputFormat string
+		timeout      time.Duration
 	}
 	cmd := &cobra.Command{
 		Use:    "enable <feature> ...",
@@ -30,6 +34,11 @@ func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			config := api.UserFacingClusterConfig{}
+
+			if opts.timeout < minTimeout {
+				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", opts.timeout, minTimeout, minTimeout)
+				opts.timeout = minTimeout
+			}
 
 			for _, feature := range args {
 				switch feature {
@@ -79,7 +88,9 @@ func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 
 			cmd.PrintErrf("Enabling %s on the cluster. This may take a few seconds, please wait.\n", strings.Join(args, ", "))
-			if err := client.UpdateClusterConfig(cmd.Context(), request); err != nil {
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+			if err := client.UpdateClusterConfig(ctx, request); err != nil {
 				cmd.PrintErrf("Error: Failed to enable %s on the cluster.\n\nThe error was: %v\n", strings.Join(args, ", "), err)
 				env.Exit(1)
 				return
@@ -90,6 +101,7 @@ func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -1,6 +1,9 @@
 package k8s
 
 import (
+	"context"
+	"time"
+
 	apiv1 "github.com/canonical/k8s/api/v1"
 	cmdutil "github.com/canonical/k8s/cmd/util"
 	"github.com/spf13/cobra"
@@ -8,7 +11,8 @@ import (
 
 func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
-		worker bool
+		worker  bool
+		timeout time.Duration
 	}
 	cmd := &cobra.Command{
 		Use:    "get-join-token <node-name>",
@@ -18,6 +22,11 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 
+			if opts.timeout < minTimeout {
+				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", opts.timeout, minTimeout, minTimeout)
+				opts.timeout = minTimeout
+			}
+
 			client, err := env.Client(cmd.Context())
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
@@ -25,7 +34,9 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			token, err := client.GetJoinToken(cmd.Context(), apiv1.GetJoinTokenRequest{Name: name, Worker: opts.worker})
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+			token, err := client.GetJoinToken(ctx, apiv1.GetJoinTokenRequest{Name: name, Worker: opts.worker})
 			if err != nil {
 				cmd.PrintErrf("Error: Could not generate a join token for %q.\n\nThe error was: %v\n", name, err)
 				env.Exit(1)
@@ -37,5 +48,6 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.worker, "worker", false, "generate a join token for a worker node")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -1,7 +1,9 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	cmdutil "github.com/canonical/k8s/cmd/util"
@@ -20,6 +22,7 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
 		force        bool
 		outputFormat string
+		timeout      time.Duration
 	}
 	cmd := &cobra.Command{
 		Use:    "remove-node <node-name>",
@@ -27,6 +30,11 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Args:   cmdutil.ExactArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if opts.timeout < minTimeout {
+				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", opts.timeout, minTimeout, minTimeout)
+				opts.timeout = minTimeout
+			}
+
 			client, err := env.Client(cmd.Context())
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
@@ -36,8 +44,11 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 			name := args[0]
 
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+
 			cmd.PrintErrf("Removing %q from the Kubernetes cluster. This may take a few seconds, please wait.\n", name)
-			if err := client.RemoveNode(cmd.Context(), apiv1.RemoveNodeRequest{Name: name, Force: opts.force}); err != nil {
+			if err := client.RemoveNode(ctx, apiv1.RemoveNodeRequest{Name: name, Force: opts.force}); err != nil {
 				cmd.PrintErrf("Error: Failed to remove node %q from the cluster.\n\nThe error was: %v\n", name, err)
 				env.Exit(1)
 				return
@@ -49,5 +60,7 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.force, "force", false, "forcibly remove the cluster member")
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
+
 	return cmd
 }

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -1,6 +1,9 @@
 package k8s
 
 import (
+	"context"
+	"time"
+
 	apiv1 "github.com/canonical/k8s/api/v1"
 	cmdutil "github.com/canonical/k8s/cmd/util"
 	"github.com/spf13/cobra"
@@ -10,12 +13,18 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	var opts struct {
 		waitReady    bool
 		outputFormat string
+		timeout      time.Duration
 	}
 	cmd := &cobra.Command{
 		Use:    "status",
 		Short:  "Retrieve the current status of the cluster",
 		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
+			if opts.timeout < minTimeout {
+				cmd.PrintErrf("Timeout %v is less than minimum of %v. Using the minimum %v instead.\n", opts.timeout, minTimeout, minTimeout)
+				opts.timeout = minTimeout
+			}
+
 			client, err := env.Client(cmd.Context())
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
@@ -23,13 +32,16 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			if !client.IsBootstrapped(cmd.Context()) {
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+
+			if !client.IsBootstrapped(ctx) {
 				cmd.PrintErrln("Error: The node is not part of a Kubernetes cluster. You can bootstrap a new cluster with:\n\n  sudo k8s bootstrap")
 				env.Exit(1)
 				return
 			}
 
-			status, err := client.ClusterStatus(cmd.Context(), opts.waitReady)
+			status, err := client.ClusterStatus(ctx, opts.waitReady)
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to retrieve the cluster status.\n\nThe error was: %v\n", err)
 				env.Exit(1)
@@ -45,5 +57,6 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.waitReady, "wait-ready", false, "wait until at least one cluster node is ready")
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 	return cmd
 }


### PR DESCRIPTION
Right now, the context deadline is initially set at root level when the command is created.This causes problems for interactive commands as the deadline may b
e exceeded while the user inputs the data.
To prevent this, we remove the global timeout and specifically set 
it in each command right before the RPC calls.