### PR TITLE
Add extra config files parameters

### DIFF
--- a/src/k8s/api/v1/bootstrap_config.go
+++ b/src/k8s/api/v1/bootstrap_config.go
@@ -55,6 +55,9 @@ type BootstrapConfig struct {
 	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
 	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 
+	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
+
 	// Extra args to add to individual services (set any arg to null to delete)
 	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
 	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`

--- a/src/k8s/api/v1/bootstrap_config_test.go
+++ b/src/k8s/api/v1/bootstrap_config_test.go
@@ -48,6 +48,7 @@ func TestBootstrapConfigToMicrocluster(t *testing.T) {
 		K8sDqlitePort:                      utils.Pointer(9090),
 		DatastoreType:                      utils.Pointer("k8s-dqlite"),
 		ExtraSANs:                          []string{"custom.kubernetes"},
+		ExtraNodeConfigFiles:               map[string]string{"extra-node-config-file": "file-content"},
 		ExtraNodeKubeAPIServerArgs:         map[string]*string{"--extra-kube-apiserver-arg": utils.Pointer("extra-kube-apiserver-value")},
 		ExtraNodeKubeControllerManagerArgs: map[string]*string{"--extra-kube-controller-manager-arg": utils.Pointer("extra-kube-controller-manager-value")},
 		ExtraNodeKubeSchedulerArgs:         map[string]*string{"--extra-kube-scheduler-arg": utils.Pointer("extra-kube-scheduler-value")},

--- a/src/k8s/api/v1/join_config.go
+++ b/src/k8s/api/v1/join_config.go
@@ -26,6 +26,9 @@ type ControlPlaneNodeJoinConfig struct {
 	KubeletClientCert *string `json:"kubelet-client-crt,omitempty" yaml:"kubelet-client-crt,omitempty"`
 	KubeletClientKey  *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 
+	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
+
 	// Extra args to add to individual services (set any arg to null to delete)
 	ExtraNodeKubeAPIServerArgs         map[string]*string `json:"extra-node-kube-apiserver-args,omitempty" yaml:"extra-node-kube-apiserver-args,omitempty"`
 	ExtraNodeKubeControllerManagerArgs map[string]*string `json:"extra-node-kube-controller-manager-args,omitempty" yaml:"extra-node-kube-controller-manager-args,omitempty"`
@@ -43,6 +46,9 @@ type WorkerNodeJoinConfig struct {
 	KubeletClientKey    *string `json:"kubelet-client-key,omitempty" yaml:"kubelet-client-key,omitempty"`
 	KubeProxyClientCert *string `json:"kube-proxy-client-crt,omitempty" yaml:"kube-proxy-client-crt,omitempty"`
 	KubeProxyClientKey  *string `json:"kube-proxy-client-key,omitempty" yaml:"kube-proxy-client-key,omitempty"`
+
+	// ExtraNodeConfigFiles will be written to /var/snap/k8s/common/args/conf.d
+	ExtraNodeConfigFiles map[string]string `json:"extra-node-config-files,omitempty" yaml:"extra-node-config-files,omitempty"`
 
 	// Extra args to add to individual services (set any arg to null to delete)
 	ExtraNodeKubeProxyArgs         map[string]*string `json:"extra-node-kube-proxy-args,omitempty" yaml:"extra-node-kube-proxy-args,omitempty"`

--- a/src/k8s/cmd/k8s/k8s_bootstrap_test.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap_test.go
@@ -72,6 +72,7 @@ var testCases = []testCase{
 			K8sDqlitePort:                      utils.Pointer(9090),
 			DatastoreType:                      utils.Pointer("k8s-dqlite"),
 			ExtraSANs:                          []string{"custom.kubernetes"},
+			ExtraNodeConfigFiles:               map[string]string{"extra-node-config-file": "/path/to/extra/config.yaml"},
 			ExtraNodeKubeAPIServerArgs:         map[string]*string{"--extra-kube-apiserver-arg": utils.Pointer("extra-kube-apiserver-value")},
 			ExtraNodeKubeControllerManagerArgs: map[string]*string{"--extra-kube-controller-manager-arg": utils.Pointer("extra-kube-controller-manager-value")},
 			ExtraNodeKubeSchedulerArgs:         map[string]*string{"--extra-kube-scheduler-arg": utils.Pointer("extra-kube-scheduler-value")},
@@ -122,7 +123,7 @@ func TestGetConfigYaml(t *testing.T) {
 			mustAddConfigToTestDir(t, configPath, tc.yamlConfig)
 
 			// Get the config from the test directory
-			bootstrapConfig, err := getConfigFromYaml(cmdutil.DefaultExecutionEnvironment(), configPath)
+			bootstrapConfig, err := getConfigFromYaml[apiv1.BootstrapConfig](cmdutil.DefaultExecutionEnvironment(), configPath)
 
 			if tc.expectedError != "" {
 				g.Expect(err).To(HaveOccurred())
@@ -145,7 +146,7 @@ func TestGetConfigFromYaml_Stdin(t *testing.T) {
 	env.Stdin = bytes.NewBufferString(input)
 
 	// Call the getConfigFromYaml function with "-" as filePath
-	config, err := getConfigFromYaml(env, "-")
+	config, err := getConfigFromYaml[apiv1.BootstrapConfig](env, "-")
 	g.Expect(err).ToNot(HaveOccurred())
 
 	expectedConfig := apiv1.BootstrapConfig{SecurePort: utils.Pointer(5000)}

--- a/src/k8s/cmd/k8s/k8s_join_cluster_test.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster_test.go
@@ -1,0 +1,91 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cmdutil "github.com/canonical/k8s/cmd/util"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestReadAndParseConfigFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		configContent  string
+		files          map[string]string
+		expectedOutput string
+		expectErr      bool
+		errMessage     string
+	}{
+		{
+			name: "ValidConfigWithoutExtraFiles",
+			configContent: `
+key1: value1
+key2: value2
+`,
+			expectedOutput: "key1: value1\nkey2: value2\n",
+			expectErr:      false,
+		},
+		{
+			name: "ValidConfigWithExtraFiles",
+			configContent: `
+key1: value1
+extra-node-config-files:
+  - $TMPDIR/file1
+  - $TMPDIR/file2
+`,
+			files: map[string]string{
+				"file1": "content of file1",
+				"file2": "content of file2",
+			},
+			expectedOutput: "extra-node-config-files:\n- content of file1\n- content of file2\nkey1: value1\n",
+			expectErr:      false,
+		},
+		{
+			name: "FileReadError",
+			configContent: `
+key1: value1
+extra-node-config-files:
+  - missing_file
+`,
+			expectErr:  true,
+			errMessage: "failed to read extra node config file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			tmpDir := t.TempDir()
+			configFilePath := filepath.Join(tmpDir, "config.yaml")
+
+			// Write the config content to the config file
+			configContent := strings.ReplaceAll(tt.configContent, "$TMPDIR", tmpDir)
+			err := os.WriteFile(configFilePath, []byte(configContent), 0600)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Write the extra files
+			for filename, content := range tt.files {
+				err := os.WriteFile(filepath.Join(tmpDir, filename), []byte(content), 0600)
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			env := cmdutil.ExecutionEnvironment{
+				Stdin: os.Stdin,
+			}
+
+			result, err := readAndParseConfigFile(env, configFilePath)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errMessage))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(result).To(Equal(tt.expectedOutput))
+			}
+		})
+	}
+}

--- a/src/k8s/cmd/k8s/testdata/bootstrap-config-full.yaml
+++ b/src/k8s/cmd/k8s/testdata/bootstrap-config-full.yaml
@@ -31,6 +31,8 @@ k8s-dqlite-port: 9090
 datastore-type: k8s-dqlite
 extra-sans:
 - custom.kubernetes
+extra-node-config-files:
+  extra-node-config-file: /path/to/extra/config.yaml
 extra-node-kube-apiserver-args:
   --extra-kube-apiserver-arg: extra-kube-apiserver-value
 extra-node-kube-controller-manager-args:

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -201,6 +201,9 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string, joinCon
 	if err := setup.K8sAPIServerProxy(snap, response.APIServers, joinConfig.ExtraNodeK8sAPIServerProxyArgs); err != nil {
 		return fmt.Errorf("failed to configure k8s-apiserver-proxy: %w", err)
 	}
+	if err := setup.ExtraNodeConfigFiles(snap, joinConfig.ExtraNodeConfigFiles); err != nil {
+		return fmt.Errorf("failed to write extra node config files: %w", err)
+	}
 
 	// TODO(berkayoz): remove the lock on cleanup
 	if err := snaputil.MarkAsWorkerNode(snap, true); err != nil {
@@ -370,6 +373,10 @@ func (a *App) onBootstrapControlPlane(s *state.State, bootstrapConfig apiv1.Boot
 	}
 	if err := setup.KubeAPIServer(snap, cfg.Network.GetServiceCIDR(), s.Address().Path("1.0", "kubernetes", "auth", "webhook").String(), true, cfg.Datastore, cfg.APIServer.GetAuthorizationMode(), bootstrapConfig.ExtraNodeKubeAPIServerArgs); err != nil {
 		return fmt.Errorf("failed to configure kube-apiserver: %w", err)
+	}
+
+	if err := setup.ExtraNodeConfigFiles(snap, bootstrapConfig.ExtraNodeConfigFiles); err != nil {
+		return fmt.Errorf("failed to write extra node config files: %w", err)
 	}
 
 	// Write cluster configuration to dqlite

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -162,6 +162,10 @@ func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
 		return fmt.Errorf("failed to configure kube-apiserver: %w", err)
 	}
 
+	if err := setup.ExtraNodeConfigFiles(snap, joinConfig.ExtraNodeConfigFiles); err != nil {
+		return fmt.Errorf("failed to write extra node config files: %w", err)
+	}
+
 	if err := snapdconfig.SetSnapdFromK8sd(s.Context, cfg.ToUserFacing(), snap); err != nil {
 		return fmt.Errorf("failed to set snapd configuration from k8sd: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/setup/util_extra_files.go
+++ b/src/k8s/pkg/k8sd/setup/util_extra_files.go
@@ -1,0 +1,45 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/snap"
+)
+
+// ExtraNodeConfigFiles writes the file contents to the specified filenames in the snap.ExtraFilesDir directory.
+// The files are created with 0400 permissions and owned by root.
+// The filenames must not contain any slashes to prevent path traversal.
+func ExtraNodeConfigFiles(snap snap.Snap, files map[string]string) error {
+	for filename, content := range files {
+		if strings.Contains(filename, "/") {
+			return fmt.Errorf("file name %q must not contain any slashes (possible path-traversal prevented)", filename)
+		}
+
+		filePath := path.Join(snap.ServiceExtraConfigDir(), filename)
+		// Create or truncate the file
+		file, err := os.Create(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to create file %s: %w", filePath, err)
+		}
+		defer file.Close()
+
+		// Write the content to the file
+		_, err = file.WriteString(content)
+		if err != nil {
+			return fmt.Errorf("failed to write to file %s: %w", filePath, err)
+		}
+
+		// Set file owner to root
+		if err := os.Chown(filePath, snap.UID(), snap.GID()); err != nil {
+			return fmt.Errorf("failed to change owner of file %s: %w", filePath, err)
+		}
+
+		if err := os.Chmod(filePath, 0400); err != nil {
+			return fmt.Errorf("failed to change mode of file %s: %w", filePath, err)
+		}
+	}
+	return nil
+}

--- a/src/k8s/pkg/k8sd/setup/util_extra_files_test.go
+++ b/src/k8s/pkg/k8sd/setup/util_extra_files_test.go
@@ -42,8 +42,8 @@ func TestExtraNodeConfigFiles(t *testing.T) {
 			snap := &mock.Snap{
 				Mock: mock.Mock{
 					ServiceExtraConfigDir: tmpDir,
-					UID:                   1000,
-					GID:                   1000,
+					UID:                   os.Getuid(),
+					GID:                   os.Getgid(),
 				},
 			}
 

--- a/src/k8s/pkg/k8sd/setup/util_extra_files_test.go
+++ b/src/k8s/pkg/k8sd/setup/util_extra_files_test.go
@@ -1,0 +1,73 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/onsi/gomega"
+)
+
+func TestExtraNodeConfigFiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		files      map[string]string
+		expectErr  bool
+		errMessage string
+	}{
+		{
+			name: "ValidFiles",
+			files: map[string]string{
+				"config1": "content1",
+				"config2": "content2",
+			},
+			expectErr: false,
+		},
+		{
+			name: "InvalidFilename",
+			files: map[string]string{
+				"invalid/config": "content",
+			},
+			expectErr:  true,
+			errMessage: "file name \"invalid/config\" must not contain any slashes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+
+			tmpDir := t.TempDir()
+			snap := &mock.Snap{
+				Mock: mock.Mock{
+					ServiceExtraConfigDir: tmpDir,
+					UID:                   1000,
+					GID:                   1000,
+				},
+			}
+
+			err := ExtraNodeConfigFiles(snap, tt.files)
+			if tt.expectErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.errMessage))
+			} else {
+				g.Expect(err).ToNot(gomega.HaveOccurred())
+
+				for filename, content := range tt.files {
+					filePath := filepath.Join(tmpDir, filename)
+
+					// Verify the file exists
+					info, err := os.Stat(filePath)
+					g.Expect(err).ToNot(gomega.HaveOccurred())
+					g.Expect(info.Mode().Perm()).To(gomega.Equal(os.FileMode(0400)))
+
+					// Verify the file content
+					actualContent, err := os.ReadFile(filePath)
+					g.Expect(err).ToNot(gomega.HaveOccurred())
+					g.Expect(string(actualContent)).To(gomega.Equal(content))
+				}
+			}
+		})
+	}
+}

--- a/tests/integration/templates/bootstrap-extra-node-args.yaml
+++ b/tests/integration/templates/bootstrap-extra-node-args.yaml
@@ -1,0 +1,18 @@
+# Contains extra node args for the bootstrap node.
+# All features are disabled as we don't need them for this test.
+extra-node-config-files:
+  bootstrap-extra-file.yaml: /home/ubuntu/extra-args-test-file.yaml
+extra-node-kube-apiserver-args:
+  --request-timeout: 2m
+extra-node-kube-controller-manager-args:
+  --leader-elect-retry-period: 3s
+extra-node-kube-scheduler-args:
+  --authorization-webhook-cache-authorized-ttl: 11s
+extra-node-kube-proxy-args:
+  --config-sync-period: 14m
+extra-node-kubelet-args:
+  --authentication-token-webhook-cache-ttl: 3m
+extra-node-containerd-args:
+  --log-level: debug
+extra-node-k8s-dqlite-args:
+  --watch-storage-available-size-interval: 6s

--- a/tests/integration/templates/join-extra-node-args.yaml
+++ b/tests/integration/templates/join-extra-node-args.yaml
@@ -1,0 +1,18 @@
+# Contains extra node args for the joining cp node.
+# Differs from the bootstrap-extra-node-args.yaml to verify that the correct values are applied.
+extra-node-config-files:
+  join-extra-file.yaml: /home/ubuntu/extra-args-test-file.yaml
+extra-node-kube-apiserver-args:
+  --request-timeout: 3m
+extra-node-kube-controller-manager-args:
+  --leader-elect-retry-period: 4s
+extra-node-kube-scheduler-args:
+  --authorization-webhook-cache-authorized-ttl: 12s
+extra-node-kube-proxy-args:
+  --config-sync-period: 13m
+extra-node-kubelet-args:
+  --authentication-token-webhook-cache-ttl: 4m
+extra-node-containerd-args:
+  --log-level: warning
+extra-node-k8s-dqlite-args:
+  --watch-storage-available-size-interval: 7s

--- a/tests/integration/templates/worker-extra-node-args.yaml
+++ b/tests/integration/templates/worker-extra-node-args.yaml
@@ -1,0 +1,11 @@
+# Contains extra node args for the worker node.
+extra-node-config-files:
+  worker-extra-file.yaml: /home/ubuntu/extra-args-test-file.yaml
+extra-node-kube-proxy-args:
+  --config-sync-period: 12m
+extra-node-kubelet-args:
+  --authentication-token-webhook-cache-ttl: 5m
+extra-node-containerd-args:
+  --log-level: error
+extra-node-k8s-apiserver-proxy-args:
+  --refresh-interval: 29s

--- a/tests/integration/tests/test_node_config.py
+++ b/tests/integration/tests/test_node_config.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import harness, util, config
+from test_util import config, harness, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_node_config.py
+++ b/tests/integration/tests/test_node_config.py
@@ -1,0 +1,102 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+import logging
+from typing import List
+
+import pytest
+from test_util import harness, util, config
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.disable_k8s_bootstrapping()
+def test_extra_node_args(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_cp_node = instances[1]
+    joining_worker_node = instances[2]
+
+    extra_args_config_path = "/home/ubuntu/extra-args.yaml"
+    extra_args_test_file_path = "/home/ubuntu/extra-args-test-file.yaml"
+
+    cluster_node.send_file(
+        (config.MANIFESTS_DIR / "bootstrap-extra-node-args.yaml").as_posix(),
+        extra_args_config_path,
+    )
+    # Create a test file on the instance that is loaded by the extra args config.
+    cluster_node.exec(["touch", extra_args_test_file_path])
+    cluster_node.exec(["k8s", "bootstrap", "--file", extra_args_config_path])
+
+    # Check if the extra file was written to the correct location.
+    cluster_node.exec(
+        ["cat", "/var/snap/k8s/common/args/conf.d/bootstrap-extra-file.yaml"]
+    )
+
+    # For each service, verify that the extra arg was written to the args file.
+    for service, value in {
+        "kube-apiserver": "--request-timeout=2m",
+        "kube-controller-manager": "--leader-elect-retry-period=3s",
+        "kube-scheduler": "--authorization-webhook-cache-authorized-ttl=11s",
+        "kube-proxy": "--config-sync-period=14m",
+        "kubelet": "--authentication-token-webhook-cache-ttl=3m",
+        "containerd": "--log-level=debug",
+        "k8s-dqlite": "--watch-storage-available-size-interval=6s",
+    }.items():
+        args = cluster_node.exec(
+            ["cat", f"/var/snap/k8s/common/args/{service}"], capture_output=True
+        )
+        assert value in args.stdout.decode()
+
+    # Join a control-plane to the cluster.
+    joining_cp_node.send_file(
+        (config.MANIFESTS_DIR / "join-extra-node-args.yaml").as_posix(),
+        extra_args_config_path,
+    )
+    joining_cp_node.exec(["touch", extra_args_test_file_path])
+
+    join_token = util.get_join_token(cluster_node, joining_cp_node)
+    util.join_cluster(joining_cp_node, join_token, "--file", extra_args_config_path)
+
+    joining_cp_node.exec(
+        ["cat", "/var/snap/k8s/common/args/conf.d/join-extra-file.yaml"]
+    )
+
+    for service, value in {
+        "kube-apiserver": "--request-timeout=3m",
+        "kube-controller-manager": "--leader-elect-retry-period=4s",
+        "kube-scheduler": "--authorization-webhook-cache-authorized-ttl=12s",
+        "kube-proxy": "--config-sync-period=13m",
+        "kubelet": "--authentication-token-webhook-cache-ttl=4m",
+        "containerd": "--log-level=warning",
+        "k8s-dqlite": "--watch-storage-available-size-interval=7s",
+    }.items():
+        args = joining_cp_node.exec(
+            ["cat", f"/var/snap/k8s/common/args/{service}"], capture_output=True
+        )
+        assert value in args.stdout.decode()
+
+    # Join a worker to the cluster.
+    joining_worker_node.send_file(
+        (config.MANIFESTS_DIR / "worker-extra-node-args.yaml").as_posix(),
+        extra_args_config_path,
+    )
+    joining_worker_node.exec(["touch", extra_args_test_file_path])
+
+    join_token = util.get_join_token(cluster_node, joining_worker_node, "--worker")
+    util.join_cluster(joining_worker_node, join_token, "--file", extra_args_config_path)
+
+    joining_worker_node.exec(
+        ["cat", "/var/snap/k8s/common/args/conf.d/worker-extra-file.yaml"]
+    )
+
+    for service, value in {
+        "kube-proxy": "--config-sync-period=12m",
+        "kubelet": "--authentication-token-webhook-cache-ttl=5m",
+        "containerd": "--log-level=error",
+        "k8s-apiserver-proxy": "--refresh-interval=29s",
+    }.items():
+        args = joining_worker_node.exec(
+            ["cat", f"/var/snap/k8s/common/args/{service}"], capture_output=True
+        )
+        assert value in args.stdout.decode()

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -223,8 +223,8 @@ def get_join_token(
 
 
 # Join an existing cluster.
-def join_cluster(instance: harness.Instance, join_token: str):
-    instance.exec(["k8s", "join-cluster", join_token])
+def join_cluster(instance: harness.Instance, join_token: str, *args: str):
+    instance.exec(["k8s", "join-cluster", join_token, *args])
 
 
 def get_default_cidr(instance: harness.Instance, instance_default_ip: str):


### PR DESCRIPTION
Extends the `Bootstrap/JoinConfigs` to allow additional files to be loaded when joining the cluster. Those can then e.g. be pointed to by `ExtraNodeXArgs`.

Also, added an integration test that verifies all extra service configs are correctly set and extra files are uploaded to the correct place on the node.