### PR TITLE
Add command to retrieve images used by k8s-snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,7 +82,7 @@ parts:
       for binary in k8s k8sd k8s-apiserver-proxy; do
         cp -P "bin/static/${binary}" "${INSTALL}/bin/${binary}"
       done
-      ./bin/static/k8s x-list-images > "${INSTALL}/images.txt"
+      ./bin/static/k8s list-images > "${INSTALL}/images.txt"
 
   cni:
     after: [build-deps]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,15 +73,16 @@ parts:
     source: src/k8s
     plugin: nil
     override-build: |
-      INSTALL="${SNAPCRAFT_PART_INSTALL}/bin"
-      mkdir -p "${INSTALL}"
+      INSTALL="${SNAPCRAFT_PART_INSTALL}"
 
       export DQLITE_BUILD_SCRIPTS_DIR="${SNAPCRAFT_STAGE}/static-dqlite-deps"
       make static -j
 
+      mkdir -p "${INSTALL}/bin"
       for binary in k8s k8sd k8s-apiserver-proxy; do
-        cp -P "bin/static/${binary}" "${INSTALL}/${binary}"
+        cp -P "bin/static/${binary}" "${INSTALL}/bin/${binary}"
       done
+      ./bin/static/k8s x-list-images > "${INSTALL}/images.txt"
 
   cni:
     after: [build-deps]

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -95,7 +95,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		xPrintShimPidsCmd,
 		newXSnapdConfigCmd(env),
 		newXWaitForCmd(env),
-		newXListImagesCmd(env),
+		newListImagesCmd(env),
 	)
 
 	cmd.DisableAutoGenTag = true

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -95,6 +95,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		xPrintShimPidsCmd,
 		newXSnapdConfigCmd(env),
 		newXWaitForCmd(env),
+		newXListImagesCmd(env),
 	)
 
 	cmd.DisableAutoGenTag = true

--- a/src/k8s/cmd/k8s/k8s_x_list_images.go
+++ b/src/k8s/cmd/k8s/k8s_x_list_images.go
@@ -1,0 +1,21 @@
+package k8s
+
+import (
+	"strings"
+
+	cmdutil "github.com/canonical/k8s/cmd/util"
+	"github.com/canonical/k8s/pkg/k8sd/images"
+	"github.com/spf13/cobra"
+)
+
+func newXListImagesCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "x-list-images",
+		Short:  "List all images used by the current version of k8s-snap",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.PrintErrln(strings.Join(images.Images(), "\n"))
+		},
+	}
+	return cmd
+}

--- a/src/k8s/cmd/k8s/k8s_x_list_images.go
+++ b/src/k8s/cmd/k8s/k8s_x_list_images.go
@@ -8,11 +8,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newXListImagesCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+func newListImagesCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "x-list-images",
-		Short:  "List all images used by the current version of k8s-snap",
+		Hidden:  true,
+		Aliases: []string{"list-images"},
+		Short:   "List all images used by this build",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Println(strings.Join(images.Images(), "\n"))
 		},

--- a/src/k8s/cmd/k8s/k8s_x_list_images.go
+++ b/src/k8s/cmd/k8s/k8s_x_list_images.go
@@ -14,7 +14,7 @@ func newXListImagesCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Use:    "x-list-images",
 		Short:  "List all images used by the current version of k8s-snap",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.PrintErrln(strings.Join(images.Images(), "\n"))
+			cmd.Println(strings.Join(images.Images(), "\n"))
 		},
 	}
 	return cmd

--- a/src/k8s/pkg/k8sd/features/calico/register.go
+++ b/src/k8s/pkg/k8sd/features/calico/register.go
@@ -1,0 +1,37 @@
+package calico
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8sd/images"
+)
+
+func init() {
+	images.Register(
+		fmt.Sprintf("%s/%s:%s", tigeraOperatorRegistry, tigeraOperatorImage, tigeraOperatorVersion),
+	)
+
+	// TODO: configurable Calico images, include in this list
+	//
+	// Hardcoded list based on "k8s kubectl get node -o template='{{ range .items }}{{ .metadata.name }}{{":"}}{{ range .status.images }}{{ "\n- " }}{{ index .names 1 }}{{ end }}{{"\n"}}{{ end }}' | grep calico":
+	//
+	// - docker.io/calico/node:v3.28.0
+	// - docker.io/calico/cni:v3.28.0
+	// - docker.io/calico/apiserver:v3.28.0
+	// - docker.io/calico/kube-controllers:v3.28.0
+	// - docker.io/calico/typha:v3.28.0
+	// - docker.io/calico/node-driver-registrar:v3.28.0
+	// - docker.io/calico/csi:v3.28.0
+	// - docker.io/calico/pod2daemon-flexvol:v3.28.0
+
+	images.Register(
+		"docker.io/calico/node:v3.28.0",
+		"docker.io/calico/cni:v3.28.0",
+		"docker.io/calico/apiserver:v3.28.0",
+		"docker.io/calico/kube-controllers:v3.28.0",
+		"docker.io/calico/typha:v3.28.0",
+		"docker.io/calico/node-driver-registrar:v3.28.0",
+		"docker.io/calico/csi:v3.28.0",
+		"docker.io/calico/pod2daemon-flexvol:v3.28.0",
+	)
+}

--- a/src/k8s/pkg/k8sd/features/cilium/register.go
+++ b/src/k8s/pkg/k8sd/features/cilium/register.go
@@ -1,0 +1,14 @@
+package cilium
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8sd/images"
+)
+
+func init() {
+	images.Register(
+		fmt.Sprintf("%s:%s", ciliumAgentImageRepo, ciliumAgentImageTag),
+		fmt.Sprintf("%s:%s", ciliumOperatorImageRepository, ciliumOperatorImageTag),
+	)
+}

--- a/src/k8s/pkg/k8sd/features/coredns/register.go
+++ b/src/k8s/pkg/k8sd/features/coredns/register.go
@@ -1,0 +1,13 @@
+package coredns
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8sd/images"
+)
+
+func init() {
+	images.Register(
+		fmt.Sprintf("%s:%s", imageRepo, imageTag),
+	)
+}

--- a/src/k8s/pkg/k8sd/features/localpv/register.go
+++ b/src/k8s/pkg/k8sd/features/localpv/register.go
@@ -1,0 +1,29 @@
+package localpv
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8sd/images"
+)
+
+func init() {
+	images.Register(
+		fmt.Sprintf("%s:%s", imageRepo, imageTag),
+	)
+
+	// TODO: configurable CSI images, include in this list
+	//
+	// Hardcoded list based on "k8s kubectl get node -o template='{{ range .items }}{{ .metadata.name }}{{":"}}{{ range .status.images }}{{ "\n- " }}{{ index .names 1 }}{{ end }}{{"\n"}}{{ end }}' | grep csi"
+	//
+	// - k8s.gcr.io/sig-storage/csi-provisioner:v3.4.1
+	// - k8s.gcr.io/sig-storage/csi-resizer:v1.7.0
+	// - k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1
+	// - k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.10.0
+
+	images.Register(
+		"k8s.gcr.io/sig-storage/csi-provisioner:v3.4.1",
+		"k8s.gcr.io/sig-storage/csi-resizer:v1.7.0",
+		"k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1",
+		"k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.10.0",
+	)
+}

--- a/src/k8s/pkg/k8sd/features/metrics-server/register.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/register.go
@@ -1,0 +1,13 @@
+package metrics_server
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8sd/images"
+)
+
+func init() {
+	images.Register(
+		fmt.Sprintf("%s:%s", imageRepo, imageTag),
+	)
+}

--- a/src/k8s/pkg/k8sd/images/images.go
+++ b/src/k8s/pkg/k8sd/images/images.go
@@ -1,0 +1,22 @@
+package images
+
+import "slices"
+
+var registeredImages []string
+
+// Images returns the list of images registered by individual components.
+func Images() []string {
+	if registeredImages == nil {
+		return nil
+	}
+	images := make([]string, len(registeredImages))
+	copy(images, registeredImages)
+	slices.Sort(images)
+	return images
+}
+
+// Register images that are used by k8s-snap.
+// Register is used by the `init()` method in individual packages.
+func Register(images ...string) {
+	registeredImages = append(registeredImages, images...)
+}

--- a/src/k8s/pkg/k8sd/setup/containerd.go
+++ b/src/k8s/pkg/k8sd/setup/containerd.go
@@ -6,12 +6,15 @@ import (
 	"os"
 	"path"
 
+	"github.com/canonical/k8s/pkg/k8sd/images"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/pelletier/go-toml"
 )
+
+const defaultPauseImage = "ghcr.io/canonical/k8s-snap/pause:3.10"
 
 var (
 	containerdConfigTomlTemplate = mustTemplate("containerd", "config.toml")
@@ -124,7 +127,7 @@ func Containerd(snap snap.Snap, registries []types.ContainerdRegistry, extraArgs
 		CNIBinDir:         snap.CNIBinDir(),
 		ImportsDir:        snap.ContainerdExtraConfigDir(),
 		RegistryConfigDir: snap.ContainerdRegistryConfigDir(),
-		PauseImage:        "ghcr.io/canonical/k8s-snap/pause:3.10",
+		PauseImage:        defaultPauseImage,
 	}); err != nil {
 		return fmt.Errorf("failed to write config.toml: %w", err)
 	}
@@ -207,4 +210,8 @@ func Containerd(snap snap.Snap, registries []types.ContainerdRegistry, extraArgs
 	}
 
 	return nil
+}
+
+func init() {
+	images.Register(defaultPauseImage)
 }


### PR DESCRIPTION
### Summary

Add a hidden command that can be used to retrieve the list of images a particular build of `k8s-snap` will use.

### Changes

- Add `pkg/k8sd/images` package. This exports two functions: `Registrer` and `Images`
- Individual packages "register" their images by using a `func init() { images.Register(...) }`
- The list-images command simply retrieves the list using `images.Images()`.

### Notes

- This way, individual implementations (e.g. calico or cilium) simply have an `init()` that registers the images. `init()` does not run for packages that are not imported by the code.
- We currently implicitly depend on more images than just the ones in our configs. Added TODOs to resolve them separately.