### PR TITLE
Add command for k8sd recovery after quorum loss

### DIFF
--- a/docs/src/snap/howto/index.md
+++ b/docs/src/snap/howto/index.md
@@ -22,6 +22,7 @@ external-datastore
 proxy
 backup-restore
 refresh-certs
+restore-quorum
 contribute
 support
 ```

--- a/docs/src/snap/howto/restore-quorum.md
+++ b/docs/src/snap/howto/restore-quorum.md
@@ -1,0 +1,166 @@
+# Recovering a Cluster After Quorum Loss
+
+Highly available {{product}} clusters can survive losing one or more
+nodes. [Dqlite], the default datastore, implements a [Raft] based protocol where
+an elected leader holds the definitive copy of the database, which is then
+replicated on two or more secondary nodes.
+
+When the a majority of the nodes are lost, the cluster becomes unavailable.
+If at least one database node survived, the cluster can be recovered using the
+steps outlined in this document.
+
+```{note}
+This guide can be used to recover the default {{product}} datastore,
+dqlite. Persistent volumes on the lost nodes are *not* recovered.
+```
+
+## Dqlite Configuration
+
+Be aware that {{product}} uses not one, but two dqlite databases:
+
+* k8s-dqlite - used by Kubernetes itself
+* k8sd - Kubernetes cluster management data
+
+Each database has its own state directory:
+
+* ``/var/snap/k8s/common/var/lib/k8s-dqlite``
+* ``/var/snap/k8s/common/var/lib/k8sd/state``
+
+The state directory normally contains:
+
+* ``info.yaml`` - the id, address and cluster role of this node
+* ``cluster.yaml`` - the state of the cluster, as seen by this dqlite node.
+  It includes the same information as info.yaml, but for all cluster nodes.
+* ``00000abcxx-00000abcxx``, ``open-abc`` - database segments
+* ``cluster.crt``, ``cluster.key`` - node certificates
+* ``snapshot-abc-abc-abc.meta``
+* ``metadata{1,2}``
+* ``*.sock`` - control unix sockets
+
+K8sd contains additional files to manage cluster memberships and member's
+secure communication:
+
+* ``server.crt``, ``server.key`` certificates
+* ``truststore`` folder, containing trusted certificates
+* ``daemon.yaml`` - k8sd daemon configuration
+* separate ``database`` folder
+
+Dqlite cluster members have one of the following roles:
+
+| Role enum | Role name | Replicates database | Voting in leader elections |
+|-----------|-----------|---------------------|----------------------------|
+| 0         | voter     | yes                 | yes                        |
+| 1         | stand-by  | yes                 | no                         |
+| 2         | spare     | no                  | no                         |
+
+## Stop {{product}} Services on All Nodes
+
+Before recovering the cluster, all remaining {{product}} services
+must be stopped. Use the following command on every node:
+
+```
+sudo snap stop k8s
+```
+
+## Recover the Database
+
+Choose one of the remaining alive cluster nodes that has the most recent version
+of the Raft log.
+
+Update the ``cluster.yaml`` files, changing the role of the lost nodes to
+"spare" (2). Additionally, double check the addresses and IDs specified in
+``cluster.yaml``, ``info.yaml`` and ``daemon.yaml``, especially if database
+files were moved across nodes.
+
+The following command guides us through the recovery process, prompting a text
+editor with informative inline comments for each of the dqlite configuration files.
+
+```
+sudo /snap/k8s/current/bin/k8sd cluster-recover \
+    --state-dir=/var/snap/k8s/common/var/lib/k8sd/state \
+    --k8s-dqlite-state-dir=/var/snap/k8s/common/var/lib/k8s-dqlite \
+    --log-level 0
+```
+
+Please adjust the log level for additional debug messages by increasing its value.
+The command creates database backups before making any changes.
+
+The above command will reconfigure the Raft members and create recovery tarballs
+that are used to restore the lost nodes, once the Dqlite configuration is updated.
+
+```{note}
+By default, the command will recover both Dqlite databases. If one of the databases
+needs to be skipped, use the ``--skip-k8sd`` or ``--skip-k8s-dqlite`` flags.
+This can be useful when using an external Etcd database.
+```
+
+Once the "cluster-recover" command completes, restart the k8s services on the node:
+
+```
+sudo snap start k8s
+```
+
+Ensure that the services started successfully by using ``sudo snap services k8s``.
+Use ``k8s status --wait-ready`` to wait for the cluster to become ready.
+
+You may notice that we have not returned to an HA cluster yet: ``high availability: no``.
+This is expected as we need to recover
+
+## Recover the remaining nodes
+
+The k8s-dqlite and k8sd recovery tarballs need to be copied over to all cluster
+nodes.
+
+For k8sd, copy ``recovery_db.tar.gz`` to
+``/var/snap/k8s/common/var/lib/k8sd/state/recovery_db.tar.gz``. When the k8sd
+service starts, it will load the archive and perform the necessary recovery steps.
+
+The k8s-dqlite archive needs to be extracted manually. First, create a backup
+of the current k8s-dqlite state directory:
+
+```
+sudo mv /var/snap/k8s/common/var/lib/k8s-dqlite /var/snap/k8s/common/var/lib/k8s-dqlite.bkp
+```
+
+Then, extract the backup archive:
+
+```
+sudo mkdir /var/snap/k8s/common/var/lib/k8s-dqlite
+sudo tar xf  recovery-k8s-dqlite-$timestamp-post-recovery.tar.gz -C /var/snap/k8s/common/var/lib/k8s-dqlite
+```
+
+Node specific files need to be copied back to the k8s-dqlite state dir:
+
+```
+sudo cp /var/snap/k8s/common/var/lib/k8s-dqlite.bkp/cluster.crt /var/snap/k8s/common/var/lib/k8s-dqlite
+sudo cp /var/snap/k8s/common/var/lib/k8s-dqlite.bkp/cluster.key /var/snap/k8s/common/var/lib/k8s-dqlite
+sudo cp /var/snap/k8s/common/var/lib/k8s-dqlite.bkp/info.yaml /var/snap/k8s/common/var/lib/k8s-dqlite
+```
+
+Once these steps are completed, restart the k8s services:
+
+```
+sudo snap start k8s
+```
+
+Repeat these steps for all remaining nodes. Once a quorum is achieved, the cluster
+will be reported as "highly available":
+
+```
+$ sudo k8s status
+cluster status:           ready
+control plane nodes:      10.80.130.168:6400 (voter), 10.80.130.167:6400 (voter), 10.80.130.164:6400 (voter)
+high availability:        yes
+datastore:                k8s-dqlite
+network:                  enabled
+dns:                      enabled at 10.152.183.193
+ingress:                  disabled
+load-balancer:            disabled
+local-storage:            enabled at /var/snap/k8s/common/rawfile-storage
+gateway                   enabled
+```
+
+
+<!-- LINKS -->
+[Dqlite]: https://dqlite.io/
+[Raft]: https://raft.github.io/

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -20,6 +20,17 @@ var rootCmdOpts struct {
 	disableCSRSigningController         bool
 }
 
+func addCommands(root *cobra.Command, group *cobra.Group, commands ...*cobra.Command) {
+	if group != nil {
+		root.AddGroup(group)
+		for _, command := range commands {
+			command.GroupID = group.ID
+		}
+	}
+
+	root.AddCommand(commands...)
+}
+
 func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "k8sd",
@@ -76,6 +87,12 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")
 
 	cmd.AddCommand(newSqlCmd(env))
+
+	addCommands(
+		cmd,
+		&cobra.Group{ID: "cluster", Title: "K8sd clustering commands:"},
+		newClusterRecoverCmd(),
+	)
 
 	return cmd
 }

--- a/src/k8s/cmd/k8sd/k8sd_cluster_recover.go
+++ b/src/k8s/cmd/k8sd/k8sd_cluster_recover.go
@@ -1,0 +1,529 @@
+package k8sd
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/app"
+	"github.com/canonical/go-dqlite/client"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/termios"
+	"github.com/canonical/microcluster/v3/cluster"
+	"github.com/canonical/microcluster/v3/microcluster"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+	"gopkg.in/yaml.v2"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/utils"
+)
+
+const recoveryConfirmation = `You should only run this command if:
+ - A quorum of cluster members is permanently lost
+ - You are *absolutely* sure all k8s daemons are stopped (sudo snap stop k8s)
+ - This instance has the most up to date database
+
+Note that before applying any changes, a database backup is created at:
+* k8sd (microcluster): /var/snap/k8s/common/var/lib/k8sd/state/db_backup.<timestamp>.tar.gz
+* k8s-dqlite: /var/snap/k8s/common/recovery-k8s-dqlite-<timestamp>-pre-recovery.tar.gz
+
+Do you want to proceed? (yes/no): `
+
+const clusterK8sdYamlRecoveryComment = `# Member roles can be modified. Unrecoverable nodes should be given the role "spare".
+#
+# "voter" (0) - Voting member of the database. A majority of voters is a quorum.
+# "stand-by" (1) - Non-voting member of the database; can be promoted to voter.
+# "spare" (2) - Not a member of the database.
+#
+# The edit is aborted if:
+# - the number of members changes
+# - the name of any member changes
+# - the ID of any member changes
+# - the address of any member changes
+# - no changes are made
+`
+
+const clusterK8sDqliteRecoveryComment = `# Member roles can be modified. Unrecoverable nodes should be given the role 2 (spare).
+#
+# 0 (voter) - Voting member of the database. A majority of voters is a quorum.
+# 1 (stand-by) - Non-voting member of the database; can be promoted to voter.
+# 2 (spare) - Not a member of the database.
+`
+
+const infoYamlRecoveryComment = `# Verify the ID, address and role of the local node.
+#
+# Cluster members:
+`
+
+const daemonYamlRecoveryComment = `# Verify the name and address of the local node.
+#
+# Cluster members:
+`
+
+// Used as part of a regex search, avoid adding special characters.
+const yamlHelperCommentFooter = "# ------- everything below will be written -------\n"
+
+var clusterRecoverOpts struct {
+	K8sDqliteStateDir string
+	SkipK8sd          bool
+	SkipK8sDqlite     bool
+}
+
+func logDebugf(format string, args ...interface{}) {
+	// TODO: there may be a problem with the logger, only log.V(0) messages
+	// get printed regardless of the specified log level. For now, we'll use our
+	// own helper.
+	if rootCmdOpts.logDebug {
+		msg := fmt.Sprintf(format, args...)
+		log.L().Info(msg)
+	}
+
+}
+
+func newClusterRecoverCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster-recover",
+		Short: "Recover the cluster from this member if quorum is lost",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Configure(log.Options{
+				LogLevel:     rootCmdOpts.logLevel,
+				AddDirHeader: true,
+			})
+
+			if err := recoveryCmdPrechecks(cmd.Context()); err != nil {
+				return err
+			}
+
+			if clusterRecoverOpts.SkipK8sd {
+				cmd.Printf("Skipping k8sd recovery.")
+			} else {
+				k8sdTarballPath, err := recoverK8sd()
+				if err != nil {
+					return fmt.Errorf("failed to recover k8sd, error: %w", err)
+				}
+				cmd.Printf("K8sd cluster changes applied.\n")
+				cmd.Printf("New database state saved to %s\n", k8sdTarballPath)
+				cmd.Printf("*Before* starting any cluster member, copy %s to %s "+
+					"on all remaining cluster members.\n",
+					k8sdTarballPath, k8sdTarballPath)
+				cmd.Printf("K8sd will load this file during startup.\n\n")
+			}
+
+			if clusterRecoverOpts.SkipK8sDqlite {
+				cmd.Printf("Skipping k8s-dqlite recovery.")
+			} else {
+				k8sDqlitePreRecoveryTarball, k8sDqlitePostRecoveryTarball, err := recoverK8sDqlite()
+				if err != nil {
+					return fmt.Errorf(
+						"failed to recover k8s-dqlite, error: %w, "+
+							"pre-recovery backup: %s",
+						err, k8sDqlitePreRecoveryTarball,
+					)
+				}
+				cmd.Printf("K8s-dqlite cluster changes applied.\n")
+				cmd.Printf("New database state saved to %s\n",
+					k8sDqlitePostRecoveryTarball)
+				cmd.Printf("*Before* starting any cluster member, copy %s "+
+					"on all remaining cluster members and extract the archive to %s.\n",
+					k8sDqlitePostRecoveryTarball, clusterRecoverOpts.K8sDqliteStateDir)
+				cmd.Printf("Pre-recovery database backup: %s\n\n", k8sDqlitePreRecoveryTarball)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&clusterRecoverOpts.K8sDqliteStateDir, "k8s-dqlite-state-dir",
+		"", "k8s-dqlite datastore location")
+	cmd.Flags().BoolVar(&clusterRecoverOpts.SkipK8sd, "skip-k8sd",
+		false, "skip k8sd recovery")
+	cmd.Flags().BoolVar(&clusterRecoverOpts.SkipK8sDqlite, "skip-k8s-dqlite",
+		false, "skip k8s-dqlite recovery")
+
+	return cmd
+}
+
+func removeYamlHelperComments(content []byte) []byte {
+	pattern := fmt.Sprintf("(?s).*?%s *", yamlHelperCommentFooter)
+	re := regexp.MustCompile(pattern)
+	out := re.ReplaceAll(content, nil)
+	return out
+}
+
+func removeEmptyLines(content []byte) []byte {
+	re := regexp.MustCompile(`(?m)^\s*$`)
+	out := re.ReplaceAll(content, nil)
+	return out
+}
+
+func recoveryCmdPrechecks(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	log.V(1).Info("Running prechecks.")
+
+	if !termios.IsTerminal(unix.Stdin) {
+		return fmt.Errorf("this command is meant to be run in an interactive terminal")
+	}
+
+	if clusterRecoverOpts.K8sDqliteStateDir == "" {
+		return fmt.Errorf("k8s-dqlite state dir not specified")
+	}
+	if rootCmdOpts.stateDir == "" {
+		return fmt.Errorf("k8sd state dir not specified")
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print(recoveryConfirmation)
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("couldn't read user input, error: %w", err)
+	}
+	input = strings.TrimSuffix(input, "\n")
+
+	if strings.ToLower(input) != "yes" {
+		return fmt.Errorf("cluster edit aborted; no changes made")
+	}
+
+	if !clusterRecoverOpts.SkipK8sDqlite {
+		if err = ensureK8sDqliteMembersStopped(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureK8sDqliteMembersStopped(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	log.V(1).Info("Ensuring that all k8s-dqlite members are stopped.")
+
+	clusterYamlPath := path.Join(clusterRecoverOpts.K8sDqliteStateDir, "cluster.yaml")
+	membersYaml, err := os.ReadFile(clusterYamlPath)
+	if err != nil {
+		return fmt.Errorf("could not read k8s-dqlite cluster.yaml, error: %w", err)
+	}
+
+	members := []dqlite.NodeInfo{}
+	if err = yaml.Unmarshal(membersYaml, &members); err != nil {
+		return fmt.Errorf("couldn't parse k8s-dqlite cluster.yaml, error: %w", err)
+	}
+
+	crt := path.Join(clusterRecoverOpts.K8sDqliteStateDir, "cluster.crt")
+	key := path.Join(clusterRecoverOpts.K8sDqliteStateDir, "cluster.key")
+
+	keypair, err := tls.LoadX509KeyPair(crt, key)
+	if err != nil {
+		return fmt.Errorf("could not load k8s-dqlite certificates, error: %w", err)
+	}
+
+	data, err := os.ReadFile(crt)
+	if err != nil {
+		return fmt.Errorf("could not read k8s-dqlite certificate, error: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(data) {
+		return fmt.Errorf("invalid k8s-dqlite certificate")
+	}
+
+	dial := client.DialFuncWithTLS(client.DefaultDialFunc, app.SimpleDialTLSConfig(keypair, pool))
+
+	// We'll dial all members concurrently, passing the reachable addresses
+	// through a channel.
+	availableMembers := []string{}
+	c := make(chan string)
+	for _, member := range members {
+		log.V(1).Info("Checking k8s-dqlite member", "member", member)
+
+		if member.Address == "" {
+			return fmt.Errorf("k8s-dqlite member check failed, missing member address.")
+		}
+
+		go func(ctx context.Context, dialFunc client.DialFunc, addr string) {
+			// We expect the member nodes to be unavailable, let's not wait
+			// more than 3 seconds during this sanity test.
+			ctx_timeout, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+
+			log.V(1).Info("testing k8s-dqlite member connectivity", "addr", addr)
+			conn, err := dialFunc(ctx_timeout, addr)
+			if err == nil {
+				log.V(1).Info("k8s-dqlite member reachable", "addr", addr)
+				conn.Close()
+				// The cluster member is reachable, pass back the address.
+				c <- addr
+			} else {
+				log.V(1).Info("k8s-dqlite member unreachable",
+					"addr", addr, "error", err)
+				c <- ""
+			}
+		}(ctx, dial, member.Address)
+	}
+
+	for _, _ = range members {
+		addr, ok := <-c
+		if !ok {
+			return fmt.Errorf("channel closed unexpectedly")
+		}
+		if addr != "" {
+			availableMembers = append(availableMembers, addr)
+		}
+	}
+
+	if len(availableMembers) != 0 {
+		return fmt.Errorf("Some k8s-dqlite services are still running, "+
+			"please stop them and try again: %v. "+
+			"Run `sudo snap stop k8s` to stop all k8s services on a given node.",
+			availableMembers)
+	}
+
+	return nil
+}
+
+// yamlEditorGuide is a convenience wrapper around shared.TextEditor
+// that passes the current file contents prepended by the guide contents,
+// which are meant to assist the user. Returns the user-edited file contents.
+// If applyChanges is set, the changes made by the user are applied to the file.
+func yamlEditorGuide(
+	path string,
+	readFile bool,
+	guideContent []byte,
+	applyChanges bool,
+) ([]byte, error) {
+	currContent := []byte{}
+	var err error
+	if readFile {
+		currContent, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("could not read file: %s, error: %w", path, err)
+		}
+		currContent = removeEmptyLines(currContent)
+	}
+
+	textEditorContent := slices.Concat(
+		[]byte(guideContent),
+		[]byte("\n"),
+		currContent)
+	newContent, err := shared.TextEditor("", textEditorContent)
+	if err != nil {
+		return nil, fmt.Errorf("text editor failed, error: %w", err)
+	}
+
+	newContent = removeYamlHelperComments(newContent)
+	newContent = removeEmptyLines(newContent)
+
+	if applyChanges {
+		err = os.WriteFile(path, newContent, os.FileMode(0o644))
+		if err != nil {
+			return nil, fmt.Errorf("could not write file: %s, error: %w", path, err)
+		}
+	}
+
+	return newContent, err
+}
+
+func createK8sDqliteRecoveryTarball(pathSuffix string) (string, error) {
+	timestamp := time.Now().Format("2006-01-02T150405Z0700")
+	fname := fmt.Sprintf("recovery-k8s-dqlite-%s-%s.tar.gz", timestamp, pathSuffix)
+	tarballPath := path.Join("/var/snap/k8s/common", fname)
+
+	// info.yaml is used by go-dqlite to keep track of the current cluster member's
+	// ID and address. We shouldn't replicate the recovery member's info.yaml
+	// to all other members, so exclude it from the tarball:
+	err := utils.CreateTarball(
+		tarballPath, clusterRecoverOpts.K8sDqliteStateDir, ".",
+		[]string{"info.yaml", "k8s-dqlite.sock", "cluster.key", "cluster.crt"})
+
+	return tarballPath, err
+}
+
+// On success, returns the recovery tarball path.
+func recoverK8sd() (string, error) {
+	m, err := microcluster.App(
+		microcluster.Args{
+			StateDir: rootCmdOpts.stateDir,
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("could not initialize microcluster app, error: %w", err)
+	}
+
+	// The following method parses cluster.yaml and filters out the entries
+	// that are not included in the trust store. Note that in case of k8s-dqlite,
+	// there is no trust store.
+	members, err := m.GetDqliteClusterMembers()
+	if err != nil {
+		return "", fmt.Errorf("could not retrieve K8sd cluster members, error: %w", err)
+	}
+
+	oldMembersYaml, err := yaml.Marshal(members)
+	if err != nil {
+		return "", fmt.Errorf("could not serialize cluster members, error: %w", err)
+	}
+
+	clusterYamlPath := path.Join(m.FileSystem.DatabaseDir, "cluster.yaml")
+	clusterYamlCommentHeader := fmt.Sprintf("# K8sd cluster configuration\n# (based on the trust store and %s)\n", clusterYamlPath)
+
+	clusterYamlContent, err := yamlEditorGuide(
+		"",
+		false,
+		slices.Concat(
+			[]byte(clusterYamlCommentHeader),
+			[]byte("#\n"),
+			[]byte(clusterK8sdYamlRecoveryComment),
+			[]byte(yamlHelperCommentFooter),
+			[]byte("\n"),
+			oldMembersYaml,
+		),
+		false,
+	)
+	if err != nil {
+		return "", fmt.Errorf("interactive text editor failed, error: %w", err)
+	}
+
+	infoYamlPath := path.Join(m.FileSystem.DatabaseDir, "info.yaml")
+	infoYamlCommentHeader := fmt.Sprintf("# K8sd info.yaml\n# (%s)\n", infoYamlPath)
+	_, err = yamlEditorGuide(
+		infoYamlPath,
+		true,
+		slices.Concat(
+			[]byte(infoYamlCommentHeader),
+			[]byte("#\n"),
+			[]byte(infoYamlRecoveryComment),
+			utils.YamlCommentLines(clusterYamlContent),
+			[]byte("\n"),
+			[]byte(yamlHelperCommentFooter),
+		),
+		true,
+	)
+	if err != nil {
+		return "", fmt.Errorf("interactive text editor failed, error: %w", err)
+	}
+
+	daemonYamlPath := path.Join(m.FileSystem.StateDir, "daemon.yaml")
+	daemonYamlCommentHeader := fmt.Sprintf("# K8sd daemon.yaml\n# (%s)\n", daemonYamlPath)
+	_, err = yamlEditorGuide(
+		daemonYamlPath,
+		true,
+		slices.Concat(
+			[]byte(daemonYamlCommentHeader),
+			[]byte("#\n"),
+			[]byte(daemonYamlRecoveryComment),
+			utils.YamlCommentLines(clusterYamlContent),
+			[]byte("\n"),
+			[]byte(yamlHelperCommentFooter),
+		),
+		true,
+	)
+	if err != nil {
+		return "", fmt.Errorf("interactive text editor failed, error: %w", err)
+	}
+
+	newMembers := []cluster.DqliteMember{}
+	if err = yaml.Unmarshal(clusterYamlContent, &newMembers); err != nil {
+		return "", fmt.Errorf("couldn't parse cluster.yaml, error: %w", err)
+	}
+
+	// As of 2.0.2, the following microcluster method will:
+	// * validate the member changes
+	//     * ensure that no members were added or removed
+	//     * the member IDs hasn't changed
+	//     * there is at least one voter
+	//     * the addresses can be parsed
+	//     * there are no duplicate addresses
+	// * ensure that all cluster members are stopped
+	// * create a database backup
+	// * reconfigure Raft
+	// * address changes based on the new cluster.yaml:
+	//     * refresh the local info.yaml and daemon.yaml
+	//     * update the trust store addresses
+	//     * prepare an sql script that updates the member addresses from the
+	//       "core_cluster_members" table, executed when k8sd starts.
+	// * rewrite cluster.yaml
+	// * create a recovery tarball of the k8sd database dir and store it
+	//   in the state dir.
+	tarballPath, err := m.RecoverFromQuorumLoss(newMembers)
+	if err != nil {
+		return "", fmt.Errorf("k8sd recovery failed, error: %w", err)
+	}
+
+	return tarballPath, nil
+}
+
+func recoverK8sDqlite() (string, string, error) {
+	k8sDqliteStateDir := clusterRecoverOpts.K8sDqliteStateDir
+
+	clusterYamlPath := path.Join(k8sDqliteStateDir, "cluster.yaml")
+	clusterYamlCommentHeader := fmt.Sprintf("# k8s-dqlite cluster configuration\n# (%s)\n", clusterYamlPath)
+	clusterYamlContent, err := yamlEditorGuide(
+		clusterYamlPath,
+		true,
+		slices.Concat(
+			[]byte(clusterYamlCommentHeader),
+			[]byte("#\n"),
+			[]byte(clusterK8sDqliteRecoveryComment),
+			[]byte(yamlHelperCommentFooter),
+		),
+		true,
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("interactive text editor failed, error: %w", err)
+	}
+
+	infoYamlPath := path.Join(k8sDqliteStateDir, "info.yaml")
+	infoYamlCommentHeader := fmt.Sprintf("# k8s-dqlite info.yaml\n# (%s)\n", infoYamlPath)
+	_, err = yamlEditorGuide(
+		infoYamlPath,
+		true,
+		slices.Concat(
+			[]byte(infoYamlCommentHeader),
+			[]byte("#\n"),
+			[]byte(infoYamlRecoveryComment),
+			utils.YamlCommentLines(clusterYamlContent),
+			[]byte("\n"),
+			[]byte(yamlHelperCommentFooter),
+		),
+		true,
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("interactive text editor failed, error: %w", err)
+	}
+
+	newMembers := []dqlite.NodeInfo{}
+	if err = yaml.Unmarshal(clusterYamlContent, &newMembers); err != nil {
+		return "", "", fmt.Errorf("couldn't parse cluster.yaml, error: %w", err)
+	}
+
+	// microcluster creates two backup tarballs, one before the recovery was attempted
+	// and another one after. We'll do the same.
+	preRecoveryTarball, err := createK8sDqliteRecoveryTarball("pre-recovery")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create pre-recovery backup tarball, error: %w", err)
+	}
+
+	if err = dqlite.ReconfigureMembershipExt(k8sDqliteStateDir, newMembers); err != nil {
+		return preRecoveryTarball, "", fmt.Errorf("k8s-dqlite recovery failed, error: %w", err)
+	}
+
+	postRecoveryTarball, err := createK8sDqliteRecoveryTarball("post-recovery")
+	if err != nil {
+		return preRecoveryTarball, "", fmt.Errorf("failed to create post-recovery backup tarball, error: %w", err)
+	}
+
+	// TODO: steps performed by the microcluster lib for k8sd that could also
+	// apply to k8s-dqlite:
+	//   * validate cluster.yaml changes
+	return preRecoveryTarball, postRecoveryTarball, nil
+}

--- a/src/k8s/hack/static-go-build.sh
+++ b/src/k8s/hack/static-go-build.sh
@@ -5,6 +5,7 @@ DIR="$(realpath `dirname "${0}"`)"
 . "${DIR}/static-dqlite.sh"
 
 go build \
+  -gcflags=all="-N -l" \
   -tags dqlite,libsqlite3 \
-  -ldflags '-s -w -linkmode "external" -extldflags "-static"' \
+  -ldflags '--linkmode "external" -extldflags "-static"' \
   "${@}"

--- a/src/k8s/pkg/utils/yaml.go
+++ b/src/k8s/pkg/utils/yaml.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"regexp"
+)
+
+// YamlCommentLines adds "# " at the beginning of each line.
+func YamlCommentLines(content []byte) []byte {
+	re := regexp.MustCompile("(?m)^")
+	out := re.ReplaceAll(content, []byte("# "))
+	return out
+}


### PR DESCRIPTION
We're adding a command that can be used to recover Canonical K8s clusters after dqlite quorum loss.

The command will:

* assist the user in making the necessary k8s-dqlite and k8sd configuration changes
* create pre-recovery and post-recovery backups that can be applied to other nodes
* issue a dqlite reconfigure request, updating the raft members
* attempt to contact the other dqlite members in order to ensure that all cluster members are offline before attempting to perform the recovery steps

Based on the microcloud command, which leverages the microcluster implementation:

* https://github.com/canonical/microcloud/blob/main/cmd/microcloud/cluster_members.go
* https://github.com/canonical/microcluster/blob/42551841a56dd2d4697d577428bdb4d7d5f877d0/internal/recover/recover.go#L72

For reference, here are the microk8s and microcluster docs on cluster recovery:

* https://microk8s.io/docs/restore-quorum#backup-the-database
* https://discourse.ubuntu.com/t/microcluster-microcloud-quorum-recovery/45560