### PR TITLE
update runc patch for runc v1.1.13

### DIFF
--- a/build-scripts/components/runc/strict-patches/v1.1.13/0001-apparmor-change-profile-immediately-not-on-exec.patch
+++ b/build-scripts/components/runc/strict-patches/v1.1.13/0001-apparmor-change-profile-immediately-not-on-exec.patch
@@ -1,0 +1,36 @@
+From a367e391600dfab0d9eb3deaec4db300a2fb1fa1 Mon Sep 17 00:00:00 2001
+From: Alberto Mardegan <mardy@users.sourceforge.net>
+Date: Wed, 16 Jun 2021 15:04:16 +0300
+Subject: [PATCH 1/3] apparmor: change profile immediately, not on exec
+
+---
+ libcontainer/apparmor/apparmor_linux.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libcontainer/apparmor/apparmor_linux.go b/libcontainer/apparmor/apparmor_linux.go
+index 8b1483c..292cfa6 100644
+--- a/libcontainer/apparmor/apparmor_linux.go
++++ b/libcontainer/apparmor/apparmor_linux.go
+@@ -48,9 +48,9 @@ func setProcAttr(attr, value string) error {
+ 	return err
+ }
+ 
+-// changeOnExec reimplements aa_change_onexec from libapparmor in Go
+-func changeOnExec(name string) error {
+-	if err := setProcAttr("exec", "exec "+name); err != nil {
++// changeProfile reimplements aa_change_profile from libapparmor in Go
++func changeProfile(name string) error {
++	if err := setProcAttr("current", "changeprofile "+name); err != nil {
+ 		return fmt.Errorf("apparmor failed to apply profile: %w", err)
+ 	}
+ 	return nil
+@@ -64,5 +64,5 @@ func applyProfile(name string) error {
+ 		return nil
+ 	}
+ 
+-	return changeOnExec(name)
++	return changeProfile(name)
+ }
+-- 
+2.34.1
+

--- a/build-scripts/components/runc/strict-patches/v1.1.13/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
+++ b/build-scripts/components/runc/strict-patches/v1.1.13/0002-setns_init_linux-set-the-NNP-flag-after-changing-the.patch
@@ -1,0 +1,47 @@
+From 5351ef6f5b592472e077512714b2516cdbae1b51 Mon Sep 17 00:00:00 2001
+From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+Date: Thu, 1 Feb 2024 11:23:08 +0200
+Subject: [PATCH 2/3] setns_init_linux: set the NNP flag after changing the
+ apparmor profile
+
+With the current version of the AppArmor kernel module, it's not
+possible to switch the AppArmor profile if the NoNewPrivileges flag is
+set. So, we invert the order of the two operations.
+
+Adjusts the previous patch for runc version v1.1.12
+
+Co-Authored-By: Alberto Mardegan <mardy@users.sourceforge.net>
+---
+ libcontainer/setns_init_linux.go | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libcontainer/setns_init_linux.go b/libcontainer/setns_init_linux.go
+index d1bb122..00407ce 100644
+--- a/libcontainer/setns_init_linux.go
++++ b/libcontainer/setns_init_linux.go
+@@ -56,11 +56,6 @@ func (l *linuxSetnsInit) Init() error {
+ 			return err
+ 		}
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return err
+-		}
+-	}
+ 	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
+ 		return err
+ 	}
+@@ -84,6 +79,11 @@ func (l *linuxSetnsInit) Init() error {
+ 	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+ 		return err
+ 	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return err
++		}
++	}
+
+ 	// Check for the arg before waiting to make sure it exists and it is
+ 	// returned as a create time error.
+--
+2.34.1

--- a/build-scripts/components/runc/strict-patches/v1.1.13/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/components/runc/strict-patches/v1.1.13/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,7 +1,7 @@
 From c59036481c53398b8aa029b8219f5f5f2a7a1498 Mon Sep 17 00:00:00 2001
 From: eaudetcobello <etienne.audet-cobello@canonical.com>
 Date: Thu, 18 Jul 2024 19:09:02 -0400
-Subject: [PATCH] standard_init_linux: change AppArmor profile as late as 
+Subject: [PATCH 3/3] standard_init_linux: change AppArmor profile as late as 
  possible
 
 ---

--- a/build-scripts/components/runc/strict-patches/v1.1.13/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
+++ b/build-scripts/components/runc/strict-patches/v1.1.13/0003-standard_init_linux-change-AppArmor-profile-as-late-.patch
@@ -1,0 +1,55 @@
+From c59036481c53398b8aa029b8219f5f5f2a7a1498 Mon Sep 17 00:00:00 2001
+From: eaudetcobello <etienne.audet-cobello@canonical.com>
+Date: Thu, 18 Jul 2024 19:09:02 -0400
+Subject: [PATCH] standard_init_linux: change AppArmor profile as late as 
+ possible
+
+---
+ libcontainer/standard_init_linux.go | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/libcontainer/standard_init_linux.go b/libcontainer/standard_init_linux.go
+index ec2e8143..12490abe 100644
+--- a/libcontainer/standard_init_linux.go
++++ b/libcontainer/standard_init_linux.go
+@@ -127,9 +127,6 @@ func (l *linuxStandardInit) Init() error {
+ 			return &os.SyscallError{Syscall: "setdomainname", Err: err}
+ 		}
+ 	}
+-	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
+-		return fmt.Errorf("unable to apply apparmor profile: %w", err)
+-	}
+ 
+ 	for key, value := range l.config.Config.Sysctl {
+ 		if err := writeSystemProperty(key, value); err != nil {
+@@ -150,11 +147,6 @@ func (l *linuxStandardInit) Init() error {
+ 	if err != nil {
+ 		return fmt.Errorf("can't get pdeath signal: %w", err)
+ 	}
+-	if l.config.NoNewPrivileges {
+-		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+-			return &os.SyscallError{Syscall: "prctl(SET_NO_NEW_PRIVS)", Err: err}
+-		}
+-	}
+ 
+ 	if l.config.Config.Scheduler != nil {
+ 		if err := setupScheduler(l.config.Config); err != nil {
+@@ -173,6 +165,15 @@ func (l *linuxStandardInit) Init() error {
+ 	if err := syncParentReady(l.pipe); err != nil {
+ 		return fmt.Errorf("sync ready: %w", err)
+ 	}
++	if err := apparmor.ApplyProfile(l.config.AppArmorProfile); err != nil {
++		return fmt.Errorf("unable to apply apparmor profile: %w", err)
++	}
++	if l.config.NoNewPrivileges {
++		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
++			return &os.SyscallError{Syscall: "prctl(SET_NO_NEW_PRIVS)", Err: err}
++		}
++	}
++
+ 	if err := selinux.SetExecLabel(l.config.ProcessLabel); err != nil {
+ 		return fmt.Errorf("can't set process label: %w", err)
+ 	}
+-- 
+2.43.0
+


### PR DESCRIPTION
the previous version of the patch was compatible with runc v1.1.12 but the code the patch touches was changed in v1.1.13 which is the version of runc we would like to update to

patch 1 and 2 are identical to v1.1.12, only patch 3 is modified

Merge this before https://github.com/canonical/k8s-snap/pull/559 and https://github.com/canonical/k8s-snap/pull/558