### PR TITLE
show features on `k8s enable/disable`

### DIFF
--- a/docs/src/_parts/commands/k8s_disable.md
+++ b/docs/src/_parts/commands/k8s_disable.md
@@ -7,7 +7,7 @@ Disable core cluster features
 Disable one of network, dns, gateway, ingress, local-storage, load-balancer.
 
 ```
-k8s disable <feature> ... [flags]
+k8s disable [network|dns|gateway|ingress|local-storage|load-balancer] ... [flags]
 ```
 
 ### Options
@@ -21,4 +21,3 @@ k8s disable <feature> ... [flags]
 ### SEE ALSO
 
 * [k8s](k8s.md)	 - Canonical Kubernetes CLI
-

--- a/docs/src/_parts/commands/k8s_disable.md
+++ b/docs/src/_parts/commands/k8s_disable.md
@@ -21,3 +21,4 @@ k8s disable [network|dns|gateway|ingress|local-storage|load-balancer] ... [flags
 ### SEE ALSO
 
 * [k8s](k8s.md)	 - Canonical Kubernetes CLI
+

--- a/docs/src/_parts/commands/k8s_enable.md
+++ b/docs/src/_parts/commands/k8s_enable.md
@@ -21,3 +21,4 @@ k8s enable [network|dns|gateway|ingress|local-storage|load-balancer] ... [flags]
 ### SEE ALSO
 
 * [k8s](k8s.md)	 - Canonical Kubernetes CLI
+

--- a/docs/src/_parts/commands/k8s_enable.md
+++ b/docs/src/_parts/commands/k8s_enable.md
@@ -7,7 +7,7 @@ Enable core cluster features
 Enable one of network, dns, gateway, ingress, local-storage, load-balancer.
 
 ```
-k8s enable <feature> ... [flags]
+k8s enable [network|dns|gateway|ingress|local-storage|load-balancer] ... [flags]
 ```
 
 ### Options
@@ -21,4 +21,3 @@ k8s enable <feature> ... [flags]
 ### SEE ALSO
 
 * [k8s](k8s.md)	 - Canonical Kubernetes CLI
-

--- a/src/k8s/cmd/k8s/k8s_disable.go
+++ b/src/k8s/cmd/k8s/k8s_disable.go
@@ -27,7 +27,7 @@ func newDisableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		timeout      time.Duration
 	}
 	cmd := &cobra.Command{
-		Use:    "disable <feature> ...",
+		Use:    fmt.Sprintf("disable [%s] ...", strings.Join(featureList, "|")),
 		Short:  "Disable core cluster features",
 		Long:   fmt.Sprintf("Disable one of %s.", strings.Join(featureList, ", ")),
 		Args:   cmdutil.MinimumNArgs(env, 1),

--- a/src/k8s/cmd/k8s/k8s_enable.go
+++ b/src/k8s/cmd/k8s/k8s_enable.go
@@ -27,7 +27,7 @@ func newEnableCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		timeout      time.Duration
 	}
 	cmd := &cobra.Command{
-		Use:    "enable <feature> ...",
+		Use:    fmt.Sprintf("enable [%s] ...", strings.Join(featureList, "|")),
 		Short:  "Enable core cluster features",
 		Long:   fmt.Sprintf("Enable one of %s.", strings.Join(featureList, ", ")),
 		Args:   cmdutil.MinimumNArgs(env, 1),


### PR DESCRIPTION
### Summary

Closes #523 

### Changes

```bash
$ ./src/k8s/bin/static/k8s enable
Error: requires at least 1 arg(s), only received 0
Usage:
  k8s enable [network|dns|gateway|ingress|local-storage|load-balancer] ... [flags]

Flags:
  -h, --help                   help for enable
      --output-format string   set the output format to one of plain, json or yaml (default "plain")
      --timeout duration       the max time to wait for the command to execute (default 1m30s)
```