### PR TITLE
Add k8s endpoint check to markNodeReady

### DIFF
--- a/src/k8s/pkg/client/kubernetes/status.go
+++ b/src/k8s/pkg/client/kubernetes/status.go
@@ -20,6 +20,16 @@ func (c *Client) WaitKubernetesEndpointAvailable(ctx context.Context) error {
 	})
 }
 
+func (c *Client) CheckKubernetesEndpoint(ctx context.Context) error {
+	if endpoint, err := c.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{}); err != nil {
+		return fmt.Errorf("failed to get kubernetes endpoint: %w", err)
+	} else if endpoint == nil {
+		return fmt.Errorf("kubernetes endpoint not found")
+	}
+
+	return nil
+}
+
 // HasReadyNodes checks the status of all nodes in the Kubernetes cluster.
 // HasReadyNodes returns true if there is at least one Ready node in the cluster, false otherwise.
 func (c *Client) HasReadyNodes(ctx context.Context) (bool, error) {

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/utils"
 	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
 	"github.com/canonical/microcluster/v2/state"
@@ -17,7 +18,11 @@ import (
 
 func (a *App) onStart(ctx context.Context, s state.State) error {
 	// start a goroutine to mark the node as running
-	go a.markNodeReady(ctx, s)
+	go func() {
+		if err := a.markNodeReady(ctx, s); err != nil {
+			log.FromContext(ctx).Error(err, "Failed to mark node as ready")
+		}
+	}()
 
 	// start node config controller
 	if a.nodeConfigController != nil {


### PR DESCRIPTION
# Summary
`onStart` hook happens before `onBootstrap`. because of this, on non-fresh machines (non-fresh == `/etc/kubernetes/admin.conf` is available) we use invalid/old `admin.conf` kubeconfig for csrsigining controller client. this PR makes sure that we prevent running controllers until we have the correct `.conf` files and we can reach the k8s cluster.

# How to test
build and install k8s on a fresh machine, run `bootstrap` and check logs and confirm the csrsigning controller is running, e.g.:
```text
Aug 21 08:28:20 test k8s.k8sd[1642]: I0821 08:28:20.897429    1642 controller/controller.go:181] "Starting Controller" logger="k8sd.csrsigning" controller="certificatesignin
grequest" controllerGroup="certificates.k8s.io" controllerKind="CertificateSigningRequest"
Aug 21 08:28:21 test k8s.k8sd[1642]: I0821 08:28:21.005667    1642 controller/controller.go:215] "Starting workers" logger="k8sd.csrsigning" controller="certificatesigningre
quest" controllerGroup="certificates.k8s.io" controllerKind="CertificateSigningRequest" worker count=1
```
also confirm that there are kubeconfigs available in `/etc/kubernetes/`, specifically `admin.conf`.
now remove the k8s snap and reinstall k8s (same snap). Run `bootstrap` and like above confirm that csrsigning controller is started and running.