### PR TITLE
Add MAAS infrastructure tab for CAPI tutorial

### DIFF
--- a/docs/src/capi/tutorial/getting-started.md
+++ b/docs/src/capi/tutorial/getting-started.md
@@ -94,7 +94,49 @@ export AWS_B64ENCODED_CREDENTIALS=$(clusterawsadm bootstrap credentials encode-a
 ```
 
 You are now all set to deploy the AWS CAPI infrastructure provider.
+````
 
+````{group-tab} MAAS
+Start by setting up environment variables defining the MAAS credentials, if
+these are not already defined:
+
+```
+export MAAS_API_KEY="<maas-api-key>"
+export MAAS_ENDPOINT="http://<maas-endpoint>/MAAS"
+export MAAS_DNS_DOMAIN="<maas-dns-domain>"
+```
+The MAAS infrastructure provider uses these credentials to deploy machines, create DNS records and perform various other operations for workload clusters.
+
+```{warning}
+The management cluster needs to be able to resolve dns records from the MAAS domain.
+This usually means the management cluster also needs to be deployed on a MAAS machine.
+```
+
+Continue with setting up environment variables defining the machine image and minimum compute resources of the control plane and worker nodes:
+
+```
+export CONTROL_PLANE_MACHINE_MINCPU="2"
+export CONTROL_PLANE_MACHINE_MINMEMORY="4096"
+export CONTROL_PLANE_MACHINE_IMAGE="ubuntu"
+
+export WORKER_MACHINE_MINCPU="2"
+export WORKER_MACHINE_MINMEMORY="4096"
+export WORKER_MACHINE_IMAGE="ubuntu"
+```
+
+Optional environment variables can be defined for specifying resource pools and machine tags like:
+
+```
+# (optional) Configure resource pools for control plane and worker machines
+# export CONTROL_PLANE_MACHINE_RESOURCEPOOL="kvm-pool"
+# export WORKER_MACHINE_RESOURCEPOOL="bare-metal-pool"
+
+# (optional) Configure (comma-separated) tags for control plane and worker machines
+# export CONTROL_PLANE_MACHINE_TAGS="control-plane,controller"
+# export WORKER_MACHINE_TAGS="worker,compute"
+```
+
+You are now all set to deploy the MAAS CAPI infrastructure provider.
 ````
 `````
 

--- a/docs/src/capi/tutorial/getting-started.md
+++ b/docs/src/capi/tutorial/getting-started.md
@@ -104,13 +104,16 @@ export MAAS_API_KEY="<maas-api-key>"
 export MAAS_ENDPOINT="http://<maas-endpoint>/MAAS"
 export MAAS_DNS_DOMAIN="<maas-dns-domain>"
 ```
-The MAAS infrastructure provider uses these credentials to deploy machines, create DNS records and perform various other operations for workload clusters.
+The MAAS infrastructure provider uses these credentials to deploy machines,
+create DNS records and perform various other operations for workload clusters.
 
 ```{warning}
-The management cluster needs to resolve dns records from the MAAS domain, therefore it should be deployed on a MAAS machine.
+The management cluster needs to resolve DNS records from the MAAS domain, 
+therefore it should be deployed on a MAAS machine.
 ```
 
-Define further environment variables for the machine image and minimum compute resources of the control plane and worker nodes:
+Define further environment variables for the machine image and minimum compute
+resources of the control plane and worker nodes:
 
 ```
 export CONTROL_PLANE_MACHINE_MINCPU="1"
@@ -123,10 +126,12 @@ export WORKER_MACHINE_IMAGE="ubuntu"
 ```
 
 ```{note}
-The minimum resource variables are used for selecting machines that have resources more than or equal to the provided values.
+The minimum resource variables are used to select machines with resources more
+than or equal to the provided values.
 ```
 
-Optional environment variables can be defined for specifying resource pools and machine tags:
+Optional environment variables can be defined for specifying resource pools
+and machine tags:
 
 ```
 # (optional) Configure resource pools for control plane and worker machines

--- a/docs/src/capi/tutorial/getting-started.md
+++ b/docs/src/capi/tutorial/getting-started.md
@@ -97,8 +97,7 @@ You are now all set to deploy the AWS CAPI infrastructure provider.
 ````
 
 ````{group-tab} MAAS
-Start by setting up environment variables defining the MAAS credentials, if
-these are not already defined:
+Start by setting up environment variables to allow access to MAAS:
 
 ```
 export MAAS_API_KEY="<maas-api-key>"
@@ -108,11 +107,10 @@ export MAAS_DNS_DOMAIN="<maas-dns-domain>"
 The MAAS infrastructure provider uses these credentials to deploy machines, create DNS records and perform various other operations for workload clusters.
 
 ```{warning}
-The management cluster needs to be able to resolve dns records from the MAAS domain.
-This usually means the management cluster also needs to be deployed on a MAAS machine.
+The management cluster needs to resolve dns records from the MAAS domain, therefore it should be deployed on a MAAS machine.
 ```
 
-Continue with setting up environment variables defining the machine image and minimum compute resources of the control plane and worker nodes:
+Define further environment variables for the machine image and minimum compute resources of the control plane and worker nodes:
 
 ```
 export CONTROL_PLANE_MACHINE_MINCPU="2"
@@ -124,7 +122,7 @@ export WORKER_MACHINE_MINMEMORY="4096"
 export WORKER_MACHINE_IMAGE="ubuntu"
 ```
 
-Optional environment variables can be defined for specifying resource pools and machine tags like:
+Optional environment variables can be defined for specifying resource pools and machine tags:
 
 ```
 # (optional) Configure resource pools for control plane and worker machines

--- a/docs/src/capi/tutorial/getting-started.md
+++ b/docs/src/capi/tutorial/getting-started.md
@@ -122,6 +122,10 @@ export WORKER_MACHINE_MINMEMORY="4096"
 export WORKER_MACHINE_IMAGE="ubuntu"
 ```
 
+```{note}
+The minimum resource variables are used for selecting machines that have resources more than or equal to the provided values.
+```
+
 Optional environment variables can be defined for specifying resource pools and machine tags:
 
 ```

--- a/docs/src/capi/tutorial/getting-started.md
+++ b/docs/src/capi/tutorial/getting-started.md
@@ -113,12 +113,12 @@ The management cluster needs to resolve dns records from the MAAS domain, theref
 Define further environment variables for the machine image and minimum compute resources of the control plane and worker nodes:
 
 ```
-export CONTROL_PLANE_MACHINE_MINCPU="2"
-export CONTROL_PLANE_MACHINE_MINMEMORY="4096"
+export CONTROL_PLANE_MACHINE_MINCPU="1"
+export CONTROL_PLANE_MACHINE_MINMEMORY="2048"
 export CONTROL_PLANE_MACHINE_IMAGE="ubuntu"
 
-export WORKER_MACHINE_MINCPU="2"
-export WORKER_MACHINE_MINMEMORY="4096"
+export WORKER_MACHINE_MINCPU="1"
+export WORKER_MACHINE_MINMEMORY="2048"
 export WORKER_MACHINE_IMAGE="ubuntu"
 ```
 


### PR DESCRIPTION
This PR adds a tab for the MAAS infrastructure in the CAPI tutorial.