### PR TITLE
Microcluster timeouts during `k8s bootstrap` and `k8s join-cluster`

### DIFF
--- a/src/k8s/api/v1/cluster.go
+++ b/src/k8s/api/v1/cluster.go
@@ -1,5 +1,7 @@
 package apiv1
 
+import "time"
+
 // GetClusterStatusRequest is used to request the current status of the cluster.
 type GetClusterStatusRequest struct{}
 
@@ -13,6 +15,7 @@ type PostClusterBootstrapRequest struct {
 	Name    string          `json:"name"`
 	Address string          `json:"address"`
 	Config  BootstrapConfig `json:"config"`
+	Timeout time.Duration   `json:"timeout"`
 }
 
 // GetKubeConfigRequest is used to ask for the admin kubeconfig

--- a/src/k8s/api/v1/cluster_node.go
+++ b/src/k8s/api/v1/cluster_node.go
@@ -1,11 +1,14 @@
 package apiv1
 
+import "time"
+
 // JoinClusterRequest is used to request to add a node to the cluster.
 type JoinClusterRequest struct {
-	Name    string `json:"name"`
-	Address string `json:"address"`
-	Token   string `json:"token"`
-	Config  string `json:"config"`
+	Name    string        `json:"name"`
+	Address string        `json:"address"`
+	Token   string        `json:"token"`
+	Config  string        `json:"config"`
+	Timeout time.Duration `json:"timeout"`
 }
 
 // RemoveNodeRequest is used to request to remove a node from the cluster.

--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -125,16 +124,12 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 			cmd.PrintErrln("Bootstrapping the cluster. This may take a few seconds, please wait.")
 
-			request := apiv1.PostClusterBootstrapRequest{
+			node, err := client.BootstrapCluster(cmd.Context(), apiv1.PostClusterBootstrapRequest{
 				Name:    opts.name,
 				Address: address,
 				Config:  bootstrapConfig,
-			}
-
-			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
-			cobra.OnFinalize(cancel)
-
-			node, err := client.BootstrapCluster(ctx, request)
+				Timeout: opts.timeout,
+			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to bootstrap the cluster.\n\nThe error was: %v\n", err)
 				env.Exit(1)

--- a/src/k8s/cmd/k8s/k8s_join_cluster.go
+++ b/src/k8s/cmd/k8s/k8s_join_cluster.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -98,11 +97,14 @@ func newJoinClusterCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				joinClusterConfig = string(b)
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
-			cobra.OnFinalize(cancel)
-
 			cmd.PrintErrln("Joining the cluster. This may take a few seconds, please wait.")
-			if err := client.JoinCluster(ctx, apiv1.JoinClusterRequest{Name: opts.name, Address: address, Token: token, Config: joinClusterConfig}); err != nil {
+			if err := client.JoinCluster(cmd.Context(), apiv1.JoinClusterRequest{
+				Name:    opts.name,
+				Address: address,
+				Token:   token,
+				Config:  joinClusterConfig,
+				Timeout: opts.timeout,
+			}); err != nil {
 				cmd.PrintErrf("Error: Failed to join the cluster using the provided token.\n\nThe error was: %v\n", err)
 				env.Exit(1)
 				return

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/utils"
@@ -34,9 +36,15 @@ func (e *Endpoints) postClusterBootstrap(s *state.State, r *http.Request) respon
 		return response.BadRequest(fmt.Errorf("cluster is already bootstrapped"))
 	}
 
+	// NOTE(neoaggelos): microcluster adds an implicit 30 second timeout if no context deadline is set.
+	ctx, cancel := context.WithTimeout(r.Context(), time.Hour)
+	defer cancel()
+
+	// NOTE(neoaggelos): pass the timeout as a config option, so that the context cancel will propagate errors.
+	config = utils.MicroclusterConfigWithTimeout(config, req.Timeout)
+
 	// Bootstrap the cluster
-	if err := e.provider.MicroCluster().NewCluster(r.Context(), hostname, req.Address, config); err != nil {
-		// TODO move node cleanup here
+	if err := e.provider.MicroCluster().NewCluster(ctx, hostname, req.Address, config); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to bootstrap new cluster: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -26,7 +26,6 @@ func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
 		defer cancel()
 	}
 
-
 	joinConfig, err := apiv1.ControlPlaneJoinConfigFromMicrocluster(initConfig)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal control plane join config: %w", err)

--- a/src/k8s/pkg/utils/microcluster.go
+++ b/src/k8s/pkg/utils/microcluster.go
@@ -1,0 +1,26 @@
+package utils
+
+import "time"
+
+// MicroclusterConfigWithTimeout adds a "timeout" configuration value to the config struct.
+// If timeout is zero, the configuration is not affected.
+func MicroclusterConfigWithTimeout(config map[string]string, timeout time.Duration) map[string]string {
+	if timeout == 0 {
+		return config
+	}
+
+	config["_timeout"] = timeout.String()
+	return config
+}
+
+// MicroclusterTimeoutFromConfig returns the configured timeout option from the config struct.
+// If case of an invalid or empty value, 0 is returned.
+func MicroclusterTimeoutFromConfig(config map[string]string) time.Duration {
+	if v, ok := config["_timeout"]; !ok {
+		return 0
+	} else if d, err := time.ParseDuration(v); err != nil {
+		return 0
+	} else {
+		return d
+	}
+}

--- a/src/k8s/pkg/utils/microcluster_test.go
+++ b/src/k8s/pkg/utils/microcluster_test.go
@@ -1,0 +1,28 @@
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/canonical/k8s/pkg/utils"
+	. "github.com/onsi/gomega"
+)
+
+func TestMicroclusterTimeout(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		g := NewWithT(t)
+
+		m := map[string]string{}
+		g.Expect(utils.MicroclusterTimeoutFromConfig(m)).To(BeZero())
+	})
+
+	t.Run("Normal", func(t *testing.T) {
+		g := NewWithT(t)
+
+		timeout := 5 * time.Second
+		m := map[string]string{}
+
+		mWithTimeout := utils.MicroclusterConfigWithTimeout(m, timeout)
+		g.Expect(utils.MicroclusterTimeoutFromConfig(mWithTimeout)).To(Equal(timeout))
+	})
+}


### PR DESCRIPTION
### Summary

This is a pre-requisite for fixing how k8sd cleans up when a bootstrap or join cluster operation fails.

Merge after #518 

### Changes

Handle context cancellations during the bootstrap and join hooks. Without this change:

1. microcluster always applies a 30-second timeout if the context has no deadline set, effectively ignoring the timeout passed by the client
2. context deadline exceeded now cancels the bootstrap or join hook. Previously, this was using `s.Context` (from microcluster daemon), and therefore the hooks would keep running.

