### PR TITLE
Consistently use path/filepath for file paths

### DIFF
--- a/src/k8s/cmd/k8s/k8s_helm.go
+++ b/src/k8s/cmd/k8s/k8s_helm.go
@@ -2,7 +2,7 @@ package k8s
 
 import (
 	"os/exec"
-	"path"
+	"path/filepath"
 	"syscall"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
@@ -44,7 +44,7 @@ func newHelmCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			command := append([]string{"helm"}, args...)
 			environ := cmdutil.EnvironWithDefaults(
 				env.Environ,
-				"KUBECONFIG", path.Join(env.Snap.KubernetesConfigDir(), "admin.conf"),
+				"KUBECONFIG", filepath.Join(env.Snap.KubernetesConfigDir(), "admin.conf"),
 			)
 			if err := syscall.Exec(binary, command, environ); err != nil {
 				cmd.PrintErrf("Failed to run %s.\n\nThe error was: %v\n", command, err)

--- a/src/k8s/cmd/k8s/k8s_kubectl.go
+++ b/src/k8s/cmd/k8s/k8s_kubectl.go
@@ -2,7 +2,7 @@ package k8s
 
 import (
 	"os/exec"
-	"path"
+	"path/filepath"
 	"syscall"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
@@ -44,7 +44,7 @@ func newKubectlCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			command := append([]string{"kubectl"}, args...)
 			environ := cmdutil.EnvironWithDefaults(
 				env.Environ,
-				"KUBECONFIG", path.Join(env.Snap.KubernetesConfigDir(), "admin.conf"),
+				"KUBECONFIG", filepath.Join(env.Snap.KubernetesConfigDir(), "admin.conf"),
 				"EDITOR", "nano",
 			)
 			if err := syscall.Exec(binary, command, environ); err != nil {

--- a/src/k8s/cmd/main.go
+++ b/src/k8s/cmd/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"syscall"
 
 	"github.com/canonical/k8s/cmd/k8s"
@@ -29,7 +29,7 @@ func main() {
 	cobra.EnableTraverseRunHooks = true
 
 	// choose command based on the binary name
-	base := path.Base(os.Args[0])
+	base := filepath.Base(os.Args[0])
 	switch base {
 	case "k8s-apiserver-proxy":
 		k8s_apiserver_proxy.NewRootCmd(env).ExecuteContext(ctx)

--- a/src/k8s/pkg/client/dqlite/remove_test.go
+++ b/src/k8s/pkg/client/dqlite/remove_test.go
@@ -2,7 +2,7 @@ package dqlite_test
 
 import (
 	"context"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/client/dqlite"
@@ -14,7 +14,7 @@ func TestRemoveNodeByAddress(t *testing.T) {
 		withDqliteCluster(t, 2, func(ctx context.Context, dirs []string) {
 			g := NewWithT(t)
 			client, err := dqlite.NewClient(ctx, dqlite.ClientOpts{
-				ClusterYAML: path.Join(dirs[0], "cluster.yaml"),
+				ClusterYAML: filepath.Join(dirs[0], "cluster.yaml"),
 			})
 			g.Expect(err).To(BeNil())
 			g.Expect(client).NotTo(BeNil())
@@ -39,7 +39,7 @@ func TestRemoveNodeByAddress(t *testing.T) {
 		withDqliteCluster(t, 2, func(ctx context.Context, dirs []string) {
 			g := NewWithT(t)
 			client, err := dqlite.NewClient(ctx, dqlite.ClientOpts{
-				ClusterYAML: path.Join(dirs[0], "cluster.yaml"),
+				ClusterYAML: filepath.Join(dirs[0], "cluster.yaml"),
 			})
 			g.Expect(err).To(BeNil())
 			g.Expect(client).NotTo(BeNil())

--- a/src/k8s/pkg/client/helm/client.go
+++ b/src/k8s/pkg/client/helm/client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/log"
 	"helm.sh/helm/v3/pkg/action"
@@ -80,7 +80,7 @@ func (h *client) Apply(ctx context.Context, c InstallableChart, desired State, v
 		install.Namespace = c.Namespace
 		install.CreateNamespace = true
 
-		chart, err := loader.Load(path.Join(h.manifestsBaseDir, c.ManifestPath))
+		chart, err := loader.Load(filepath.Join(h.manifestsBaseDir, c.ManifestPath))
 		if err != nil {
 			return false, fmt.Errorf("failed to load manifest for %s: %w", c.Name, err)
 		}
@@ -95,7 +95,7 @@ func (h *client) Apply(ctx context.Context, c InstallableChart, desired State, v
 		upgrade.Namespace = c.Namespace
 		upgrade.ReuseValues = true
 
-		chart, err := loader.Load(path.Join(h.manifestsBaseDir, c.ManifestPath))
+		chart, err := loader.Load(filepath.Join(h.manifestsBaseDir, c.ManifestPath))
 		if err != nil {
 			return false, fmt.Errorf("failed to load manifest for %s: %w", c.Name, err)
 		}

--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -3,7 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -25,7 +25,7 @@ func setupKubeconfigs(s *state.State, kubeConfigDir string, securePort int, pki 
 		{file: "scheduler.conf", crt: pki.KubeSchedulerClientCert, key: pki.KubeSchedulerClientKey},
 		{file: "kubelet.conf", crt: pki.KubeletClientCert, key: pki.KubeletClientKey},
 	} {
-		if err := setup.Kubeconfig(path.Join(kubeConfigDir, kubeconfig.file), fmt.Sprintf("127.0.0.1:%d", securePort), pki.CACert, kubeconfig.crt, kubeconfig.key); err != nil {
+		if err := setup.Kubeconfig(filepath.Join(kubeConfigDir, kubeconfig.file), fmt.Sprintf("127.0.0.1:%d", securePort), pki.CACert, kubeconfig.crt, kubeconfig.key); err != nil {
 			return fmt.Errorf("failed to write kubeconfig %s: %w", kubeconfig.file, err)
 		}
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 
 	apiv1 "github.com/canonical/k8s/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/database"
@@ -208,10 +208,10 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s *state.State, encoded
 	}
 
 	// Kubeconfigs
-	if err := setup.Kubeconfig(path.Join(snap.KubernetesConfigDir(), "kubelet.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
 		return fmt.Errorf("failed to generate kubelet kubeconfig: %w", err)
 	}
-	if err := setup.Kubeconfig(path.Join(snap.KubernetesConfigDir(), "proxy.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
 		return fmt.Errorf("failed to generate kube-proxy kubeconfig: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
@@ -2,9 +2,8 @@ package controllers_test
 
 import (
 	"context"
-	"github.com/canonical/k8s/pkg/utils"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap/mock"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils"
 	. "github.com/onsi/gomega"
 )
 
@@ -33,8 +33,8 @@ func TestControlPlaneConfigController(t *testing.T) {
 
 		s := &mock.Snap{
 			Mock: mock.Mock{
-				EtcdPKIDir:          path.Join(dir, "etcd-pki"),
-				ServiceArgumentsDir: path.Join(dir, "args"),
+				EtcdPKIDir:          filepath.Join(dir, "etcd-pki"),
+				ServiceArgumentsDir: filepath.Join(dir, "args"),
 				UID:                 os.Getuid(),
 				GID:                 os.Getgid(),
 			},
@@ -74,9 +74,9 @@ func TestControlPlaneConfigController(t *testing.T) {
 					"--etcd-servers": "http://127.0.0.1:2379",
 				},
 				expectFilesToExist: map[string]bool{
-					path.Join(dir, "etcd-pki", "ca.crt"):     false,
-					path.Join(dir, "etcd-pki", "client.crt"): false,
-					path.Join(dir, "etcd-pki", "client.key"): false,
+					filepath.Join(dir, "etcd-pki", "ca.crt"):     false,
+					filepath.Join(dir, "etcd-pki", "client.crt"): false,
+					filepath.Join(dir, "etcd-pki", "client.key"): false,
 				},
 				expectServiceRestarts: []string{"kube-apiserver"},
 			},
@@ -93,14 +93,14 @@ func TestControlPlaneConfigController(t *testing.T) {
 				},
 				expectKubeAPIServerArgs: map[string]string{
 					"--etcd-servers":  "https://127.0.0.1:2379",
-					"--etcd-cafile":   path.Join(dir, "etcd-pki", "ca.crt"),
-					"--etcd-certfile": path.Join(dir, "etcd-pki", "client.crt"),
-					"--etcd-keyfile":  path.Join(dir, "etcd-pki", "client.key"),
+					"--etcd-cafile":   filepath.Join(dir, "etcd-pki", "ca.crt"),
+					"--etcd-certfile": filepath.Join(dir, "etcd-pki", "client.crt"),
+					"--etcd-keyfile":  filepath.Join(dir, "etcd-pki", "client.key"),
 				},
 				expectFilesToExist: map[string]bool{
-					path.Join(dir, "etcd-pki", "ca.crt"):     true,
-					path.Join(dir, "etcd-pki", "client.crt"): true,
-					path.Join(dir, "etcd-pki", "client.key"): true,
+					filepath.Join(dir, "etcd-pki", "ca.crt"):     true,
+					filepath.Join(dir, "etcd-pki", "client.crt"): true,
+					filepath.Join(dir, "etcd-pki", "client.key"): true,
 				},
 				expectServiceRestarts: []string{"kube-apiserver"},
 			},
@@ -132,14 +132,14 @@ func TestControlPlaneConfigController(t *testing.T) {
 				},
 				expectKubeAPIServerArgs: map[string]string{
 					"--etcd-servers":  "https://127.0.0.1:2379",
-					"--etcd-cafile":   path.Join(dir, "etcd-pki", "ca.crt"),
-					"--etcd-certfile": path.Join(dir, "etcd-pki", "client.crt"),
-					"--etcd-keyfile":  path.Join(dir, "etcd-pki", "client.key"),
+					"--etcd-cafile":   filepath.Join(dir, "etcd-pki", "ca.crt"),
+					"--etcd-certfile": filepath.Join(dir, "etcd-pki", "client.crt"),
+					"--etcd-keyfile":  filepath.Join(dir, "etcd-pki", "client.key"),
 				},
 				expectFilesToExist: map[string]bool{
-					path.Join(dir, "etcd-pki", "ca.crt"):     true,
-					path.Join(dir, "etcd-pki", "client.crt"): true,
-					path.Join(dir, "etcd-pki", "client.key"): true,
+					filepath.Join(dir, "etcd-pki", "ca.crt"):     true,
+					filepath.Join(dir, "etcd-pki", "client.crt"): true,
+					filepath.Join(dir, "etcd-pki", "client.key"): true,
 				},
 				expectKubeControllerManagerArgs: map[string]string{
 					"--cloud-provider": "external",
@@ -163,9 +163,9 @@ func TestControlPlaneConfigController(t *testing.T) {
 					"--etcd-keyfile":  "",
 				},
 				expectFilesToExist: map[string]bool{
-					path.Join(dir, "etcd-pki", "ca.crt"):     false,
-					path.Join(dir, "etcd-pki", "client.crt"): false,
-					path.Join(dir, "etcd-pki", "client.key"): false,
+					filepath.Join(dir, "etcd-pki", "ca.crt"):     false,
+					filepath.Join(dir, "etcd-pki", "client.crt"): false,
+					filepath.Join(dir, "etcd-pki", "client.key"): false,
 				},
 				expectKubeControllerManagerArgs: map[string]string{
 					"--cloud-provider": "",
@@ -217,7 +217,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 
 				t.Run("Certs", func(t *testing.T) {
 					for file, mustExist := range tc.expectFilesToExist {
-						t.Run(path.Base(file), func(t *testing.T) {
+						t.Run(filepath.Base(file), func(t *testing.T) {
 							g := NewWithT(t)
 
 							_, err := os.Stat(file)
@@ -238,9 +238,9 @@ func TestControlPlaneConfigController(t *testing.T) {
 
 		s := &mock.Snap{
 			Mock: mock.Mock{
-				EtcdPKIDir:          path.Join(dir, "etcd-pki"),
-				ServiceArgumentsDir: path.Join(dir, "args"),
-				LockFilesDir:        path.Join(dir, "locks"),
+				EtcdPKIDir:          filepath.Join(dir, "etcd-pki"),
+				ServiceArgumentsDir: filepath.Join(dir, "args"),
+				LockFilesDir:        filepath.Join(dir, "locks"),
 				UID:                 os.Getuid(),
 				GID:                 os.Getgid(),
 			},
@@ -310,7 +310,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 				t.Run(cert, func(t *testing.T) {
 					g := NewWithT(t)
 
-					_, err := os.Stat(path.Join(dir, "etcd-pki", cert))
+					_, err := os.Stat(filepath.Join(dir, "etcd-pki", cert))
 					g.Expect(err).To(MatchError(os.ErrNotExist))
 				})
 			}

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/rsa"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -118,7 +118,7 @@ func TestConfigPropagation(t *testing.T) {
 
 	s := &mock.Snap{
 		Mock: mock.Mock{
-			ServiceArgumentsDir:  path.Join(t.TempDir(), "args"),
+			ServiceArgumentsDir:  filepath.Join(t.TempDir(), "args"),
 			UID:                  os.Getuid(),
 			GID:                  os.Getgid(),
 			KubernetesNodeClient: &kubernetes.Client{Interface: clientset},

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration_test.go
@@ -3,7 +3,7 @@ package controllers_test
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -67,8 +67,8 @@ func TestUpdateNodeConfigurationController(t *testing.T) {
 
 			s := &mock.Snap{
 				Mock: mock.Mock{
-					EtcdPKIDir:          path.Join(dir, "etcd-pki"),
-					ServiceArgumentsDir: path.Join(dir, "args"),
+					EtcdPKIDir:          filepath.Join(dir, "etcd-pki"),
+					ServiceArgumentsDir: filepath.Join(dir, "args"),
 					UID:                 os.Getuid(),
 					GID:                 os.Getgid(),
 					KubernetesClient:    &kubernetes.Client{Interface: clientset},

--- a/src/k8s/pkg/k8sd/features/calico/chart.go
+++ b/src/k8s/pkg/k8sd/features/calico/chart.go
@@ -1,7 +1,7 @@
 package calico
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 )
@@ -11,7 +11,7 @@ var (
 	chartCalico = helm.InstallableChart{
 		Name:         "ck-network",
 		Namespace:    "tigera-operator",
-		ManifestPath: path.Join("charts", "tigera-operator-v3.28.0.tgz"),
+		ManifestPath: filepath.Join("charts", "tigera-operator-v3.28.0.tgz"),
 	}
 
 	// Note: Tigera is the company behind Calico and the tigera-operator is the operator for Calico.

--- a/src/k8s/pkg/k8sd/features/calico/cleanup.go
+++ b/src/k8s/pkg/k8sd/features/calico/cleanup.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -45,7 +45,7 @@ func CleanupNetwork(ctx context.Context, snap snap.Snap) error {
 
 	for _, entry := range entries {
 		if strings.HasPrefix(entry.Name(), "cali-") {
-			nsPath := path.Join(netnsDir, entry.Name())
+			nsPath := filepath.Join(netnsDir, entry.Name())
 
 			if err := unix.Unmount(nsPath, unix.MNT_DETACH); err != nil {
 				return fmt.Errorf("failed to unmount network namespace %s: %w", entry.Name(), err)

--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -1,7 +1,7 @@
 package cilium
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 )
@@ -11,28 +11,28 @@ var (
 	chartCilium = helm.InstallableChart{
 		Name:         "ck-network",
 		Namespace:    "kube-system",
-		ManifestPath: path.Join("charts", "cilium-1.15.2.tgz"),
+		ManifestPath: filepath.Join("charts", "cilium-1.15.2.tgz"),
 	}
 
 	// chartCiliumLoadBalancer represents manifests to deploy Cilium LoadBalancer resources.
 	chartCiliumLoadBalancer = helm.InstallableChart{
 		Name:         "ck-loadbalancer",
 		Namespace:    "kube-system",
-		ManifestPath: path.Join("charts", "ck-loadbalancer"),
+		ManifestPath: filepath.Join("charts", "ck-loadbalancer"),
 	}
 
 	// chartGateway represents manifests to deploy Gateway API CRDs.
 	chartGateway = helm.InstallableChart{
 		Name:         "ck-gateway",
 		Namespace:    "kube-system",
-		ManifestPath: path.Join("charts", "gateway-api-1.0.0.tgz"),
+		ManifestPath: filepath.Join("charts", "gateway-api-1.0.0.tgz"),
 	}
 
 	//chartGatewayClass represents a manifest to deploy a GatewayClass called ck-gateway.
 	chartGatewayClass = helm.InstallableChart{
 		Name:         "ck-gateway-class",
 		Namespace:    "default",
-		ManifestPath: path.Join("charts", "ck-gateway-cilium"),
+		ManifestPath: filepath.Join("charts", "ck-gateway-cilium"),
 	}
 
 	// ciliumAgentImageRepo represents the image to use for cilium-agent.

--- a/src/k8s/pkg/k8sd/features/contour/chart.go
+++ b/src/k8s/pkg/k8sd/features/contour/chart.go
@@ -1,7 +1,7 @@
 package contour
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 )
@@ -12,26 +12,26 @@ var (
 	chartContour = helm.InstallableChart{
 		Name:         "ck-ingress",
 		Namespace:    "projectcontour",
-		ManifestPath: path.Join("charts", "contour-17.0.4.tgz"),
+		ManifestPath: filepath.Join("charts", "contour-17.0.4.tgz"),
 	}
 	// chartGateway represents manifests to deploy Contour Gateway.
 	// This excludes shared CRDs.
 	chartGateway = helm.InstallableChart{
 		Name:         "ck-gateway",
 		Namespace:    "projectcontour",
-		ManifestPath: path.Join("charts", "ck-gateway-contour-1.28.2.tgz"),
+		ManifestPath: filepath.Join("charts", "ck-gateway-contour-1.28.2.tgz"),
 	}
 	// chartDefaultTLS represents manifests to deploy a delegation resource for the default TLS secret.
 	chartDefaultTLS = helm.InstallableChart{
 		Name:         "ck-ingress-tls",
 		Namespace:    "projectcontour-root",
-		ManifestPath: path.Join("charts", "ck-ingress-tls"),
+		ManifestPath: filepath.Join("charts", "ck-ingress-tls"),
 	}
 	// chartCommonContourCRDS represents manifests to deploy common Contour CRDs.
 	chartCommonContourCRDS = helm.InstallableChart{
 		Name:         "ck-contour-common",
 		Namespace:    "projectcontour",
-		ManifestPath: path.Join("charts", "ck-contour-common-1.28.2.tgz"),
+		ManifestPath: filepath.Join("charts", "ck-contour-common-1.28.2.tgz"),
 	}
 
 	// contourGatewayProvisionerEnvoyImageRepo represents the image to use for envoy in the gateway.

--- a/src/k8s/pkg/k8sd/features/coredns/chart.go
+++ b/src/k8s/pkg/k8sd/features/coredns/chart.go
@@ -1,7 +1,7 @@
 package coredns
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 )
@@ -11,7 +11,7 @@ var (
 	chart = helm.InstallableChart{
 		Name:         "ck-dns",
 		Namespace:    "kube-system",
-		ManifestPath: path.Join("charts", "coredns-1.29.0.tgz"),
+		ManifestPath: filepath.Join("charts", "coredns-1.29.0.tgz"),
 	}
 
 	// imageRepo is the image to use for CoreDNS.

--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -1,7 +1,7 @@
 package localpv
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 )
@@ -11,7 +11,7 @@ var (
 	chart = helm.InstallableChart{
 		Name:         "ck-storage",
 		Namespace:    "kube-system",
-		ManifestPath: path.Join("charts", "rawfile-csi-0.9.0.tgz"),
+		ManifestPath: filepath.Join("charts", "rawfile-csi-0.9.0.tgz"),
 	}
 
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.

--- a/src/k8s/pkg/k8sd/features/metallb/chart.go
+++ b/src/k8s/pkg/k8sd/features/metallb/chart.go
@@ -1,7 +1,7 @@
 package metallb
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 )
@@ -11,14 +11,14 @@ var (
 	chartMetalLB = helm.InstallableChart{
 		Name:         "metallb",
 		Namespace:    "metallb-system",
-		ManifestPath: path.Join("charts", "metallb-0.14.5.tgz"),
+		ManifestPath: filepath.Join("charts", "metallb-0.14.5.tgz"),
 	}
 
 	// chartMetalLBLoadBalancer represents manifests to deploy MetalLB L2 or BGP resources.
 	chartMetalLBLoadBalancer = helm.InstallableChart{
 		Name:         "metallb-loadbalancer",
 		Namespace:    "metallb-system",
-		ManifestPath: path.Join("charts", "ck-loadbalancer"),
+		ManifestPath: filepath.Join("charts", "ck-loadbalancer"),
 	}
 
 	// controllerImageRepo is the image to use for metallb-controller.

--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -1,7 +1,7 @@
 package metrics_server
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 )
@@ -11,7 +11,7 @@ var (
 	chart = helm.InstallableChart{
 		Name:         "metrics-server",
 		Namespace:    "kube-system",
-		ManifestPath: path.Join("charts", "metrics-server-3.12.0.tgz"),
+		ManifestPath: filepath.Join("charts", "metrics-server-3.12.0.tgz"),
 	}
 
 	// imageRepo is the image to use for metrics-server.

--- a/src/k8s/pkg/k8sd/setup/certificates.go
+++ b/src/k8s/pkg/k8sd/setup/certificates.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/snap"
@@ -61,7 +61,7 @@ func ensureFiles(uid, gid int, mode fs.FileMode, files map[string]string) (bool,
 	var changed bool
 	for fname, content := range files {
 		if v, err := ensureFile(fname, content, uid, gid, mode); err != nil {
-			return false, fmt.Errorf("failed to configure %s: %w", path.Base(fname), err)
+			return false, fmt.Errorf("failed to configure %s: %w", filepath.Base(fname), err)
 		} else if v {
 			changed = true
 		}
@@ -74,9 +74,9 @@ func ensureFiles(uid, gid int, mode fs.FileMode, files map[string]string) (bool,
 // It returns true if one or more files were updated and any error that occurred.
 func EnsureExtDatastorePKI(snap snap.Snap, certificates *pki.ExternalDatastorePKI) (bool, error) {
 	return ensureFiles(snap.UID(), snap.GID(), 0600, map[string]string{
-		path.Join(snap.EtcdPKIDir(), "ca.crt"):     certificates.DatastoreCACert,
-		path.Join(snap.EtcdPKIDir(), "client.key"): certificates.DatastoreClientKey,
-		path.Join(snap.EtcdPKIDir(), "client.crt"): certificates.DatastoreClientCert,
+		filepath.Join(snap.EtcdPKIDir(), "ca.crt"):     certificates.DatastoreCACert,
+		filepath.Join(snap.EtcdPKIDir(), "client.key"): certificates.DatastoreClientKey,
+		filepath.Join(snap.EtcdPKIDir(), "client.crt"): certificates.DatastoreClientCert,
 	})
 }
 
@@ -85,8 +85,8 @@ func EnsureExtDatastorePKI(snap snap.Snap, certificates *pki.ExternalDatastorePK
 // It returns true if one or more files were updated and any error that occurred.
 func EnsureK8sDqlitePKI(snap snap.Snap, certificates *pki.K8sDqlitePKI) (bool, error) {
 	return ensureFiles(snap.UID(), snap.GID(), 0600, map[string]string{
-		path.Join(snap.K8sDqliteStateDir(), "cluster.crt"): certificates.K8sDqliteCert,
-		path.Join(snap.K8sDqliteStateDir(), "cluster.key"): certificates.K8sDqliteKey,
+		filepath.Join(snap.K8sDqliteStateDir(), "cluster.crt"): certificates.K8sDqliteCert,
+		filepath.Join(snap.K8sDqliteStateDir(), "cluster.key"): certificates.K8sDqliteKey,
 	})
 }
 
@@ -95,20 +95,20 @@ func EnsureK8sDqlitePKI(snap snap.Snap, certificates *pki.K8sDqlitePKI) (bool, e
 // It returns true if one or more files were updated and any error that occurred.
 func EnsureControlPlanePKI(snap snap.Snap, certificates *pki.ControlPlanePKI) (bool, error) {
 	return ensureFiles(snap.UID(), snap.GID(), 0600, map[string]string{
-		path.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.crt"): certificates.APIServerKubeletClientCert,
-		path.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.key"): certificates.APIServerKubeletClientKey,
-		path.Join(snap.KubernetesPKIDir(), "apiserver.crt"):                certificates.APIServerCert,
-		path.Join(snap.KubernetesPKIDir(), "apiserver.key"):                certificates.APIServerKey,
-		path.Join(snap.KubernetesPKIDir(), "ca.crt"):                       certificates.CACert,
-		path.Join(snap.KubernetesPKIDir(), "client-ca.crt"):                certificates.ClientCACert,
-		path.Join(snap.KubernetesPKIDir(), "ca.key"):                       certificates.CAKey,
-		path.Join(snap.KubernetesPKIDir(), "front-proxy-ca.crt"):           certificates.FrontProxyCACert,
-		path.Join(snap.KubernetesPKIDir(), "front-proxy-ca.key"):           certificates.FrontProxyCAKey,
-		path.Join(snap.KubernetesPKIDir(), "front-proxy-client.crt"):       certificates.FrontProxyClientCert,
-		path.Join(snap.KubernetesPKIDir(), "front-proxy-client.key"):       certificates.FrontProxyClientKey,
-		path.Join(snap.KubernetesPKIDir(), "kubelet.crt"):                  certificates.KubeletCert,
-		path.Join(snap.KubernetesPKIDir(), "kubelet.key"):                  certificates.KubeletKey,
-		path.Join(snap.KubernetesPKIDir(), "serviceaccount.key"):           certificates.ServiceAccountKey,
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.crt"): certificates.APIServerKubeletClientCert,
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.key"): certificates.APIServerKubeletClientKey,
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver.crt"):                certificates.APIServerCert,
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver.key"):                certificates.APIServerKey,
+		filepath.Join(snap.KubernetesPKIDir(), "ca.crt"):                       certificates.CACert,
+		filepath.Join(snap.KubernetesPKIDir(), "client-ca.crt"):                certificates.ClientCACert,
+		filepath.Join(snap.KubernetesPKIDir(), "ca.key"):                       certificates.CAKey,
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.crt"):           certificates.FrontProxyCACert,
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.key"):           certificates.FrontProxyCAKey,
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-client.crt"):       certificates.FrontProxyClientCert,
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-client.key"):       certificates.FrontProxyClientKey,
+		filepath.Join(snap.KubernetesPKIDir(), "kubelet.crt"):                  certificates.KubeletCert,
+		filepath.Join(snap.KubernetesPKIDir(), "kubelet.key"):                  certificates.KubeletKey,
+		filepath.Join(snap.KubernetesPKIDir(), "serviceaccount.key"):           certificates.ServiceAccountKey,
 	})
 }
 
@@ -117,9 +117,9 @@ func EnsureControlPlanePKI(snap snap.Snap, certificates *pki.ControlPlanePKI) (b
 // It returns true if one or more files were updated and any error that occurred.
 func EnsureWorkerPKI(snap snap.Snap, certificates *pki.WorkerNodePKI) (bool, error) {
 	return ensureFiles(snap.UID(), snap.GID(), 0600, map[string]string{
-		path.Join(snap.KubernetesPKIDir(), "ca.crt"):        certificates.CACert,
-		path.Join(snap.KubernetesPKIDir(), "client-ca.crt"): certificates.ClientCACert,
-		path.Join(snap.KubernetesPKIDir(), "kubelet.crt"):   certificates.KubeletCert,
-		path.Join(snap.KubernetesPKIDir(), "kubelet.key"):   certificates.KubeletKey,
+		filepath.Join(snap.KubernetesPKIDir(), "ca.crt"):        certificates.CACert,
+		filepath.Join(snap.KubernetesPKIDir(), "client-ca.crt"): certificates.ClientCACert,
+		filepath.Join(snap.KubernetesPKIDir(), "kubelet.crt"):   certificates.KubeletCert,
+		filepath.Join(snap.KubernetesPKIDir(), "kubelet.key"):   certificates.KubeletKey,
 	})
 }

--- a/src/k8s/pkg/k8sd/setup/certificates_internal_test.go
+++ b/src/k8s/pkg/k8sd/setup/certificates_internal_test.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -13,7 +13,7 @@ func TestEnsureFile(t *testing.T) {
 		g := NewWithT(t)
 
 		tempDir := t.TempDir()
-		fname := path.Join(tempDir, "test")
+		fname := filepath.Join(tempDir, "test")
 		updated, err := ensureFile(fname, "test", os.Getuid(), os.Getgid(), 0777)
 		g.Expect(err).To(BeNil())
 		g.Expect(updated).To(BeTrue())
@@ -25,7 +25,7 @@ func TestEnsureFile(t *testing.T) {
 	t.Run("DeleteFile", func(t *testing.T) {
 		g := NewWithT(t)
 		tempDir := t.TempDir()
-		fname := path.Join(tempDir, "test")
+		fname := filepath.Join(tempDir, "test")
 
 		// Create a file with some content.
 		updated, err := ensureFile(fname, "test", os.Getuid(), os.Getgid(), 0777)
@@ -44,7 +44,7 @@ func TestEnsureFile(t *testing.T) {
 	t.Run("ChangeContent", func(t *testing.T) {
 		g := NewWithT(t)
 		tempDir := t.TempDir()
-		fname := path.Join(tempDir, "test")
+		fname := filepath.Join(tempDir, "test")
 
 		// Create a file with some content.
 		updated, err := ensureFile(fname, "test", os.Getuid(), os.Getgid(), 0777)
@@ -73,7 +73,7 @@ func TestEnsureFile(t *testing.T) {
 	t.Run("NotExist", func(t *testing.T) {
 		g := NewWithT(t)
 		tempDir := t.TempDir()
-		fname := path.Join(tempDir, "test")
+		fname := filepath.Join(tempDir, "test")
 
 		// ensureFile on inexistent file with empty content should return that the file was not updated.
 		updated, err := ensureFile(fname, "", os.Getuid(), os.Getgid(), 0777)

--- a/src/k8s/pkg/k8sd/setup/containerd_test.go
+++ b/src/k8s/pkg/k8sd/setup/containerd_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
+	"path/filepath"
 	"syscall"
 	"testing"
 
@@ -21,20 +21,20 @@ func TestContainerd(t *testing.T) {
 
 	dir := t.TempDir()
 
-	g.Expect(os.WriteFile(path.Join(dir, "mockcni"), []byte("echo hi"), 0600)).To(Succeed())
+	g.Expect(os.WriteFile(filepath.Join(dir, "mockcni"), []byte("echo hi"), 0600)).To(Succeed())
 
 	s := &mock.Snap{
 		Mock: mock.Mock{
-			ContainerdConfigDir:         path.Join(dir, "containerd"),
-			ContainerdRootDir:           path.Join(dir, "containerd-root"),
-			ContainerdSocketDir:         path.Join(dir, "containerd-run"),
-			ContainerdRegistryConfigDir: path.Join(dir, "containerd-hosts"),
-			ContainerdStateDir:          path.Join(dir, "containerd-state"),
-			ContainerdExtraConfigDir:    path.Join(dir, "containerd-confd"),
-			ServiceArgumentsDir:         path.Join(dir, "args"),
-			CNIBinDir:                   path.Join(dir, "opt-cni-bin"),
-			CNIConfDir:                  path.Join(dir, "cni-netd"),
-			CNIPluginsBinary:            path.Join(dir, "mockcni"),
+			ContainerdConfigDir:         filepath.Join(dir, "containerd"),
+			ContainerdRootDir:           filepath.Join(dir, "containerd-root"),
+			ContainerdSocketDir:         filepath.Join(dir, "containerd-run"),
+			ContainerdRegistryConfigDir: filepath.Join(dir, "containerd-hosts"),
+			ContainerdStateDir:          filepath.Join(dir, "containerd-state"),
+			ContainerdExtraConfigDir:    filepath.Join(dir, "containerd-confd"),
+			ServiceArgumentsDir:         filepath.Join(dir, "args"),
+			CNIBinDir:                   filepath.Join(dir, "opt-cni-bin"),
+			CNIConfDir:                  filepath.Join(dir, "cni-netd"),
+			CNIPluginsBinary:            filepath.Join(dir, "mockcni"),
 			CNIPlugins:                  []string{"plugin1", "plugin2"},
 			UID:                         os.Getuid(),
 			GID:                         os.Getgid(),
@@ -63,16 +63,16 @@ func TestContainerd(t *testing.T) {
 
 	t.Run("Config", func(t *testing.T) {
 		g := NewWithT(t)
-		b, err := os.ReadFile(path.Join(dir, "containerd", "config.toml"))
+		b, err := os.ReadFile(filepath.Join(dir, "containerd", "config.toml"))
 		g.Expect(err).To(BeNil())
 		g.Expect(string(b)).To(SatisfyAll(
-			ContainSubstring(fmt.Sprintf(`imports = ["%s/*.toml"]`, path.Join(dir, "containerd-confd"))),
-			ContainSubstring(fmt.Sprintf(`conf_dir = "%s"`, path.Join(dir, "cni-netd"))),
-			ContainSubstring(fmt.Sprintf(`bin_dir = "%s"`, path.Join(dir, "opt-cni-bin"))),
-			ContainSubstring(fmt.Sprintf(`config_path = "%s"`, path.Join(dir, "containerd-hosts"))),
+			ContainSubstring(fmt.Sprintf(`imports = ["%s/*.toml"]`, filepath.Join(dir, "containerd-confd"))),
+			ContainSubstring(fmt.Sprintf(`conf_dir = "%s"`, filepath.Join(dir, "cni-netd"))),
+			ContainSubstring(fmt.Sprintf(`bin_dir = "%s"`, filepath.Join(dir, "opt-cni-bin"))),
+			ContainSubstring(fmt.Sprintf(`config_path = "%s"`, filepath.Join(dir, "containerd-hosts"))),
 		))
 
-		info, err := os.Stat(path.Join(dir, "containerd", "config.toml"))
+		info, err := os.Stat(filepath.Join(dir, "containerd", "config.toml"))
 		g.Expect(err).To(BeNil())
 		g.Expect(info.Mode().Perm()).To(Equal(fs.FileMode(0600)))
 
@@ -88,12 +88,12 @@ func TestContainerd(t *testing.T) {
 	t.Run("CNI", func(t *testing.T) {
 		g := NewWithT(t)
 		for _, plugin := range []string{"plugin1", "plugin2"} {
-			link, err := os.Readlink(path.Join(dir, "opt-cni-bin", plugin))
+			link, err := os.Readlink(filepath.Join(dir, "opt-cni-bin", plugin))
 			g.Expect(err).To(BeNil())
 			g.Expect(link).To(Equal("cni"))
 		}
 
-		info, err := os.Stat(path.Join(dir, "opt-cni-bin"))
+		info, err := os.Stat(filepath.Join(dir, "opt-cni-bin"))
 		g.Expect(err).To(BeNil())
 		g.Expect(info.Mode().Perm()).To(Equal(fs.FileMode(0700)))
 
@@ -108,9 +108,9 @@ func TestContainerd(t *testing.T) {
 
 	t.Run("Args", func(t *testing.T) {
 		for key, expectedVal := range map[string]string{
-			"--config":       path.Join(dir, "containerd", "config.toml"),
-			"--root":         path.Join(dir, "containerd-root"),
-			"--state":        path.Join(dir, "containerd-state"),
+			"--config":       filepath.Join(dir, "containerd", "config.toml"),
+			"--root":         filepath.Join(dir, "containerd-root"),
+			"--state":        filepath.Join(dir, "containerd-state"),
 			"--log-level":    "debug",
 			"--metrics":      "true",
 			"--my-extra-arg": "my-extra-val",
@@ -136,7 +136,7 @@ func TestContainerd(t *testing.T) {
 			t.Run("docker.io", func(t *testing.T) {
 				g := NewWithT(t)
 
-				b, err := os.ReadFile(path.Join(dir, "containerd-hosts", "docker.io", "hosts.toml"))
+				b, err := os.ReadFile(filepath.Join(dir, "containerd-hosts", "docker.io", "hosts.toml"))
 				g.Expect(err).To(BeNil())
 				g.Expect(string(b)).To(Equal(`server = "https://registry-1.mirror.internal"
 
@@ -153,7 +153,7 @@ func TestContainerd(t *testing.T) {
 			t.Run("ghcr.io", func(t *testing.T) {
 				g := NewWithT(t)
 
-				b, err := os.ReadFile(path.Join(dir, "containerd-hosts", "ghcr.io", "hosts.toml"))
+				b, err := os.ReadFile(filepath.Join(dir, "containerd-hosts", "ghcr.io", "hosts.toml"))
 				g.Expect(err).To(BeNil())
 				g.Expect(string(b)).To(Equal(`server = "https://ghcr.mirror.internal"
 
@@ -168,7 +168,7 @@ func TestContainerd(t *testing.T) {
 		t.Run("Auth", func(t *testing.T) {
 			g := NewWithT(t)
 
-			b, err := os.ReadFile(path.Join(dir, "containerd-confd", "k8sd-auths.toml"))
+			b, err := os.ReadFile(filepath.Join(dir, "containerd-confd", "k8sd-auths.toml"))
 			g.Expect(err).To(BeNil())
 			g.Expect(string(b)).To(Equal(`version = 2
 

--- a/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/proxy"
 	"github.com/canonical/k8s/pkg/snap"
@@ -12,14 +12,14 @@ import (
 
 // K8sAPIServerProxy prepares configuration for k8s-apiserver-proxy.
 func K8sAPIServerProxy(snap snap.Snap, servers []string, extraArgs map[string]*string) error {
-	configFile := path.Join(snap.ServiceExtraConfigDir(), "k8s-apiserver-proxy.json")
+	configFile := filepath.Join(snap.ServiceExtraConfigDir(), "k8s-apiserver-proxy.json")
 	if err := proxy.WriteEndpointsConfig(servers, configFile); err != nil {
 		return fmt.Errorf("failed to write proxy configuration file: %w", err)
 	}
 
 	if _, err := snaputil.UpdateServiceArguments(snap, "k8s-apiserver-proxy", map[string]string{
 		"--endpoints":  configFile,
-		"--kubeconfig": path.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
+		"--kubeconfig": filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
 		"--listen":     "127.0.0.1:6443",
 	}, nil); err != nil {
 		return fmt.Errorf("failed to write arguments file: %w", err)

--- a/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy_test.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy_test.go
@@ -3,7 +3,7 @@ package setup_test
 import (
 	"encoding/json"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -16,8 +16,8 @@ import (
 
 func setK8sApiServerMock(s *mock.Snap, dir string) {
 	s.Mock = mock.Mock{
-		ServiceArgumentsDir:   path.Join(dir, "args"),
-		ServiceExtraConfigDir: path.Join(dir, "args/conf.d"),
+		ServiceArgumentsDir:   filepath.Join(dir, "args"),
+		ServiceExtraConfigDir: filepath.Join(dir, "args/conf.d"),
 	}
 }
 
@@ -33,8 +33,8 @@ func TestK8sApiServerProxy(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--endpoints", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "k8s-apiserver-proxy.json")},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
+			{key: "--endpoints", expectedVal: filepath.Join(s.Mock.ServiceExtraConfigDir, "k8s-apiserver-proxy.json")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--listen", expectedVal: "127.0.0.1:6443"},
 		}
 		for _, tc := range tests {
@@ -46,7 +46,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 			})
 		}
 
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "k8s-apiserver-proxy"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "k8s-apiserver-proxy"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -67,8 +67,8 @@ func TestK8sApiServerProxy(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--endpoints", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "k8s-apiserver-proxy.json")},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "overridden-kubelet.conf")},
+			{key: "--endpoints", expectedVal: filepath.Join(s.Mock.ServiceExtraConfigDir, "k8s-apiserver-proxy.json")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "overridden-kubelet.conf")},
 			{key: "--my-extra-arg", expectedVal: "my-extra-val"},
 		}
 		for _, tc := range tests {
@@ -87,7 +87,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 			g.Expect(val).To(BeZero())
 		})
 
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "k8s-apiserver-proxy"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "k8s-apiserver-proxy"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -116,7 +116,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setK8sApiServerMock)
 
 		endpoints := []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
-		fileName := path.Join(s.Mock.ServiceExtraConfigDir, "k8s-apiserver-proxy.json")
+		fileName := filepath.Join(s.Mock.ServiceExtraConfigDir, "k8s-apiserver-proxy.json")
 
 		g.Expect(setup.K8sAPIServerProxy(s, endpoints, nil)).To(Succeed())
 

--- a/src/k8s/pkg/k8sd/setup/k8s_dqlite.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_dqlite.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/snap"
@@ -33,12 +32,12 @@ func K8sDqlite(snap snap.Snap, address string, cluster []string, extraArgs map[s
 		return fmt.Errorf("failed to create init.yaml file for address=%s cluster=%v: %w", address, cluster, err)
 	}
 
-	if err := os.WriteFile(path.Join(snap.K8sDqliteStateDir(), "init.yaml"), b, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(snap.K8sDqliteStateDir(), "init.yaml"), b, 0600); err != nil {
 		return fmt.Errorf("failed to write init.yaml: %w", err)
 	}
 
 	if _, err := snaputil.UpdateServiceArguments(snap, "k8s-dqlite", map[string]string{
-		"--listen":      fmt.Sprintf("unix://%s", path.Join(snap.K8sDqliteStateDir(), "k8s-dqlite.sock")),
+		"--listen":      fmt.Sprintf("unix://%s", filepath.Join(snap.K8sDqliteStateDir(), "k8s-dqlite.sock")),
 		"--storage-dir": snap.K8sDqliteStateDir(),
 	}, nil); err != nil {
 		return fmt.Errorf("failed to write arguments file: %w", err)

--- a/src/k8s/pkg/k8sd/setup/k8s_dqlite_test.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_dqlite_test.go
@@ -3,7 +3,7 @@ package setup_test
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -15,8 +15,8 @@ import (
 
 func setK8sDqliteMock(s *mock.Snap, dir string) {
 	s.Mock = mock.Mock{
-		ServiceArgumentsDir: path.Join(dir, "args"),
-		K8sDqliteStateDir:   path.Join(dir, "k8s-dqlite"),
+		ServiceArgumentsDir: filepath.Join(dir, "args"),
+		K8sDqliteStateDir:   filepath.Join(dir, "k8s-dqlite"),
 	}
 }
 
@@ -35,7 +35,7 @@ func TestK8sDqlite(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--listen", expectedVal: fmt.Sprintf("unix://%s", path.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
+			{key: "--listen", expectedVal: fmt.Sprintf("unix://%s", filepath.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
 			{key: "--storage-dir", expectedVal: s.Mock.K8sDqliteStateDir},
 		}
 		for _, tc := range tests {
@@ -48,7 +48,7 @@ func TestK8sDqlite(t *testing.T) {
 		}
 
 		// Ensure the K8sDqlite arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "k8s-dqlite"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "k8s-dqlite"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -93,7 +93,7 @@ func TestK8sDqlite(t *testing.T) {
 		})
 
 		// Ensure the K8sDqlite arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "k8s-dqlite"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "k8s-dqlite"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -114,7 +114,7 @@ func TestK8sDqlite(t *testing.T) {
 
 		g.Expect(setup.K8sDqlite(s, "192.168.0.1:1234", cluster, nil)).To(BeNil())
 
-		b, err := os.ReadFile(path.Join(s.Mock.K8sDqliteStateDir, "init.yaml"))
+		b, err := os.ReadFile(filepath.Join(s.Mock.K8sDqliteStateDir, "init.yaml"))
 		g.Expect(err).To(BeNil())
 		g.Expect(string(b)).To(Equal(expectedYaml))
 	})

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -50,7 +50,7 @@ var (
 
 // KubeAPIServer configures kube-apiserver on the local node.
 func KubeAPIServer(snap snap.Snap, nodeIP net.IP, serviceCIDR string, authWebhookURL string, enableFrontProxy bool, datastore types.Datastore, authorizationMode string, extraArgs map[string]*string) error {
-	authTokenWebhookConfigFile := path.Join(snap.ServiceExtraConfigDir(), "auth-token-webhook.conf")
+	authTokenWebhookConfigFile := filepath.Join(snap.ServiceExtraConfigDir(), "auth-token-webhook.conf")
 	authTokenWebhookFile, err := os.OpenFile(authTokenWebhookConfigFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open auth-token-webhook.conf: %w", err)
@@ -58,7 +58,7 @@ func KubeAPIServer(snap snap.Snap, nodeIP net.IP, serviceCIDR string, authWebhoo
 
 	if err := apiserverAuthTokenWebhookTemplate.Execute(authTokenWebhookFile, apiserverAuthTokenWebhookTemplateConfig{
 		URL:    authWebhookURL,
-		CAPath: path.Join(snap.K8sdStateDir(), "cluster.crt"),
+		CAPath: filepath.Join(snap.K8sdStateDir(), "cluster.crt"),
 	}); err != nil {
 		return fmt.Errorf("failed to write auth-token-webhook.conf: %w", err)
 	}
@@ -69,22 +69,22 @@ func KubeAPIServer(snap snap.Snap, nodeIP net.IP, serviceCIDR string, authWebhoo
 		"--allow-privileged":                         "true",
 		"--authentication-token-webhook-config-file": authTokenWebhookConfigFile,
 		"--authorization-mode":                       authorizationMode,
-		"--client-ca-file":                           path.Join(snap.KubernetesPKIDir(), "client-ca.crt"),
+		"--client-ca-file":                           filepath.Join(snap.KubernetesPKIDir(), "client-ca.crt"),
 		"--enable-admission-plugins":                 "NodeRestriction",
-		"--kubelet-certificate-authority":            path.Join(snap.KubernetesPKIDir(), "ca.crt"),
-		"--kubelet-client-certificate":               path.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.crt"),
-		"--kubelet-client-key":                       path.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.key"),
+		"--kubelet-certificate-authority":            filepath.Join(snap.KubernetesPKIDir(), "ca.crt"),
+		"--kubelet-client-certificate":               filepath.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.crt"),
+		"--kubelet-client-key":                       filepath.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.key"),
 		"--kubelet-preferred-address-types":          "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP",
 		"--profiling":                                "false",
 		"--request-timeout":                          "300s",
 		"--secure-port":                              "6443",
 		"--service-account-issuer":                   "https://kubernetes.default.svc",
-		"--service-account-key-file":                 path.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
-		"--service-account-signing-key-file":         path.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
+		"--service-account-key-file":                 filepath.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
+		"--service-account-signing-key-file":         filepath.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
 		"--service-cluster-ip-range":                 serviceCIDR,
-		"--tls-cert-file":                            path.Join(snap.KubernetesPKIDir(), "apiserver.crt"),
+		"--tls-cert-file":                            filepath.Join(snap.KubernetesPKIDir(), "apiserver.crt"),
 		"--tls-cipher-suites":                        strings.Join(apiserverTLSCipherSuites, ","),
-		"--tls-private-key-file":                     path.Join(snap.KubernetesPKIDir(), "apiserver.key"),
+		"--tls-private-key-file":                     filepath.Join(snap.KubernetesPKIDir(), "apiserver.key"),
 	}
 
 	if nodeIP != nil && !nodeIP.IsLoopback() {
@@ -103,13 +103,13 @@ func KubeAPIServer(snap snap.Snap, nodeIP net.IP, serviceCIDR string, authWebhoo
 	}
 
 	if enableFrontProxy {
-		args["--requestheader-client-ca-file"] = path.Join(snap.KubernetesPKIDir(), "front-proxy-ca.crt")
+		args["--requestheader-client-ca-file"] = filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.crt")
 		args["--requestheader-allowed-names"] = "front-proxy-client"
 		args["--requestheader-extra-headers-prefix"] = "X-Remote-Extra-"
 		args["--requestheader-group-headers"] = "X-Remote-Group"
 		args["--requestheader-username-headers"] = "X-Remote-User"
-		args["--proxy-client-cert-file"] = path.Join(snap.KubernetesPKIDir(), "front-proxy-client.crt")
-		args["--proxy-client-key-file"] = path.Join(snap.KubernetesPKIDir(), "front-proxy-client.key")
+		args["--proxy-client-cert-file"] = filepath.Join(snap.KubernetesPKIDir(), "front-proxy-client.crt")
+		args["--proxy-client-key-file"] = filepath.Join(snap.KubernetesPKIDir(), "front-proxy-client.key")
 	}
 	if _, err := snaputil.UpdateServiceArguments(snap, "kube-apiserver", args, deleteArgs); err != nil {
 		return fmt.Errorf("failed to render arguments file: %w", err)

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -21,11 +21,11 @@ func setKubeAPIServerMock(s *mock.Snap, dir string) {
 	s.Mock = mock.Mock{
 		UID:                   os.Getuid(),
 		GID:                   os.Getgid(),
-		KubernetesConfigDir:   path.Join(dir, "kubernetes"),
-		KubernetesPKIDir:      path.Join(dir, "kubernetes-pki"),
-		ServiceArgumentsDir:   path.Join(dir, "args"),
-		ServiceExtraConfigDir: path.Join(dir, "args/conf.d"),
-		K8sDqliteStateDir:     path.Join(dir, "k8s-dqlite"),
+		KubernetesConfigDir:   filepath.Join(dir, "kubernetes"),
+		KubernetesPKIDir:      filepath.Join(dir, "kubernetes-pki"),
+		ServiceArgumentsDir:   filepath.Join(dir, "args"),
+		ServiceExtraConfigDir: filepath.Join(dir, "args/conf.d"),
+		K8sDqliteStateDir:     filepath.Join(dir, "k8s-dqlite"),
 	}
 }
 
@@ -47,32 +47,32 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--advertise-address", expectedVal: "192.168.0.1"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--allow-privileged", expectedVal: "true"},
-			{key: "--authentication-token-webhook-config-file", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
+			{key: "--authentication-token-webhook-config-file", expectedVal: filepath.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
 			{key: "--authorization-mode", expectedVal: "Node,RBAC"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--enable-admission-plugins", expectedVal: "NodeRestriction"},
-			{key: "--kubelet-certificate-authority", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--kubelet-client-certificate", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
-			{key: "--kubelet-client-key", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
+			{key: "--kubelet-certificate-authority", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--kubelet-client-certificate", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
+			{key: "--kubelet-client-key", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
 			{key: "--kubelet-preferred-address-types", expectedVal: "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP"},
 			{key: "--profiling", expectedVal: "false"},
 			{key: "--secure-port", expectedVal: "6443"},
 			{key: "--service-account-issuer", expectedVal: "https://kubernetes.default.svc"},
-			{key: "--service-account-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
-			{key: "--service-account-signing-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--service-account-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--service-account-signing-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--service-cluster-ip-range", expectedVal: "10.0.0.0/24"},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
-			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", path.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
+			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", filepath.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
 			{key: "--request-timeout", expectedVal: "300s"},
-			{key: "--requestheader-client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-ca.crt")},
+			{key: "--requestheader-client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "front-proxy-ca.crt")},
 			{key: "--requestheader-allowed-names", expectedVal: "front-proxy-client"},
 			{key: "--requestheader-extra-headers-prefix", expectedVal: "X-Remote-Extra-"},
 			{key: "--requestheader-group-headers", expectedVal: "X-Remote-Group"},
 			{key: "--requestheader-username-headers", expectedVal: "X-Remote-User"},
-			{key: "--proxy-client-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.crt")},
-			{key: "--proxy-client-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.key")},
+			{key: "--proxy-client-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.crt")},
+			{key: "--proxy-client-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.key")},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestKubeAPIServer(t *testing.T) {
 		}
 
 		// Ensure the kube-apiserver arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -106,25 +106,25 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--advertise-address", expectedVal: "192.168.0.1"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--allow-privileged", expectedVal: "true"},
-			{key: "--authentication-token-webhook-config-file", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
+			{key: "--authentication-token-webhook-config-file", expectedVal: filepath.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
 			{key: "--authorization-mode", expectedVal: "Node,RBAC"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--enable-admission-plugins", expectedVal: "NodeRestriction"},
-			{key: "--kubelet-certificate-authority", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--kubelet-client-certificate", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
-			{key: "--kubelet-client-key", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
+			{key: "--kubelet-certificate-authority", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--kubelet-client-certificate", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
+			{key: "--kubelet-client-key", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
 			{key: "--kubelet-preferred-address-types", expectedVal: "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP"},
 			{key: "--profiling", expectedVal: "false"},
 			{key: "--request-timeout", expectedVal: "300s"},
 			{key: "--secure-port", expectedVal: "6443"},
 			{key: "--service-account-issuer", expectedVal: "https://kubernetes.default.svc"},
-			{key: "--service-account-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
-			{key: "--service-account-signing-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--service-account-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--service-account-signing-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--service-cluster-ip-range", expectedVal: "10.0.0.0/24"},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
-			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", path.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
+			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", filepath.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -136,7 +136,7 @@ func TestKubeAPIServer(t *testing.T) {
 		}
 
 		// Ensure the kube-apiserver arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -162,32 +162,32 @@ func TestKubeAPIServer(t *testing.T) {
 		}{
 			{key: "--advertise-address", expectedVal: "192.168.0.1"},
 			{key: "--anonymous-auth", expectedVal: "false"},
-			{key: "--authentication-token-webhook-config-file", expectedVal: path.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
+			{key: "--authentication-token-webhook-config-file", expectedVal: filepath.Join(s.Mock.ServiceExtraConfigDir, "auth-token-webhook.conf")},
 			{key: "--authorization-mode", expectedVal: "Node,RBAC"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
 			{key: "--enable-admission-plugins", expectedVal: "NodeRestriction"},
-			{key: "--kubelet-certificate-authority", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--kubelet-client-certificate", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
-			{key: "--kubelet-client-key", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
+			{key: "--kubelet-certificate-authority", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--kubelet-client-certificate", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.crt")},
+			{key: "--kubelet-client-key", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver-kubelet-client.key")},
 			{key: "--kubelet-preferred-address-types", expectedVal: "InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP"},
 			{key: "--profiling", expectedVal: "false"},
 			{key: "--secure-port", expectedVal: "1337"},
 			{key: "--service-account-issuer", expectedVal: "https://kubernetes.default.svc"},
-			{key: "--service-account-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
-			{key: "--service-account-signing-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--service-account-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--service-account-signing-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--service-cluster-ip-range", expectedVal: "10.0.0.0/24"},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
-			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", path.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
+			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", filepath.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
 			{key: "--request-timeout", expectedVal: "300s"},
-			{key: "--requestheader-client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-ca.crt")},
+			{key: "--requestheader-client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "front-proxy-ca.crt")},
 			{key: "--requestheader-allowed-names", expectedVal: "front-proxy-client"},
 			{key: "--requestheader-extra-headers-prefix", expectedVal: "X-Remote-Extra-"},
 			{key: "--requestheader-group-headers", expectedVal: "X-Remote-Group"},
 			{key: "--requestheader-username-headers", expectedVal: "X-Remote-User"},
-			{key: "--proxy-client-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.crt")},
-			{key: "--proxy-client-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.key")},
+			{key: "--proxy-client-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.crt")},
+			{key: "--proxy-client-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "front-proxy-client.key")},
 			{key: "--my-extra-arg", expectedVal: "my-extra-val"},
 		}
 		for _, tc := range tests {
@@ -204,7 +204,7 @@ func TestKubeAPIServer(t *testing.T) {
 		g.Expect(val).To(BeZero())
 
 		// Ensure the kube-apiserver arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -217,7 +217,7 @@ func TestKubeAPIServer(t *testing.T) {
 		g.Expect(setup.KubeAPIServer(s, net.ParseIP("192.168.0.1"), "10.0.0.0/24,fd01::/64", "https://auth-webhook.url", false, types.Datastore{Type: utils.Pointer("external"), ExternalServers: utils.Pointer([]string{"datastoreurl1", "datastoreurl2"})}, "Node,RBAC", nil)).To(BeNil())
 
 		g.Expect(snaputil.GetServiceArgument(s, "kube-apiserver", "--service-cluster-ip-range")).To(Equal("10.0.0.0/24,fd01::/64"))
-		_, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
+		_, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -230,7 +230,7 @@ func TestKubeAPIServer(t *testing.T) {
 		g.Expect(setup.KubeAPIServer(s, net.ParseIP("192.168.0.1"), "10.0.0.0/24", "https://auth-webhook.url", false, types.Datastore{Type: utils.Pointer("external"), ExternalServers: utils.Pointer([]string{"datastoreurl1", "datastoreurl2"})}, "Node,RBAC", nil)).To(BeNil())
 
 		g.Expect(snaputil.GetServiceArgument(s, "kube-apiserver", "--etcd-servers")).To(Equal("datastoreurl1,datastoreurl2"))
-		_, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
+		_, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-apiserver"))
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/src/k8s/pkg/k8sd/setup/kube_controller_manager.go
+++ b/src/k8s/pkg/k8sd/setup/kube_controller_manager.go
@@ -3,7 +3,7 @@ package setup
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
@@ -13,21 +13,21 @@ import (
 // KubeControllerManager configures kube-controller-manager on the local node.
 func KubeControllerManager(snap snap.Snap, extraArgs map[string]*string) error {
 	args := map[string]string{
-		"--authentication-kubeconfig":        path.Join(snap.KubernetesConfigDir(), "controller.conf"),
-		"--authorization-kubeconfig":         path.Join(snap.KubernetesConfigDir(), "controller.conf"),
-		"--kubeconfig":                       path.Join(snap.KubernetesConfigDir(), "controller.conf"),
+		"--authentication-kubeconfig":        filepath.Join(snap.KubernetesConfigDir(), "controller.conf"),
+		"--authorization-kubeconfig":         filepath.Join(snap.KubernetesConfigDir(), "controller.conf"),
+		"--kubeconfig":                       filepath.Join(snap.KubernetesConfigDir(), "controller.conf"),
 		"--leader-elect-lease-duration":      "30s",
 		"--leader-elect-renew-deadline":      "15s",
 		"--profiling":                        "false",
-		"--root-ca-file":                     path.Join(snap.KubernetesPKIDir(), "ca.crt"),
-		"--service-account-private-key-file": path.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
+		"--root-ca-file":                     filepath.Join(snap.KubernetesPKIDir(), "ca.crt"),
+		"--service-account-private-key-file": filepath.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
 		"--terminated-pod-gc-threshold":      "12500",
 		"--use-service-account-credentials":  "true",
 	}
 	// enable cluster-signing if certificates are available
-	if _, err := os.Stat(path.Join(snap.KubernetesPKIDir(), "ca.key")); err == nil {
-		args["--cluster-signing-cert-file"] = path.Join(snap.KubernetesPKIDir(), "ca.crt")
-		args["--cluster-signing-key-file"] = path.Join(snap.KubernetesPKIDir(), "ca.key")
+	if _, err := os.Stat(filepath.Join(snap.KubernetesPKIDir(), "ca.key")); err == nil {
+		args["--cluster-signing-cert-file"] = filepath.Join(snap.KubernetesPKIDir(), "ca.crt")
+		args["--cluster-signing-key-file"] = filepath.Join(snap.KubernetesPKIDir(), "ca.key")
 	}
 	if _, err := snaputil.UpdateServiceArguments(snap, "kube-controller-manager", args, nil); err != nil {
 		return fmt.Errorf("failed to render arguments file: %w", err)

--- a/src/k8s/pkg/k8sd/setup/kube_controller_manager_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_controller_manager_test.go
@@ -2,7 +2,7 @@ package setup_test
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -14,9 +14,9 @@ import (
 
 func setKubeControllerManagerMock(s *mock.Snap, dir string) {
 	s.Mock = mock.Mock{
-		ServiceArgumentsDir: path.Join(dir, "args"),
-		KubernetesConfigDir: path.Join(dir, "k8s-config"),
-		KubernetesPKIDir:    path.Join(dir, "k8s-pki"),
+		ServiceArgumentsDir: filepath.Join(dir, "args"),
+		KubernetesConfigDir: filepath.Join(dir, "k8s-config"),
+		KubernetesPKIDir:    filepath.Join(dir, "k8s-pki"),
 	}
 }
 
@@ -28,7 +28,7 @@ func TestKubeControllerManager(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setKubeControllerManagerMock)
 
 		// Create ca.key so that cluster-signing-cert-file and cluster-signing-key-file are added to the arguments
-		os.Create(path.Join(s.Mock.KubernetesPKIDir, "ca.key"))
+		os.Create(filepath.Join(s.Mock.KubernetesPKIDir, "ca.key"))
 
 		// Call the kube controller manager setup function
 		g.Expect(setup.KubeControllerManager(s, nil)).To(BeNil())
@@ -38,18 +38,18 @@ func TestKubeControllerManager(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--authentication-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
-			{key: "--authorization-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--authentication-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--authorization-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
 			{key: "--leader-elect-lease-duration", expectedVal: "30s"},
 			{key: "--leader-elect-renew-deadline", expectedVal: "15s"},
 			{key: "--profiling", expectedVal: "false"},
-			{key: "--root-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--service-account-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--root-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--service-account-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
-			{key: "--cluster-signing-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--cluster-signing-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.key")},
+			{key: "--cluster-signing-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--cluster-signing-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.key")},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestKubeControllerManager(t *testing.T) {
 		}
 
 		// Ensure the kube controller manager arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-controller-manager"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-controller-manager"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 
@@ -86,14 +86,14 @@ func TestKubeControllerManager(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--authentication-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
-			{key: "--authorization-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--authentication-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--authorization-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
 			{key: "--leader-elect-lease-duration", expectedVal: "30s"},
 			{key: "--leader-elect-renew-deadline", expectedVal: "15s"},
 			{key: "--profiling", expectedVal: "false"},
-			{key: "--root-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--service-account-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--root-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--service-account-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
 		}
@@ -107,7 +107,7 @@ func TestKubeControllerManager(t *testing.T) {
 		}
 
 		// Ensure the kube controller manager arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-controller-manager"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-controller-manager"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 
@@ -125,7 +125,7 @@ func TestKubeControllerManager(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setKubeControllerManagerMock)
 
 		// Create ca.key so that cluster-signing-cert-file and cluster-signing-key-file are added to the arguments
-		os.Create(path.Join(s.Mock.KubernetesPKIDir, "ca.key"))
+		os.Create(filepath.Join(s.Mock.KubernetesPKIDir, "ca.key"))
 
 		extraArgs := map[string]*string{
 			"--leader-elect-lease-duration": nil,
@@ -140,17 +140,17 @@ func TestKubeControllerManager(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--authentication-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
-			{key: "--authorization-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--authentication-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--authorization-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "controller.conf")},
 			{key: "--leader-elect-renew-deadline", expectedVal: "15s"},
 			{key: "--profiling", expectedVal: "true"},
-			{key: "--root-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--service-account-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
+			{key: "--root-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--service-account-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
-			{key: "--cluster-signing-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
-			{key: "--cluster-signing-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "ca.key")},
+			{key: "--cluster-signing-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
+			{key: "--cluster-signing-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.key")},
 			{key: "--my-extra-arg", expectedVal: "my-extra-val"},
 		}
 		for _, tc := range tests {
@@ -168,7 +168,7 @@ func TestKubeControllerManager(t *testing.T) {
 		g.Expect(val).To(BeZero())
 
 		// Ensure the kube controller manager arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-controller-manager"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-controller-manager"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -3,7 +3,7 @@ package setup
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
@@ -16,7 +16,7 @@ func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR str
 	serviceArgs := map[string]string{
 		"--cluster-cidr":         podCIDR,
 		"--healthz-bind-address": "127.0.0.1",
-		"--kubeconfig":           path.Join(snap.KubernetesConfigDir(), "proxy.conf"),
+		"--kubeconfig":           filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"),
 		"--profiling":            "false",
 	}
 

--- a/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
@@ -3,7 +3,6 @@ package setup_test
 import (
 	"context"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -21,8 +20,8 @@ func TestKubeProxy(t *testing.T) {
 
 	s := &mock.Snap{
 		Mock: mock.Mock{
-			KubernetesConfigDir: path.Join(dir, "kubernetes"),
-			ServiceArgumentsDir: path.Join(dir, "args"),
+			KubernetesConfigDir: filepath.Join(dir, "kubernetes"),
+			ServiceArgumentsDir: filepath.Join(dir, "args"),
 			OnLXD:               false,
 			UID:                 os.Getuid(),
 			GID:                 os.Getgid(),
@@ -37,7 +36,7 @@ func TestKubeProxy(t *testing.T) {
 		for key, expectedVal := range map[string]string{
 			"--cluster-cidr":           "10.1.0.0/16",
 			"--hostname-override":      "myhostname",
-			"--kubeconfig":             path.Join(dir, "kubernetes", "proxy.conf"),
+			"--kubeconfig":             filepath.Join(dir, "kubernetes", "proxy.conf"),
 			"--profiling":              "false",
 			"--conntrack-max-per-core": "",
 		} {
@@ -61,7 +60,7 @@ func TestKubeProxy(t *testing.T) {
 		for key, expectedVal := range map[string]string{
 			"--cluster-cidr":           "10.1.0.0/16",
 			"--hostname-override":      "myoverriddenhostname",
-			"--kubeconfig":             path.Join(dir, "kubernetes", "proxy.conf"),
+			"--kubeconfig":             filepath.Join(dir, "kubernetes", "proxy.conf"),
 			"--profiling":              "false",
 			"--conntrack-max-per-core": "",
 			"--my-extra-arg":           "my-extra-val",

--- a/src/k8s/pkg/k8sd/setup/kube_scheduler.go
+++ b/src/k8s/pkg/k8sd/setup/kube_scheduler.go
@@ -2,7 +2,7 @@ package setup
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
@@ -12,9 +12,9 @@ import (
 // KubeScheduler configures kube-scheduler on the local node.
 func KubeScheduler(snap snap.Snap, extraArgs map[string]*string) error {
 	if _, err := snaputil.UpdateServiceArguments(snap, "kube-scheduler", map[string]string{
-		"--authentication-kubeconfig":   path.Join(snap.KubernetesConfigDir(), "scheduler.conf"),
-		"--authorization-kubeconfig":    path.Join(snap.KubernetesConfigDir(), "scheduler.conf"),
-		"--kubeconfig":                  path.Join(snap.KubernetesConfigDir(), "scheduler.conf"),
+		"--authentication-kubeconfig":   filepath.Join(snap.KubernetesConfigDir(), "scheduler.conf"),
+		"--authorization-kubeconfig":    filepath.Join(snap.KubernetesConfigDir(), "scheduler.conf"),
+		"--kubeconfig":                  filepath.Join(snap.KubernetesConfigDir(), "scheduler.conf"),
 		"--leader-elect-lease-duration": "30s",
 		"--leader-elect-renew-deadline": "15s",
 		"--profiling":                   "false",

--- a/src/k8s/pkg/k8sd/setup/kube_scheduler_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_scheduler_test.go
@@ -1,7 +1,7 @@
 package setup_test
 
 import (
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -13,8 +13,8 @@ import (
 
 func setKubeSchedulerMock(s *mock.Snap, dir string) {
 	s.Mock = mock.Mock{
-		ServiceArgumentsDir: path.Join(dir, "args"),
-		KubernetesConfigDir: path.Join(dir, "k8s-config"),
+		ServiceArgumentsDir: filepath.Join(dir, "args"),
+		KubernetesConfigDir: filepath.Join(dir, "k8s-config"),
 	}
 }
 
@@ -33,9 +33,9 @@ func TestKubeScheduler(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--authentication-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
-			{key: "--authorization-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
+			{key: "--authentication-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
+			{key: "--authorization-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
 			{key: "--leader-elect-lease-duration", expectedVal: "30s"},
 			{key: "--leader-elect-renew-deadline", expectedVal: "15s"},
 			{key: "--profiling", expectedVal: "false"},
@@ -50,7 +50,7 @@ func TestKubeScheduler(t *testing.T) {
 		}
 
 		// Ensure the kube scheduler arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-scheduler"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-scheduler"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 
@@ -75,9 +75,9 @@ func TestKubeScheduler(t *testing.T) {
 			key         string
 			expectedVal string
 		}{
-			{key: "--authentication-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
-			{key: "--authorization-kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
+			{key: "--authentication-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
+			{key: "--authorization-kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
 			{key: "--leader-elect-renew-deadline", expectedVal: "15s"},
 			{key: "--profiling", expectedVal: "true"},
 			{key: "--my-extra-arg", expectedVal: "my-extra-val"},
@@ -97,7 +97,7 @@ func TestKubeScheduler(t *testing.T) {
 		g.Expect(val).To(BeZero())
 
 		// Ensure the kube scheduler arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kube-scheduler"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kube-scheduler"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 

--- a/src/k8s/pkg/k8sd/setup/kubelet.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet.go
@@ -3,7 +3,7 @@ package setup
 import (
 	"fmt"
 	"net"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/canonical/k8s/pkg/snap"
@@ -51,20 +51,20 @@ func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, 
 		"--authorization-mode":           "Webhook",
 		"--anonymous-auth":               "false",
 		"--authentication-token-webhook": "true",
-		"--client-ca-file":               path.Join(snap.KubernetesPKIDir(), "client-ca.crt"),
-		"--container-runtime-endpoint":   path.Join(snap.ContainerdSocketDir(), "containerd.sock"),
-		"--containerd":                   path.Join(snap.ContainerdSocketDir(), "containerd.sock"),
+		"--client-ca-file":               filepath.Join(snap.KubernetesPKIDir(), "client-ca.crt"),
+		"--container-runtime-endpoint":   filepath.Join(snap.ContainerdSocketDir(), "containerd.sock"),
+		"--containerd":                   filepath.Join(snap.ContainerdSocketDir(), "containerd.sock"),
 		"--eviction-hard":                "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'",
 		"--fail-swap-on":                 "false",
-		"--kubeconfig":                   path.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
+		"--kubeconfig":                   filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
 		"--node-labels":                  strings.Join(labels, ","),
 		"--read-only-port":               "0",
 		"--register-with-taints":         strings.Join(taints, ","),
 		"--root-dir":                     snap.KubeletRootDir(),
 		"--serialize-image-pulls":        "false",
 		"--tls-cipher-suites":            strings.Join(kubeletTLSCipherSuites, ","),
-		"--tls-cert-file":                path.Join(snap.KubernetesPKIDir(), "kubelet.crt"),
-		"--tls-private-key-file":         path.Join(snap.KubernetesPKIDir(), "kubelet.key"),
+		"--tls-cert-file":                filepath.Join(snap.KubernetesPKIDir(), "kubelet.crt"),
+		"--tls-private-key-file":         filepath.Join(snap.KubernetesPKIDir(), "kubelet.key"),
 	}
 
 	if hostname != snap.Hostname() {

--- a/src/k8s/pkg/k8sd/setup/kubelet_test.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet_test.go
@@ -2,7 +2,7 @@ package setup_test
 
 import (
 	"net"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -30,11 +30,11 @@ func mustSetupSnapAndDirectories(t *testing.T, createMock func(*mock.Snap, strin
 
 func setKubeletMock(s *mock.Snap, dir string) {
 	s.Mock = mock.Mock{
-		KubernetesPKIDir:    path.Join(dir, "pki"),
-		KubernetesConfigDir: path.Join(dir, "k8s-config"),
-		KubeletRootDir:      path.Join(dir, "kubelet-root"),
-		ServiceArgumentsDir: path.Join(dir, "args"),
-		ContainerdSocketDir: path.Join(dir, "containerd-run"),
+		KubernetesPKIDir:    filepath.Join(dir, "pki"),
+		KubernetesConfigDir: filepath.Join(dir, "k8s-config"),
+		KubeletRootDir:      filepath.Join(dir, "kubelet-root"),
+		ServiceArgumentsDir: filepath.Join(dir, "args"),
+		ContainerdSocketDir: filepath.Join(dir, "containerd-run"),
 	}
 }
 
@@ -56,21 +56,21 @@ func TestKubelet(t *testing.T) {
 			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
-			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
-			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--container-runtime-endpoint", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--containerd", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--eviction-hard", expectedVal: "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'"},
 			{key: "--fail-swap-on", expectedVal: "false"},
 			{key: "--hostname-override", expectedVal: "dev"},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedControlPlaneLabels},
 			{key: "--read-only-port", expectedVal: "0"},
 			{key: "--register-with-taints", expectedVal: ""},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			{key: "--cloud-provider", expectedVal: "provider"},
 			{key: "--cluster-domain", expectedVal: "test-cluster.local"},
@@ -86,7 +86,7 @@ func TestKubelet(t *testing.T) {
 		}
 
 		// Ensure the kubelet arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -113,21 +113,21 @@ func TestKubelet(t *testing.T) {
 			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
-			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
-			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--container-runtime-endpoint", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--containerd", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--eviction-hard", expectedVal: "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'"},
 			{key: "--fail-swap-on", expectedVal: "false"},
 			{key: "--hostname-override", expectedVal: "dev"},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedControlPlaneLabels},
 			{key: "--read-only-port", expectedVal: "0"},
 			{key: "--register-with-taints", expectedVal: ""},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			// Overwritten by extraArgs
 			{key: "--cluster-domain", expectedVal: "override.local"},
@@ -149,7 +149,7 @@ func TestKubelet(t *testing.T) {
 		g.Expect(val).To(BeZero())
 
 		// Ensure the kubelet arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -170,21 +170,21 @@ func TestKubelet(t *testing.T) {
 			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
-			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
-			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--container-runtime-endpoint", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--containerd", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--eviction-hard", expectedVal: "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'"},
 			{key: "--fail-swap-on", expectedVal: "false"},
 			{key: "--hostname-override", expectedVal: "dev"},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedControlPlaneLabels},
 			{key: "--read-only-port", expectedVal: "0"},
 			{key: "--register-with-taints", expectedVal: ""},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestKubelet(t *testing.T) {
 		}
 
 		// Ensure the kubelet arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -218,21 +218,21 @@ func TestKubelet(t *testing.T) {
 			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
-			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
-			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--container-runtime-endpoint", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--containerd", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--eviction-hard", expectedVal: "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'"},
 			{key: "--fail-swap-on", expectedVal: "false"},
 			{key: "--hostname-override", expectedVal: "dev"},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedWorkerLabels},
 			{key: "--read-only-port", expectedVal: "0"},
 			{key: "--register-with-taints", expectedVal: ""},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
 			{key: "--cloud-provider", expectedVal: "provider"},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			{key: "--cluster-domain", expectedVal: "test-cluster.local"},
@@ -248,7 +248,7 @@ func TestKubelet(t *testing.T) {
 		}
 
 		// Ensure the kubelet arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -275,21 +275,21 @@ func TestKubelet(t *testing.T) {
 			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
-			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
-			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--container-runtime-endpoint", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--containerd", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--eviction-hard", expectedVal: "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'"},
 			{key: "--fail-swap-on", expectedVal: "false"},
 			{key: "--hostname-override", expectedVal: "dev"},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedWorkerLabels},
 			{key: "--read-only-port", expectedVal: "0"},
 			{key: "--register-with-taints", expectedVal: ""},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 			{key: "--cluster-dns", expectedVal: "10.152.1.1"},
 			{key: "--cluster-domain", expectedVal: "override.local"},
 			{key: "--node-ip", expectedVal: "192.168.0.1"},
@@ -309,7 +309,7 @@ func TestKubelet(t *testing.T) {
 		g.Expect(val).To(BeZero())
 
 		// Ensure the kubelet arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})
@@ -331,21 +331,21 @@ func TestKubelet(t *testing.T) {
 			{key: "--authorization-mode", expectedVal: "Webhook"},
 			{key: "--anonymous-auth", expectedVal: "false"},
 			{key: "--authentication-token-webhook", expectedVal: "true"},
-			{key: "--client-ca-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
-			{key: "--container-runtime-endpoint", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
-			{key: "--containerd", expectedVal: path.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--client-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "client-ca.crt")},
+			{key: "--container-runtime-endpoint", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
+			{key: "--containerd", expectedVal: filepath.Join(s.Mock.ContainerdSocketDir, "containerd.sock")},
 			{key: "--eviction-hard", expectedVal: "'memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi'"},
 			{key: "--fail-swap-on", expectedVal: "false"},
 			{key: "--hostname-override", expectedVal: "dev"},
-			{key: "--kubeconfig", expectedVal: path.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
+			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedWorkerLabels},
 			{key: "--read-only-port", expectedVal: "0"},
 			{key: "--register-with-taints", expectedVal: ""},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},
-			{key: "--tls-cert-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
-			{key: "--tls-private-key-file", expectedVal: path.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
+			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.crt")},
+			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "kubelet.key")},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -357,7 +357,7 @@ func TestKubelet(t *testing.T) {
 		}
 
 		// Ensure the kubelet arguments file has exactly the expected number of arguments
-		args, err := utils.ParseArgumentFile(path.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
+		args, err := utils.ParseArgumentFile(filepath.Join(s.Mock.ServiceArgumentsDir, "kubelet"))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(len(args)).To(Equal(len(tests)))
 	})

--- a/src/k8s/pkg/k8sd/setup/util_extra_files.go
+++ b/src/k8s/pkg/k8sd/setup/util_extra_files.go
@@ -3,7 +3,7 @@ package setup
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/canonical/k8s/pkg/snap"
@@ -18,7 +18,7 @@ func ExtraNodeConfigFiles(snap snap.Snap, files map[string]string) error {
 			return fmt.Errorf("file name %q must not contain any slashes (possible path-traversal prevented)", filename)
 		}
 
-		filePath := path.Join(snap.ServiceExtraConfigDir(), filename)
+		filePath := filepath.Join(snap.ServiceExtraConfigDir(), filename)
 		// Write the content to the file
 		if err := os.WriteFile(filePath, []byte(content), 0400); err != nil {
 			return fmt.Errorf("failed to write to file %s: %w", filePath, err)

--- a/src/k8s/pkg/k8sd/types/cluster_config_datastore.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_datastore.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -45,7 +45,7 @@ func (c Datastore) ToKubeAPIServerArguments(p DatastorePathsProvider) (map[strin
 
 	switch c.GetType() {
 	case "k8s-dqlite":
-		updateArgs["--etcd-servers"] = fmt.Sprintf("unix://%s", path.Join(p.K8sDqliteStateDir(), "k8s-dqlite.sock"))
+		updateArgs["--etcd-servers"] = fmt.Sprintf("unix://%s", filepath.Join(p.K8sDqliteStateDir(), "k8s-dqlite.sock"))
 		deleteArgs = []string{"--etcd-cafile", "--etcd-certfile", "--etcd-keyfile"}
 	case "external":
 		updateArgs["--etcd-servers"] = strings.Join(c.GetExternalServers(), ",")
@@ -61,7 +61,7 @@ func (c Datastore) ToKubeAPIServerArguments(p DatastorePathsProvider) (map[strin
 			{cert: c.GetExternalClientKey(), arg: "--etcd-keyfile", path: "client.key"},
 		} {
 			if loop.cert != "" {
-				updateArgs[loop.arg] = path.Join(p.EtcdPKIDir(), loop.path)
+				updateArgs[loop.arg] = filepath.Join(p.EtcdPKIDir(), loop.path)
 			} else {
 				deleteArgs = append(deleteArgs, loop.arg)
 			}

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/dqlite"
@@ -105,15 +104,15 @@ func (s *snap) Hostname() string {
 }
 
 func (s *snap) ContainerdConfigDir() string {
-	return path.Join(s.snapCommonDir, "etc", "containerd")
+	return filepath.Join(s.snapCommonDir, "etc", "containerd")
 }
 
 func (s *snap) ContainerdRootDir() string {
-	return path.Join(s.snapCommonDir, "var", "lib", "containerd")
+	return filepath.Join(s.snapCommonDir, "var", "lib", "containerd")
 }
 
 func (s *snap) ContainerdSocketDir() string {
-	return path.Join(s.snapCommonDir, "run")
+	return filepath.Join(s.snapCommonDir, "run")
 }
 
 func (s *snap) ContainerdStateDir() string {
@@ -129,7 +128,7 @@ func (s *snap) CNIBinDir() string {
 }
 
 func (s *snap) CNIPluginsBinary() string {
-	return path.Join(s.snapDir, "bin", "cni")
+	return filepath.Join(s.snapDir, "bin", "cni")
 }
 
 func (s *snap) CNIPlugins() []string {
@@ -170,31 +169,31 @@ func (s *snap) KubeletRootDir() string {
 }
 
 func (s *snap) K8sdStateDir() string {
-	return path.Join(s.snapCommonDir, "var", "lib", "k8sd", "state")
+	return filepath.Join(s.snapCommonDir, "var", "lib", "k8sd", "state")
 }
 
 func (s *snap) K8sDqliteStateDir() string {
-	return path.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite")
+	return filepath.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite")
 }
 
 func (s *snap) ServiceArgumentsDir() string {
-	return path.Join(s.snapCommonDir, "args")
+	return filepath.Join(s.snapCommonDir, "args")
 }
 
 func (s *snap) ServiceExtraConfigDir() string {
-	return path.Join(s.snapCommonDir, "args", "conf.d")
+	return filepath.Join(s.snapCommonDir, "args", "conf.d")
 }
 
 func (s *snap) LockFilesDir() string {
-	return path.Join(s.snapCommonDir, "lock")
+	return filepath.Join(s.snapCommonDir, "lock")
 }
 
 func (s *snap) ContainerdExtraConfigDir() string {
-	return path.Join(s.snapCommonDir, "etc", "containerd", "conf.d")
+	return filepath.Join(s.snapCommonDir, "etc", "containerd", "conf.d")
 }
 
 func (s *snap) ContainerdRegistryConfigDir() string {
-	return path.Join(s.snapCommonDir, "etc", "containerd", "hosts.d")
+	return filepath.Join(s.snapCommonDir, "etc", "containerd", "hosts.d")
 }
 
 func (s *snap) restClientGetter(path string, namespace string) genericclioptions.RESTClientGetter {
@@ -208,27 +207,27 @@ func (s *snap) restClientGetter(path string, namespace string) genericclioptions
 }
 
 func (s *snap) KubernetesClient(namespace string) (*kubernetes.Client, error) {
-	return kubernetes.NewClient(s.restClientGetter(path.Join(s.KubernetesConfigDir(), "admin.conf"), namespace))
+	return kubernetes.NewClient(s.restClientGetter(filepath.Join(s.KubernetesConfigDir(), "admin.conf"), namespace))
 }
 
 func (s *snap) KubernetesNodeClient(namespace string) (*kubernetes.Client, error) {
-	return kubernetes.NewClient(s.restClientGetter(path.Join(s.KubernetesConfigDir(), "kubelet.conf"), namespace))
+	return kubernetes.NewClient(s.restClientGetter(filepath.Join(s.KubernetesConfigDir(), "kubelet.conf"), namespace))
 }
 
 func (s *snap) HelmClient() helm.Client {
 	return helm.NewClient(
 		filepath.Join(s.snapDir, "k8s", "manifests"),
 		func(namespace string) genericclioptions.RESTClientGetter {
-			return s.restClientGetter(path.Join(s.KubernetesConfigDir(), "admin.conf"), namespace)
+			return s.restClientGetter(filepath.Join(s.KubernetesConfigDir(), "admin.conf"), namespace)
 		},
 	)
 }
 
 func (s *snap) K8sDqliteClient(ctx context.Context) (*dqlite.Client, error) {
 	client, err := dqlite.NewClient(ctx, dqlite.ClientOpts{
-		ClusterYAML: path.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite", "cluster.yaml"),
-		ClusterCert: path.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite", "cluster.crt"),
-		ClusterKey:  path.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite", "cluster.key"),
+		ClusterYAML: filepath.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite", "cluster.yaml"),
+		ClusterCert: filepath.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite", "cluster.crt"),
+		ClusterKey:  filepath.Join(s.snapCommonDir, "var", "lib", "k8s-dqlite", "cluster.key"),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default k8s-dqlite client: %w", err)

--- a/src/k8s/pkg/snap/util/node.go
+++ b/src/k8s/pkg/snap/util/node.go
@@ -3,18 +3,18 @@ package snaputil
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
 )
 
 func IsWorker(snap snap.Snap) (bool, error) {
-	return utils.FileExists(path.Join(snap.LockFilesDir(), "worker"))
+	return utils.FileExists(filepath.Join(snap.LockFilesDir(), "worker"))
 }
 
 func MarkAsWorkerNode(snap snap.Snap, mark bool) error {
-	fname := path.Join(snap.LockFilesDir(), "worker")
+	fname := filepath.Join(snap.LockFilesDir(), "worker")
 
 	if mark {
 		lock, err := os.Create(fname)

--- a/src/k8s/pkg/snap/util/node_test.go
+++ b/src/k8s/pkg/snap/util/node_test.go
@@ -2,7 +2,7 @@ package snaputil_test
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/snap/mock"
@@ -20,7 +20,7 @@ func TestIsWorker(t *testing.T) {
 	t.Run("WorkerFileExists", func(t *testing.T) {
 		g := NewWithT(t)
 
-		fname := path.Join(mock.LockFilesDir(), "worker")
+		fname := filepath.Join(mock.LockFilesDir(), "worker")
 		lock, err := os.Create(fname)
 		g.Expect(err).ToNot(HaveOccurred())
 		lock.Close()
@@ -54,7 +54,7 @@ func TestMarkAsWorkerNode(t *testing.T) {
 		err := snaputil.MarkAsWorkerNode(mock, true)
 		g.Expect(err).To(BeNil())
 
-		workerFile := path.Join(mock.LockFilesDir(), "worker")
+		workerFile := filepath.Join(mock.LockFilesDir(), "worker")
 		g.Expect(workerFile).To(BeAnExistingFile())
 
 		// Clean up
@@ -64,7 +64,7 @@ func TestMarkAsWorkerNode(t *testing.T) {
 
 	t.Run("UnmarkWorker", func(t *testing.T) {
 		g := NewWithT(t)
-		workerFile := path.Join(mock.LockFilesDir(), "worker")
+		workerFile := filepath.Join(mock.LockFilesDir(), "worker")
 		_, err := os.Create(workerFile)
 		g.Expect(err).To(BeNil())
 


### PR DESCRIPTION
### Summary

From `go doc path`

```
package path // import "path"

Package path implements utility routines for manipulating slash-separated paths.

The path package should only be used for paths separated by forward slashes,
such as the paths in URLs. This package does not deal with Windows paths with
drive letters or backslashes; to manipulate operating system paths, use the
path/filepath package.
```