### PR TITLE
Enable dualstack and add test files

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -71,6 +71,12 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network) error 
 				"useDigest":  false,
 			},
 		},
+		"ipv4": map[string]any{
+			"enabled": ipv4CIDR != "",
+		},
+		"ipv6": map[string]any{
+			"enabled": ipv6CIDR != "",
+		},
 		"ipam": map[string]any{
 			"operator": map[string]any{
 				"clusterPoolIPv4PodCIDRList": ipv4CIDR,

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
@@ -132,6 +132,19 @@ func TestKubeAPIServer(t *testing.T) {
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
 
+	t.Run("ArgsDualstack", func(t *testing.T) {
+		g := NewWithT(t)
+
+		s := mustSetupSnapAndDirectories(t, setKubeAPIServerMock)
+
+		// Setup without proxy to simplify argument list
+		g.Expect(setup.KubeAPIServer(s, "10.0.0.0/24,fd01::/64", "https://auth-webhook.url", false, types.Datastore{Type: utils.Pointer("external"), ExternalServers: utils.Pointer([]string{"datastoreurl1", "datastoreurl2"})}, "Node,RBAC")).To(BeNil())
+
+		g.Expect(snaputil.GetServiceArgument(s, "kube-apiserver", "--service-cluster-ip-range")).To(Equal("10.0.0.0/24,fd01::/64"))
+		_, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
 	t.Run("ArgsExternalDatastore", func(t *testing.T) {
 		g := NewWithT(t)
 

--- a/tests/integration/templates/nginx-dualstack.yaml
+++ b/tests/integration/templates/nginx-dualstack.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginxdualstack
+spec:
+  selector:
+    matchLabels:
+      run: nginxdualstack
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: nginxdualstack
+    spec:
+      containers:
+      - name: nginxdualstack
+        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx6
+  labels:
+    run: nginxdualstack
+spec:
+  type: NodePort
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: RequireDualStack
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: nginxdualstack


### PR DESCRIPTION
# Summary
This PR contains the relevant changes to make dualstack (IPv4/IPv6) work on the k8s-snap. 

# Changes 
The current implementation for Kubernetes works out of the box as the only requirements from there is to set the proper `PodCIDR` and `ServiceCIDR` as `IPv4CIDR,IPv6CIDR`. A tiny unittest verifies that the kube-apiserver CIDR is properly set with both CIDRs.

For Cilium, IPv6 is disabled by default. Hence, we need to explicitly enable it if the IPv6 CIDR is set. 

Lastly, the `nginx-dualstack.yaml` was added to manually verify dualstack and will later be used in the integration tests.