### PR TITLE
Add disable-config-controller options to k8sd

### DIFF
--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -13,6 +13,8 @@ var rootCmdOpts struct {
 	pprofAddress                        string
 	disableNodeConfigController         bool
 	disableControlPlaneConfigController bool
+	disableFeatureController            bool
+	disableUpdateNodeConfigController   bool
 }
 
 func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
@@ -28,6 +30,8 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				PprofAddress:                        rootCmdOpts.pprofAddress,
 				DisableNodeConfigController:         rootCmdOpts.disableNodeConfigController,
 				DisableControlPlaneConfigController: rootCmdOpts.disableControlPlaneConfigController,
+				DisableUpdateNodeConfigController:   rootCmdOpts.disableUpdateNodeConfigController,
+				DisableFeatureController:            rootCmdOpts.disableFeatureController,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd: %v", err)
@@ -51,8 +55,10 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.pprofAddress, "pprof-address", "", "Listen address for pprof endpoints, e.g. \"127.0.0.1:4217\"")
-	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeConfigController, "disable-node-config-controller", false, "Disable the Node Config Controller (defaults to `false`)")
-	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableControlPlaneConfigController, "disable-control-plane-config-controller", false, "Disable the Control Plane Config Controller (defaults to `false`)")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeConfigController, "disable-node-config-controller", false, "Disable the Node Config Controller")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableControlPlaneConfigController, "disable-control-plane-config-controller", false, "Disable the Control Plane Config Controller")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableUpdateNodeConfigController, "disable-update-node-config-controller", false, "Disable the Update Node Config Controller")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableFeatureController, "disable-feature-controller", false, "Disable the Feature Controller")
 
 	cmd.Flags().Uint("port", 0, "Default port for the HTTP API")
 	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -7,10 +7,12 @@ import (
 )
 
 var rootCmdOpts struct {
-	logDebug     bool
-	logVerbose   bool
-	stateDir     string
-	pprofAddress string
+	logDebug                            bool
+	logVerbose                          bool
+	stateDir                            string
+	pprofAddress                        string
+	disableNodeConfigController         bool
+	disableControlPlaneConfigController bool
 }
 
 func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
@@ -19,11 +21,13 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short: "Canonical Kubernetes orchestrator and clustering daemon",
 		Run: func(cmd *cobra.Command, args []string) {
 			app, err := app.New(app.Config{
-				Debug:        rootCmdOpts.logDebug,
-				Verbose:      rootCmdOpts.logVerbose,
-				StateDir:     rootCmdOpts.stateDir,
-				Snap:         env.Snap,
-				PprofAddress: rootCmdOpts.pprofAddress,
+				Debug:                               rootCmdOpts.logDebug,
+				Verbose:                             rootCmdOpts.logVerbose,
+				StateDir:                            rootCmdOpts.stateDir,
+				Snap:                                env.Snap,
+				PprofAddress:                        rootCmdOpts.pprofAddress,
+				DisableNodeConfigController:         rootCmdOpts.disableNodeConfigController,
+				DisableControlPlaneConfigController: rootCmdOpts.disableControlPlaneConfigController,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd: %v", err)
@@ -47,6 +51,8 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&rootCmdOpts.logVerbose, "verbose", "v", true, "Show all information messages")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.pprofAddress, "pprof-address", "", "Listen address for pprof endpoints, e.g. \"127.0.0.1:4217\"")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeConfigController, "disable-node-config-controller", false, "Disable the Node Config Controller (defaults to `false`)")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableControlPlaneConfigController, "disable-control-plane-config-controller", false, "Disable the Control Plane Config Controller (defaults to `false`)")
 
 	cmd.Flags().Uint("port", 0, "Default port for the HTTP API")
 	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -97,7 +97,7 @@ func New(cfg Config) (*App, error) {
 			app.readyWg.Wait,
 		)
 	} else {
-		log.Println("node config controller was not initialized. change this behvaiour by unsetting --disable-node-config-controller (or setting it to `false` which is the default).")
+		log.Println("node-config-controller disabled via config")
 	}
 
 	if !cfg.DisableControlPlaneConfigController {
@@ -107,7 +107,7 @@ func New(cfg Config) (*App, error) {
 			time.NewTicker(10*time.Second).C,
 		)
 	} else {
-		log.Println("control plane config controller was not initialized. change this behvaiour by unsetting --disable-control-plane-config-controller (or setting it to `false` which is the default).")
+		log.Println("control-plane-config-controller disabled via config")
 	}
 
 	app.triggerUpdateNodeConfigControllerCh = make(chan struct{}, 1)
@@ -119,7 +119,7 @@ func New(cfg Config) (*App, error) {
 			app.triggerUpdateNodeConfigControllerCh,
 		)
 	} else {
-		log.Println("update node config controller was not initialized. change this behvaiour by unsetting --disable-update-node-config-controller (or setting it to `false` which is the default).")
+		log.Println("update-node-config-controller disabled via config")
 	}
 
 	app.triggerFeatureControllerNetworkCh = make(chan struct{}, 1)
@@ -143,7 +143,7 @@ func New(cfg Config) (*App, error) {
 			TriggerMetricsServerCh: app.triggerFeatureControllerMetricsServerCh,
 		})
 	} else {
-		log.Println("feature controller was not initialized. change this behvaiour by unsetting --disable-feature-controller (or setting it to `false` which is the default).")
+		log.Println("feature-controller disabled via config")
 	}
 
 	return app, nil

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -34,6 +34,10 @@ type Config struct {
 	DisableNodeConfigController bool
 	// DisableControlPlaneConfigController is a bool flag to disable control-plane config controller
 	DisableControlPlaneConfigController bool
+	// DisableUpdateNodeConfigController is a bool flag to disable update node config controller
+	DisableUpdateNodeConfigController bool
+	// DisableFeatureController is a bool flag to disable feature controller
+	DisableFeatureController bool
 }
 
 // App is the k8sd microcluster instance.
@@ -87,31 +91,36 @@ func New(cfg Config) (*App, error) {
 	}
 	app.readyWg.Add(1)
 
-	if cfg.DisableNodeConfigController {
-		log.Println("node config controller was not initialized. change this behvaiour by unsetting --disable-node-config-controller (or setting it to `false` which is the default).")
-	} else {
+	if !cfg.DisableNodeConfigController {
 		app.nodeConfigController = controllers.NewNodeConfigurationController(
 			cfg.Snap,
 			app.readyWg.Wait,
 		)
+	} else {
+		log.Println("node config controller was not initialized. change this behvaiour by unsetting --disable-node-config-controller (or setting it to `false` which is the default).")
 	}
 
-	if cfg.DisableControlPlaneConfigController {
-		log.Println("control plane config controller was not initialized. change this behvaiour by unsetting --disable-control-plane-config-controller (or setting it to `false` which is the default).")
-	} else {
+	if !cfg.DisableControlPlaneConfigController {
 		app.controlPlaneConfigController = controllers.NewControlPlaneConfigurationController(
 			cfg.Snap,
 			app.readyWg.Wait,
 			time.NewTicker(10*time.Second).C,
 		)
+	} else {
+		log.Println("control plane config controller was not initialized. change this behvaiour by unsetting --disable-control-plane-config-controller (or setting it to `false` which is the default).")
 	}
 
 	app.triggerUpdateNodeConfigControllerCh = make(chan struct{}, 1)
-	app.updateNodeConfigController = controllers.NewUpdateNodeConfigurationController(
-		cfg.Snap,
-		app.readyWg.Wait,
-		app.triggerUpdateNodeConfigControllerCh,
-	)
+
+	if !cfg.DisableUpdateNodeConfigController {
+		app.updateNodeConfigController = controllers.NewUpdateNodeConfigurationController(
+			cfg.Snap,
+			app.readyWg.Wait,
+			app.triggerUpdateNodeConfigControllerCh,
+		)
+	} else {
+		log.Println("update node config controller was not initialized. change this behvaiour by unsetting --disable-update-node-config-controller (or setting it to `false` which is the default).")
+	}
 
 	app.triggerFeatureControllerNetworkCh = make(chan struct{}, 1)
 	app.triggerFeatureControllerGatewayCh = make(chan struct{}, 1)
@@ -120,17 +129,22 @@ func New(cfg Config) (*App, error) {
 	app.triggerFeatureControllerLocalStorageCh = make(chan struct{}, 1)
 	app.triggerFeatureControllerMetricsServerCh = make(chan struct{}, 1)
 	app.triggerFeatureControllerDNSCh = make(chan struct{}, 1)
-	app.featureController = controllers.NewFeatureController(controllers.FeatureControllerOpts{
-		Snap:                   cfg.Snap,
-		WaitReady:              app.readyWg.Wait,
-		TriggerNetworkCh:       app.triggerFeatureControllerNetworkCh,
-		TriggerGatewayCh:       app.triggerFeatureControllerGatewayCh,
-		TriggerIngressCh:       app.triggerFeatureControllerIngressCh,
-		TriggerLoadBalancerCh:  app.triggerFeatureControllerLoadBalancerCh,
-		TriggerDNSCh:           app.triggerFeatureControllerDNSCh,
-		TriggerLocalStorageCh:  app.triggerFeatureControllerLocalStorageCh,
-		TriggerMetricsServerCh: app.triggerFeatureControllerMetricsServerCh,
-	})
+
+	if !cfg.DisableFeatureController {
+		app.featureController = controllers.NewFeatureController(controllers.FeatureControllerOpts{
+			Snap:                   cfg.Snap,
+			WaitReady:              app.readyWg.Wait,
+			TriggerNetworkCh:       app.triggerFeatureControllerNetworkCh,
+			TriggerGatewayCh:       app.triggerFeatureControllerGatewayCh,
+			TriggerIngressCh:       app.triggerFeatureControllerIngressCh,
+			TriggerLoadBalancerCh:  app.triggerFeatureControllerLoadBalancerCh,
+			TriggerDNSCh:           app.triggerFeatureControllerDNSCh,
+			TriggerLocalStorageCh:  app.triggerFeatureControllerLocalStorageCh,
+			TriggerMetricsServerCh: app.triggerFeatureControllerMetricsServerCh,
+		})
+	} else {
+		log.Println("feature controller was not initialized. change this behvaiour by unsetting --disable-feature-controller (or setting it to `false` which is the default).")
+	}
 
 	return app, nil
 }

--- a/src/k8s/pkg/utils/sys.go
+++ b/src/k8s/pkg/utils/sys.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 )
 
-// runCommand executes a command with a given context.
-// runCommand returns nil if the command completes successfully and the exit code is 0.
+// RunCommand executes a command with a given context.
+// RunCommand returns nil if the command completes successfully and the exit code is 0.
 func RunCommand(ctx context.Context, command []string, opts ...func(*exec.Cmd)) error {
 	var args []string
 	if len(command) > 1 {

--- a/src/k8s/pkg/utils/sys.go
+++ b/src/k8s/pkg/utils/sys.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 )
 
-// RunCommand executes a command with a given context.
-// RunCommand returns nil if the command completes successfully and the exit code is 0.
+// runCommand executes a command with a given context.
+// runCommand returns nil if the command completes successfully and the exit code is 0.
 func RunCommand(ctx context.Context, command []string, opts ...func(*exec.Cmd)) error {
 	var args []string
 	if len(command) > 1 {


### PR DESCRIPTION
# Summary
Added to flags to `k8sd` in order to disable node and control-plane config controllers:
`--disable-node-config-controller`
`--disable-control-plane-config-controller`
`--disable-update-node-config-controller`
`--disable-feature-controller`

# How to Test
```shell
/snap/k8s/current/bin/k8sd --disable-node-config-controller --disable-control-plane-config-controller --disable-update-node-config-controller --disable-feature-controller
```
And you should see the logs stating that the config controllers were not initialized.
```text
2024/06/25 16:36:14 node-config-controller disabled via config
2024/06/25 16:36:14 control-plane-config-controller disabled via config
2024/06/25 16:36:14 update-node-config-controller disabled via config
2024/06/25 16:36:14 feature-controller disabled via config
```