### PR TITLE
E2E test use lxd 5.21 & ubuntu 24.04 LTS

### DIFF
--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -6,7 +6,6 @@ on:
       - main
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/sync/**'
-      - 'KU-1019/e2e-matrix' # TODO: remove testing
   pull_request:
 
 permissions:

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/sync/**'
+      - 'KU-1019/e2e-matrix' # TODO: remove testing
   pull_request:
 
 permissions:
@@ -28,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install lxd
         run: |
+          sudo snap refresh lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
@@ -67,7 +69,7 @@ jobs:
         run: pip install tox
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.19/stable
+          sudo snap refresh lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,7 +9,6 @@ on:
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
       - 'autoupdate/sync/**'
-      - 'KU-1019/e2e-matrix' #TODO rm testing
   pull_request:
 
 permissions:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install lxd
         run: |
+          sudo snap refresh lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
@@ -48,7 +49,7 @@ jobs:
     name: Test ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu:20.04", "ubuntu:22.04"]
+        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
     runs-on: ubuntu-20.04
     needs: build
 
@@ -63,7 +64,7 @@ jobs:
         run: pip install tox
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.19/stable
+          sudo snap refresh lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,6 +9,7 @@ on:
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
       - 'autoupdate/sync/**'
+      - 'KU-1019/e2e-matrix' #TODO rm testing
   pull_request:
 
 permissions:

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -2,7 +2,10 @@ name: Nightly Latest/Edge Tests
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Runs every midnight
+    - cron: "0 0 * * *" # Runs every midnight
+  push:
+    branches:
+      - KU-1019/e2e-matrix #TODO: rm testing
 
 permissions:
   contents: read
@@ -12,7 +15,7 @@ jobs:
     name: Integration Test ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.releases }}
     strategy:
       matrix:
-        os: ["ubuntu:20.04", "ubuntu:22.04"]
+        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
         arch: ["amd64", "arm64"]
         releases: ["latest/edge"]
       fail-fast: false # TODO: remove once arm64 works

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -2,10 +2,7 @@ name: Nightly Latest/Edge Tests
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Runs every midnight
-  push:
-    branches:
-      - KU-1019/e2e-matrix #TODO: rm testing
+    - cron: '0 0 * * *' # Runs every midnight
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
This PR updates our workflows to include the new 24.04 LTS OS and use 5.21 lxd LTS.
- explicitly use lxd 5.21 in nightly, informing-integration and integration
- add test on 24.04 to integration test