### PR TITLE
Forces volume umount when snap is removed

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -60,9 +60,17 @@ k8s::remove::containers() {
   # delete cni network namespaces
   ip netns list | cut -f1 -d' ' | grep -- "^cni-" | xargs -n1 -r -t ip netns delete || true
 
+  # unmount NFS volumes forcefully, as unmounting them normally may hang otherwise.
+  cat /proc/mounts | grep /run/containerd/io.containerd. | grep "nfs[34]" | cut -f2 -d' ' | xargs -r -t umount -f || true
+  cat /proc/mounts | grep /var/lib/kubelet/pods | grep "nfs[34]" | cut -f2 -d' ' | xargs -r -t umount -f || true
+
   # unmount volumes
   cat /proc/mounts | grep /run/containerd/io.containerd. | cut -f2 -d' ' | xargs -r -t umount || true
   cat /proc/mounts | grep /var/lib/kubelet/pods | cut -f2 -d' ' | xargs -r -t umount || true
+
+  # umount lingering volumes by force, to prevent potential volume leaks.
+  cat /proc/mounts | grep /run/containerd/io.containerd. | cut -f2 -d' ' | xargs -r -t umount -f || true
+  cat /proc/mounts | grep /var/lib/kubelet/pods | cut -f2 -d' ' | xargs -r -t umount -f || true
 }
 
 # Run a ctr command against the local containerd socket


### PR DESCRIPTION
Some Kubernetes volumes may not be easily removed (e.g.: NFS volumes from a local NFS provider), leading to a significantly increased snap removal time and leaked volume mounts.

Due to the volume leak, the ``/var/lib/kubelet`` folder is never cleaned up properly either, which means that on reinstalling the k8s snap afterwards and bootstrapping the cluster, the current node will not be registered to the cluster.

This adds the ``-f`` option to ``umount``, forcing the unmount.

Fixes: https://github.com/canonical/k8s-snap/issues/612