### PR TITLE
Consistent field names in k8s status outputs

### DIFF
--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -76,13 +76,13 @@ type ClusterStatus struct {
 	Config    UserFacingClusterConfig `json:"config,omitempty"`
 	Datastore Datastore               `json:"datastore,omitempty"`
 
-	DNS           FeatureStatus `json:"dns,omitempty"`
-	Network       FeatureStatus `json:"network,omitempty"`
-	LoadBalancer  FeatureStatus `json:"load-balancer,omitempty"`
-	Ingress       FeatureStatus `json:"ingress,omitempty"`
-	Gateway       FeatureStatus `json:"gateway,omitempty"`
-	MetricsServer FeatureStatus `json:"metrics-server,omitempty"`
-	LocalStorage  FeatureStatus `json:"local-storage,omitempty"`
+	DNS           FeatureStatus `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Network       FeatureStatus `json:"network,omitempty" yaml:"network,omitempty"`
+	LoadBalancer  FeatureStatus `json:"load-balancer,omitempty" yaml:"load-balancer,omitempty"`
+	Ingress       FeatureStatus `json:"ingress,omitempty" yaml:"ingress,omitempty"`
+	Gateway       FeatureStatus `json:"gateway,omitempty" yaml:"gateway,omitempty"`
+	MetricsServer FeatureStatus `json:"metrics-server,omitempty" yaml:"metrics-server,omitempty"`
+	LocalStorage  FeatureStatus `json:"local-storage,omitempty" yaml:"local-storage,omitempty"`
 }
 
 // HaClusterFormed returns true if the cluster is in high-availability mode (more than two voter nodes).

--- a/src/k8s/api/v1/types.go
+++ b/src/k8s/api/v1/types.go
@@ -31,26 +31,26 @@ const (
 type NodeStatus struct {
 	// Name is the name for this cluster member that was when joining the cluster.
 	// This is typically the hostname of the node.
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Address is the IP address of the node.
-	Address string `json:"address,omitempty"`
+	Address string `json:"address,omitempty" yaml:"address,omitempty"`
 	// ClusterRole is the role that the node has within the k8s cluster.
-	ClusterRole ClusterRole `json:"cluster-role,omitempty"`
+	ClusterRole ClusterRole `json:"cluster-role,omitempty" yaml:"cluster-role,omitempty"`
 	// DatastoreRole is the role that the node has within the datastore cluster.
 	// Only applicable for control-plane nodes, empty for workers.
-	DatastoreRole DatastoreRole `json:"datastore-role,omitempty"`
+	DatastoreRole DatastoreRole `json:"datastore-role,omitempty" yaml:"datastore-role,omitempty"`
 }
 
 // FeatureStatus encapsulates the deployment status of a feature.
 type FeatureStatus struct {
 	// Enabled shows whether or not the deployment of manifests for a status was successful.
-	Enabled bool
+	Enabled bool `json:"enabled" yaml:"enabled"`
 	// Message contains information about the status of a feature. It is only supposed to be human readable and informative and should not be programmatically parsed.
-	Message string
+	Message string `json:"message" yaml:"message"`
 	// Version shows the version of the deployed feature.
-	Version string
+	Version string `json:"version" yaml:"version"`
 	// UpdatedAt shows when the last update was done.
-	UpdatedAt time.Time
+	UpdatedAt time.Time `json:"updated-at" yaml:"updated-at"`
 }
 
 func (f FeatureStatus) String() string {

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -53,8 +53,8 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			status.Config.MetricsServer = apiv1.MetricsServerConfig{}
-			status.Config.CloudProvider = nil
+			// silence the config, this should be retrieved with "k8s get".
+			status.Config = apiv1.UserFacingClusterConfig{}
 
 			outputFormatter.Print(status)
 		},


### PR DESCRIPTION
### Summary

Fix issues in `k8s status` formatting.

### Previous outputs

- properly format `load-balancer` and `local-storage` in `k8s status --output-format yaml`:

```
$ k8s status
localstorage:
  enabled: true
  message: enabled at /var/snap/k8s/common/rawfile-storage
  version: 0.8.0-ck5
  updatedat: 2024-08-07T11:30:54Z
```

- properly format node statuses in `k8s status --output-format yaml`:

```
$ k8s status
members:
- name: ip-172-31-34-101
  address: 172.31.34.101:6400
  clusterrole: control-plane
  datastorerole: voter
```

- properly format feature status in `k8s status --output-format json`:

```
$ k8s status --output-format json
  "dns": {
    "Enabled": true,
    "Message": "enabled at 10.152.183.153",
    "Version": "1.11.1-ck4",
    "UpdatedAt": "2024-08-07T11:30:54Z"
  },
```