### PR TITLE
Disable cilium e2e on Github Actions

### DIFF
--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -21,7 +21,7 @@ CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CI
     ARCH not in CILIUM_CLI_ARCH_MAP, reason=f"Platform {ARCH} not supported"
 )
 @pytest.mark.skipif(
-    os.getenv("RUN_CILIUM_E2E_TEST") == "true",
+    os.getenv("TEST_CILIUM_E2E") == "true",
     reason="Test is known to be flaky on GitHub Actions",
 )
 def test_cilium_e2e(instances: List[harness.Instance]):

--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -21,7 +21,7 @@ CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CI
     ARCH not in CILIUM_CLI_ARCH_MAP, reason=f"Platform {ARCH} not supported"
 )
 @pytest.mark.skipif(
-    os.getenv("GITHUB_ACTIONS") == "true",
+    os.getenv("RUN_CILIUM_E2E_TEST") == "true",
     reason="Test is known to be flaky on GitHub Actions",
 )
 def test_cilium_e2e(instances: List[harness.Instance]):

--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -16,15 +16,12 @@ CILIUM_CLI_ARCH_MAP = {"aarch64": "arm64", "x86_64": "amd64"}
 CILIUM_CLI_VERSION = "v0.16.3"
 CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CILIUM_CLI_VERSION}/cilium-linux-{CILIUM_CLI_ARCH_MAP.get(ARCH)}.tar.gz"  # noqa
 
-print("-----------------")
-print(os.environ)
-print("-----------------")
 
 @pytest.mark.skipif(
     ARCH not in CILIUM_CLI_ARCH_MAP, reason=f"Platform {ARCH} not supported"
 )
 @pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS", False),
+    os.getenv("GITHUB_ACTIONS") == "true",
     reason="Test is known to be flaky on GitHub Actions",
 )
 def test_cilium_e2e(instances: List[harness.Instance]):

--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
+import os
 import platform
 from typing import List
 
@@ -15,9 +16,16 @@ CILIUM_CLI_ARCH_MAP = {"aarch64": "arm64", "x86_64": "amd64"}
 CILIUM_CLI_VERSION = "v0.16.3"
 CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CILIUM_CLI_VERSION}/cilium-linux-{CILIUM_CLI_ARCH_MAP.get(ARCH)}.tar.gz"  # noqa
 
+print("-----------------")
+print(os.environ)
+print("-----------------")
 
 @pytest.mark.skipif(
     ARCH not in CILIUM_CLI_ARCH_MAP, reason=f"Platform {ARCH} not supported"
+)
+@pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS", False),
+    reason="Test is known to be flaky on GitHub Actions",
 )
 def test_cilium_e2e(instances: List[harness.Instance]):
     instance = instances[0]


### PR DESCRIPTION
The cilium e2e test is known to be flaky on the Github Actions runners.
We know that Cilium works in the snap and this test causes more trouble then it is useful for now.