### PR TITLE
use cilium 1.15.2-ck2 images

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -32,11 +32,11 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// ciliumAgentImageTag is the tag to use for the cilium-agent image.
-	ciliumAgentImageTag = "1.15.2-ck1"
+	ciliumAgentImageTag = "1.15.2-ck2"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
-	ciliumOperatorImageRepository = "ghcr.io/canonical/cilium-operator"
+	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.15.2-ck1"
+	ciliumOperatorImageTag = "1.15.2-ck2"
 )

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -48,7 +48,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, _ type
 		"operator": map[string]any{
 			"replicas": 1,
 			"image": map[string]any{
-				"repository": ciliumOperatorImageRepository,
+				"repository": ciliumOperatorImageRepo,
 				"tag":        ciliumOperatorImageTag,
 				"useDigest":  false,
 			},

--- a/src/k8s/pkg/k8sd/features/cilium/register.go
+++ b/src/k8s/pkg/k8sd/features/cilium/register.go
@@ -9,6 +9,6 @@ import (
 func init() {
 	images.Register(
 		fmt.Sprintf("%s:%s", ciliumAgentImageRepo, ciliumAgentImageTag),
-		fmt.Sprintf("%s:%s", ciliumOperatorImageRepository, ciliumOperatorImageTag),
+		fmt.Sprintf("%s-generic:%s", ciliumOperatorImageRepo, ciliumOperatorImageTag),
 	)
 }


### PR DESCRIPTION
### Summary

Bump to Cilium 1.15.2-ck2 images, (adds support for arm64)

### Notes

- Also does a drive-by fix to the cilium-operator image we report, as Cilium adds the `-generic` suffix for the pods. 