### PR TITLE
Fixup how to checkout from origin

### DIFF
--- a/.github/workflows/fast-forward.yaml
+++ b/.github/workflows/fast-forward.yaml
@@ -40,12 +40,13 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY_TO_UPDATE_STRICT_BRANCH }}
       - name: Checkout branches
         run: |
+          git fetch origin
           git checkout ${{ steps.branch.outputs.upstream }}
           git checkout ${{ steps.branch.outputs.target }}
       - name: Merge ${{ steps.branch.outputs.upstream }} into ${{ steps.branch.outputs.target }}
         run: |
           git checkout ${{ steps.branch.outputs.target }}
-          git merge origin/${{ steps.branch.outputs.upstream }} -m "Auto-merge ${{ steps.branch.outputs.upstream }}"
+          git merge ${{ steps.branch.outputs.upstream }} -m "Auto-merge ${{ steps.branch.outputs.upstream }}"
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
### Summary

Followup from #531 #534: GitHub actions do not fetch all of `origin` branches automatically: https://github.com/canonical/k8s-snap/actions/runs/9839344218/job/27161226404