### PR TITLE
Sync Calico CNI images from upstream

### DIFF
--- a/build-scripts/hack/upstream-images.yaml
+++ b/build-scripts/hack/upstream-images.yaml
@@ -7,3 +7,30 @@ sync:
   - source: registry.k8s.io/pause:3.10
     target: ghcr.io/canonical/k8s-snap/pause:3.10
     type: image
+  - source: docker.io/calico/apiserver:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/apiserver:v3.28.0
+    type: image
+  - source: docker.io/calico/cni:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/cni:v3.28.0
+    type: image
+  - source: docker.io/calico/csi:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/csi:v3.28.0
+    type: image
+  - source: docker.io/calico/kube-controllers:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/kube-controllers:v3.28.0
+    type: image
+  - source: docker.io/calico/node-driver-registrar:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/node-driver-registrar:v3.28.0
+    type: image
+  - source: docker.io/calico/node:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/node:v3.28.0
+    type: image
+  - source: docker.io/calico/pod2daemon-flexvol:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/pod2daemon-flexvol:v3.28.0
+    type: image
+  - source: docker.io/calico/typha:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/typha:v3.28.0
+    type: image
+  - source: quay.io/tigera/operator:v1.34.0
+    target: ghcr.io/canonical/k8s-snap/tigera/operator:v1.34.0
+    type: image

--- a/build-scripts/hack/upstream-images.yaml
+++ b/build-scripts/hack/upstream-images.yaml
@@ -16,6 +16,9 @@ sync:
   - source: docker.io/calico/csi:v3.28.0
     target: ghcr.io/canonical/k8s-snap/calico/csi:v3.28.0
     type: image
+  - source: docker.io/calico/ctl:v3.28.0
+    target: ghcr.io/canonical/k8s-snap/calico/ctl:v3.28.0
+    type: image
   - source: docker.io/calico/kube-controllers:v3.28.0
     target: ghcr.io/canonical/k8s-snap/calico/kube-controllers:v3.28.0
     type: image

--- a/src/k8s/pkg/k8sd/features/calico/chart.go
+++ b/src/k8s/pkg/k8sd/features/calico/chart.go
@@ -19,6 +19,11 @@ var (
 	// imageRepo represents the repo to fetch the Calico CNI images.
 	imageRepo = "ghcr.io/canonical/k8s-snap"
 
+	// calicoImageRepo represents the repo to fetch the calico images.
+	calicoImageRepo = "ghcr.io/canonical/k8s-snap/calico"
+	// calicoTag represents the tag to use for the calico images.
+	calicoTag = "v3.28.0"
+
 	// tigeraOperatorImage represents the image to fetch for calico.
 	tigeraOperatorImage = "tigera/operator"
 

--- a/src/k8s/pkg/k8sd/features/calico/chart.go
+++ b/src/k8s/pkg/k8sd/features/calico/chart.go
@@ -17,7 +17,7 @@ var (
 	// tigeraOperatorRepo represents the repo to fetch the tigera-operator image for calico.
 	// Note: Tigera is the company behind Calico and the tigera-operator is the operator for Calico.
 	// TODO: use ROCKs instead of upstream
-	tigeraOperatorRegistry = "quay.io"
+	tigeraOperatorRegistry = "ghcr.io/canonical/k8s-snap"
 
 	// tigeraOperatorImage represents the image to fetch for calico.
 	tigeraOperatorImage = "tigera/operator"
@@ -27,7 +27,7 @@ var (
 
 	// calicoCtlImage represents the image to fetch for calicoctl.
 	// TODO: use ROCKs instead of upstream
-	calicoCtlImage = "docker.io/calico/ctl"
+	calicoCtlImage = "ghcr.io/canonical/k8s-snap/calico/ctl"
 	// calicoCtlTag represents the tag to use for the calicoctl image.
 	calicoCtlTag = "v3.28.0"
 )

--- a/src/k8s/pkg/k8sd/features/calico/chart.go
+++ b/src/k8s/pkg/k8sd/features/calico/chart.go
@@ -14,10 +14,10 @@ var (
 		ManifestPath: path.Join("charts", "tigera-operator-v3.28.0.tgz"),
 	}
 
-	// tigeraOperatorRepo represents the repo to fetch the tigera-operator image for calico.
 	// Note: Tigera is the company behind Calico and the tigera-operator is the operator for Calico.
 	// TODO: use ROCKs instead of upstream
-	tigeraOperatorRegistry = "ghcr.io/canonical/k8s-snap"
+	// imageRepo represents the repo to fetch the Calico CNI images.
+	imageRepo = "ghcr.io/canonical/k8s-snap"
 
 	// tigeraOperatorImage represents the image to fetch for calico.
 	tigeraOperatorImage = "tigera/operator"

--- a/src/k8s/pkg/k8sd/features/calico/network.go
+++ b/src/k8s/pkg/k8sd/features/calico/network.go
@@ -55,7 +55,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, _ type
 
 	values := map[string]any{
 		"tigeraOperator": map[string]any{
-			"registry": tigeraOperatorRegistry,
+			"registry": imageRepo,
 			"image":    tigeraOperatorImage,
 			"version":  tigeraOperatorVersion,
 		},
@@ -67,7 +67,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, _ type
 			"calicoNetwork": map[string]any{
 				"ipPools": podIpPools,
 			},
-			"registry": tigeraOperatorRegistry,
+			"registry": imageRepo,
 		},
 		"serviceCIDRs": serviceCIDRs,
 	}

--- a/src/k8s/pkg/k8sd/features/calico/network.go
+++ b/src/k8s/pkg/k8sd/features/calico/network.go
@@ -67,6 +67,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, _ type
 			"calicoNetwork": map[string]any{
 				"ipPools": podIpPools,
 			},
+			"registry": tigeraOperatorRegistry,
 		},
 		"serviceCIDRs": serviceCIDRs,
 	}

--- a/src/k8s/pkg/k8sd/features/calico/register.go
+++ b/src/k8s/pkg/k8sd/features/calico/register.go
@@ -15,23 +15,23 @@ func init() {
 	//
 	// Hardcoded list based on "k8s kubectl get node -o template='{{ range .items }}{{ .metadata.name }}{{":"}}{{ range .status.images }}{{ "\n- " }}{{ index .names 1 }}{{ end }}{{"\n"}}{{ end }}' | grep calico":
 	//
-	// - docker.io/calico/node:v3.28.0
-	// - docker.io/calico/cni:v3.28.0
-	// - docker.io/calico/apiserver:v3.28.0
-	// - docker.io/calico/kube-controllers:v3.28.0
-	// - docker.io/calico/typha:v3.28.0
-	// - docker.io/calico/node-driver-registrar:v3.28.0
-	// - docker.io/calico/csi:v3.28.0
-	// - docker.io/calico/pod2daemon-flexvol:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/node:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/cni:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/apiserver:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/kube-controllers:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/typha:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/node-driver-registrar:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/csi:v3.28.0
+	// - ghcr.io/canonical/k8s-snap/calico/pod2daemon-flexvol:v3.28.0
 
 	images.Register(
-		"docker.io/calico/node:v3.28.0",
-		"docker.io/calico/cni:v3.28.0",
-		"docker.io/calico/apiserver:v3.28.0",
-		"docker.io/calico/kube-controllers:v3.28.0",
-		"docker.io/calico/typha:v3.28.0",
-		"docker.io/calico/node-driver-registrar:v3.28.0",
-		"docker.io/calico/csi:v3.28.0",
-		"docker.io/calico/pod2daemon-flexvol:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/node:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/cni:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/apiserver:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/kube-controllers:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/typha:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/node-driver-registrar:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/csi:v3.28.0",
+		"ghcr.io/canonical/k8s-snap/calico/pod2daemon-flexvol:v3.28.0",
 	)
 }

--- a/src/k8s/pkg/k8sd/features/calico/register.go
+++ b/src/k8s/pkg/k8sd/features/calico/register.go
@@ -8,30 +8,17 @@ import (
 
 func init() {
 	images.Register(
+		// Tigera images
 		fmt.Sprintf("%s/%s:%s", imageRepo, tigeraOperatorImage, tigeraOperatorVersion),
-	)
-
-	// TODO: configurable Calico images, include in this list
-	//
-	// Hardcoded list based on "k8s kubectl get node -o template='{{ range .items }}{{ .metadata.name }}{{":"}}{{ range .status.images }}{{ "\n- " }}{{ index .names 1 }}{{ end }}{{"\n"}}{{ end }}' | grep calico":
-	//
-	// - ghcr.io/canonical/k8s-snap/calico/node:v3.28.0
-	// - ghcr.io/canonical/k8s-snap/calico/cni:v3.28.0
-	// - ghcr.io/canonical/k8s-snap/calico/apiserver:v3.28.0
-	// - ghcr.io/canonical/k8s-snap/calico/kube-controllers:v3.28.0
-	// - ghcr.io/canonical/k8s-snap/calico/typha:v3.28.0
-	// - ghcr.io/canonical/k8s-snap/calico/node-driver-registrar:v3.28.0
-	// - ghcr.io/canonical/k8s-snap/calico/csi:v3.28.0
-	// - ghcr.io/canonical/k8s-snap/calico/pod2daemon-flexvol:v3.28.0
-
-	images.Register(
-		"ghcr.io/canonical/k8s-snap/calico/node:v3.28.0",
-		"ghcr.io/canonical/k8s-snap/calico/cni:v3.28.0",
-		"ghcr.io/canonical/k8s-snap/calico/apiserver:v3.28.0",
-		"ghcr.io/canonical/k8s-snap/calico/kube-controllers:v3.28.0",
-		"ghcr.io/canonical/k8s-snap/calico/typha:v3.28.0",
-		"ghcr.io/canonical/k8s-snap/calico/node-driver-registrar:v3.28.0",
-		"ghcr.io/canonical/k8s-snap/calico/csi:v3.28.0",
-		"ghcr.io/canonical/k8s-snap/calico/pod2daemon-flexvol:v3.28.0",
+		// Calico images
+		fmt.Sprintf("%s/apiserver:%s", calicoImageRepo, calicoTag),
+		fmt.Sprintf("%s/cni:%s", calicoImageRepo, calicoTag),
+		fmt.Sprintf("%s/csi:%s", calicoImageRepo, calicoTag),
+		fmt.Sprintf("%s/ctl:%s", calicoImageRepo, calicoCtlTag),
+		fmt.Sprintf("%s/kube-controllers:%s", calicoImageRepo, calicoTag),
+		fmt.Sprintf("%s/node:%s", calicoImageRepo, calicoTag),
+		fmt.Sprintf("%s/node-driver-registrar:%s", calicoImageRepo, calicoTag),
+		fmt.Sprintf("%s/pod2daemon-flexvol:%s", calicoImageRepo, calicoTag),
+		fmt.Sprintf("%s/typha:%s", calicoImageRepo, calicoTag),
 	)
 }

--- a/src/k8s/pkg/k8sd/features/calico/register.go
+++ b/src/k8s/pkg/k8sd/features/calico/register.go
@@ -8,7 +8,7 @@ import (
 
 func init() {
 	images.Register(
-		fmt.Sprintf("%s/%s:%s", tigeraOperatorRegistry, tigeraOperatorImage, tigeraOperatorVersion),
+		fmt.Sprintf("%s/%s:%s", imageRepo, tigeraOperatorImage, tigeraOperatorVersion),
 	)
 
 	// TODO: configurable Calico images, include in this list


### PR DESCRIPTION
## Overview
Sync Calico CNI images from upstream to the ghcr.io registry.
## Rationale
We have encountered that we hit the rate limits of DockerHub. This pull request mirrors the images we are using in Calico to ghcr.io, allowing the k8s snap to pull them from there instead of DockerHub.
## Testing
```
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  21s   default-scheduler  Successfully assigned calico-system/calico-node-ps4zh to kcp-1
  Normal   Pulled     22s   kubelet            Container image "ghcr.io/canonical/k8s-snap/calico/pod2daemon-flexvol:v3.28.0" already present on machine
  Normal   Created    22s   kubelet            Created container flexvol-driver
  Normal   Started    22s   kubelet            Started container flexvol-driver
  Normal   Pulling    21s   kubelet            Pulling image "ghcr.io/canonical/k8s-snap/calico/cni:v3.28.0"
  Normal   Pulled     15s   kubelet            Successfully pulled image "ghcr.io/canonical/k8s-snap/calico/cni:v3.28.0" in 5.746s (5.746s including waiting). Image size: 94536228 bytes.
  Normal   Created    15s   kubelet            Created container install-cni
  Normal   Started    15s   kubelet            Started container install-cni
  Normal   Pulling    14s   kubelet            Pulling image "ghcr.io/canonical/k8s-snap/calico/node:v3.28.0"
  Normal   Pulled     7s    kubelet            Successfully pulled image "ghcr.io/canonical/k8s-snap/calico/node:v3.28.0" in 7.202s (7.202s including waiting). Image size: 115239232 bytes.
  Normal   Created    7s    kubelet            Created container calico-node
  Normal   Started    7s    kubelet            Started container calico-node
  Warning  Unhealthy  6s    kubelet            Readiness probe failed: calico/node is not ready: BIRD is not ready: Error querying BIRD: unable to connect to BIRDv4 socket: dial unix /var/run/bird/bird.ctl: connect: no such file or directory
  Warning  Unhealthy  5s    kubelet            Readiness probe failed: calico/node is not ready: BIRD is not ready: Error querying BIRD: unable to connect to BIRDv4 socket: dial unix /var/run/calico/bird.ctl: connect: connection refused
```
