### PR TITLE
Do not set --hostname-override on kubelet and kube-proxy if hostname matches

### DIFF
--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -16,11 +16,13 @@ func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR str
 	serviceArgs := map[string]string{
 		"--cluster-cidr":         podCIDR,
 		"--healthz-bind-address": "127.0.0.1",
-		"--hostname-override":    hostname,
 		"--kubeconfig":           path.Join(snap.KubernetesConfigDir(), "proxy.conf"),
 		"--profiling":            "false",
 	}
 
+	if hostname != snap.Hostname() {
+		serviceArgs["--hostname-override"] = hostname
+	}
 	onLXD, err := snap.OnLXD(ctx)
 	if err != nil {
 		log.Printf("failed to check if on lxd: %v", err)

--- a/src/k8s/pkg/k8sd/setup/kubelet.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet.go
@@ -51,7 +51,6 @@ func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, 
 		"--containerd":                   path.Join(snap.ContainerdSocketDir(), "containerd.sock"),
 		"--eviction-hard":                "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'",
 		"--fail-swap-on":                 "false",
-		"--hostname-override":            hostname,
 		"--kubeconfig":                   path.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
 		"--node-labels":                  strings.Join(labels, ","),
 		"--read-only-port":               "0",
@@ -61,6 +60,10 @@ func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, 
 		"--tls-cipher-suites":            strings.Join(kubeletTLSCipherSuites, ","),
 		"--tls-cert-file":                path.Join(snap.KubernetesPKIDir(), "kubelet.crt"),
 		"--tls-private-key-file":         path.Join(snap.KubernetesPKIDir(), "kubelet.key"),
+	}
+
+	if hostname != snap.Hostname() {
+		args["--hostname-override"] = hostname
 	}
 	if cloudProvider != "" {
 		args["--cloud-provider"] = cloudProvider

--- a/src/k8s/pkg/k8sd/setup/kubelet_test.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet_test.go
@@ -379,4 +379,19 @@ func TestKubelet(t *testing.T) {
 
 		g.Expect(setup.KubeletWorker(s, "dev", net.ParseIP("192.168.0.1"), "10.152.1.1", "test-cluster.local", "provider", nil)).ToNot(Succeed())
 	})
+
+	t.Run("HostnameOverride", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Create a mock snap
+		s := mustSetupSnapAndDirectories(t, setKubeletMock)
+		s.Mock.Hostname = "dev"
+
+		// Call the kubelet control plane setup function
+		g.Expect(setup.KubeletControlPlane(s, "dev", net.ParseIP("192.168.0.1"), "10.152.1.1", "test-cluster.local", "provider", nil, nil)).To(Succeed())
+
+		val, err := snaputil.GetServiceArgument(s, "kubelet", "--hostname-override")
+		g.Expect(err).To(BeNil())
+		g.Expect(val).To(BeEmpty())
+	})
 }

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -14,8 +14,9 @@ type Snap interface {
 	Strict() bool                        // Strict returns true if the snap is installed with strict confinement.
 	OnLXD(context.Context) (bool, error) // OnLXD returns true if the host runs on LXD.
 
-	UID() int // UID is the user ID to set on config files.
-	GID() int // GID is the group ID to set on config files.
+	UID() int         // UID is the user ID to set on config files.
+	GID() int         // GID is the group ID to set on config files.
+	Hostname() string // Hostname is the name of the node.
 
 	StartService(ctx context.Context, serviceName string) error   // snapctl start $service
 	StopService(ctx context.Context, serviceName string) error    // snapctl stop $service

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -17,6 +17,7 @@ type Mock struct {
 	OnLXDErr                    error
 	UID                         int
 	GID                         int
+	Hostname                    string
 	KubernetesConfigDir         string
 	KubernetesPKIDir            string
 	EtcdPKIDir                  string
@@ -99,6 +100,9 @@ func (s *Snap) UID() int {
 }
 func (s *Snap) GID() int {
 	return s.Mock.GID
+}
+func (s *Snap) Hostname() string {
+	return s.Mock.Hostname
 }
 func (s *Snap) ContainerdConfigDir() string {
 	return s.Mock.ContainerdConfigDir

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -95,6 +95,14 @@ func (s *snap) GID() int {
 	return 0
 }
 
+func (s *snap) Hostname() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "dev"
+	}
+	return hostname
+}
+
 func (s *snap) ContainerdConfigDir() string {
 	return path.Join(s.snapCommonDir, "etc", "containerd")
 }


### PR DESCRIPTION
### Summary

When configuring kubelet and kube-proxy, only specify the `--hostname-override` flag if the node name does not match.

### Changes

- Add a `snap.Snap.Hostname() string` method, which returns `os.Hostname()` or falls back to `"dev"`
- When configuring kubelet and kube-proxy, if the node name (coming from microcluster config) does not match the hostname (from snap.Hostname()`, only then configure `--hostname-override`
