### PR TITLE
Improve Network Integration Tests

### DIFF
--- a/build-scripts/patches/moonray/apply
+++ b/build-scripts/patches/moonray/apply
@@ -16,8 +16,6 @@ rm "${DIR}/../../../tests/integration/tests/test_gateway.py"
 rm "${DIR}/../../../tests/integration/tests/test_ingress.py"
 ## TODO: restore when cleanup is implemented
 rm "${DIR}/../../../tests/integration/tests/test_cleanup.py"
-## TODO: restore when network test is fixed
-rm "${DIR}/../../../tests/integration/tests/test_network.py"
 
 git commit -a -m "Remove unrelated tests"
 

--- a/src/k8s/pkg/k8sd/features/status.go
+++ b/src/k8s/pkg/k8sd/features/status.go
@@ -6,11 +6,15 @@ import (
 	"github.com/canonical/k8s/pkg/snap"
 )
 
+// StatusInterface defines the interface for checking the status of the built-in features.
 type StatusInterface interface {
+	// CheckDNS checks the status of the DNS feature.
 	CheckDNS(context.Context, snap.Snap) error
+	// CheckNetwork checks the status of the Network feature.
 	CheckNetwork(context.Context, snap.Snap) error
 }
 
+// statusChecks implements the StatusInterface.
 type statusChecks struct {
 	checkDNS     func(context.Context, snap.Snap) error
 	checkNetwork func(context.Context, snap.Snap) error

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -51,13 +51,6 @@ def test_network(session_instance: harness.Instance):
     assert len(out["items"]) > 0, "No NGINX pod found"
     podIP = out["items"][0]["status"]["podIP"]
 
-    p = session_instance.exec(
-        [
-            "curl",
-            "-s",
-            f"http://{podIP}",
-        ],
-        capture_output=True,
-    )
-
-    assert "Welcome to nginx!" in p.stdout.decode()
+    util.stubbornly(retries=5, delay_s=5).on(session_instance).until(
+        lambda p: "Welcome to nginx!" in p.stdout.decode()
+    ).exec(["curl", "-s", f"http://{podIP}"])

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -12,48 +12,6 @@ LOG = logging.getLogger(__name__)
 
 
 def test_network(session_instance: harness.Instance):
-    p = session_instance.exec(
-        [
-            "k8s",
-            "kubectl",
-            "get",
-            "pod",
-            "-n",
-            "kube-system",
-            "-l",
-            "k8s-app=cilium",
-            "-o",
-            "json",
-        ],
-        capture_output=True,
-    )
-
-    out = json.loads(p.stdout.decode())
-    assert len(out["items"]) > 0
-
-    cilium_pod = out["items"][0]
-
-    p = session_instance.exec(
-        [
-            "k8s",
-            "kubectl",
-            "exec",
-            "-it",
-            cilium_pod["metadata"]["name"],
-            "-n",
-            "kube-system",
-            "-c",
-            "cilium-agent",
-            "--",
-            "cilium",
-            "status",
-            "--brief",
-        ],
-        capture_output=True,
-    )
-
-    assert p.stdout.decode().strip() == "OK"
-
     manifest = MANIFESTS_DIR / "nginx-pod.yaml"
     p = session_instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
@@ -78,20 +36,28 @@ def test_network(session_instance: harness.Instance):
         [
             "k8s",
             "kubectl",
-            "exec",
-            "-it",
-            cilium_pod["metadata"]["name"],
-            "-n",
-            "kube-system",
-            "-c",
-            "cilium-agent",
-            "--",
-            "cilium",
-            "endpoint",
-            "list",
+            "get",
+            "pod",
+            "-l",
+            "app=nginx",
             "-o",
             "json",
         ],
         capture_output=True,
     )
-    assert "nginx" in p.stdout.decode().strip()
+
+    out = json.loads(p.stdout.decode())
+
+    assert len(out["items"]) > 0, "No NGINX pod found"
+    podIP = out["items"][0]["status"]["podIP"]
+
+    p = session_instance.exec(
+        [
+            "curl",
+            "-s",
+            f"http://{podIP}",
+        ],
+        capture_output=True,
+    )
+
+    assert "Welcome to nginx!" in p.stdout.decode()


### PR DESCRIPTION
## Overview
Make the network tests more generic. This will allow us to test on any implementation of the network feature.

## Changes
- Removed Cilium bits from the Network integration tests
- Drive-by fixes for the `x-wait-for` error messages and improvements to the StatusInterface docs.