### PR TITLE
Allow Helm Client to Create Namespaces

### DIFF
--- a/src/k8s/pkg/client/helm/client.go
+++ b/src/k8s/pkg/client/helm/client.go
@@ -73,6 +73,7 @@ func (h *client) Apply(ctx context.Context, c InstallableChart, desired State, v
 	case !isInstalled && desired == StatePresent:
 		// there is no release installed, so we must run an install action
 		install := action.NewInstall(cfg)
+		install.CreateNamespace = true
 		install.ReleaseName = c.Name
 		install.Namespace = c.Namespace
 


### PR DESCRIPTION
## Overview
Allow the Helm SDK client to create the required Namespaces for a chart