### PR TITLE
Add CIDR for microcluster Network Interface Configuration

### DIFF
--- a/docs/src/_parts/commands/k8s_bootstrap.md
+++ b/docs/src/_parts/commands/k8s_bootstrap.md
@@ -13,7 +13,7 @@ k8s bootstrap [flags]
 ### Options
 
 ```
-      --address string         microcluster address, defaults to the node IP address
+      --address string         microcluster address or CIDR, defaults to the node IP address
       --file string            path to the YAML file containing your custom cluster bootstrap configuration. Use '-' to read from stdin.
   -h, --help                   help for bootstrap
       --interactive            interactively configure the most important cluster options

--- a/docs/src/_parts/commands/k8s_join-cluster.md
+++ b/docs/src/_parts/commands/k8s_join-cluster.md
@@ -9,7 +9,7 @@ k8s join-cluster <join-token> [flags]
 ### Options
 
 ```
-      --address string         microcluster address, defaults to the node IP address
+      --address string         microcluster address or CIDR, defaults to the node IP address
       --file string            path to the YAML file containing your custom cluster join configuration. Use '-' to read from stdin.
   -h, --help                   help for join-cluster
       --name string            node name, defaults to hostname

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"slices"
 	"strings"
@@ -76,7 +77,19 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			if opts.address == "" {
 				opts.address = util.NetworkInterfaceAddress()
 			}
-			opts.address = util.CanonicalNetworkAddress(opts.address, config.DefaultPort)
+
+			ip := opts.address
+			if _, ipNet, err := net.ParseCIDR(opts.address); err == nil {
+				matchingIP, err := utils.FindMatchingNodeAddress(ipNet)
+				if err != nil {
+					cmd.PrintErrf("Error: Failed to find a matching node address for %q.\n\nThe error was: %v\n", ip, err)
+					env.Exit(1)
+					return
+				}
+				ip = matchingIP.String()
+			}
+
+			opts.address = util.CanonicalNetworkAddress(ip, config.DefaultPort)
 
 			client, err := env.Client(cmd.Context())
 			if err != nil {
@@ -147,7 +160,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.interactive, "interactive", false, "interactively configure the most important cluster options")
 	cmd.Flags().StringVar(&opts.configFile, "file", "", "path to the YAML file containing your custom cluster bootstrap configuration. Use '-' to read from stdin.")
 	cmd.Flags().StringVar(&opts.name, "name", "", "node name, defaults to hostname")
-	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address, defaults to the node IP address")
+	cmd.Flags().StringVar(&opts.address, "address", "", "microcluster address or CIDR, defaults to the node IP address")
 	cmd.Flags().StringVar(&opts.outputFormat, "output-format", "plain", "set the output format to one of plain, json or yaml")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -79,8 +79,6 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			opts.address = address
-
 			client, err := env.Client(cmd.Context())
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
@@ -129,7 +127,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 			request := apiv1.PostClusterBootstrapRequest{
 				Name:    opts.name,
-				Address: opts.address,
+				Address: address,
 				Config:  bootstrapConfig,
 			}
 

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -62,8 +62,6 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			opts.address = address
-
 			client, err := env.Client(cmd.Context())
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
@@ -104,7 +102,7 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			cobra.OnFinalize(cancel)
 
 			cmd.PrintErrln("Joining the cluster. This may take a few seconds, please wait.")
-			if err := client.JoinCluster(ctx, apiv1.JoinClusterRequest{Name: opts.name, Address: opts.address, Token: token, Config: joinClusterConfig}); err != nil {
+			if err := client.JoinCluster(ctx, apiv1.JoinClusterRequest{Name: opts.name, Address: address, Token: token, Config: joinClusterConfig}); err != nil {
 				cmd.PrintErrf("Error: Failed to join the cluster using the provided token.\n\nThe error was: %v\n", err)
 				env.Exit(1)
 				return

--- a/src/k8s/pkg/utils/cidr.go
+++ b/src/k8s/pkg/utils/cidr.go
@@ -18,7 +18,7 @@ func findMatchingNodeAddress(cidr *net.IPNet) (net.IP, error) {
 	}
 
 	var selectedIP net.IP
-	selectedSubnetBits := 32
+	selectedSubnetBits := -1
 
 	for _, addr := range addrs {
 		ipNet, ok := addr.(*net.IPNet)
@@ -26,7 +26,8 @@ func findMatchingNodeAddress(cidr *net.IPNet) (net.IP, error) {
 			continue
 		}
 		if cidr.Contains(ipNet.IP) {
-			if _, subnetBits := cidr.Mask.Size(); subnetBits < selectedSubnetBits {
+			_, subnetBits := cidr.Mask.Size()
+			if selectedSubnetBits == -1 || subnetBits < selectedSubnetBits {
 				// Prefer the address with the fewest subnet bits
 				selectedIP = ipNet.IP
 				selectedSubnetBits = subnetBits

--- a/src/k8s/pkg/utils/cidr.go
+++ b/src/k8s/pkg/utils/cidr.go
@@ -7,6 +7,26 @@ import (
 	"strings"
 )
 
+// FindMatchingNodeAddress returns the IP address of a network interface that belongs to the given CIDR.
+func FindMatchingNodeAddress(cidr *net.IPNet) (net.IP, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("could not get interface addresses: %w", err)
+	}
+
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if cidr.Contains(ipNet.IP) {
+			return ipNet.IP, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not find a matching address for CIDR %q", cidr.String())
+}
+
 // GetFirstIP returns the first IP address of a subnet. Use big.Int so that it can handle both IPv4 and IPv6 addreses.
 func GetFirstIP(subnet string) (net.IP, error) {
 	_, cidr, err := net.ParseCIDR(subnet)

--- a/src/k8s/pkg/utils/cidr.go
+++ b/src/k8s/pkg/utils/cidr.go
@@ -84,6 +84,10 @@ func ParseAddressString(address string, port int64) (string, error) {
 		}
 	}
 
+	if port < 0 || port > 65535 {
+		return "", fmt.Errorf("invalid port number %d", port)
+	}
+
 	if address == "" {
 		address = util.NetworkInterfaceAddress()
 	} else if _, ipNet, err := net.ParseCIDR(address); err == nil {


### PR DESCRIPTION
## Overview
Infer the address for the microcluster by specifying a CIDR in the address flag.
## Rationale
This allows us to have configuration in the ClusterAPI resources (where individual node IPs are not known yet) to choose the network interface that will be used by microcluster.

## Testing
**Bootstrapping**
```
root@kcp-1:/k8s# k8s bootstrap --address 10.20.30.0/24
Bootstrapping the cluster. This may take a few seconds, please wait.
Bootstrapped a new Kubernetes cluster with node address "10.20.30.241:6400".
The node will be 'Ready' to host workloads after the CNI is deployed successfully.

root@kcp-1:/k8s# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
55: eth0@if56: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:16:3e:5d:e3:df brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 10.45.248.89/24 metric 100 brd 10.45.248.255 scope global dynamic eth0
       valid_lft 3503sec preferred_lft 3503sec
    inet6 fe80::216:3eff:fe5d:e3df/64 scope link
       valid_lft forever preferred_lft forever
57: eth1@if58: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:16:3e:68:18:bb brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 10.20.30.241/24 brd 10.20.30.255 scope global dynamic eth1
       valid_lft 3522sec preferred_lft 3522sec
    inet6 fe80::216:3eff:fe68:18bb/64 scope link
       valid_lft forever preferred_lft forever
```
**Joining**
```
root@kcp-3:~# k8s join-cluster eyJuYW1lIjoia2NwLTMiLCJzZWNyZXQiOiI5NzE0MmIxZDU3MGFkZTlmYzU2ZGE4ZGU4M2Q5Y2NlZDI2ZWM3ZjdkMjg0MGE0ZTZmZmM5ZTcyNWI0YzQ0OGExIiwiZmluZ2VycHJpbnQiOiI0MWJjYTVhZGVhMTZlZDJkNjgzYTY2MmY2M2EyYTJiNTEzMjlmNDkwNzllMjJiZjY0M2ZlN2NmNTlhOWZkZmVlIiwiam9pbl9hZGRyZXNzZXMiOlsiMTAuMjAuMzAuMjQxOjY0MDAiLCIxMC4yMC4zMC4xMTI6NjQwMCJdfQ== --address 10.20.30.0/24
Joining the cluster. This may take a few seconds, please wait.
Cluster services have started on "kcp-3".
Please allow some time for initial Kubernetes node registration.
```
microcluster running on the specified CIDR:
```
Netid  State   Recv-Q  Send-Q          Local Address:Port      Peer Address:Port  Process
tcp    LISTEN  0       4096             10.20.30.126:6400           0.0.0.0:*      users:(("k8sd",pid=1705,fd=12))
```