### PR TITLE
Ensure binaries do not hang during bootstrap

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -11,11 +11,3 @@ k8s::cmd::k8s x-snapd-config disable
 # In order to interact with the REST API the k8sd service
 # needs to be started and configured in the installation step.
 k8s::init::k8sd
-
-# NOTE(neoaggelos): in some environments the Kubernetes might hang when running for the first time
-# This works around the issue by running them once during the install hook
-"${SNAP}"/bin/kube-apiserver --version
-"${SNAP}"/bin/kube-controller-manager --version
-"${SNAP}"/bin/kube-scheduler --version
-"${SNAP}"/bin/kube-proxy --version
-"${SNAP}"/bin/kubelet --version

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -11,3 +11,11 @@ k8s::cmd::k8s x-snapd-config disable
 # In order to interact with the REST API the k8sd service
 # needs to be started and configured in the installation step.
 k8s::init::k8sd
+
+# NOTE(neoaggelos): in some environments the Kubernetes might hang when running for the first time
+# This works around the issue by running them once during the install hook
+"${SNAP}"/bin/kube-apiserver --version
+"${SNAP}"/bin/kube-controller-manager --version
+"${SNAP}"/bin/kube-scheduler --version
+"${SNAP}"/bin/kube-proxy --version
+"${SNAP}"/bin/kubelet --version

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -179,6 +179,12 @@ func (a *App) onBootstrapWorkerNode(s *state.State, encodedToken string, joinCon
 			K8sdPublicKey: utils.Pointer(response.K8sdPublicKey),
 		},
 	}
+
+	// Pre-init checks
+	if err := snap.PreInitChecks(s.Context, cfg); err != nil {
+		return fmt.Errorf("pre-init checks failed for worker node: %w", err)
+	}
+
 	if err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		if _, err := database.SetClusterConfig(ctx, tx, cfg); err != nil {
 			return fmt.Errorf("failed to write cluster configuration: %w", err)
@@ -338,6 +344,11 @@ func (a *App) onBootstrapControlPlane(s *state.State, bootstrapConfig apiv1.Boot
 	cfg.Certificates.AdminClientKey = utils.Pointer(certificates.AdminClientKey)
 	cfg.Certificates.K8sdPublicKey = utils.Pointer(certificates.K8sdPublicKey)
 	cfg.Certificates.K8sdPrivateKey = utils.Pointer(certificates.K8sdPrivateKey)
+
+	// Pre-init checks
+	if err := snap.PreInitChecks(s.Context, cfg); err != nil {
+		return fmt.Errorf("pre-init checks failed for bootstrap node: %w", err)
+	}
 
 	// Generate kubeconfigs
 	if err := setupKubeconfigs(s, snap.KubernetesConfigDir(), cfg.APIServer.GetSecurePort(), *certificates); err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -109,6 +109,13 @@ func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
 	if err := certificates.CompleteCertificates(); err != nil {
 		return fmt.Errorf("failed to initialize control plane certificates: %w", err)
 	}
+
+	// Pre-init checks
+	if err := snap.PreInitChecks(s.Context, cfg); err != nil {
+		return fmt.Errorf("pre-init checks failed for joining node: %w", err)
+	}
+
+	// Write certificates to disk
 	if _, err := setup.EnsureControlPlanePKI(snap, certificates); err != nil {
 		return fmt.Errorf("failed to write control plane certificates: %w", err)
 	}

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -6,6 +6,7 @@ import (
 	"github.com/canonical/k8s/pkg/client/dqlite"
 	"github.com/canonical/k8s/pkg/client/helm"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 )
 
 // Snap abstracts file system paths and interacting with the k8s services.
@@ -54,4 +55,6 @@ type Snap interface {
 	HelmClient() helm.Client // admin helm client
 
 	K8sDqliteClient(ctx context.Context) (*dqlite.Client, error) // go-dqlite client for k8s-dqlite
+
+	PreInitChecks(ctx context.Context, config types.ClusterConfig) error // pre-init checks before k8s-snap can start
 }

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -7,6 +7,7 @@ import (
 	"github.com/canonical/k8s/pkg/client/dqlite"
 	"github.com/canonical/k8s/pkg/client/helm"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
 )
 
@@ -55,6 +56,9 @@ type Snap struct {
 	SnapctlSetErr        error
 	SnapctlGetCalledWith [][]string
 	SnapctlGetErr        error
+
+	PreInitChecksCalledWith []types.ClusterConfig
+	PreInitChecksErr        error
 
 	Mock Mock
 }
@@ -172,6 +176,10 @@ func (s *Snap) SnapctlGet(ctx context.Context, args ...string) ([]byte, error) {
 func (s *Snap) SnapctlSet(ctx context.Context, args ...string) error {
 	s.SnapctlSetCalledWith = append(s.SnapctlGetCalledWith, args)
 	return s.SnapctlSetErr
+}
+func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig) error {
+	s.PreInitChecksCalledWith = append(s.PreInitChecksCalledWith, config)
+	return s.PreInitChecksErr
 }
 
 var _ snap.Snap = &Snap{}

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/k8s/pkg/client/dqlite"
 	"github.com/canonical/k8s/pkg/client/helm"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/moby/sys/mountinfo"
 	"gopkg.in/yaml.v2"
@@ -236,6 +237,20 @@ func (s *snap) SnapctlGet(ctx context.Context, args ...string) ([]byte, error) {
 
 func (s *snap) SnapctlSet(ctx context.Context, args ...string) error {
 	return s.runCommand(ctx, append([]string{"snapctl", "set"}, args...))
+}
+
+func (s *snap) PreInitChecks(ctx context.Context, config types.ClusterConfig) error {
+	// TODO: check for available ports for k8s-dqlite, apiserver, containerd, etc
+
+	// NOTE(neoaggelos): in some environments the Kubernetes might hang when running for the first time
+	// This works around the issue by running them once during the install hook
+	for _, binary := range []string{"kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy", "kubelet"} {
+		if err := s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", binary, "--version")}); err != nil {
+			return fmt.Errorf("%q binary could not run: %w", binary, err)
+		}
+	}
+
+	return nil
 }
 
 var _ Snap = &snap{}

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -245,7 +245,7 @@ func (s *snap) PreInitChecks(ctx context.Context, config types.ClusterConfig) er
 	// NOTE(neoaggelos): in some environments the Kubernetes might hang when running for the first time
 	// This works around the issue by running them once during the install hook
 	for _, binary := range []string{"kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy", "kubelet"} {
-		if err := s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", binary, "--version")}); err != nil {
+		if err := s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", binary), "--version"}); err != nil {
 			return fmt.Errorf("%q binary could not run: %w", binary, err)
 		}
 	}


### PR DESCRIPTION
### Summary

Workaround for services sometimes hanging during `k8s bootstrap`. From investigation, the hang happens before exec'ing the `kube-apiserver` binary (similar for other binaries).

```bash
Jun 14 07:56:40 $HOSTNAME systemd[1]: Started Service for snap application k8s.kube-apiserver.
Jun 14 07:56:40 $HOSTNAME k8s.kube-apiserver[497086]: + exec /snap/k8s/491/bin/kube-apiserver --allow-privileged=true --authentication-token-webhook-config-file=/var/snap/k8s/common/args/conf.d/auth-token-webhook.conf --authorization-mode=Node,RBAC --client-ca-file=/etc/kubernetes/pki/client-ca.crt --enable-admission-plugins=NodeRestriction --etcd-servers=unix:///var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock --kubelet-certificate-authority=/etc/kubernetes/pki/ca.crt --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key --kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key --requestheader-allowed-names=front-proxy-client --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --requestheader-extra-headers-prefix=X-Remote-Extra- --requestheader-group-headers=X-Remote-Group --requestheader-username-headers=X-Remote-User --secure-port=6443 --service-account-issuer=https://kubernetes.default.svc --service-account-key-file=/etc/kubernetes/pki/serviceaccount.key --service-account-signing-key-file=/etc/kubernetes/pki/serviceaccount.key --service-cluster-ip-range=10.152.183.0/24 --tls-cert-file=/etc/kubernetes/pki/apiserver.crt --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384 --tls-private-key-file=/etc/kubernetes/pki/apiserver.key
Jun 14 07:57:06 $HOSTNAME systemd[1]: Stopping Service for snap application k8s.kube-apiserver...
Jun 14 07:57:06 $HOSTNAME systemd[1]: snap.k8s.kube-apiserver.service: Deactivated successfully.
Jun 14 07:57:06 $HOSTNAME systemd[1]: Stopped Service for snap application k8s.kube-apiserver.
Jun 14 07:57:06 $HOSTNAME systemd[1]: snap.k8s.kube-apiserver.service: Consumed 8.747s CPU time.

```