### PR TITLE
Fix markdownlinter: _ not -

### DIFF
--- a/docs/src/.markdownlint.json
+++ b/docs/src/.markdownlint.json
@@ -1,7 +1,7 @@
 {
     "default": false,
     "MD003": { "style": "atx" },
-    "MD013": { "code-blocks": false, "tables": false, "stern": true, "line_length": 80},
+    "MD013": { "code_blocks": false, "tables": false, "stern": true, "line_length": 80},
     "MD014": true,
     "MD018": true,
     "MD022": true,


### PR DESCRIPTION
It was a typo in the config file :) @bschimke95 @louiseschmidtgen 