### PR TITLE
Update bootstrap-config-reference.md

### DIFF
--- a/docs/src/snap/reference/bootstrap-config-reference.md
+++ b/docs/src/snap/reference/bootstrap-config-reference.md
@@ -302,7 +302,8 @@ Can be used to point to an external datastore like etcd.
 **Type:** `list[string]` <br>
 **Required:** `No` <br>
 
-The server addresses to be used when `datastore-type` is set to `external`.
+The server addresses, in URL form,
+ to be used when `datastore-type` is set to `external`.
 
 ### datastore-ca-crt
 


### PR DESCRIPTION
It can be confusing that the datastore address needs the protocol and if it doesn't have it bootstrapping fails.