### PR TITLE
add arguments to improve cis compliance and adjust tests accordingly

### DIFF
--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -64,6 +64,7 @@ func KubeAPIServer(snap snap.Snap, serviceCIDR string, authWebhookURL string, en
 	defer authTokenWebhookFile.Close()
 
 	args := map[string]string{
+		"--anonymous-auth":                           "false",
 		"--allow-privileged":                         "true",
 		"--authentication-token-webhook-config-file": authTokenWebhookConfigFile,
 		"--authorization-mode":                       authorizationMode,
@@ -73,6 +74,8 @@ func KubeAPIServer(snap snap.Snap, serviceCIDR string, authWebhookURL string, en
 		"--kubelet-client-certificate":               path.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.crt"),
 		"--kubelet-client-key":                       path.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.key"),
 		"--kubelet-preferred-address-types":          "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP",
+		"--profiling":                                "false",
+		"--request-timeout":                          "300s",
 		"--secure-port":                              "6443",
 		"--service-account-issuer":                   "https://kubernetes.default.svc",
 		"--service-account-key-file":                 path.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
@@ -43,6 +43,7 @@ func TestKubeAPIServer(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--allow-privileged", expectedVal: "true"},
 			{key: "--authentication-token-webhook-config-file", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
 			{key: "--authorization-mode", expectedVal: "Node,RBAC"},
@@ -52,6 +53,7 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--kubelet-client-certificate", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
 			{key: "--kubelet-client-key", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
 			{key: "--kubelet-preferred-address-types", expectedVal: "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP"},
+			{key: "--profiling", expectedVal: "false"},
 			{key: "--secure-port", expectedVal: "6443"},
 			{key: "--service-account-issuer", expectedVal: "https://kubernetes.default.svc"},
 			{key: "--service-account-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
@@ -61,6 +63,7 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
 			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
 			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", path.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
+			{key: "--request-timeout", expectedVal: "300s"},
 			{key: "--requestheader-client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-ca.crt")},
 			{key: "--requestheader-allowed-names", expectedVal: "front-proxy-client"},
 			{key: "--requestheader-extra-headers-prefix", expectedVal: "X-Remote-Extra-"},
@@ -98,6 +101,7 @@ func TestKubeAPIServer(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--allow-privileged", expectedVal: "true"},
 			{key: "--authentication-token-webhook-config-file", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
 			{key: "--authorization-mode", expectedVal: "Node,RBAC"},
@@ -107,6 +111,8 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--kubelet-client-certificate", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
 			{key: "--kubelet-client-key", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
 			{key: "--kubelet-preferred-address-types", expectedVal: "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP"},
+			{key: "--profiling", expectedVal: "false"},
+			{key: "--request-timeout", expectedVal: "300s"},
 			{key: "--secure-port", expectedVal: "6443"},
 			{key: "--service-account-issuer", expectedVal: "https://kubernetes.default.svc"},
 			{key: "--service-account-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
@@ -151,6 +157,7 @@ func TestKubeAPIServer(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook-config-file", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
 			{key: "--authorization-mode", expectedVal: "Node,RBAC"},
 			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
@@ -159,6 +166,7 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--kubelet-client-certificate", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
 			{key: "--kubelet-client-key", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
 			{key: "--kubelet-preferred-address-types", expectedVal: "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP"},
+			{key: "--profiling", expectedVal: "false"},
 			{key: "--secure-port", expectedVal: "1337"},
 			{key: "--service-account-issuer", expectedVal: "https://kubernetes.default.svc"},
 			{key: "--service-account-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
@@ -168,6 +176,7 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
 			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
 			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", path.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
+			{key: "--request-timeout", expectedVal: "300s"},
 			{key: "--requestheader-client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-ca.crt")},
 			{key: "--requestheader-allowed-names", expectedVal: "front-proxy-client"},
 			{key: "--requestheader-extra-headers-prefix", expectedVal: "X-Remote-Extra-"},

--- a/src/k8s/pkg/k8sd/setup/kube_controller_manager.go
+++ b/src/k8s/pkg/k8sd/setup/kube_controller_manager.go
@@ -21,6 +21,7 @@ func KubeControllerManager(snap snap.Snap, extraArgs map[string]*string) error {
 		"--profiling":                        "false",
 		"--root-ca-file":                     path.Join(snap.KubernetesPKIDir(), "ca.crt"),
 		"--service-account-private-key-file": path.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
+		"--terminated-pod-gc-threshold":      "12500",
 		"--use-service-account-credentials":  "true",
 	}
 	// enable cluster-signing if certificates are available

--- a/src/k8s/pkg/k8sd/setup/kube_controller_manager_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_controller_manager_test.go
@@ -46,6 +46,7 @@ func TestKubeControllerManager(t *testing.T) {
 			{key: "--profiling", expectedVal: "false"},
 			{key: "--root-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--service-account-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
 			{key: "--cluster-signing-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--cluster-signing-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.key")},
@@ -93,6 +94,7 @@ func TestKubeControllerManager(t *testing.T) {
 			{key: "--profiling", expectedVal: "false"},
 			{key: "--root-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--service-account-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
 		}
 		for _, tc := range tests {
@@ -145,6 +147,7 @@ func TestKubeControllerManager(t *testing.T) {
 			{key: "--profiling", expectedVal: "true"},
 			{key: "--root-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--service-account-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
 			{key: "--cluster-signing-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--cluster-signing-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.key")},

--- a/src/k8s/pkg/k8sd/setup/kubelet.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet.go
@@ -43,9 +43,9 @@ func KubeletWorker(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS st
 // kubelet configures kubelet on the local node.
 func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, clusterDomain string, cloudProvider string, taints []string, labels []string, extraArgs map[string]*string) error {
 	args := map[string]string{
+		"--authorization-mode":           "Webhook",
 		"--anonymous-auth":               "false",
 		"--authentication-token-webhook": "true",
-		"--cert-dir":                     snap.KubernetesPKIDir(),
 		"--client-ca-file":               path.Join(snap.KubernetesPKIDir(), "client-ca.crt"),
 		"--container-runtime-endpoint":   path.Join(snap.ContainerdSocketDir(), "containerd.sock"),
 		"--containerd":                   path.Join(snap.ContainerdSocketDir(), "containerd.sock"),
@@ -59,6 +59,8 @@ func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, 
 		"--root-dir":                     snap.KubeletRootDir(),
 		"--serialize-image-pulls":        "false",
 		"--tls-cipher-suites":            strings.Join(kubeletTLSCipherSuites, ","),
+		"--tls-cert-file":                path.Join(snap.KubernetesPKIDir(), "kubelet.crt"),
+		"--tls-private-key-file":         path.Join(snap.KubernetesPKIDir(), "kubelet.key"),
 	}
 	if cloudProvider != "" {
 		args["--cloud-provider"] = cloudProvider

--- a/src/k8s/pkg/k8sd/setup/kubelet_test.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet_test.go
@@ -53,9 +53,9 @@ func TestKubelet(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--cert-dir", expectedVal: s.Mock.KubernetesPKIDir},
 			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
@@ -69,6 +69,8 @@ func TestKubelet(t *testing.T) {
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
+			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			{key: "--cloud-provider", expectedVal: "provider"},
 			{key: "--cluster-domain", expectedVal: "test-cluster.local"},
@@ -108,9 +110,9 @@ func TestKubelet(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--cert-dir", expectedVal: s.Mock.KubernetesPKIDir},
 			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
@@ -124,6 +126,8 @@ func TestKubelet(t *testing.T) {
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
+			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			// Overwritten by extraArgs
 			{key: "--cluster-domain", expectedVal: "override.local"},
@@ -163,9 +167,9 @@ func TestKubelet(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--cert-dir", expectedVal: s.Mock.KubernetesPKIDir},
 			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
@@ -179,6 +183,8 @@ func TestKubelet(t *testing.T) {
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
+			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -209,9 +215,9 @@ func TestKubelet(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--cert-dir", expectedVal: s.Mock.KubernetesPKIDir},
 			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
@@ -225,6 +231,8 @@ func TestKubelet(t *testing.T) {
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
+			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
+			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
 			{key: "--cloud-provider", expectedVal: "provider"},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			{key: "--cluster-domain", expectedVal: "test-cluster.local"},
@@ -264,9 +272,9 @@ func TestKubelet(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--cert-dir", expectedVal: s.Mock.KubernetesPKIDir},
 			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
@@ -280,6 +288,8 @@ func TestKubelet(t *testing.T) {
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
+			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			{key: "--cluster-domain", expectedVal: "override.local"},
 			{key: "--node-ip", expectedVal: "192.168.0.1"},
@@ -318,9 +328,9 @@ func TestKubelet(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
+			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--cert-dir", expectedVal: s.Mock.KubernetesPKIDir},
 			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
@@ -334,6 +344,8 @@ func TestKubelet(t *testing.T) {
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
+			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {


### PR DESCRIPTION
This adds default arguments to kubelet, api server, controller manager services that improve our compliance with CIS guidelines. Also modifies our tests to reflect these changes.