### PR TITLE
Switch to microcluster fork without join name verification

### DIFF
--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -27,6 +27,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.4
 )
 
+replace github.com/canonical/microcluster/v2 v2.0.2 => github.com/canonical/k8s-microcluster/v2 v2.1.0
+
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -27,6 +27,9 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.4
 )
 
+// We are switching to the microcluster fork temporarily which removes the join name verification to unblock CAPI work.
+// This will be reverted once a proper solution that addresses CAPI requirements is merged upstream.
+// https://github.com/canonical/microcluster/issues/234
 replace github.com/canonical/microcluster/v2 v2.0.2 => github.com/canonical/k8s-microcluster/v2 v2.1.0
 
 require (

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -99,12 +99,12 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite v1.22.0 h1:DuJmfcREl4gkQJyvZzjl2GHFZROhbPyfdjDRQXpkOyw=
 github.com/canonical/go-dqlite v1.22.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
+github.com/canonical/k8s-microcluster/v2 v2.1.0 h1:zoK/fYzEkhCKAWf6NcZHG6+3U2c4PqkDTUVtwju951I=
+github.com/canonical/k8s-microcluster/v2 v2.1.0/go.mod h1:09N/J8tuijpAJdOER+e8IVWpn9cjzw9KzZvIunii/pA=
 github.com/canonical/k8s-snap-api v1.0.2 h1:9tyIneGQ6dPouX/8DH/HBqQIk+PF+MtQB3Qwt43Cuu4=
 github.com/canonical/k8s-snap-api v1.0.2/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
 github.com/canonical/lxd v0.0.0-20240730172021-8e39e5d4f55f h1:bTaF5FmQk66wI8ILr+pzelTY6iNLXE9c2Ks2HG4Sp5U=
 github.com/canonical/lxd v0.0.0-20240730172021-8e39e5d4f55f/go.mod h1:BVyKLSsJLTLX3o6WW0f5YDOO+J5HE3Np2WwYVrug0sY=
-github.com/canonical/microcluster/v2 v2.0.2 h1:T0Bc3EQTdR17nAhKlAmGORL4y7FPcgAR09fWj/WlQck=
-github.com/canonical/microcluster/v2 v2.0.2/go.mod h1:09N/J8tuijpAJdOER+e8IVWpn9cjzw9KzZvIunii/pA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
Switch to microcluster v2 fork without join name verification to unblock CAPI work while we work towards a proper solution.