### PR TITLE
Add worker token TTL

### DIFF
--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -2,6 +2,8 @@ module github.com/canonical/k8s
 
 go 1.22.6
 
+replace github.com/canonical/k8s-snap-api => /home/benjamin/work/k8s-snap-api
+
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite v1.22.0

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -2,8 +2,6 @@ module github.com/canonical/k8s
 
 go 1.22.6
 
-replace github.com/canonical/k8s-snap-api => /home/benjamin/work/k8s-snap-api
-
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite v1.22.0

--- a/src/k8s/pkg/k8sd/api/cluster_tokens.go
+++ b/src/k8s/pkg/k8sd/api/cluster_tokens.go
@@ -29,7 +29,7 @@ func (e *Endpoints) postClusterJoinTokens(s state.State, r *http.Request) respon
 
 	var token string
 	if req.Worker {
-		token, err = getOrCreateWorkerToken(r.Context(), s, hostname)
+		token, err = getOrCreateWorkerToken(r.Context(), s, hostname, req.TTL)
 	} else {
 		token, err = getOrCreateJoinToken(r.Context(), e.provider.MicroCluster(), hostname, req.TTL)
 	}
@@ -65,11 +65,11 @@ func getOrCreateJoinToken(ctx context.Context, m *microcluster.MicroCluster, tok
 	return token, nil
 }
 
-func getOrCreateWorkerToken(ctx context.Context, s state.State, nodeName string) (string, error) {
+func getOrCreateWorkerToken(ctx context.Context, s state.State, nodeName string, ttl time.Duration) (string, error) {
 	var token string
 	if err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
-		token, err = database.GetOrCreateWorkerNodeToken(ctx, tx, nodeName)
+		token, err = database.GetOrCreateWorkerNodeToken(ctx, tx, nodeName, time.Now().Add(ttl))
 		if err != nil {
 			return fmt.Errorf("failed to create worker node token: %w", err)
 		}

--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -12,10 +12,16 @@ import (
 )
 
 var (
+	// SchemaExtensions defines the schema updates for the database.
+	// SchemaExtensions are apply only.
+	// Note(ben): Never change the order or remove a migration as this would break the internal microcluster counter!
 	SchemaExtensions = []schema.Update{
 		schemaApplyMigration("kubernetes-auth-tokens", "000-create.sql"),
 		schemaApplyMigration("cluster-configs", "000-create.sql"),
+
 		schemaApplyMigration("worker-tokens", "000-create.sql"),
+		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
+
 		schemaApplyMigration("feature-status", "000-feature-status.sql"),
 	}
 

--- a/src/k8s/pkg/k8sd/database/sql/migrations/worker-tokens/001-add-expiry.sql
+++ b/src/k8s/pkg/k8sd/database/sql/migrations/worker-tokens/001-add-expiry.sql
@@ -1,7 +1,2 @@
 ALTER TABLE worker_tokens
-ADD COLUMN expiry DATETIME;
-
--- set default value for existing values.
-UPDATE worker_tokens
-SET expiry = '2100-01-01 23:59:59'
-WHERE expiry IS NULL;
+ADD COLUMN expiry DATETIME DEFAULT '2100-01-01 23:59:59';

--- a/src/k8s/pkg/k8sd/database/sql/migrations/worker-tokens/001-add-expiry.sql
+++ b/src/k8s/pkg/k8sd/database/sql/migrations/worker-tokens/001-add-expiry.sql
@@ -1,0 +1,7 @@
+ALTER TABLE worker_tokens
+ADD COLUMN expiry DATETIME;
+
+-- set default value for existing values.
+UPDATE worker_tokens
+SET expiry = '2100-01-01 23:59:59'
+WHERE expiry IS NULL;

--- a/src/k8s/pkg/k8sd/database/sql/queries/worker-tokens/insert.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/worker-tokens/insert.sql
@@ -1,4 +1,4 @@
 INSERT INTO
-    worker_tokens(name, token)
+    worker_tokens(name, token, expiry)
 VALUES
-    ( ?, ? )
+    ( ?, ?, ? )

--- a/src/k8s/pkg/k8sd/database/sql/queries/worker-tokens/select.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/worker-tokens/select.sql
@@ -1,5 +1,5 @@
 SELECT
-    t.name
+    t.name, t.expiry
 FROM
     worker_tokens AS t
 WHERE

--- a/src/k8s/pkg/k8sd/database/worker.go
+++ b/src/k8s/pkg/k8sd/database/worker.go
@@ -31,7 +31,9 @@ func CheckWorkerNodeToken(ctx context.Context, tx *sql.Tx, nodeName string, toke
 	var tokenNodeName string
 	var expiry time.Time
 	if selectTxStmt.QueryRowContext(ctx, token).Scan(&tokenNodeName, &expiry) == nil {
-		return (tokenNodeName == "" || subtle.ConstantTimeCompare([]byte(nodeName), []byte(tokenNodeName)) == 1) && time.Now().Before(expiry), nil
+		isValidToken := subtle.ConstantTimeCompare([]byte(nodeName), []byte(tokenNodeName)) == 1
+		notExpired := time.Now().Before(expiry)
+		return isValidToken && notExpired, nil
 	}
 	return false, nil
 }

--- a/src/k8s/pkg/k8sd/database/worker.go
+++ b/src/k8s/pkg/k8sd/database/worker.go
@@ -31,8 +31,9 @@ func CheckWorkerNodeToken(ctx context.Context, tx *sql.Tx, nodeName string, toke
 	var tokenNodeName string
 	var expiry time.Time
 	if selectTxStmt.QueryRowContext(ctx, token).Scan(&tokenNodeName, &expiry) == nil {
-		isValidToken := subtle.ConstantTimeCompare([]byte(nodeName), []byte(tokenNodeName)) == 1
+		isValidToken := tokenNodeName == "" || subtle.ConstantTimeCompare([]byte(nodeName), []byte(tokenNodeName)) == 1
 		notExpired := time.Now().Before(expiry)
+		fmt.Printf("isValidToken: %v, notExpired: %v\n", isValidToken, notExpired)
 		return isValidToken && notExpired, nil
 	}
 	return false, nil

--- a/src/k8s/pkg/k8sd/database/worker.go
+++ b/src/k8s/pkg/k8sd/database/worker.go
@@ -33,7 +33,6 @@ func CheckWorkerNodeToken(ctx context.Context, tx *sql.Tx, nodeName string, toke
 	if selectTxStmt.QueryRowContext(ctx, token).Scan(&tokenNodeName, &expiry) == nil {
 		isValidToken := tokenNodeName == "" || subtle.ConstantTimeCompare([]byte(nodeName), []byte(tokenNodeName)) == 1
 		notExpired := time.Now().Before(expiry)
-		fmt.Printf("isValidToken: %v, notExpired: %v\n", isValidToken, notExpired)
 		return isValidToken && notExpired, nil
 	}
 	return false, nil

--- a/src/k8s/pkg/k8sd/database/worker_test.go
+++ b/src/k8s/pkg/k8sd/database/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	. "github.com/onsi/gomega"
@@ -12,17 +13,18 @@ import (
 func TestWorkerNodeToken(t *testing.T) {
 	WithDB(t, func(ctx context.Context, db DB) {
 		_ = db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			tokenExpiry := time.Now().Add(time.Hour)
 			t.Run("Default", func(t *testing.T) {
 				g := NewWithT(t)
 				exists, err := database.CheckWorkerNodeToken(ctx, tx, "somenode", "sometoken")
 				g.Expect(err).To(BeNil())
 				g.Expect(exists).To(BeFalse())
 
-				token, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "somenode")
+				token, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "somenode", tokenExpiry)
 				g.Expect(err).To(BeNil())
 				g.Expect(token).To(HaveLen(48))
 
-				othertoken, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "someothernode")
+				othertoken, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "someothernode", tokenExpiry)
 				g.Expect(err).To(BeNil())
 				g.Expect(othertoken).To(HaveLen(48))
 				g.Expect(othertoken).NotTo(Equal(token))
@@ -46,15 +48,39 @@ func TestWorkerNodeToken(t *testing.T) {
 				g.Expect(err).To(BeNil())
 				g.Expect(valid).To(BeFalse())
 
-				newToken, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "somenode")
+				newToken, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "somenode", tokenExpiry)
 				g.Expect(err).To(BeNil())
 				g.Expect(newToken).To(HaveLen(48))
 				g.Expect(newToken).ToNot(Equal(token))
 			})
 
+			t.Run("Expiry", func(t *testing.T) {
+				t.Run("Valid", func(t *testing.T) {
+					g := NewWithT(t)
+					token, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "nodeExpiry1", time.Now().Add(time.Hour))
+					g.Expect(err).To(BeNil())
+					g.Expect(token).To(HaveLen(48))
+
+					valid, err := database.CheckWorkerNodeToken(ctx, tx, "nodeExpiry1", token)
+					g.Expect(err).To(BeNil())
+					g.Expect(valid).To(BeTrue())
+				})
+
+				t.Run("Expired", func(t *testing.T) {
+					g := NewWithT(t)
+					token, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "nodeExpiry2", time.Now().Add(-time.Hour))
+					g.Expect(err).To(BeNil())
+					g.Expect(token).To(HaveLen(48))
+
+					valid, err := database.CheckWorkerNodeToken(ctx, tx, "nodeExpiry2", token)
+					g.Expect(err).To(BeNil())
+					g.Expect(valid).To(BeFalse())
+				})
+			})
+
 			t.Run("AnyNodeName", func(t *testing.T) {
 				g := NewWithT(t)
-				token, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "")
+				token, err := database.GetOrCreateWorkerNodeToken(ctx, tx, "", tokenExpiry)
 				g.Expect(err).To(BeNil())
 				g.Expect(token).To(HaveLen(48))
 


### PR DESCRIPTION
Add an optional TTL for worker tokens similar to https://github.com/canonical/k8s-snap/pull/620

This PR requires the (backward-compatible) update in the k8s-snap-api.
https://github.com/canonical/k8s-snap-api/pull/5
Once this PR is reviewed and approved, I will merge the API change, create a new tag (1.0.3) and update this k8s-snap PR to use the new API version.