### PR TITLE
Add unit tests for csrsigning controller

### DIFF
--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/cli-runtime v0.30.0
 	k8s.io/client-go v0.30.1
 	k8s.io/klog/v2 v2.120.1
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.18.4
 )
 
@@ -173,7 +174,6 @@ require (
 	k8s.io/component-base v0.30.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/kubectl v0.30.0 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	oras.land/oras-go v1.2.5 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect

--- a/src/k8s/pkg/client/k8s/mock/mock.go
+++ b/src/k8s/pkg/client/k8s/mock/mock.go
@@ -1,0 +1,106 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	certv1 "k8s.io/api/certificates/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type getArgs struct {
+	name types.NamespacedName
+	obj  client.Object
+	opts []client.GetOption
+}
+
+type getRet struct {
+	csr certv1.CertificateSigningRequest
+	err error
+}
+
+type K8sMock struct {
+	client.Client
+
+	t    *testing.T
+	srcm *subResourceClientMock
+
+	getCalledWith getArgs
+	getReturns    getRet
+}
+
+func New(
+	t *testing.T,
+	srcm *subResourceClientMock,
+	getCSR certv1.CertificateSigningRequest,
+	getErr error,
+) *K8sMock {
+	return &K8sMock{
+		t:    t,
+		srcm: srcm,
+		getReturns: getRet{
+			csr: getCSR,
+			err: getErr,
+		},
+	}
+}
+
+func (m *K8sMock) Get(ctx context.Context, name types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+	m.getCalledWith = getArgs{name, obj, opts}
+	csr, ok := obj.(*certv1.CertificateSigningRequest)
+	if !ok {
+		m.t.Fatalf("unexpected object type: %T", obj)
+	}
+	*csr = m.getReturns.csr
+	return m.getReturns.err
+}
+
+func (m *K8sMock) Status() client.SubResourceWriter {
+	return m.srcm
+}
+
+func (m *K8sMock) SubResource(subResource string) client.SubResourceClient {
+	switch subResource {
+	case "approval":
+		return m.srcm
+	default:
+		m.t.Fatalf("unexpected subResource: %s", subResource)
+	}
+	return nil
+}
+
+func (m *K8sMock) AssertUpdateCalled(t *testing.T) {
+	m.srcm.assertUpdateCalled(t)
+}
+
+type updateArgs struct {
+	obj  client.Object
+	opts []client.SubResourceUpdateOption
+}
+
+type subResourceClientMock struct {
+	client.SubResourceClient
+
+	updateCalledWith []updateArgs
+	updateErr        error
+}
+
+func NewSubResourceClientMock(
+	updateErr error,
+) *subResourceClientMock {
+	return &subResourceClientMock{
+		updateErr: updateErr,
+	}
+}
+
+func (src *subResourceClientMock) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	src.updateCalledWith = append(src.updateCalledWith, updateArgs{obj, opts})
+	return src.updateErr
+}
+
+func (src *subResourceClientMock) assertUpdateCalled(t *testing.T) {
+	if len(src.updateCalledWith) == 0 {
+		t.Error("expected update to have been called")
+	}
+}

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/controller.go
@@ -88,11 +88,13 @@ func (c *Controller) Run(ctx context.Context, getClusterConfig func(context.Cont
 	}
 
 	if err := (&csrSigningReconciler{
-		Manager: mgr,
-		Logger:  mgr.GetLogger(),
-		Client:  mgr.GetClient(),
+		Manager:            mgr,
+		Logger:             mgr.GetLogger(),
+		Client:             mgr.GetClient(),
+		managedSignerNames: managedSignerNames,
 
-		getClusterConfig: getClusterConfig,
+		getClusterConfig:     getClusterConfig,
+		reconcileAutoApprove: reconcileAutoApprove,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("failed to setup csrsigning controller: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile.go
@@ -76,7 +76,7 @@ func (r *csrSigningReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to load cluster RSA key: %w", err)
 			}
-			return r.reconcileAutoApprove(ctx, log, obj, priv, r.Client, validateCSR)
+			return r.reconcileAutoApprove(ctx, log, obj, priv, r.Client)
 		}
 
 		log.Info("Requeue while waiting for CSR to be approved")

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile.go
@@ -37,7 +37,7 @@ func (r *csrSigningReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// skip CSRs with an unknown signerName.
-	if _, ok := managedSignerNames[obj.Spec.SignerName]; !ok {
+	if _, ok := r.managedSignerNames[obj.Spec.SignerName]; !ok {
 		return ctrl.Result{}, nil
 	}
 
@@ -76,7 +76,7 @@ func (r *csrSigningReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to load cluster RSA key: %w", err)
 			}
-			return r.reconcileAutoApprove(ctx, log, obj, priv)
+			return r.reconcileAutoApprove(ctx, log, obj, priv, r.Client, validateCSR)
 		}
 
 		log.Info("Requeue while waiting for CSR to be approved")

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_approve.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_approve.go
@@ -13,8 +13,7 @@ import (
 )
 
 func reconcileAutoApprove(ctx context.Context, log log.Logger, csr *certv1.CertificateSigningRequest,
-	priv *rsa.PrivateKey, client client.Client,
-	validateCSR func(obj *certv1.CertificateSigningRequest, priv *rsa.PrivateKey) error) (ctrl.Result, error) {
+	priv *rsa.PrivateKey, client client.Client) (ctrl.Result, error) {
 	var result certv1.RequestConditionType
 
 	if err := validateCSR(csr, priv); err != nil {

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_approve_test.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_approve_test.go
@@ -1,0 +1,123 @@
+package csrsigning
+
+import (
+	"context"
+	"crypto/rsa"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	certv1 "k8s.io/api/certificates/v1"
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	k8smock "github.com/canonical/k8s/pkg/client/k8s/mock"
+	"github.com/canonical/k8s/pkg/log"
+)
+
+func TestAutoApprove(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		csr         certv1.CertificateSigningRequest
+		validateCSR func(obj *certv1.CertificateSigningRequest, priv *rsa.PrivateKey) error
+		updateErr   error
+
+		expCtrl      ctrl.Result
+		expErr       error
+		expCondition certv1.CertificateSigningRequestCondition
+	}{
+		{
+			name: "InvalidCSR--UpdateSuccessful",
+			csr:  certv1.CertificateSigningRequest{},
+			validateCSR: func(obj *certv1.CertificateSigningRequest, priv *rsa.PrivateKey) error {
+				return errors.New("invalid")
+			},
+			updateErr: nil,
+			expCtrl:   ctrl.Result{},
+			expErr:    nil,
+			expCondition: certv1.CertificateSigningRequestCondition{
+				Type:    certv1.CertificateDenied,
+				Status:  v1.ConditionTrue,
+				Reason:  "K8sdDeny",
+				Message: "CSR is not valid: invalid",
+			},
+		},
+		{
+			name: "InvalidCSR--UpdateFailed",
+			csr:  certv1.CertificateSigningRequest{},
+			validateCSR: func(obj *certv1.CertificateSigningRequest, priv *rsa.PrivateKey) error {
+				return errors.New("invalid")
+			},
+			updateErr: errors.New("failed to update"),
+			expCtrl:   ctrl.Result{},
+			expErr:    errors.New("failed to update"),
+			expCondition: certv1.CertificateSigningRequestCondition{
+				Type:    certv1.CertificateDenied,
+				Status:  v1.ConditionTrue,
+				Reason:  "K8sdDeny",
+				Message: "CSR is not valid: invalid",
+			},
+		},
+		{
+			name: "ValidCSR--UpdateSuccessful",
+			csr:  certv1.CertificateSigningRequest{},
+			validateCSR: func(obj *certv1.CertificateSigningRequest, priv *rsa.PrivateKey) error {
+				return nil
+			},
+			updateErr: nil,
+			expCtrl:   ctrl.Result{},
+			expErr:    nil,
+			expCondition: certv1.CertificateSigningRequestCondition{
+				Type:    certv1.CertificateApproved,
+				Status:  v1.ConditionTrue,
+				Reason:  "K8sdApprove",
+				Message: "CSR approved by k8sd",
+			},
+		},
+		{
+			name: "ValidCSR--UpdateFailed",
+			csr:  certv1.CertificateSigningRequest{},
+			validateCSR: func(obj *certv1.CertificateSigningRequest, priv *rsa.PrivateKey) error {
+				return nil
+			},
+			updateErr: errors.New("failed to update"),
+			expCtrl:   ctrl.Result{},
+			expErr:    errors.New("failed to update"),
+			expCondition: certv1.CertificateSigningRequestCondition{
+				Type:    certv1.CertificateApproved,
+				Status:  v1.ConditionTrue,
+				Reason:  "K8sdApprove",
+				Message: "CSR approved by k8sd",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			k8sM := k8smock.New(
+				t,
+				k8smock.NewSubResourceClientMock(tc.updateErr),
+				tc.csr,
+				nil, // we don't call get in reconcileAutoApprove
+			)
+
+			result, err := reconcileAutoApprove(
+				context.Background(),
+				log.L(),
+				&tc.csr,
+				nil, // not important, validateCSR is mocked
+				k8sM,
+				tc.validateCSR,
+			)
+
+			g := NewWithT(t)
+
+			k8sM.AssertUpdateCalled(t)
+			g.Expect(result).To(Equal(tc.expCtrl))
+			if tc.expErr == nil {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err).To(MatchError(tc.expErr))
+			}
+			g.Expect(tc.csr.Status.Conditions).To(ContainElement(tc.expCondition))
+		})
+	}
+}

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_test.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_test.go
@@ -1,0 +1,548 @@
+package csrsigning
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509/pkix"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	certv1 "k8s.io/api/certificates/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	k8smock "github.com/canonical/k8s/pkg/client/k8s/mock"
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/log"
+	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
+)
+
+func TestCSRNotFound(t *testing.T) {
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		certv1.CertificateSigningRequest{},
+		&apierrors.StatusError{
+			ErrStatus: v1.Status{
+				Reason: v1.StatusReasonNotFound,
+			},
+		},
+	)
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+	}
+
+	g := NewWithT(t)
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestFailedToGetCSR(t *testing.T) {
+	getErr := &apierrors.StatusError{
+		ErrStatus: v1.Status{
+			Reason: v1.StatusReasonInternalError,
+		},
+	}
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		certv1.CertificateSigningRequest{},
+		getErr,
+	)
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+	}
+
+	g := NewWithT(t)
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).To(MatchError(getErr))
+}
+
+func TestHasSignedCertificate(t *testing.T) {
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		certv1.CertificateSigningRequest{
+			Status: certv1.CertificateSigningRequestStatus{
+				Certificate: []byte("cert"),
+			},
+		},
+		nil,
+	)
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+	}
+
+	g := NewWithT(t)
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestSkipUnmanagedSignerName(t *testing.T) {
+	unmanagedSignerName := "unknown"
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		certv1.CertificateSigningRequest{
+			Spec: certv1.CertificateSigningRequestSpec{
+				SignerName: unmanagedSignerName,
+			},
+		},
+		nil,
+	)
+
+	managedSigners := map[string]struct{}{
+		"signer1": {},
+		"signer2": {},
+	}
+
+	g := NewWithT(t)
+	// just to make sure the test is correct
+	g.Expect(managedSigners).ToNot(HaveKey(unmanagedSignerName))
+
+	reconciler := &csrSigningReconciler{
+		Client:             k8sM,
+		managedSignerNames: managedSigners,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestCertificateDenied(t *testing.T) {
+	managedSigner := "managed-signer"
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		certv1.CertificateSigningRequest{
+			Spec: certv1.CertificateSigningRequestSpec{
+				SignerName: managedSigner,
+			},
+			Status: certv1.CertificateSigningRequestStatus{
+				Conditions: []certv1.CertificateSigningRequestCondition{
+					{
+						Type: certv1.CertificateDenied,
+					},
+				},
+			},
+		},
+		nil,
+	)
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+		managedSignerNames: map[string]struct{}{
+			managedSigner: {},
+		},
+	}
+
+	g := NewWithT(t)
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestCertificateFailed(t *testing.T) {
+	managedSigner := "managed-signer"
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		certv1.CertificateSigningRequest{
+			Spec: certv1.CertificateSigningRequestSpec{
+				SignerName: "k8sd.io/kubelet-serving",
+			},
+			Status: certv1.CertificateSigningRequestStatus{
+				Conditions: []certv1.CertificateSigningRequestCondition{
+					{
+						Type: certv1.CertificateFailed,
+					},
+				},
+			},
+		},
+		nil,
+	)
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+		managedSignerNames: map[string]struct{}{
+			managedSigner: {},
+		},
+	}
+
+	g := NewWithT(t)
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestFailedToGetClusterConfig(t *testing.T) {
+	managedSigner := "managed-signer"
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		certv1.CertificateSigningRequest{
+			Spec: certv1.CertificateSigningRequestSpec{
+				SignerName: managedSigner,
+			},
+			Status: certv1.CertificateSigningRequestStatus{
+				Conditions: []certv1.CertificateSigningRequestCondition{
+					{
+						Type: certv1.CertificateApproved,
+					},
+				},
+			},
+		},
+		nil,
+	)
+
+	getCCErr := errors.New("failed to get cluster config")
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+		managedSignerNames: map[string]struct{}{
+			managedSigner: {},
+		},
+		getClusterConfig: func(context.Context) (types.ClusterConfig, error) {
+			return types.ClusterConfig{}, getCCErr
+		},
+	}
+
+	g := NewWithT(t)
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).To(MatchError(getCCErr))
+}
+
+func TestNotApprovedCSR(t *testing.T) {
+	t.Run("NoAutoApprove", func(t *testing.T) {
+		managedSigner := "managed-signer"
+		k8sM := k8smock.New(
+			t,
+			k8smock.NewSubResourceClientMock(nil),
+			certv1.CertificateSigningRequest{
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: managedSigner,
+				},
+			},
+			nil,
+		)
+
+		reconciler := &csrSigningReconciler{
+			Client: k8sM,
+			managedSignerNames: map[string]struct{}{
+				managedSigner: {},
+			},
+			getClusterConfig: func(context.Context) (types.ClusterConfig, error) {
+				return types.ClusterConfig{}, nil
+			},
+		}
+
+		g := NewWithT(t)
+
+		result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: requeueAfterWaitingForApproved}))
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("WithAutoApprove", func(t *testing.T) {
+		managedSigner := "managed-signer"
+		k8sM := k8smock.New(
+			t,
+			k8smock.NewSubResourceClientMock(nil),
+			certv1.CertificateSigningRequest{
+				Spec: certv1.CertificateSigningRequestSpec{
+					SignerName: managedSigner,
+				},
+			},
+			nil,
+		)
+
+		priv, _, err := pkiutil.GenerateRSAKey(2048)
+
+		g := NewWithT(t)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var called bool
+		reconciler := &csrSigningReconciler{
+			Client: k8sM,
+			managedSignerNames: map[string]struct{}{
+				managedSigner: {},
+			},
+			getClusterConfig: func(context.Context) (types.ClusterConfig, error) {
+				return types.ClusterConfig{
+					Annotations: map[string]string{
+						"k8sd/v1alpha1/csrsigning/auto-approve": "true",
+					},
+					Certificates: types.Certificates{
+						K8sdPrivateKey: ptr.To(priv),
+					},
+				}, nil
+			},
+			reconcileAutoApprove: func(ctx context.Context, l log.Logger, csr *certv1.CertificateSigningRequest, pk *rsa.PrivateKey, c client.Client, f func(*certv1.CertificateSigningRequest, *rsa.PrivateKey) error) (ctrl.Result, error) {
+				called = true
+				return ctrl.Result{}, nil
+			},
+		}
+
+		_, _ = reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+		g.Expect(called).To(BeTrue())
+	})
+}
+
+func TestInvalidCSR(t *testing.T) {
+	managedSigner := "managed-signer"
+	csr := certv1.CertificateSigningRequest{
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: managedSigner,
+			Request:    []byte("invalid-csr"),
+		},
+		Status: certv1.CertificateSigningRequestStatus{
+			Conditions: []certv1.CertificateSigningRequestCondition{
+				{
+					Type: certv1.CertificateApproved,
+				},
+			},
+		},
+	}
+
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		csr,
+		nil,
+	)
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+		managedSignerNames: map[string]struct{}{
+			managedSigner: {},
+		},
+		getClusterConfig: func(context.Context) (types.ClusterConfig, error) {
+			return types.ClusterConfig{
+				Certificates: types.Certificates{},
+			}, nil
+		},
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g := NewWithT(t)
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestInvalidCACertificate(t *testing.T) {
+	csrPEM, _, err := pkiutil.GenerateCSR(
+		pkix.Name{
+			CommonName:   "system:node:valid-node",
+			Organization: []string{"system:nodes"},
+		},
+		2048,
+		nil,
+		nil,
+	)
+
+	g := NewWithT(t)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	managedSigner := "k8sd.io/kubelet-serving"
+	csr := certv1.CertificateSigningRequest{
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: managedSigner,
+			Request:    []byte(csrPEM),
+		},
+		Status: certv1.CertificateSigningRequestStatus{
+			Conditions: []certv1.CertificateSigningRequestCondition{
+				{
+					Type: certv1.CertificateApproved,
+				},
+			},
+		},
+	}
+
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		csr,
+		nil,
+	)
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+		managedSignerNames: map[string]struct{}{
+			managedSigner: {},
+		},
+		getClusterConfig: func(context.Context) (types.ClusterConfig, error) {
+			return types.ClusterConfig{
+				Certificates: types.Certificates{
+					CACert: ptr.To("invalid"),
+					CAKey:  ptr.To("invalid"),
+				},
+			}, nil
+		},
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestUpdateCSRFailed(t *testing.T) {
+	csrPEM, _, err := pkiutil.GenerateCSR(
+		pkix.Name{
+			CommonName:   "system:node:valid-node",
+			Organization: []string{"system:nodes"},
+		},
+		2048,
+		nil,
+		nil,
+	)
+
+	g := NewWithT(t)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	managedSigner := "k8sd.io/kubelet-serving"
+	csr := certv1.CertificateSigningRequest{
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: managedSigner,
+			Request:    []byte(csrPEM),
+		},
+		Status: certv1.CertificateSigningRequestStatus{
+			Conditions: []certv1.CertificateSigningRequestCondition{
+				{
+					Type: certv1.CertificateApproved,
+				},
+			},
+		},
+	}
+	updateErr := errors.New("failed to update")
+
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(
+			updateErr,
+		),
+		csr,
+		nil,
+	)
+
+	caCert, caKey, err := pkiutil.GenerateSelfSignedCA(pkix.Name{CommonName: "kubernetes-ca"}, 10, 2048)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+		managedSignerNames: map[string]struct{}{
+			managedSigner: {},
+		},
+		getClusterConfig: func(context.Context) (types.ClusterConfig, error) {
+			return types.ClusterConfig{
+				Certificates: types.Certificates{
+					CACert: ptr.To(caCert),
+					CAKey:  ptr.To(caKey),
+				},
+			}, nil
+		},
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).To(MatchError(updateErr))
+	k8sM.AssertUpdateCalled(t)
+}
+
+func TestUpdateCSRSucceed(t *testing.T) {
+	csrPEM, _, err := pkiutil.GenerateCSR(
+		pkix.Name{
+			CommonName:   "system:node:valid-node",
+			Organization: []string{"system:nodes"},
+		},
+		2048,
+		nil,
+		nil,
+	)
+
+	g := NewWithT(t)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	managedSigner := "k8sd.io/kubelet-serving"
+	csr := certv1.CertificateSigningRequest{
+		Spec: certv1.CertificateSigningRequestSpec{
+			SignerName: managedSigner,
+			Request:    []byte(csrPEM),
+		},
+		Status: certv1.CertificateSigningRequestStatus{
+			Conditions: []certv1.CertificateSigningRequestCondition{
+				{
+					Type: certv1.CertificateApproved,
+				},
+			},
+		},
+	}
+
+	k8sM := k8smock.New(
+		t,
+		k8smock.NewSubResourceClientMock(nil),
+		csr,
+		nil,
+	)
+
+	caCert, caKey, err := pkiutil.GenerateSelfSignedCA(pkix.Name{CommonName: "kubernetes-ca"}, 10, 2048)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	reconciler := &csrSigningReconciler{
+		Client: k8sM,
+		managedSignerNames: map[string]struct{}{
+			managedSigner: {},
+		},
+		getClusterConfig: func(context.Context) (types.ClusterConfig, error) {
+			return types.ClusterConfig{
+				Certificates: types.Certificates{
+					CACert: ptr.To(caCert),
+					CAKey:  ptr.To(caKey),
+				},
+			}, nil
+		},
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), getDefaultRequest())
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+	k8sM.AssertUpdateCalled(t)
+}
+
+func getDefaultRequest() ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: k8stypes.NamespacedName{
+			Name:      "csr-1",
+			Namespace: "default",
+		},
+	}
+}

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_test.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/reconcile_test.go
@@ -16,7 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8smock "github.com/canonical/k8s/pkg/client/k8s/mock"
+	k8smock "github.com/canonical/k8s/pkg/k8sd/controllers/csrsigning/test"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
 	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
@@ -304,7 +304,7 @@ func TestNotApprovedCSR(t *testing.T) {
 					},
 				}, nil
 			},
-			reconcileAutoApprove: func(ctx context.Context, l log.Logger, csr *certv1.CertificateSigningRequest, pk *rsa.PrivateKey, c client.Client, f func(*certv1.CertificateSigningRequest, *rsa.PrivateKey) error) (ctrl.Result, error) {
+			reconcileAutoApprove: func(ctx context.Context, l log.Logger, csr *certv1.CertificateSigningRequest, pk *rsa.PrivateKey, c client.Client) (ctrl.Result, error) {
 				called = true
 				return ctrl.Result{}, nil
 			},

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/setup.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/setup.go
@@ -2,8 +2,10 @@ package csrsigning
 
 import (
 	"context"
+	"crypto/rsa"
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/log"
 	"github.com/go-logr/logr"
 	certv1 "k8s.io/api/certificates/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -13,17 +15,21 @@ import (
 )
 
 type csrSigningReconciler struct {
-	Manager manager.Manager
-	Logger  logr.Logger
-	Client  client.Client
+	Manager            manager.Manager
+	Logger             logr.Logger
+	Client             client.Client
+	managedSignerNames map[string]struct{}
 
-	getClusterConfig func(context.Context) (types.ClusterConfig, error)
+	getClusterConfig     func(context.Context) (types.ClusterConfig, error)
+	reconcileAutoApprove func(context.Context, log.Logger, *certv1.CertificateSigningRequest,
+		*rsa.PrivateKey, client.Client,
+		func(*certv1.CertificateSigningRequest, *rsa.PrivateKey) error) (ctrl.Result, error)
 }
 
 var managedSignerNames = map[string]struct{}{
-	"k8sd.io/kubelet-serving":   struct{}{},
-	"k8sd.io/kubelet-client":    struct{}{},
-	"k8sd.io/kube-proxy-client": struct{}{},
+	"k8sd.io/kubelet-serving":   {},
+	"k8sd.io/kubelet-client":    {},
+	"k8sd.io/kube-proxy-client": {},
 }
 
 func (r *csrSigningReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -32,7 +38,7 @@ func (r *csrSigningReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			if csr, ok := object.(*certv1.CertificateSigningRequest); !ok {
 				return false
-			} else if _, ok := managedSignerNames[csr.Spec.SignerName]; !ok {
+			} else if _, ok := r.managedSignerNames[csr.Spec.SignerName]; !ok {
 				return false
 			}
 			return true

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/setup.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/setup.go
@@ -21,9 +21,7 @@ type csrSigningReconciler struct {
 	managedSignerNames map[string]struct{}
 
 	getClusterConfig     func(context.Context) (types.ClusterConfig, error)
-	reconcileAutoApprove func(context.Context, log.Logger, *certv1.CertificateSigningRequest,
-		*rsa.PrivateKey, client.Client,
-		func(*certv1.CertificateSigningRequest, *rsa.PrivateKey) error) (ctrl.Result, error)
+	reconcileAutoApprove func(context.Context, log.Logger, *certv1.CertificateSigningRequest, *rsa.PrivateKey, client.Client) (ctrl.Result, error)
 }
 
 var managedSignerNames = map[string]struct{}{

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/test/k8s_mock.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/test/k8s_mock.go
@@ -1,4 +1,4 @@
-package mock
+package test
 
 import (
 	"context"


### PR DESCRIPTION
I was inspired by the [upstream kubernetes](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/volumemanager/reconciler/reconciler_test.go). 