### PR TITLE
Provide pytest marker to set custom bootstrap config

### DIFF
--- a/tests/integration/templates/bootstrap-control-plain-taints.yaml
+++ b/tests/integration/templates/bootstrap-control-plain-taints.yaml
@@ -1,0 +1,1 @@
+control-plane-taints: ["node-role.kubernetes.io/control-plane:NoSchedule"]

--- a/tests/integration/templates/bootstrap-control-plain-taints.yaml
+++ b/tests/integration/templates/bootstrap-control-plain-taints.yaml
@@ -1,1 +1,0 @@
-control-plane-taints: ["node-role.kubernetes.io/control-plane:NoSchedule"]

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -53,7 +53,7 @@ def pytest_configure(config):
         "disable_k8s_bootstrapping: By default, the first k8s node is bootstrapped. This marker disables that.\n"
         "dualstack: Support dualstack on the instances.\n"
         "etcd_count: Mark a test to specify how many etcd instance nodes need to be created (None by default)\n"
-        "node_count: Mark a test to specify how many instance nodes need to be created\n"
+        "node_count: Mark a test to specify how many instance nodes need to be created\n",
     )
 
 

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -3,7 +3,7 @@
 #
 import logging
 from pathlib import Path
-from typing import Generator, List
+from typing import Generator, List, Union
 
 import pytest
 from test_util import config, harness, util

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -91,7 +91,7 @@ def instances(
     node_count: int,
     tmp_path: Path,
     disable_k8s_bootstrapping: bool,
-    bootstrap_config: Path | None,
+    bootstrap_config: str | None,
     dualstack: bool,
 ) -> Generator[List[harness.Instance], None, None]:
     """Construct instances for a cluster.

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -91,7 +91,7 @@ def instances(
     node_count: int,
     tmp_path: Path,
     disable_k8s_bootstrapping: bool,
-    bootstrap_config: str | None,
+    bootstrap_config: Union[str, None],
     dualstack: bool,
 ) -> Generator[List[harness.Instance], None, None]:
     """Construct instances for a cluster.

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -72,7 +72,7 @@ def disable_k8s_bootstrapping(request) -> bool:
 
 
 @pytest.fixture(scope="function")
-def bootstrap_config(request) -> Path | None:
+def bootstrap_config(request) -> Union[Path, None]:
     bootstrap_config_marker = request.node.get_closest_marker("bootstrap_config")
     if not bootstrap_config_marker:
         return None

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -72,12 +72,12 @@ def disable_k8s_bootstrapping(request) -> bool:
 
 
 @pytest.fixture(scope="function")
-def bootstrap_config(request) -> Union[Path, None]:
+def bootstrap_config(request) -> Union[str, None]:
     bootstrap_config_marker = request.node.get_closest_marker("bootstrap_config")
     if not bootstrap_config_marker:
         return None
     config, *_ = bootstrap_config_marker.args
-    return Path(config)
+    return config
 
 
 @pytest.fixture(scope="function")
@@ -121,7 +121,7 @@ def instances(
         if bootstrap_config is not None:
             first_node.exec(
                 ["k8s", "bootstrap", "--file", "-"],
-                input=str.encode(bootstrap_config.read_text()),
+                input=str.encode(bootstrap_config),
             )
         else:
             first_node.exec(["k8s", "bootstrap"])

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -49,9 +49,11 @@ def h() -> harness.Harness:
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
-        "node_count: Mark a test to specify how many instance nodes need to be created\n"
+        "bootstrap_config: Provide a custom bootstrap config to the bootstrapping node.\n"
         "disable_k8s_bootstrapping: By default, the first k8s node is bootstrapped. This marker disables that.\n"
-        "etcd_count: Mark a test to specify how many etcd instance nodes need to be created (None by default)\n",
+        "dualstack: Support dualstack on the instances.\n"
+        "etcd_count: Mark a test to specify how many etcd instance nodes need to be created (None by default)\n"
+        "node_count: Mark a test to specify how many instance nodes need to be created\n"
     )
 
 
@@ -65,13 +67,32 @@ def node_count(request) -> int:
 
 
 @pytest.fixture(scope="function")
-def disable_k8s_bootstrapping(request) -> int:
+def disable_k8s_bootstrapping(request) -> bool:
     return bool(request.node.get_closest_marker("disable_k8s_bootstrapping"))
 
 
 @pytest.fixture(scope="function")
+def bootstrap_config(request) -> Path | None:
+    bootstrap_config_marker = request.node.get_closest_marker("bootstrap_config")
+    if not bootstrap_config_marker:
+        return None
+    config, *_ = bootstrap_config_marker.args
+    return Path(config)
+
+
+@pytest.fixture(scope="function")
+def dualstack(request) -> bool:
+    return bool(request.node.get_closest_marker("dualstack"))
+
+
+@pytest.fixture(scope="function")
 def instances(
-    h: harness.Harness, node_count: int, tmp_path: Path, disable_k8s_bootstrapping: bool
+    h: harness.Harness,
+    node_count: int,
+    tmp_path: Path,
+    disable_k8s_bootstrapping: bool,
+    bootstrap_config: Path | None,
+    dualstack: bool,
 ) -> Generator[List[harness.Instance], None, None]:
     """Construct instances for a cluster.
 
@@ -90,13 +111,20 @@ def instances(
 
     for _ in range(node_count):
         # Create <node_count> instances and setup the k8s snap in each.
-        instance = h.new_instance()
+        instance = h.new_instance(dualstack=dualstack)
         instances.append(instance)
         util.setup_k8s_snap(instance, snap_path)
 
     if not disable_k8s_bootstrapping:
         first_node, *_ = instances
-        first_node.exec(["k8s", "bootstrap"])
+
+        if bootstrap_config is not None:
+            first_node.exec(
+                ["k8s", "bootstrap", "--file", "-"],
+                input=str.encode(bootstrap_config.read_text()),
+            )
+        else:
+            first_node.exec(["k8s", "bootstrap"])
 
     yield instances
 

--- a/tests/integration/tests/test_control_plane_taints.py
+++ b/tests/integration/tests/test_control_plane_taints.py
@@ -6,7 +6,6 @@ import time
 from typing import List
 
 import pytest
-import yaml
 from test_util import config, harness, util
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/tests/test_control_plane_taints.py
+++ b/tests/integration/tests/test_control_plane_taints.py
@@ -6,14 +6,14 @@ import time
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import harness, util
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(1)
 @pytest.mark.bootstrap_config(
-    "control-plane-taints: [\"node-role.kubernetes.io/control-plane:NoSchedule\"]"
+    'control-plane-taints: ["node-role.kubernetes.io/control-plane:NoSchedule"]'
 )
 def test_control_plane_taints(instances: List[harness.Instance]):
     k8s_instance = instances[0]

--- a/tests/integration/tests/test_control_plane_taints.py
+++ b/tests/integration/tests/test_control_plane_taints.py
@@ -13,7 +13,7 @@ LOG = logging.getLogger(__name__)
 
 @pytest.mark.node_count(1)
 @pytest.mark.bootstrap_config(
-    config.MANIFESTS_DIR / "bootstrap-control-plane-taints.yaml"
+    "control-plane-taints: [\"node-role.kubernetes.io/control-plane:NoSchedule\"]"
 )
 def test_control_plane_taints(instances: List[harness.Instance]):
     k8s_instance = instances[0]

--- a/tests/integration/tests/test_dualstack.py
+++ b/tests/integration/tests/test_dualstack.py
@@ -3,6 +3,7 @@
 #
 import logging
 from ipaddress import IPv4Address, IPv6Address, ip_address
+from typing import List
 
 import pytest
 from test_util import config, harness, util
@@ -15,7 +16,7 @@ LOG = logging.getLogger(__name__)
     (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
 )
 @pytest.mark.dualstack()
-def test_dualstack(instances: list[harness.Instance]):
+def test_dualstack(instances: List[harness.Instance]):
     main = instances[0]
     dualstack_config = (config.MANIFESTS_DIR / "nginx-dualstack.yaml").read_text()
 

--- a/tests/integration/tests/test_dualstack.py
+++ b/tests/integration/tests/test_dualstack.py
@@ -11,7 +11,9 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(1)
-@pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text())
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
+)
 @pytest.mark.dualstack
 def test_dualstack(instances: list[harness.Instance]):
     main = instances[0]

--- a/tests/integration/tests/test_dualstack.py
+++ b/tests/integration/tests/test_dualstack.py
@@ -11,7 +11,7 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(1)
-@pytest.mark.bootstrap_config(config.MANIFESTS_DIR / "bootstrap-dualstack.yaml")
+@pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text())
 @pytest.mark.dualstack
 def test_dualstack(instances: list[harness.Instance]):
     main = instances[0]

--- a/tests/integration/tests/test_dualstack.py
+++ b/tests/integration/tests/test_dualstack.py
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.bootstrap_config(
     (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
 )
-@pytest.mark.dualstack
+@pytest.mark.dualstack()
 def test_dualstack(instances: list[harness.Instance]):
     main = instances[0]
     dualstack_config = (config.MANIFESTS_DIR / "nginx-dualstack.yaml").read_text()

--- a/tests/integration/tests/test_dualstack.py
+++ b/tests/integration/tests/test_dualstack.py
@@ -12,19 +12,10 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(1)
-def test_dualstack(h: harness.Harness, tmp_path: Path):
-    snap_path = (tmp_path / "k8s.snap").as_posix()
-    main = h.new_instance(dualstack=True)
-    util.setup_k8s_snap(main, snap_path)
-
-    bootstrap_config = (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
-
-    main.exec(
-        ["k8s", "bootstrap", "--file", "-"],
-        input=str.encode(bootstrap_config),
-    )
-    util.wait_until_k8s_ready(main, [main])
-
+@pytest.mark.bootstrap_config(config.MANIFESTS_DIR / "bootstrap-dualstack.yaml")
+@pytest.mark.dualstack
+def test_dualstack(instances: list[harness.Instance]):
+    main = instances[0]
     dualstack_config = (config.MANIFESTS_DIR / "nginx-dualstack.yaml").read_text()
 
     # Deploy nginx with dualstack service

--- a/tests/integration/tests/test_dualstack.py
+++ b/tests/integration/tests/test_dualstack.py
@@ -3,7 +3,6 @@
 #
 import logging
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from pathlib import Path
 
 import pytest
 from test_util import config, harness, util

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -14,7 +14,9 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(1)
-@pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-smoke.yaml").read_text())
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-smoke.yaml").read_text()
+)
 def test_smoke(instances: List[harness.Instance]):
     instance = instances[0]
 

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -14,7 +14,7 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(1)
-@pytest.mark.bootstrap_config(config.MANIFESTS_DIR / "bootstrap-smoke.yaml")
+@pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-smoke.yaml").read_text())
 def test_smoke(instances: List[harness.Instance]):
     instance = instances[0]
 

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -8,7 +8,7 @@ import time
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -14,18 +14,9 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(1)
-@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.bootstrap_config(config.MANIFESTS_DIR / "bootstrap-smoke.yaml")
 def test_smoke(instances: List[harness.Instance]):
     instance = instances[0]
-
-    bootstrap_smoke_config_path = "/home/ubuntu/bootstrap-smoke.yaml"
-    instance.send_file(
-        (config.MANIFESTS_DIR / "bootstrap-smoke.yaml").as_posix(),
-        bootstrap_smoke_config_path,
-    )
-
-    instance.exec(["k8s", "bootstrap", "--file", bootstrap_smoke_config_path])
-    util.wait_until_k8s_ready(instance, [instance])
 
     # Verify the functionality of the k8s config command during the smoke test.
     # It would be excessive to deploy a cluster solely for this purpose.

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -139,7 +139,7 @@ def setup_k8s_snap(instance: harness.Instance, snap_path: Path):
 def wait_until_k8s_ready(
     control_node: harness.Instance,
     instances: List[harness.Instance],
-    retries: int = 15,
+    retries: int = 30,
     delay_s: int = 5,
 ):
     """


### PR DESCRIPTION
# Summary

Simplify integration tests by adding new pytest markers for `dualstack` and custom `bootstrap_config`s

# Rationale

We have a bunch of tests that require custom bootstrap configuration (e.g. dualstack). The current approach is to disable the automatic bootstrapping of the first `instance` and instead do this setup manually in each test. Those setup steps only differ in the path of the bootstrap config, so we can simply pass this to the marker.

# Comments

Note that we still need the `disable_k8s_bootstrapping` marker for the `test_etcd` as this test requires the etcd cluster certs and needs to generate the bootstrap config dynamically.


 