### PR TITLE
Cleanup on failed `k8s bootstrap` an `k8s join-cluster` attempts

### DIFF
--- a/src/k8s/api/v1/cluster_node.go
+++ b/src/k8s/api/v1/cluster_node.go
@@ -13,6 +13,7 @@ type JoinClusterRequest struct {
 
 // RemoveNodeRequest is used to request to remove a node from the cluster.
 type RemoveNodeRequest struct {
-	Name  string `json:"name"`
-	Force bool   `json:"force"`
+	Name    string        `json:"name"`
+	Force   bool          `json:"force"`
+	Timeout time.Duration `json:"timeout"`
 }

--- a/src/k8s/cmd/k8s/k8s_remove_node.go
+++ b/src/k8s/cmd/k8s/k8s_remove_node.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -44,11 +43,8 @@ func newRemoveNodeCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 			name := args[0]
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
-			cobra.OnFinalize(cancel)
-
 			cmd.PrintErrf("Removing %q from the Kubernetes cluster. This may take a few seconds, please wait.\n", name)
-			if err := client.RemoveNode(ctx, apiv1.RemoveNodeRequest{Name: name, Force: opts.force}); err != nil {
+			if err := client.RemoveNode(cmd.Context(), apiv1.RemoveNodeRequest{Name: name, Force: opts.force, Timeout: opts.timeout}); err != nil {
 				cmd.PrintErrf("Error: Failed to remove node %q from the cluster.\n\nThe error was: %v\n", name, err)
 				env.Exit(1)
 				return

--- a/src/k8s/pkg/client/k8sd/cluster.go
+++ b/src/k8s/pkg/client/k8sd/cluster.go
@@ -45,6 +45,11 @@ func (c *k8sd) JoinCluster(ctx context.Context, request apiv1.JoinClusterRequest
 }
 
 func (c *k8sd) RemoveNode(ctx context.Context, request apiv1.RemoveNodeRequest) error {
+	// NOTE(neoaggelos): microcluster adds an arbitrary 30 second timeout in case no context deadline is set.
+	// Configure a client deadline for timeout + 30 seconds (the timeout will come from the server)
+	ctx, cancel := context.WithTimeout(ctx, request.Timeout+30*time.Second)
+	defer cancel()
+
 	if err := c.client.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster", "remove"), request, nil); err != nil {
 		return fmt.Errorf("failed to POST /k8sd/cluster/remove: %w", err)
 	}

--- a/src/k8s/pkg/client/k8sd/cluster.go
+++ b/src/k8s/pkg/client/k8sd/cluster.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
-	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -41,19 +40,6 @@ func (c *k8sd) JoinCluster(ctx context.Context, request apiv1.JoinClusterRequest
 	if err := c.client.Query(ctx, "POST", api.NewURL().Path("k8sd", "cluster", "join"), request, nil); err != nil {
 		return fmt.Errorf("failed to POST /k8sd/cluster/join: %w", err)
 	}
-
-	// NOTE(neoaggelos): we should not ignore this error
-	_ = control.WaitUntilReady(ctx, func() (bool, error) {
-		nodeStatus, err := c.NodeStatus(ctx)
-		switch {
-		case err != nil:
-			return false, fmt.Errorf("failed to get node status: %w", err)
-		case nodeStatus.DatastoreRole == apiv1.DatastoreRolePending:
-			// still waiting for node to join
-			return false, nil
-		}
-		return true, nil
-	})
 
 	return nil
 }

--- a/src/k8s/pkg/client/kubernetes/node.go
+++ b/src/k8s/pkg/client/kubernetes/node.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
 
 // DeleteNode will remove a node from the kubernetes cluster.
 // DeleteNode will retry if there is a conflict on the resource.
+// DeleteNode will not fail if the node does not
 func (c *Client) DeleteNode(ctx context.Context, nodeName string) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		err := c.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-		if err != nil {
+		if err := c.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete node: %w", err)
 		}
 		return nil

--- a/src/k8s/pkg/client/kubernetes/node_test.go
+++ b/src/k8s/pkg/client/kubernetes/node_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,7 +15,7 @@ import (
 )
 
 func TestDeleteNode(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	t.Run("node deletion is successful", func(t *testing.T) {
 		clientset := fake.NewSimpleClientset()
@@ -28,7 +28,16 @@ func TestDeleteNode(t *testing.T) {
 		}, metav1.CreateOptions{})
 
 		err := client.DeleteNode(context.Background(), nodeName)
-		g.Expect(err).To(gomega.BeNil())
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("node does not exist is successful", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		client := &Client{Interface: clientset}
+		nodeName := "test-node"
+
+		err := client.DeleteNode(context.Background(), nodeName)
+		g.Expect(err).To(BeNil())
 	})
 
 	t.Run("node deletion fails", func(t *testing.T) {
@@ -41,6 +50,6 @@ func TestDeleteNode(t *testing.T) {
 		})
 
 		err := client.DeleteNode(context.Background(), nodeName)
-		g.Expect(err).To(gomega.MatchError(fmt.Errorf("failed to delete node: %w", expectedErr)))
+		g.Expect(err).To(MatchError(fmt.Errorf("failed to delete node: %w", expectedErr)))
 	})
 }

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -1,14 +1,19 @@
 package api
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
+	"log"
 	"net/http"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/k8s/pkg/utils/control"
 	nodeutil "github.com/canonical/k8s/pkg/utils/node"
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -20,23 +25,49 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
 	}
 
-	isControlPlane, err := nodeutil.IsControlPlaneNode(r.Context(), s, req.Name)
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	if req.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
+	isControlPlane, err := nodeutil.IsControlPlaneNode(ctx, s, req.Name)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to check if node is control-plane: %w", err))
 	}
 	if isControlPlane {
+		log.Printf("Waiting for node to not be pending")
+		control.WaitUntilReady(ctx, func() (bool, error) {
+			var notPending bool
+			if err := s.Database.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+				member, err := cluster.GetInternalClusterMember(ctx, tx, req.Name)
+				if err != nil {
+					log.Printf("Failed to get member: %v", err)
+					return nil
+				}
+				log.Printf("Node %s is %s", member.Name, member.Role)
+				notPending = member.Role != cluster.Pending
+				return nil
+			}); err != nil {
+				log.Printf("Transaction to check cluster member role failed: %v", err)
+			}
+			return notPending, nil
+		})
+		log.Printf("Starting node deletion")
+
 		// Remove control plane via microcluster API.
 		// The postRemove hook will take care of cleaning up kubernetes.
 		c, err := s.Leader()
 		if err != nil {
 			return response.InternalError(fmt.Errorf("failed to create client to cluster leader: %w", err))
 		}
-		if err := c.DeleteClusterMember(r.Context(), req.Name, req.Force); err != nil {
+		if err := c.DeleteClusterMember(ctx, req.Name, req.Force); err != nil {
 			return response.InternalError(fmt.Errorf("failed to delete cluster member %s: %w", req.Name, err))
 		}
 	}
 
-	isWorker, err := databaseutil.IsWorkerNode(r.Context(), s, req.Name)
+	isWorker, err := databaseutil.IsWorkerNode(ctx, s, req.Name)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to check if node is worker: %w", err))
 	}
@@ -47,11 +78,11 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 			return response.InternalError(fmt.Errorf("failed to create k8s client: %w", err))
 		}
 
-		if err := c.DeleteNode(s.Context, req.Name); err != nil {
+		if err := c.DeleteNode(ctx, req.Name); err != nil {
 			return response.InternalError(fmt.Errorf("failed to remove k8s node %q: %w", req.Name, err))
 		}
 
-		if err := databaseutil.DeleteWorkerNodeEntry(r.Context(), s, req.Name); err != nil {
+		if err := databaseutil.DeleteWorkerNodeEntry(ctx, s, req.Name); err != nil {
 			return response.InternalError(fmt.Errorf("failed to remove worker entry %q: %w", req.Name, err))
 		}
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -27,9 +27,9 @@ func (e *Endpoints) postClusterRemove(s *state.State, r *http.Request) response.
 	if isControlPlane {
 		// Remove control plane via microcluster API.
 		// The postRemove hook will take care of cleaning up kubernetes.
-		c, err := e.provider.MicroCluster().LocalClient()
+		c, err := s.Leader()
 		if err != nil {
-			return response.InternalError(fmt.Errorf("failed to create local client: %w", err))
+			return response.InternalError(fmt.Errorf("failed to create client to cluster leader: %w", err))
 		}
 		if err := c.DeleteClusterMember(r.Context(), req.Name, req.Force); err != nil {
 			return response.InternalError(fmt.Errorf("failed to delete cluster member %s: %w", req.Name, err))

--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -51,6 +51,24 @@ func startControlPlaneServices(ctx context.Context, snap snap.Snap, datastore st
 	return nil
 }
 
+func stopControlPlaneServices(ctx context.Context, snap snap.Snap, datastore string) error {
+	// Stop services
+	switch datastore {
+	case "k8s-dqlite":
+		if err := snaputil.StopK8sDqliteServices(ctx, snap); err != nil {
+			return fmt.Errorf("failed to stop k8s-dqlite service: %w", err)
+		}
+	case "external":
+	default:
+		return fmt.Errorf("unsupported datastore %s, must be one of %v", datastore, setup.SupportedDatastores)
+	}
+
+	if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
+		return fmt.Errorf("failed to stop control plane services: %w", err)
+	}
+	return nil
+}
+
 func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 	// Wait for API server to come up
 	client, err := snap.KubernetesClient("")

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -52,8 +52,47 @@ func (a *App) onBootstrap(s *state.State, initConfig map[string]string) error {
 	return a.onBootstrapControlPlane(ctx, s, bootstrapConfig)
 }
 
-func (a *App) onBootstrapWorkerNode(ctx context.Context, s *state.State, encodedToken string, joinConfig apiv1.WorkerNodeJoinConfig) error {
+func (a *App) onBootstrapWorkerNode(ctx context.Context, s *state.State, encodedToken string, joinConfig apiv1.WorkerNodeJoinConfig) (rerr error) {
 	snap := a.Snap()
+
+	// make sure to cleanup in case of errors
+	// the code can register cleanup hooks by appending to this slice
+	var cleanups []func(context.Context) error
+	defer func() {
+		// do not cleanup if bootstrap was successful
+		if rerr == nil {
+			log.Println("Joined cluster successfully")
+			return
+		}
+
+		// annotate error with context cancellation
+		if err := ctx.Err(); err != nil {
+			rerr = fmt.Errorf("%w: %v", rerr, ctx.Err())
+		}
+
+		// start goroutine to cleanup on the background and return quickly
+		go func() {
+			log.Printf("Join cluster failed: %v", rerr)
+			log.Println("Cleaning up...")
+			for i := len(cleanups) - 1; i >= 0; i-- {
+				// run cleanup functions in reverse order
+				if err := cleanups[i](s.Context); err != nil {
+					log.Printf("Cleanup hook %d/%d failed: %v", i, len(cleanups), err)
+				}
+			}
+			log.Println("All cleanup hooks finished, resetting microcluster state")
+
+			client, err := a.microCluster.LocalClient()
+			if err != nil {
+				log.Printf("Failed to create local microcluster client, cannot reset node: %v", err)
+				return
+			}
+
+			if err := client.ResetClusterMember(s.Context, s.Name(), true); err != nil {
+				log.Printf("Failed to ResetClusterMember: %v", err)
+			}
+		}()
+	}()
 
 	token := &types.InternalWorkerNodeToken{}
 	if err := token.Decode(encodedToken); err != nil {
@@ -161,6 +200,13 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s *state.State, encoded
 	if err := certificates.CompleteCertificates(); err != nil {
 		return fmt.Errorf("failed to initialize worker node certificates: %w", err)
 	}
+	cleanups = append(cleanups, func(ctx context.Context) error {
+		log.Println("Cleaning up worker certificates")
+		if _, err := setup.EnsureWorkerPKI(snap, &pki.WorkerNodePKI{}); err != nil {
+			return fmt.Errorf("failed to cleanup worker certificates: %w", err)
+		}
+		return nil
+	})
 	if _, err := setup.EnsureWorkerPKI(snap, certificates); err != nil {
 		return fmt.Errorf("failed to write worker node certificates: %w", err)
 	}
@@ -205,6 +251,16 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s *state.State, encoded
 		return fmt.Errorf("database transaction to set cluster configuration failed: %w", err)
 	}
 
+	cleanups = append(cleanups, func(ctx context.Context) error {
+		for _, dir := range []string{snap.ServiceArgumentsDir()} {
+			log.Printf("Cleaning up config files from %v", dir)
+			if err := os.RemoveAll(dir); err != nil {
+				return fmt.Errorf("failed to delete %v: %w", dir, err)
+			}
+		}
+		return nil
+	})
+
 	// Worker node services
 	if err := setup.Containerd(snap, nil, joinConfig.ExtraNodeContainerdArgs); err != nil {
 		return fmt.Errorf("failed to configure containerd: %w", err)
@@ -222,12 +278,25 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s *state.State, encoded
 		return fmt.Errorf("failed to write extra node config files: %w", err)
 	}
 
-	// TODO(berkayoz): remove the lock on cleanup
+	cleanups = append(cleanups, func(ctx context.Context) error {
+		log.Println("Removing worker node mark")
+		if err := snaputil.MarkAsWorkerNode(snap, false); err != nil {
+			return fmt.Errorf("failed to unmark node as worker: %w", err)
+		}
+		return nil
+	})
 	if err := snaputil.MarkAsWorkerNode(snap, true); err != nil {
 		return fmt.Errorf("failed to mark node as worker: %w", err)
 	}
 
 	// Start services
+	cleanups = append(cleanups, func(ctx context.Context) error {
+		log.Println("Stopping worker services")
+		if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
+			return fmt.Errorf("failed to start worker services: %w", err)
+		}
+		return nil
+	})
 	if err := snaputil.StartWorkerServices(ctx, snap); err != nil {
 		return fmt.Errorf("failed to start worker services: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -82,13 +82,7 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s *state.State, encoded
 			}
 			log.Println("All cleanup hooks finished, resetting microcluster state")
 
-			client, err := a.microCluster.LocalClient()
-			if err != nil {
-				log.Printf("Failed to create local microcluster client, cannot reset node: %v", err)
-				return
-			}
-
-			if err := client.ResetClusterMember(s.Context, s.Name(), true); err != nil {
+			if err := a.client.ResetClusterMember(s.Context, s.Name(), true); err != nil {
 				log.Printf("Failed to ResetClusterMember: %v", err)
 			}
 		}()
@@ -334,13 +328,7 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s *state.State, boots
 			}
 			log.Println("All cleanup hooks finished, resetting microcluster state")
 
-			client, err := a.microCluster.LocalClient()
-			if err != nil {
-				log.Printf("Failed to create local microcluster client, cannot reset node: %v", err)
-				return
-			}
-
-			if err := client.ResetClusterMember(s.Context, s.Name(), true); err != nil {
+			if err := a.client.ResetClusterMember(s.Context, s.Name(), true); err != nil {
 				log.Printf("Failed to ResetClusterMember: %v", err)
 			}
 		}()

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -347,7 +347,7 @@ func (a *App) onPreRemove(s *state.State, force bool) (rerr error) {
 	}
 
 	if err := c.DeleteNode(s.Context, s.Name()); err != nil {
-		return fmt.Errorf("failed to remove Kubernetes node %q: %w", err)
+		return fmt.Errorf("failed to remove k8s node %q: %w", s.Name(), err)
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -2,29 +2,95 @@ package app
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"log"
 	"net"
+	"os"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
 	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
+	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/state"
 )
 
 // onPostJoin is called when a control plane node joins the cluster.
 // onPostJoin retrieves the cluster config from the database and configures local services.
-func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
+func (a *App) onPostJoin(s *state.State, initConfig map[string]string) (rerr error) {
 	snap := a.Snap()
 
+	// NOTE(neoaggelos): context timeout is passed over configuration, so that hook failures are propagated to the client
 	ctx, cancel := context.WithCancel(s.Context)
 	defer cancel()
 	if t := utils.MicroclusterTimeoutFromConfig(initConfig); t != 0 {
 		ctx, cancel = context.WithTimeout(ctx, t)
 		defer cancel()
 	}
+
+	// make sure to cleanup in case of errors
+	// the code can register cleanup hooks by appending to this slice
+	var cleanups []func(context.Context) error
+	defer func() {
+		log.Printf("Waiting for node to finish microcluster join")
+		control.WaitUntilReady(s.Context, func() (bool, error) {
+			var notPending bool
+			if err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
+				member, err := cluster.GetInternalClusterMember(ctx, tx, s.Name())
+				if err != nil {
+					log.Printf("Failed to get member: %v", err)
+				}
+				notPending = member.Role != cluster.Pending
+				return nil
+			}); err != nil {
+				log.Printf("Transaction to check cluster member role failed: %v", err)
+			}
+			return notPending, nil
+		})
+
+		// do not cleanup if bootstrap was successful
+		if rerr == nil {
+			log.Println("Joined cluster successfully")
+			return
+		}
+
+		// annotate error with context cancellation
+		if err := ctx.Err(); err != nil {
+			rerr = fmt.Errorf("%w: %v", rerr, ctx.Err())
+		}
+
+		// start goroutine to cleanup on the background and return quickly
+		go func() {
+			log.Printf("Join cluster failed: %v", rerr)
+
+			log.Println("Cleaning up...")
+			for i := len(cleanups) - 1; i >= 0; i-- {
+				// run cleanup functions in reverse order
+				if err := cleanups[i](s.Context); err != nil {
+					log.Printf("Cleanup hook %d/%d failed: %v", i, len(cleanups), err)
+				}
+			}
+			log.Println("All cleanup hooks finished, removing node from microcluster")
+
+			// NOTE(neoaggelos): this also runs the pre-remove hook and resets the cluster member
+			control.WaitUntilReady(s.Context, func() (bool, error) {
+				client, err := s.Leader()
+				if err != nil {
+					log.Printf("Error: failed to create client to leader: %v", err)
+					return false, nil
+				}
+				if err := client.DeleteClusterMember(s.Context, s.Name(), true); err != nil {
+					log.Printf("Error: failed to DeleteClusterMember: %v", err)
+					return false, nil
+				}
+				return true, nil
+			})
+		}()
+	}()
 
 	joinConfig, err := apiv1.ControlPlaneJoinConfigFromMicrocluster(initConfig)
 	if err != nil {
@@ -124,6 +190,13 @@ func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
 	}
 
 	// Write certificates to disk
+	cleanups = append(cleanups, func(ctx context.Context) error {
+		log.Println("Cleaning up control plane certificates")
+		if _, err := setup.EnsureControlPlanePKI(snap, &pki.ControlPlanePKI{}); err != nil {
+			return fmt.Errorf("failed to cleanup control plane certificates: %w", err)
+		}
+		return nil
+	})
 	if _, err := setup.EnsureControlPlanePKI(snap, certificates); err != nil {
 		return fmt.Errorf("failed to write control plane certificates: %w", err)
 	}
@@ -135,6 +208,7 @@ func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
 	// Configure datastore
 	switch cfg.Datastore.GetType() {
 	case "k8s-dqlite":
+		// TODO(neoaggelos): use cluster.GetInternalClusterMembers() instead
 		leader, err := s.Leader()
 		if err != nil {
 			return fmt.Errorf("failed to get dqlite leader: %w", err)
@@ -156,6 +230,16 @@ func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
 	default:
 		return fmt.Errorf("unsupported datastore %s, must be one of %v", cfg.Datastore.GetType(), setup.SupportedDatastores)
 	}
+
+	cleanups = append(cleanups, func(ctx context.Context) error {
+		for _, dir := range []string{snap.ServiceArgumentsDir()} {
+			log.Printf("Cleaning up config files from %v", dir)
+			if err := os.RemoveAll(dir); err != nil {
+				return fmt.Errorf("failed to delete %v: %w", dir, err)
+			}
+		}
+		return nil
+	})
 
 	// Configure services
 	if err := setup.Containerd(snap, nil, joinConfig.ExtraNodeContainerdArgs); err != nil {
@@ -186,6 +270,13 @@ func (a *App) onPostJoin(s *state.State, initConfig map[string]string) error {
 	}
 
 	// Start services
+	cleanups = append(cleanups, func(ctx context.Context) error {
+		log.Println("Stopping control plane services")
+		if err := stopControlPlaneServices(ctx, snap, cfg.Datastore.GetType()); err != nil {
+			return fmt.Errorf("failed to stop services: %w", err)
+		}
+		return nil
+	})
 	if err := startControlPlaneServices(ctx, snap, cfg.Datastore.GetType()); err != nil {
 		return fmt.Errorf("failed to start services: %w", err)
 	}
@@ -228,7 +319,7 @@ func (a *App) onPreRemove(s *state.State, force bool) error {
 	}
 
 	if err := c.DeleteNode(s.Context, s.Name()); err != nil {
-		return fmt.Errorf("failed to remove k8s node %q: %w", s.Name(), err)
+		log.Printf("Warning: failed to remove k8s node %q: %v", s.Name(), err)
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/provider.go
+++ b/src/k8s/pkg/k8sd/app/provider.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (a *App) MicroCluster() *microcluster.MicroCluster {
-	return a.microCluster
+	return a.cluster
 }
 
 func (a *App) Snap() snap.Snap {

--- a/src/k8s/pkg/snap/util/services.go
+++ b/src/k8s/pkg/snap/util/services.go
@@ -56,6 +56,17 @@ func StartK8sDqliteServices(ctx context.Context, snap snap.Snap) error {
 	return nil
 }
 
+// StopWorkerServices starts the worker services.
+// StopWorkerServices will return on the first failing service.
+func StopWorkerServices(ctx context.Context, snap snap.Snap) error {
+	for _, service := range workerServices {
+		if err := snap.StopService(ctx, service); err != nil {
+			return fmt.Errorf("failed to stop service %s: %w", service, err)
+		}
+	}
+	return nil
+}
+
 // StopControlPlaneServices stops the control plane services.
 // StopControlPlaneServices will return on the first failing service.
 func StopControlPlaneServices(ctx context.Context, snap snap.Snap) error {


### PR DESCRIPTION
### Summary

Merge after #520 

### Changes

- Bootstrap control plane, bootstrap worker and join control plane hooks are refactored. We always defer a function that checks the result of the hook.
- In the case of preRemove, we simply log the error and proceed, otherwise the node is removed by microcluster peers but not the underlying dqlite database, breaking the cluster
- In the case of `k8s bootstrap`, remove all configs, stop control plane services, then use `ResetClusterMember`. This resets the microcluster state. Note that this runs automatically by k8sd, no manual action from the client is required.
- In the case of `k8s join-cluster` for worker nodes, similarly revert configs, then use `ResetClusterMember`
- In the case of `k8s join-cluster` for control plane nodes: When the `postJoin` hook runs, the node has already joined microcluster. Therefore, we need to revert configs, but also make sure to use `DeleteClusterMember`, such that the failed node is removed from the cluster before resetting.

### Notes

- The wait for a node to be not Pending before removing has been moved to the `k8s remove-node` command, instead of delaying the completion of the `k8s join-cluster` command.