### PR TITLE
Prepare LXD images for e2e tests to improve runtimes

### DIFF
--- a/src/k8s/pkg/utils/shims/shims.go
+++ b/src/k8s/pkg/utils/shims/shims.go
@@ -9,7 +9,7 @@ import (
 )
 
 // reBinaryName is the regular expression used to match containerd shim and /pause processes.
-var reBinaryName = regexp.MustCompile(`(^/snap/k8s/.*/bin/containerd-shim-runc-v2|^/pause$)`)
+var reBinaryName = regexp.MustCompile(`(^(/var/lib/snapd)?/snap/k8s/.*/bin/containerd-shim-runc-v2|^/pause$)`)
 
 // RunningContainerdShimPIDs returns a list of all the pids on the system that have been started by a containerd shim.
 func RunningContainerdShimPIDs(ctx context.Context) ([]string, error) {

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -53,9 +53,86 @@ Then, run the tests with:
 export TEST_SNAP=$PWD/k8s.snap
 export TEST_SUBSTRATE=lxd
 
-export TEST_LXD_IMAGE=ubuntu:22.04          # (optionally) specify which image to use for LXD containers
-export TEST_LXD_PROFILE=k8s-integration     # (optionally) specify profile name to configure
-export TEST_SKIP_CLEANUP=1                  # (optionally) do not destroy machines after tests finish
+export TEST_LXD_IMAGE=ubuntu:22.04               # (optionally) specify which image to use for LXD containers
+export TEST_LXD_PROFILE_NAME=k8s-integration     # (optionally) specify profile name to configure
+export TEST_SKIP_CLEANUP=1                       # (optionally) do not destroy machines after tests finish
+
+cd tests/integration && tox -e integration
+```
+
+When using LXD, it is possible to reduce the amount of steps needed to setup each container and sideload all OCI images. See [./lxd/setup-image.sh](./lxd/setup-image.sh) for details. For example, to build an image `k8s-e2e/ubuntu` based on `ubuntu:24.04`:
+
+```bash
+# build custom image 'k8s-e2e/ubuntu'
+export TEST_SNAP=$PWD/k8s.snap
+export BASE_IMAGE=ubuntu:24.04
+export OUT_IMAGES_DIR=$PWD/k8s-e2e-images
+export OUT_IMAGE_ALIAS=k8s-e2e/ubuntu
+./tests/integration/lxd/setup-image.sh
+
+# run tests using custom image
+export TEST_SUBSTRATE=lxd
+export TEST_LXD_IMAGE=k8s-e2e/ubuntu
+export TEST_LXD_SIDELOAD_IMAGES_DIR=$PWD/k8s-e2e-images
+cd tests/integration && tox -e integration
+```
+
+#### Running end to end tests on LXD containers for non-Ubuntu distributions
+
+It is possible to use LXD to run the end to end tests with non-Ubuntu distributions, e.g. Debian or Alma Linux.
+
+These distributions come without snapd installed out of the box, therefore they require building a custom image with snapd installed.
+
+##### Debian 12
+
+Build an image called `k8s-e2e/debian-12` with:
+
+```bash
+export TEST_SNAP=$PWD/k8s.snap
+export BASE_IMAGE=images:debian/12
+export BASE_DISTRO=debian
+export OUT_IMAGES_DIR=$PWD/k8s-e2e-images
+export OUT_IMAGE_ALIAS=k8s-e2e/debian-12
+
+./tests/integration/lxd/setup-image.sh
+```
+
+Then, run the end to end tests with:
+
+```bash
+export TEST_SNAP=$PWD/k8s.snap
+export TEST_SUBSTRATE=lxd
+export TEST_LXD_IMAGE=k8s-e2e/debian-12
+export TEST_LXD_SIDELOAD_IMAGES_DIR=$PWD/k8s-e2e-images
+
+cd tests/integration && tox -e integration
+```
+
+##### AlmaLinux 9
+
+Build an image called `k8s-e2e/almalinux-9` with:
+
+```bash
+export TEST_SNAP=$PWD/k8s.snap
+export BASE_IMAGE=images:almalinux/9
+export BASE_DISTRO=almalinux
+export OUT_IMAGES_DIR=$PWD/k8s-e2e-images
+export OUT_IMAGE_ALIAS=k8s-e2e/almalinux-9
+
+./tests/integration/lxd/setup-image.sh
+```
+
+Then, run the end to end tests with:
+
+```bash
+export TEST_SNAP=$PWD/k8s.snap
+export TEST_SUBSTRATE=lxd
+export TEST_LXD_SIDELOAD_IMAGES_DIR=$PWD/k8s-e2e-images
+export TEST_LXD_IMAGE=k8s-e2e/almalinux-9
+
+# AlmaLinux needs a separate LXD profile
+export TEST_LXD_PROFILE_NAME=k8s-integration-almalinux
+export TEST_LXD_PROFILE="$(cat tests/integration/lxd/almalinux/lxd-profile.yaml)"
 
 cd tests/integration && tox -e integration
 ```

--- a/tests/integration/lxd/almalinux/lxd-profile.yaml
+++ b/tests/integration/lxd/almalinux/lxd-profile.yaml
@@ -1,8 +1,9 @@
-description: "LXD profile for Canonical Kubernetes"
+description: "LXD profile for Canonical Kubernetes (AlmaLinux)"
 config:
   linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,iptable_raw,netlink_diag,nf_nat,overlay,br_netfilter,xt_socket
   raw.lxc: |
-    lxc.apparmor.profile=unconfined
+    # lxc.apparmor.profile=unconfined
+    lxc.selinux.context=unconfined_t
     lxc.mount.auto=proc:rw sys:rw cgroup:rw
     lxc.cgroup.devices.allow=a
     lxc.cap.drop=

--- a/tests/integration/lxd/setup-image.sh
+++ b/tests/integration/lxd/setup-image.sh
@@ -1,0 +1,102 @@
+#!/bin/bash -xe
+
+# Description: Build an LXD image that .
+#              The image will be saved with alias 'k8s-e2e/ubuntu'
+#
+# Usage:
+#   $ ./setup-image.sh
+
+DIR=`realpath $(dirname "${0}")`
+
+################################################################################
+
+BASE_IMAGE="${BASE_IMAGE:=ubuntu:22.04}"                      # base image
+BASE_DISTRO="${BASE_DISTRO:=ubuntu}"                          # base distro of the image
+
+TEST_SNAP="${TEST_SNAP:=}"                                    # path to './k8s.snap' to test
+BASE_SNAP="${BASE_SNAP:=core20}"                              # base snap to install on the image, e.g. 'core20'
+IMAGES=""                                                     # list of images to fetch for side-loading
+
+OUT_IMAGES_DIR="${OUT_IMAGES_DIR:=${DIR}/k8s-e2e-images}"     # directory where OCI images will be fetched
+OUT_IMAGE_ALIAS="${OUT_IMAGE_ALIAS:=k8s-e2e/ubuntu}"          # image alias to create
+
+REGCTL="${REGCTL:=${DIR}/../../../src/k8s/tools/regctl.sh}"   # path to regctl binary
+
+################################################################################
+# figure out base snap and list of images
+if [ "${TEST_SNAP}" != "" ]; then
+  dir="$(mktemp -d)"
+  unsquashfs -d "${dir}/snap" "${TEST_SNAP}"
+
+  BASE_SNAP="$(cat "${dir}/snap/meta/snap.yaml" | grep base: | head -n1 | sed "s/base: //")"
+  IMAGES="$(cat "${dir}/snap/images.txt")"
+
+  rm -rf "${dir}"
+fi
+
+################################################################################
+# launch an instance from base image
+lxc launch "${BASE_IMAGE}" tmp-builder
+
+################################################################################
+# distro specific steps
+case "${BASE_DISTRO}" in
+  ubuntu)
+    # snapd is preinstalled on Ubuntu OSes
+    lxc shell tmp-builder -- bash -c "snap wait core seed.loaded"
+    lxc shell tmp-builder -- bash -c "snap install ${BASE_SNAP}"
+    ;;
+  almalinux)
+    # install snapd and ensure /snap/bin is in the environment
+    lxc shell tmp-builder -- bash -c "while ! ping -c1 snapcraft.io; do sleep 1; done"
+    lxc shell tmp-builder -- bash -c "dnf install epel-release -y"
+    lxc shell tmp-builder -- bash -c "dnf install sudo -y"
+    lxc shell tmp-builder -- bash -c "dnf install fuse squashfuse -y"
+    lxc shell tmp-builder -- bash -c "dnf install snapd -y"
+
+    lxc shell tmp-builder -- bash -c "systemctl enable --now snapd.socket"
+    lxc shell tmp-builder -- bash -c "ln -s /var/lib/snapd/snap /snap"
+    lxc shell tmp-builder -- bash -c "snap wait core seed.loaded"
+    lxc shell tmp-builder -- bash -c "snap install snapd ${BASE_SNAP}"
+    lxc shell tmp-builder -- bash -c "echo PATH=$PATH:/snap/bin >> /etc/environment"
+    ;;
+  debian)
+    # install snapd and ensure /snap/bin is in the environment
+    lxc shell tmp-builder -- bash -c 'apt update'
+    lxc shell tmp-builder -- bash -c 'apt install -y squashfuse snapd fuse'
+    lxc shell tmp-builder -- bash -c 'snap wait core seed.loaded'
+    lxc shell tmp-builder -- bash -c 'snap install snapd core20'
+    lxc shell tmp-builder -- bash -c 'echo PATH=$PATH:/snap/bin >> /etc/environment'
+    lxc shell tmp-builder -- bash -c 'apt autoremove; apt clean; apt autoclean; rm -rf /var/lib/apt/lists'
+
+    # TODO(neoaggelos): disable apparmor in containerd, as it causes trouble in the default setup
+    # lxc shell tmp-builder -- bash -c '
+    #   mkdir -p /var/snap/k8s/common/etc/containerd/conf.d
+    #   echo "
+    #   [plugins.\"io.containerd.grpc.v1.cri\"]
+    #     disable_apparmor=true
+    #   " | tee /var/snap/k8s/common/etc/containerd/conf.d/10-debian-disable-apparmor.toml
+    # '
+    ;;
+  *)
+    echo "Unsupported BASE_DISTRO value: ${BASE_DISTRO}"
+    exit 1
+    ;;
+esac
+
+################################################################################
+# create snapshot and export as image
+lxc snapshot tmp-builder snapshot
+lxc publish local:tmp-builder/snapshot --alias "${OUT_IMAGE_ALIAS}"
+
+################################################################################
+# cleanup
+lxc rm tmp-builder --force
+
+################################################################################
+# fetch images
+mkdir -p "${OUT_IMAGES_DIR}"
+for image in ${IMAGES}; do
+  file="${OUT_IMAGES_DIR}/$(echo $image | tr ':/' '-').tar"
+  [ ! -f "${file}" ] && "${REGCTL}" image export --platform=local --user-agent=containerd/v1.6.33 "${image}" "${file}"
+done

--- a/tests/integration/lxd/setup-image.sh
+++ b/tests/integration/lxd/setup-image.sh
@@ -1,14 +1,36 @@
 #!/bin/bash -xe
 
-# Description: Build an LXD image that .
-#              The image will be saved with alias 'k8s-e2e/ubuntu'
+#### Description
 #
-# Usage:
-#   $ ./setup-image.sh
+# Build an LXD image for use in the k8s-snap integration tests. A number of base
+# distros is supported (e.g. Ubuntu, Debian, AlmaLinux).
+#
+# Optionally, the script fetches the OCI images needed by k8s-snap, so that the
+# images do not have to be pulled repeatedly by the end to end tests.
+#
+#### Configuration
+#
+# See next section for all configuration options that this script accepts as environment variables.
+#
+#### Examples
+#
+# Build LXD image 'k8s/ubuntu' based on Ubuntu 24.04
+#
+#    $ BASE_IMAGE=ubuntu:22.04 OUT_IMAGE_ALIAS=k8s/ubuntu ./setup-image.sh
+#
+# Build LXD image 'k8s/debian' based on Debian 12
+#
+#   $ BASE_IMAGE=images:debian/12 BASE_DISTRO=debian OUT_IMAGE_ALIAS=k8s/debian ./setup-image.sh
+#
+# Build LXD image 'k8s/almalinux' based on AlmaLinux 9
+#
+#   $ BASE_IMAGE=images:almalinux/9 BASE_DISTRO=almalinux OUT_IMAGE_ALIAS=k8s/almalinux ./setup.image.sh
+#
 
 DIR=`realpath $(dirname "${0}")`
 
 ################################################################################
+# configuration
 
 BASE_IMAGE="${BASE_IMAGE:=ubuntu:22.04}"                      # base image
 BASE_DISTRO="${BASE_DISTRO:=ubuntu}"                          # base distro of the image
@@ -18,9 +40,11 @@ BASE_SNAP="${BASE_SNAP:=core20}"                              # base snap to ins
 IMAGES=""                                                     # list of images to fetch for side-loading
 
 OUT_IMAGES_DIR="${OUT_IMAGES_DIR:=${DIR}/k8s-e2e-images}"     # directory where OCI images will be fetched
-OUT_IMAGE_ALIAS="${OUT_IMAGE_ALIAS:=k8s-e2e/ubuntu}"          # image alias to create
+OUT_IMAGE_ALIAS="${OUT_IMAGE_ALIAS:=k8s-e2e}"                 # image alias to create
 
 REGCTL="${REGCTL:=${DIR}/../../../src/k8s/tools/regctl.sh}"   # path to regctl binary
+
+EXTRA_IMAGES="${EXTRA_IMAGES:=}"                              # space separated list of extra images to fetch for side-loading
 
 ################################################################################
 # figure out base snap and list of images
@@ -43,40 +67,40 @@ lxc launch "${BASE_IMAGE}" tmp-builder
 case "${BASE_DISTRO}" in
   ubuntu)
     # snapd is preinstalled on Ubuntu OSes
-    lxc shell tmp-builder -- bash -c "snap wait core seed.loaded"
-    lxc shell tmp-builder -- bash -c "snap install ${BASE_SNAP}"
+    lxc shell tmp-builder -- bash -c 'snap wait core seed.loaded'
+    lxc shell tmp-builder -- bash -c 'snap install '"${BASE_SNAP}"
     ;;
   almalinux)
     # install snapd and ensure /snap/bin is in the environment
-    lxc shell tmp-builder -- bash -c "while ! ping -c1 snapcraft.io; do sleep 1; done"
-    lxc shell tmp-builder -- bash -c "dnf install epel-release -y"
-    lxc shell tmp-builder -- bash -c "dnf install tar sudo -y"
-    lxc shell tmp-builder -- bash -c "dnf install fuse squashfuse -y"
-    lxc shell tmp-builder -- bash -c "dnf install snapd -y"
+    lxc shell tmp-builder -- bash -c 'while ! ping -c1 snapcraft.io; do sleep 1; done'
+    lxc shell tmp-builder -- bash -c 'dnf install epel-release -y'
+    lxc shell tmp-builder -- bash -c 'dnf install tar sudo -y'
+    lxc shell tmp-builder -- bash -c 'dnf install fuse squashfuse -y'
+    lxc shell tmp-builder -- bash -c 'dnf install snapd -y'
 
-    lxc shell tmp-builder -- bash -c "systemctl enable --now snapd.socket"
-    lxc shell tmp-builder -- bash -c "ln -s /var/lib/snapd/snap /snap"
-    lxc shell tmp-builder -- bash -c "snap wait core seed.loaded"
-    lxc shell tmp-builder -- bash -c "snap install snapd ${BASE_SNAP}"
-    lxc shell tmp-builder -- bash -c "echo PATH=$PATH:/snap/bin >> /etc/environment"
+    lxc shell tmp-builder -- bash -c 'systemctl enable --now snapd.socket'
+    lxc shell tmp-builder -- bash -c 'ln -s /var/lib/snapd/snap /snap'
+    lxc shell tmp-builder -- bash -c 'snap wait core seed.loaded'
+    lxc shell tmp-builder -- bash -c 'snap install snapd '"${BASE_SNAP}"
+    lxc shell tmp-builder -- bash -c 'echo PATH=$PATH:/snap/bin >> /etc/environment'
     ;;
   debian)
     # install snapd and ensure /snap/bin is in the environment
     lxc shell tmp-builder -- bash -c 'apt update'
     lxc shell tmp-builder -- bash -c 'apt install -y squashfuse snapd fuse'
     lxc shell tmp-builder -- bash -c 'snap wait core seed.loaded'
-    lxc shell tmp-builder -- bash -c 'snap install snapd core20'
+    lxc shell tmp-builder -- bash -c 'snap install snapd '"${BASE_SNAP}"
     lxc shell tmp-builder -- bash -c 'echo PATH=$PATH:/snap/bin >> /etc/environment'
     lxc shell tmp-builder -- bash -c 'apt autoremove; apt clean; apt autoclean; rm -rf /var/lib/apt/lists'
 
-    # TODO(neoaggelos): disable apparmor in containerd, as it causes trouble in the default setup
-    # lxc shell tmp-builder -- bash -c '
-    #   mkdir -p /var/snap/k8s/common/etc/containerd/conf.d
-    #   echo "
-    #   [plugins.\"io.containerd.grpc.v1.cri\"]
-    #     disable_apparmor=true
-    #   " | tee /var/snap/k8s/common/etc/containerd/conf.d/10-debian-disable-apparmor.toml
-    # '
+    # NOTE(neoaggelos): disable apparmor in containerd, as it causes trouble in the default setup
+    lxc shell tmp-builder -- bash -c '
+      mkdir -p /var/snap/k8s/common/etc/containerd/conf.d
+      echo "
+      [plugins.\"io.containerd.grpc.v1.cri\"]
+        disable_apparmor=true
+      " | tee /var/snap/k8s/common/etc/containerd/conf.d/10-debian-disable-apparmor.toml
+    '
     ;;
   *)
     echo "Unsupported BASE_DISTRO value: ${BASE_DISTRO}"
@@ -96,7 +120,7 @@ lxc rm tmp-builder --force
 ################################################################################
 # fetch images
 mkdir -p "${OUT_IMAGES_DIR}"
-for image in ${IMAGES}; do
+for image in ${IMAGES} ${EXTRA_IMAGES}; do
   file="${OUT_IMAGES_DIR}/$(echo $image | tr ':/' '-').tar"
   [ ! -f "${file}" ] && "${REGCTL}" image export --platform=local --user-agent=containerd/v1.6.33 "${image}" "${file}"
 done

--- a/tests/integration/lxd/setup-image.sh
+++ b/tests/integration/lxd/setup-image.sh
@@ -50,7 +50,7 @@ case "${BASE_DISTRO}" in
     # install snapd and ensure /snap/bin is in the environment
     lxc shell tmp-builder -- bash -c "while ! ping -c1 snapcraft.io; do sleep 1; done"
     lxc shell tmp-builder -- bash -c "dnf install epel-release -y"
-    lxc shell tmp-builder -- bash -c "dnf install sudo -y"
+    lxc shell tmp-builder -- bash -c "dnf install tar sudo -y"
     lxc shell tmp-builder -- bash -c "dnf install fuse squashfuse -y"
     lxc shell tmp-builder -- bash -c "dnf install snapd -y"
 

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -40,6 +40,10 @@ LXD_PROFILE = (
 # LXD_IMAGE is the image to use for LXD containers.
 LXD_IMAGE = os.getenv("TEST_LXD_IMAGE") or "ubuntu:22.04"
 
+# LXD_SIDELOAD_IMAGES_DIR is an optional directory with OCI images from the host
+# that will be mounted at /var/snap/k8s/common/images on the LXD containers.
+LXD_SIDELOAD_IMAGES_DIR = os.getenv("TEST_LXD_SIDELOAD_IMAGES_DIR") or ""
+
 # MULTIPASS_IMAGE is the image to use for Multipass VMs.
 MULTIPASS_IMAGE = os.getenv("TEST_MULTIPASS_IMAGE") or "22.04"
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -96,20 +96,11 @@ class LXDHarness(Harness):
 
                 self.exec(
                     instance_id,
-                    [
-                        "mkdir",
-                        "-p",
-                        "/var/snap/k8s/common",
-                    ],
+                    ["mkdir", "-p", "/var/snap/k8s/common"],
                 )
                 self.exec(
                     instance_id,
-                    [
-                        "cp",
-                        "-rv",
-                        "/mnt/images",
-                        "/var/snap/k8s/common/images",
-                    ],
+                    ["cp", "-rv", "/mnt/images", "/var/snap/k8s/common/images"],
                 )
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e


### PR DESCRIPTION
### Summary

Use a pre-built image and fetched OCI images for integration tests, with the aim to reduce e2e test running times and reduce the amount of fetched images.

