### PR TITLE
Add pylint in the tests dependencies to have tiobe tests passing

### DIFF
--- a/tests/integration/requirements-test.txt
+++ b/tests/integration/requirements-test.txt
@@ -2,3 +2,4 @@ coverage[toml]==7.2.5
 pytest==7.3.1
 PyYAML==6.0.1
 tenacity==8.2.3
+pylint==3.2.5


### PR DESCRIPTION
Tiobe uses pylint https://portal.tiobe.com/2020.3/docs/admin/admin_A18_analyzerpylint.html  . We would like to make it available in the tests path so some of our tests appear as expected (not gray in https://canonical.tiobe.com/tiobeweb/TICS/TqiDashboard.html#axes=ErrorSuppression(no),CodeType(Set(production,test)),Configuration(default),ProjectGroup(PublicRepos),Project(k8s-snap),Sub()&metric=tqiCodingStd&sort=T(1,worst))