### PR TITLE
Switch default encapsulation to VXLAN, add annotations for autodetection

### DIFF
--- a/src/k8s/pkg/k8sd/features/calico/chart.go
+++ b/src/k8s/pkg/k8sd/features/calico/chart.go
@@ -36,9 +36,9 @@ var (
 	// calicoCtlTag represents the tag to use for the calicoctl image.
 	calicoCtlTag = "v3.28.0"
 
-	// encapsulation represents the default encapsulation method to use for Calico.
-	encapsulation = "VXLAN"
+	// defaultEncapsulation represents the default defaultEncapsulation method to use for Calico.
+	defaultEncapsulation = "VXLAN"
 
-	// apiServerEnabled determines if the Calico API server should be enabled.
-	apiServerEnabled = false
+	// defaultApiServerEnabled determines if the Calico API server should be enabled.
+	defaultApiServerEnabled = false
 )

--- a/src/k8s/pkg/k8sd/features/calico/chart.go
+++ b/src/k8s/pkg/k8sd/features/calico/chart.go
@@ -39,6 +39,6 @@ var (
 	// defaultEncapsulation represents the default defaultEncapsulation method to use for Calico.
 	defaultEncapsulation = "VXLAN"
 
-	// defaultApiServerEnabled determines if the Calico API server should be enabled.
-	defaultApiServerEnabled = false
+	// defaultAPIServerEnabled determines if the Calico API server should be enabled.
+	defaultAPIServerEnabled = false
 )

--- a/src/k8s/pkg/k8sd/features/calico/chart.go
+++ b/src/k8s/pkg/k8sd/features/calico/chart.go
@@ -35,4 +35,10 @@ var (
 	calicoCtlImage = "ghcr.io/canonical/k8s-snap/calico/ctl"
 	// calicoCtlTag represents the tag to use for the calicoctl image.
 	calicoCtlTag = "v3.28.0"
+
+	// encapsulation represents the default encapsulation method to use for Calico.
+	encapsulation = "VXLAN"
+
+	// apiServerEnabled determines if the Calico API server should be enabled.
+	apiServerEnabled = false
 )

--- a/src/k8s/pkg/k8sd/features/calico/cleanup.go
+++ b/src/k8s/pkg/k8sd/features/calico/cleanup.go
@@ -14,16 +14,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var reDefaultCalicoInterface = regexp.MustCompile("^vxlan[-v6]*.calico|cali[a-f0-9]*|tunl[0-9]*$")
+
 func CleanupNetwork(ctx context.Context, snap snap.Snap) error {
 	interfaces, err := net.Interfaces()
 	if err != nil {
 		return fmt.Errorf("failed to list network interfaces: %w", err)
-	}
-
-	// Compile the regular expression outside the loop
-	regex, err := regexp.Compile("^vxlan[-v6]*.calico|cali[a-f0-9]*|tunl[0-9]*$")
-	if err != nil {
-		return fmt.Errorf("failed to compile regex pattern: %w", err)
 	}
 
 	// Find the interfaces created by Calico
@@ -31,7 +27,7 @@ func CleanupNetwork(ctx context.Context, snap snap.Snap) error {
 		// Check if the interface name matches the regex pattern
 		// Adapted from MicroK8s' link removal hook:
 		// https://github.com/canonical/microk8s/blob/dff3627959d4774198000795a0a0afcaa003324b/microk8s-resources/default-hooks/remove.d/10-cni-link#L15
-		match := regex.MatchString(iface.Name)
+		match := reDefaultCalicoInterface.MatchString(iface.Name)
 		if match {
 			// Perform cleanup for Calico interface
 			if err := exec.CommandContext(ctx, "ip", "link", "delete", iface.Name).Run(); err != nil {

--- a/src/k8s/pkg/k8sd/features/calico/internal.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal.go
@@ -1,0 +1,172 @@
+package calico
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+)
+
+const (
+	annotationAPIServerEnabled             = "k8sd/v1alpha1/calico/apiserver-enabled"
+	annotationEncapsulationV4              = "k8sd/v1alpha1/calico/encapsulation-v4"
+	annotationEncapsulationV6              = "k8sd/v1alpha1/calico/encapsulation-v6"
+	annotationAutodetectionV4Firstfound    = "k8sd/v1alpha1/calico/autodetection-v4/firstFound"
+	annotationAutodetectionV4Kubernetes    = "k8sd/v1alpha1/calico/autodetection-v4/kubernetes"
+	annotationAutodetectionV4Interface     = "k8sd/v1alpha1/calico/autodetection-v4/interface"
+	annotationAutodetectionV4SkipInterface = "k8sd/v1alpha1/calico/autodetection-v4/skipInterface"
+	annotationAutodetectionV4CanReach      = "k8sd/v1alpha1/calico/autodetection-v4/canReach"
+	annotationAutodetectionV4Cidrs         = "k8sd/v1alpha1/calico/autodetection-v4/cidrs"
+	annotationAutodetectionV6Firstfound    = "k8sd/v1alpha1/calico/autodetection-v6/firstFound"
+	annotationAutodetectionV6Kubernetes    = "k8sd/v1alpha1/calico/autodetection-v6/kubernetes"
+	annotationAutodetectionV6Interface     = "k8sd/v1alpha1/calico/autodetection-v6/interface"
+	annotationAutodetectionV6SkipInterface = "k8sd/v1alpha1/calico/autodetection-v6/skipInterface"
+	annotationAutodetectionV6CanReach      = "k8sd/v1alpha1/calico/autodetection-v6/canReach"
+	annotationAutodetectionV6Cidrs         = "k8sd/v1alpha1/calico/autodetection-v6/cidrs"
+)
+
+type config struct {
+	encapsulationV4  string
+	encapsulationV6  string
+	apiServerEnabled bool
+	autodetectionV4  map[string]any
+	autodetectionV6  map[string]any
+}
+
+func validateEncapsulation(encapsulation string) bool {
+	switch encapsulation {
+	case "VXLAN",
+		"IPIP",
+		"IPIPCrossSubnet",
+		"VXLANCrossSubnet",
+		"None":
+		return true
+	}
+	return false
+}
+
+func internalConfig(annotations types.Annotations) (config, error) {
+	config := config{
+		encapsulationV4:  encapsulation,
+		encapsulationV6:  encapsulation,
+		apiServerEnabled: apiServerEnabled,
+	}
+
+	if v, ok := annotations.Get(annotationAPIServerEnabled); ok {
+		config.apiServerEnabled = v == "true"
+	}
+
+	if v, ok := annotations.Get(annotationEncapsulationV4); ok {
+		if !validateEncapsulation(v) {
+			return config, fmt.Errorf("invalid encapsulation-v4 annotation: %s", v)
+		}
+		config.encapsulationV4 = v
+	}
+
+	if v, ok := annotations.Get(annotationEncapsulationV6); ok {
+		if !validateEncapsulation(v) {
+			return config, fmt.Errorf("invalid encapsulation-v6 annotation: %s", v)
+		}
+		config.encapsulationV6 = v
+	}
+
+	if v, ok := annotations.Get(annotationAutodetectionV4Firstfound); ok {
+		if config.autodetectionV4 != nil {
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+		}
+		config.autodetectionV4 = map[string]any{
+			"firstFound": v == "true",
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV4Kubernetes); ok {
+		if config.autodetectionV4 != nil {
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+		}
+		config.autodetectionV4 = map[string]any{
+			"kubernetes": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV4Interface); ok {
+		if config.autodetectionV4 != nil {
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+		}
+		config.autodetectionV4 = map[string]any{
+			"interface": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV4SkipInterface); ok {
+		if config.autodetectionV4 != nil {
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+		}
+		config.autodetectionV4 = map[string]any{
+			"skipInterface": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV4CanReach); ok {
+		if config.autodetectionV4 != nil {
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+		}
+		config.autodetectionV4 = map[string]any{
+			"canReach": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV4Cidrs); ok {
+		if config.autodetectionV4 != nil {
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+		}
+		config.autodetectionV4 = map[string]any{
+			"cidrs": strings.Split(v, ","),
+		}
+	}
+
+	if v, ok := annotations.Get(annotationAutodetectionV6Firstfound); ok {
+		if config.autodetectionV6 != nil {
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+		}
+		config.autodetectionV6 = map[string]any{
+			"firstFound": v == "true",
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV6Kubernetes); ok {
+		if config.autodetectionV6 != nil {
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+		}
+		config.autodetectionV6 = map[string]any{
+			"kubernetes": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV6Interface); ok {
+		if config.autodetectionV6 != nil {
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+		}
+		config.autodetectionV6 = map[string]any{
+			"interface": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV6SkipInterface); ok {
+		if config.autodetectionV6 != nil {
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+		}
+		config.autodetectionV6 = map[string]any{
+			"skipInterface": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV6CanReach); ok {
+		if config.autodetectionV6 != nil {
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+		}
+		config.autodetectionV6 = map[string]any{
+			"canReach": v,
+		}
+	}
+	if v, ok := annotations.Get(annotationAutodetectionV6Cidrs); ok {
+		if config.autodetectionV6 != nil {
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+		}
+		config.autodetectionV6 = map[string]any{
+			"cidrs": strings.Split(v, ","),
+		}
+	}
+
+	return config, nil
+}

--- a/src/k8s/pkg/k8sd/features/calico/internal.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal.go
@@ -11,18 +11,18 @@ const (
 	annotationAPIServerEnabled             = "k8sd/v1alpha1/calico/apiserver-enabled"
 	annotationEncapsulationV4              = "k8sd/v1alpha1/calico/encapsulation-v4"
 	annotationEncapsulationV6              = "k8sd/v1alpha1/calico/encapsulation-v6"
-	annotationAutodetectionV4Firstfound    = "k8sd/v1alpha1/calico/autodetection-v4/firstFound"
+	annotationAutodetectionV4FirstFound    = "k8sd/v1alpha1/calico/autodetection-v4/firstFound"
 	annotationAutodetectionV4Kubernetes    = "k8sd/v1alpha1/calico/autodetection-v4/kubernetes"
 	annotationAutodetectionV4Interface     = "k8sd/v1alpha1/calico/autodetection-v4/interface"
 	annotationAutodetectionV4SkipInterface = "k8sd/v1alpha1/calico/autodetection-v4/skipInterface"
 	annotationAutodetectionV4CanReach      = "k8sd/v1alpha1/calico/autodetection-v4/canReach"
-	annotationAutodetectionV4Cidrs         = "k8sd/v1alpha1/calico/autodetection-v4/cidrs"
-	annotationAutodetectionV6Firstfound    = "k8sd/v1alpha1/calico/autodetection-v6/firstFound"
+	annotationAutodetectionV4CIDRs         = "k8sd/v1alpha1/calico/autodetection-v4/cidrs"
+	annotationAutodetectionV6FirstFound    = "k8sd/v1alpha1/calico/autodetection-v6/firstFound"
 	annotationAutodetectionV6Kubernetes    = "k8sd/v1alpha1/calico/autodetection-v6/kubernetes"
 	annotationAutodetectionV6Interface     = "k8sd/v1alpha1/calico/autodetection-v6/interface"
 	annotationAutodetectionV6SkipInterface = "k8sd/v1alpha1/calico/autodetection-v6/skipInterface"
 	annotationAutodetectionV6CanReach      = "k8sd/v1alpha1/calico/autodetection-v6/canReach"
-	annotationAutodetectionV6Cidrs         = "k8sd/v1alpha1/calico/autodetection-v6/cidrs"
+	annotationAutodetectionV6CIDRs         = "k8sd/v1alpha1/calico/autodetection-v6/cidrs"
 )
 
 type config struct {
@@ -45,7 +45,7 @@ func internalConfig(annotations types.Annotations) (config, error) {
 	config := config{
 		encapsulationV4:  defaultEncapsulation,
 		encapsulationV6:  defaultEncapsulation,
-		apiServerEnabled: defaultApiServerEnabled,
+		apiServerEnabled: defaultAPIServerEnabled,
 	}
 
 	if v, ok := annotations.Get(annotationAPIServerEnabled); ok {
@@ -69,9 +69,9 @@ func internalConfig(annotations types.Annotations) (config, error) {
 	var autodetectionV4Key string
 	var autodetectionV4Value any
 
-	if v, ok := annotations.Get(annotationAutodetectionV4Firstfound); ok {
+	if v, ok := annotations.Get(annotationAutodetectionV4FirstFound); ok {
 		if autodetectionV4Key != "" {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4Firstfound)
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4FirstFound)
 		}
 		autodetectionV4Key = "firstFound"
 		autodetectionV4Value = v == "true"
@@ -104,9 +104,9 @@ func internalConfig(annotations types.Annotations) (config, error) {
 		autodetectionV4Key = "canReach"
 		autodetectionV4Value = v
 	}
-	if v, ok := annotations.Get(annotationAutodetectionV4Cidrs); ok {
+	if v, ok := annotations.Get(annotationAutodetectionV4CIDRs); ok {
 		if autodetectionV4Key != "" {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4Cidrs)
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4CIDRs)
 		}
 		autodetectionV4Key = "cidrs"
 		autodetectionV4Value = strings.Split(v, ",")
@@ -122,9 +122,9 @@ func internalConfig(annotations types.Annotations) (config, error) {
 	var autodetectionV6Key string
 	var autodetectionV6Value any
 
-	if v, ok := annotations.Get(annotationAutodetectionV6Firstfound); ok {
+	if v, ok := annotations.Get(annotationAutodetectionV6FirstFound); ok {
 		if autodetectionV6Key != "" {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6Firstfound)
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6FirstFound)
 		}
 		autodetectionV6Key = "firstFound"
 		autodetectionV6Value = v == "true"
@@ -157,9 +157,9 @@ func internalConfig(annotations types.Annotations) (config, error) {
 		autodetectionV6Key = "canReach"
 		autodetectionV6Value = v
 	}
-	if v, ok := annotations.Get(annotationAutodetectionV6Cidrs); ok {
+	if v, ok := annotations.Get(annotationAutodetectionV6CIDRs); ok {
 		if autodetectionV6Key != "" {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6Cidrs)
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6CIDRs)
 		}
 		autodetectionV6Key = "cidrs"
 		autodetectionV6Value = strings.Split(v, ",")

--- a/src/k8s/pkg/k8sd/features/calico/internal.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal.go
@@ -25,24 +25,29 @@ const (
 	annotationAutodetectionV6Cidrs         = "k8sd/v1alpha1/calico/autodetection-v6/cidrs"
 )
 
+type autodetection struct {
+	FirstFound         bool     `json:"firstFound,omitempty"`
+	Kubernetes         string   `json:"kubernetes,omitempty"`
+	InterfaceRegex     string   `json:"interface,omitempty"`
+	SkipInterfaceRegex string   `json:"skipInterface,omitempty"`
+	CanReach           string   `json:"canReach,omitempty"`
+	CIDRs              []string `json:"cidrs,omitempty"`
+}
+
 type config struct {
 	encapsulationV4  string
 	encapsulationV6  string
 	apiServerEnabled bool
-	autodetectionV4  map[string]any
-	autodetectionV6  map[string]any
+	autodetectionV4  *autodetection
+	autodetectionV6  *autodetection
 }
 
-func validateEncapsulation(encapsulation string) bool {
-	switch encapsulation {
-	case "VXLAN",
-		"IPIP",
-		"IPIPCrossSubnet",
-		"VXLANCrossSubnet",
-		"None":
-		return true
+func checkEncapsulation(v string) error {
+	switch v {
+	case "VXLAN", "IPIP", "IPIPCrossSubnet", "VXLANCrossSubnet", "None":
+		return nil
 	}
-	return false
+	return fmt.Errorf("unsupported encapsulation type: %s", v)
 }
 
 func internalConfig(annotations types.Annotations) (config, error) {
@@ -57,114 +62,114 @@ func internalConfig(annotations types.Annotations) (config, error) {
 	}
 
 	if v, ok := annotations.Get(annotationEncapsulationV4); ok {
-		if !validateEncapsulation(v) {
-			return config, fmt.Errorf("invalid encapsulation-v4 annotation: %s", v)
+		if err := checkEncapsulation(v); err != nil {
+			return config, fmt.Errorf("invalid encapsulation-v4 annotation: %w", err)
 		}
 		config.encapsulationV4 = v
 	}
 
 	if v, ok := annotations.Get(annotationEncapsulationV6); ok {
-		if !validateEncapsulation(v) {
-			return config, fmt.Errorf("invalid encapsulation-v6 annotation: %s", v)
+		if err := checkEncapsulation(v); err != nil {
+			return config, fmt.Errorf("invalid encapsulation-v6 annotation: %w", err)
 		}
 		config.encapsulationV6 = v
 	}
 
 	if v, ok := annotations.Get(annotationAutodetectionV4Firstfound); ok {
 		if config.autodetectionV4 != nil {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4Firstfound)
 		}
-		config.autodetectionV4 = map[string]any{
-			"firstFound": v == "true",
+		config.autodetectionV4 = &autodetection{
+			FirstFound: v == "true",
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV4Kubernetes); ok {
 		if config.autodetectionV4 != nil {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4Kubernetes)
 		}
-		config.autodetectionV4 = map[string]any{
-			"kubernetes": v,
+		config.autodetectionV4 = &autodetection{
+			Kubernetes: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV4Interface); ok {
 		if config.autodetectionV4 != nil {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4Interface)
 		}
-		config.autodetectionV4 = map[string]any{
-			"interface": v,
+		config.autodetectionV4 = &autodetection{
+			InterfaceRegex: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV4SkipInterface); ok {
 		if config.autodetectionV4 != nil {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4SkipInterface)
 		}
-		config.autodetectionV4 = map[string]any{
-			"skipInterface": v,
+		config.autodetectionV4 = &autodetection{
+			SkipInterfaceRegex: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV4CanReach); ok {
 		if config.autodetectionV4 != nil {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4CanReach)
 		}
-		config.autodetectionV4 = map[string]any{
-			"canReach": v,
+		config.autodetectionV4 = &autodetection{
+			CanReach: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV4Cidrs); ok {
 		if config.autodetectionV4 != nil {
-			return config, fmt.Errorf("multiple autodetection-v4 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v4 annotations found: %s", annotationAutodetectionV4Cidrs)
 		}
-		config.autodetectionV4 = map[string]any{
-			"cidrs": strings.Split(v, ","),
+		config.autodetectionV4 = &autodetection{
+			CIDRs: strings.Split(v, ","),
 		}
 	}
 
 	if v, ok := annotations.Get(annotationAutodetectionV6Firstfound); ok {
 		if config.autodetectionV6 != nil {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6Firstfound)
 		}
-		config.autodetectionV6 = map[string]any{
-			"firstFound": v == "true",
+		config.autodetectionV6 = &autodetection{
+			FirstFound: v == "true",
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV6Kubernetes); ok {
 		if config.autodetectionV6 != nil {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6Kubernetes)
 		}
-		config.autodetectionV6 = map[string]any{
-			"kubernetes": v,
+		config.autodetectionV6 = &autodetection{
+			Kubernetes: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV6Interface); ok {
 		if config.autodetectionV6 != nil {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6Interface)
 		}
-		config.autodetectionV6 = map[string]any{
-			"interface": v,
+		config.autodetectionV6 = &autodetection{
+			InterfaceRegex: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV6SkipInterface); ok {
 		if config.autodetectionV6 != nil {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6SkipInterface)
 		}
-		config.autodetectionV6 = map[string]any{
-			"skipInterface": v,
+		config.autodetectionV6 = &autodetection{
+			SkipInterfaceRegex: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV6CanReach); ok {
 		if config.autodetectionV6 != nil {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6CanReach)
 		}
-		config.autodetectionV6 = map[string]any{
-			"canReach": v,
+		config.autodetectionV6 = &autodetection{
+			CanReach: v,
 		}
 	}
 	if v, ok := annotations.Get(annotationAutodetectionV6Cidrs); ok {
 		if config.autodetectionV6 != nil {
-			return config, fmt.Errorf("multiple autodetection-v6 annotations found")
+			return config, fmt.Errorf("multiple autodetection-v6 annotations found: %s", annotationAutodetectionV6Cidrs)
 		}
-		config.autodetectionV6 = map[string]any{
-			"cidrs": strings.Split(v, ","),
+		config.autodetectionV6 = &autodetection{
+			CIDRs: strings.Split(v, ","),
 		}
 	}
 

--- a/src/k8s/pkg/k8sd/features/calico/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal_test.go
@@ -59,7 +59,7 @@ func TestInternalConfig(t *testing.T) {
 		{
 			name: "MultipleAutodetectionV4",
 			annotations: map[string]string{
-				annotationAutodetectionV4Firstfound: "true",
+				annotationAutodetectionV4FirstFound: "true",
 				annotationAutodetectionV4Kubernetes: "true",
 			},
 			expectError: true,
@@ -67,7 +67,7 @@ func TestInternalConfig(t *testing.T) {
 		{
 			name: "ValidAutodetectionCidrs",
 			annotations: map[string]string{
-				annotationAutodetectionV4Cidrs: "10.1.0.0/16,2001:0db8::/32",
+				annotationAutodetectionV4CIDRs: "10.1.0.0/16,2001:0db8::/32",
 			},
 			expectedConfig: config{
 				apiServerEnabled: false,

--- a/src/k8s/pkg/k8sd/features/calico/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal_test.go
@@ -73,8 +73,8 @@ func TestInternalConfig(t *testing.T) {
 				apiServerEnabled: false,
 				encapsulationV4:  "VXLAN",
 				encapsulationV6:  "VXLAN",
-				autodetectionV4: map[string]any{
-					"cidrs": []string{"10.1.0.0/16", "2001:0db8::/32"},
+				autodetectionV4: &autodetection{
+					CIDRs: []string{"10.1.0.0/16", "2001:0db8::/32"},
 				},
 				autodetectionV6: nil,
 			},

--- a/src/k8s/pkg/k8sd/features/calico/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal_test.go
@@ -1,0 +1,100 @@
+package calico
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestInternalConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		annotations    map[string]string
+		expectedConfig config
+		expectError    bool
+	}{
+		{
+			name:        "Empty",
+			annotations: map[string]string{},
+			expectedConfig: config{
+				apiServerEnabled: false,
+				encapsulationV4:  "VXLAN",
+				encapsulationV6:  "VXLAN",
+			},
+			expectError: false,
+		},
+		{
+			name: "Valid",
+			annotations: map[string]string{
+				annotationAPIServerEnabled: "true",
+				annotationEncapsulationV4:  "IPIP",
+			},
+			expectedConfig: config{
+				apiServerEnabled: true,
+				encapsulationV4:  "IPIP",
+				encapsulationV6:  "VXLAN",
+			},
+			expectError: false,
+		},
+		{
+			name: "InvalidEncapsulation",
+			annotations: map[string]string{
+				annotationEncapsulationV4: "Invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "InvalidAPIServerEnabled",
+			annotations: map[string]string{
+				annotationAPIServerEnabled: "invalid",
+				annotationEncapsulationV4:  "VXLAN",
+			},
+			expectedConfig: config{
+				apiServerEnabled: false,
+				encapsulationV4:  "VXLAN",
+				encapsulationV6:  "VXLAN",
+			},
+			expectError: false,
+		},
+		{
+			name: "MultipleAutodetectionV4",
+			annotations: map[string]string{
+				annotationAutodetectionV4Firstfound: "true",
+				annotationAutodetectionV4Kubernetes: "true",
+			},
+			expectError: true,
+		},
+		{
+			name: "ValidAutodetectionCidrs",
+			annotations: map[string]string{
+				annotationAutodetectionV4Cidrs: "10.1.0.0/16,2001:0db8::/32",
+			},
+			expectedConfig: config{
+				apiServerEnabled: false,
+				encapsulationV4:  "VXLAN",
+				encapsulationV6:  "VXLAN",
+				autodetectionV4: map[string]any{
+					"cidrs": []string{"10.1.0.0/16", "2001:0db8::/32"},
+				},
+				autodetectionV6: nil,
+			},
+			expectError: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			annotations := make(map[string]string)
+			for k, v := range tc.annotations {
+				annotations[k] = v
+			}
+
+			parsed, err := internalConfig(annotations)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(parsed).To(Equal(tc.expectedConfig))
+			}
+		})
+	}
+}

--- a/src/k8s/pkg/k8sd/features/calico/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal_test.go
@@ -73,8 +73,8 @@ func TestInternalConfig(t *testing.T) {
 				apiServerEnabled: false,
 				encapsulationV4:  "VXLAN",
 				encapsulationV6:  "VXLAN",
-				autodetectionV4: &autodetection{
-					CIDRs: []string{"10.1.0.0/16", "2001:0db8::/32"},
+				autodetectionV4: map[string]any{
+					"cidrs": []string{"10.1.0.0/16", "2001:0db8::/32"},
 				},
 				autodetectionV6: nil,
 			},

--- a/src/k8s/pkg/k8sd/features/calico/network.go
+++ b/src/k8s/pkg/k8sd/features/calico/network.go
@@ -72,11 +72,11 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, annota
 		},
 		"installation": map[string]any{
 			"calicoNetwork": map[string]any{
-				"ipPools": podIpPools,
+				"ipPools":                    podIpPools,
+				"nodeAddressAutodetectionV4": config.autodetectionV4,
+				"nodeAddressAutodetectionV6": config.autodetectionV6,
 			},
-			"nodeAddressAutodetectionV4": config.autodetectionV4,
-			"nodeAddressAutodetectionV6": config.autodetectionV6,
-			"registry":                   imageRepo,
+			"registry": imageRepo,
 		},
 		"apiServer": map[string]any{
 			"enabled": config.apiServerEnabled,

--- a/src/k8s/pkg/k8sd/features/calico/network.go
+++ b/src/k8s/pkg/k8sd/features/calico/network.go
@@ -72,9 +72,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, annota
 		},
 		"installation": map[string]any{
 			"calicoNetwork": map[string]any{
-				"ipPools":                    podIpPools,
-				"nodeAddressAutodetectionV4": config.autodetectionV4,
-				"nodeAddressAutodetectionV6": config.autodetectionV6,
+				"ipPools": podIpPools,
 			},
 			"registry": imageRepo,
 		},
@@ -82,6 +80,14 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, annota
 			"enabled": config.apiServerEnabled,
 		},
 		"serviceCIDRs": serviceCIDRs,
+	}
+
+	if config.autodetectionV4 != nil {
+		values["installation"].(map[string]any)["calicoNetwork"].(map[string]any)["nodeAddressAutodetectionV4"] = config.autodetectionV4
+	}
+
+	if config.autodetectionV6 != nil {
+		values["installation"].(map[string]any)["calicoNetwork"].(map[string]any)["nodeAddressAutodetectionV6"] = config.autodetectionV6
 	}
 
 	if _, err := m.Apply(ctx, chartCalico, helm.StatePresent, values); err != nil {


### PR DESCRIPTION
* Changed default encapsulation to VXLAN for both IPv4 and IPv6 pools
* Disabled Calico api server deployment by default
* Added annotations for node address auto detection