### PR TITLE
do not fail-fast on integration tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -48,6 +48,7 @@ jobs:
   test-integration:
     name: Test ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Summary

We are at a point where integration tests fail more often because of flakes rather than an actual bug, therefore do not `fail-fast` when a flake occurs