### PR TITLE
Use ubuntu:24.04 for informing integration tests

### DIFF
--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.21/stable
+          sudo snap install lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
       - name: Install snapcraft
@@ -67,7 +67,7 @@ jobs:
         run: pip install tox
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.21/stable
+          sudo snap install lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -37,7 +37,7 @@ jobs:
           ./build-scripts/patches/${{ matrix.patch }}/apply
       - name: Build snap
         run: |
-          snapcraft
+          sudo snapcraft
           mv k8s_*.snap k8s-${{ matrix.patch }}.snap
       - name: Uploading snap
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -39,6 +39,7 @@ jobs:
       - name: Build snap
         run: |
           lxc version
+          sudo snap services lxd
           snapcraft --use-lxd
           mv k8s_*.snap k8s-${{ matrix.patch }}.snap
       - name: Uploading snap

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -26,9 +26,11 @@ jobs:
           egress-policy: audit
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Install multipass
+      - name: Install LXD
         run: |
-          sudo snap install multipass
+          sudo snap install lxd --channel 5.21/stable
+          sudo lxd init --auto
+          sudo usermod -a -G lxd $USER
       - name: Install snapcraft
         run: |
           sudo snap install snapcraft --classic
@@ -37,7 +39,8 @@ jobs:
           ./build-scripts/patches/${{ matrix.patch }}/apply
       - name: Build snap
         run: |
-          sudo snapcraft
+          lxc version
+          snapcraft --use-lxd
           mv k8s_*.snap k8s-${{ matrix.patch }}.snap
       - name: Uploading snap
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -30,7 +30,6 @@ jobs:
         run: |
           sudo snap install lxd --channel 5.21/stable
           sudo lxd init --auto
-          sudo usermod --append --groups lxd $USER
       - name: Install snapcraft
         run: |
           sudo snap install snapcraft --classic
@@ -39,7 +38,7 @@ jobs:
           ./build-scripts/patches/${{ matrix.patch }}/apply
       - name: Build snap
         run: |
-          sg lxd -c 'snapcraft --use-lxd'
+          sudo snapcraft --use-lxd
           mv k8s_*.snap k8s-${{ matrix.patch }}.snap
       - name: Uploading snap
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -26,10 +26,9 @@ jobs:
           egress-policy: audit
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Install lxd
+      - name: Install multipass
         run: |
-          sudo snap install lxd --channel 5.21/stable
-          sudo lxd init --auto
+          sudo snap install multipass
       - name: Install snapcraft
         run: |
           sudo snap install snapcraft --classic
@@ -38,9 +37,7 @@ jobs:
           ./build-scripts/patches/${{ matrix.patch }}/apply
       - name: Build snap
         run: |
-          lxc version
-          sudo snap services lxd
-          snapcraft --use-lxd
+          snapcraft
           mv k8s_*.snap k8s-${{ matrix.patch }}.snap
       - name: Uploading snap
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.patch }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         patch: ["strict", "moonray"]
@@ -31,7 +31,6 @@ jobs:
           sudo snap refresh lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
-          sg lxd -c 'lxc version'
       - name: Install snapcraft
         run: |
           sudo snap install snapcraft --classic
@@ -53,10 +52,10 @@ jobs:
     name: Test ${{ matrix.patch }} ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu:20.04"]
+        os: ["ubuntu:24.04"]
         patch: ["strict", "moonray"]
       fail-fast: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -38,7 +38,7 @@ jobs:
           ./build-scripts/patches/${{ matrix.patch }}/apply
       - name: Build snap
         run: |
-          sudo snapcraft --use-lxd
+          snapcraft --use-lxd
           mv k8s_*.snap k8s-${{ matrix.patch }}.snap
       - name: Uploading snap
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -38,6 +38,7 @@ jobs:
           ./build-scripts/patches/${{ matrix.patch }}/apply
       - name: Build snap
         run: |
+          lxc version
           snapcraft --use-lxd
           mv k8s_*.snap k8s-${{ matrix.patch }}.snap
       - name: Uploading snap


### PR DESCRIPTION
### Summary

Use `ubuntu:24.04` instead of `ubuntu:20.04` for informing tests 