### PR TITLE
Add `refresh-certs` Command

### DIFF
--- a/docs/src/_parts/commands/k8s.md
+++ b/docs/src/_parts/commands/k8s.md
@@ -18,6 +18,7 @@ Canonical Kubernetes CLI
 * [k8s get-join-token](k8s_get-join-token.md)	 - Create a token for a node to join the cluster
 * [k8s join-cluster](k8s_join-cluster.md)	 - Join a cluster using the provided token
 * [k8s kubectl](k8s_kubectl.md)	 - Integrated Kubernetes kubectl client
+* [k8s refresh-certs](k8s_refresh-certs.md)	 - Refresh the certificates of the running node
 * [k8s remove-node](k8s_remove-node.md)	 - Remove a node from the cluster
 * [k8s set](k8s_set.md)	 - Set cluster configuration
 * [k8s status](k8s_status.md)	 - Retrieve the current status of the cluster

--- a/docs/src/_parts/commands/k8s_refresh-certs.md
+++ b/docs/src/_parts/commands/k8s_refresh-certs.md
@@ -9,10 +9,10 @@ k8s refresh-certs [flags]
 ### Options
 
 ```
+      --expires-in string        the time until the certificates expire
       --extra-sans stringArray   extra SANs to add to the certificates.
   -h, --help                     help for refresh-certs
       --timeout duration         the max time to wait for the command to execute (default 1m30s)
-      --ttl string               the time-to-live for the certificates.
 ```
 
 ### SEE ALSO

--- a/docs/src/_parts/commands/k8s_refresh-certs.md
+++ b/docs/src/_parts/commands/k8s_refresh-certs.md
@@ -9,7 +9,7 @@ k8s refresh-certs [flags]
 ### Options
 
 ```
-      --expires-in string        the time until the certificates expire
+      --expires-in string        the time until the certificates expire, e.g., 1h, 2d, 4mo, 5y. Aditionally, any valid time unit for ParseDuration is accepted.
       --extra-sans stringArray   extra SANs to add to the certificates.
   -h, --help                     help for refresh-certs
       --timeout duration         the max time to wait for the command to execute (default 1m30s)

--- a/docs/src/_parts/commands/k8s_refresh-certs.md
+++ b/docs/src/_parts/commands/k8s_refresh-certs.md
@@ -1,0 +1,21 @@
+## k8s refresh-certs
+
+Refresh the certificates of the running node
+
+```
+k8s refresh-certs [flags]
+```
+
+### Options
+
+```
+      --extra-sans stringArray   extra SANs to add to the certificates.
+  -h, --help                     help for refresh-certs
+      --timeout duration         the max time to wait for the command to execute (default 1m30s)
+      --ttl string               the time-to-live for the certificates.
+```
+
+### SEE ALSO
+
+* [k8s](k8s.md)	 - Canonical Kubernetes CLI
+

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -87,6 +87,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		&cobra.Group{ID: "management", Title: "Management Commands:"},
 		newEnableCmd(env),
 		newDisableCmd(env),
+		newRefreshCertsCmd(env),
 		newSetCmd(env),
 		newGetCmd(env),
 	)

--- a/src/k8s/cmd/k8s/k8s_refresh_certs.go
+++ b/src/k8s/cmd/k8s/k8s_refresh_certs.go
@@ -1,0 +1,77 @@
+package k8s
+
+import (
+	"context"
+	"time"
+
+	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	cmdutil "github.com/canonical/k8s/cmd/util"
+	"github.com/canonical/k8s/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func newRefreshCertsCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+	var opts struct {
+		extraSANs []string
+		ttl       string
+		timeout   time.Duration
+	}
+	cmd := &cobra.Command{
+		Use:    "refresh-certs",
+		Short:  "Refresh the certificates of the running node",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Run: func(cmd *cobra.Command, args []string) {
+			ttl, err := utils.TTLToSeconds(opts.ttl)
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to parse TTL. \n\nThe error was: %v\n", err)
+			}
+
+			client, err := env.Snap.K8sdClient("")
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+
+			plan, err := client.RefreshCertificatesPlan(ctx, apiv1.RefreshCertificatesPlanRequest{})
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to get the certificates refresh plan.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			if len(plan.CertificateSigningRequests) > 0 {
+				cmd.Println("The following CertificateSigningRequests should be approved. Run the following commands on any of the control plane nodes of the cluster:")
+				for _, csr := range plan.CertificateSigningRequests {
+					cmd.Printf("k8s kubectl certificate approve %s\n", csr)
+				}
+			}
+
+			runRequest := apiv1.RefreshCertificatesRunRequest{
+				Seed:              plan.Seed,
+				ExpirationSeconds: ttl,
+				ExtraSANs:         opts.extraSANs,
+			}
+
+			cmd.Println("Waiting for certificates to be created...")
+			runResponse, err := client.RefreshCertificatesRun(ctx, runRequest)
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to refresh the certificates.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			// TODO: Should we print the expiration time in a human-readable format? Should we return the UNIX epoch in the response?
+			cmd.Printf("Certificates have been successfully refreshed, and will expire at %d.\n", runResponse.ExpirationSeconds)
+		},
+	}
+	cmd.Flags().StringVar(&opts.ttl, "ttl", "", "the time-to-live for the certificates.")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
+	cmd.Flags().StringArrayVar(&opts.extraSANs, "extra-sans", []string{}, "extra SANs to add to the certificates.")
+
+	cmd.MarkFlagRequired("ttl")
+	return cmd
+}

--- a/src/k8s/cmd/k8s/k8s_refresh_certs.go
+++ b/src/k8s/cmd/k8s/k8s_refresh_certs.go
@@ -68,7 +68,7 @@ func newRefreshCertsCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			cmd.Printf("Certificates have been successfully refreshed, and will expire at %v.\n", expiryTimeUNIX)
 		},
 	}
-	cmd.Flags().StringVar(&opts.expiresIn, "expires-in", "", "the time until the certificates expire")
+	cmd.Flags().StringVar(&opts.expiresIn, "expires-in", "", "the time until the certificates expire, e.g., 1h, 2d, 4mo, 5y. Aditionally, any valid time unit for ParseDuration is accepted.")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 	cmd.Flags().StringArrayVar(&opts.extraSANs, "extra-sans", []string{}, "extra SANs to add to the certificates.")
 

--- a/src/k8s/pkg/client/k8sd/interface.go
+++ b/src/k8s/pkg/client/k8sd/interface.go
@@ -35,8 +35,8 @@ type ConfigClient interface {
 	SetClusterConfig(context.Context, apiv1.SetClusterConfigRequest) error
 }
 
-// ManagementClient implements methods to manage the cluster.
-type ManagementClient interface {
+// MaintenanceClient implements methods to manage the cluster.
+type MaintenanceClient interface {
 	// RefreshCertificatesPlan generates a plan to refresh the Kubernetes certificates of the node.
 	RefreshCertificatesPlan(context.Context, apiv1.RefreshCertificatesPlanRequest) (apiv1.RefreshCertificatesPlanResponse, error)
 	// RefreshCertificatesRun refreshes the Kubernetes certificates of the node.
@@ -59,7 +59,7 @@ type Client interface {
 	ClusterClient
 	StatusClient
 	ConfigClient
-	ManagementClient
+	MaintenanceClient
 	UserClient
 	ClusterAPIClient
 }

--- a/src/k8s/pkg/client/k8sd/interface.go
+++ b/src/k8s/pkg/client/k8sd/interface.go
@@ -35,8 +35,8 @@ type ConfigClient interface {
 	SetClusterConfig(context.Context, apiv1.SetClusterConfigRequest) error
 }
 
-// MaintenanceClient implements methods to manage the cluster.
-type MaintenanceClient interface {
+// ClusterMaintenanceClient implements methods to manage the cluster.
+type ClusterMaintenanceClient interface {
 	// RefreshCertificatesPlan generates a plan to refresh the Kubernetes certificates of the node.
 	RefreshCertificatesPlan(context.Context, apiv1.RefreshCertificatesPlanRequest) (apiv1.RefreshCertificatesPlanResponse, error)
 	// RefreshCertificatesRun refreshes the Kubernetes certificates of the node.
@@ -59,7 +59,7 @@ type Client interface {
 	ClusterClient
 	StatusClient
 	ConfigClient
-	MaintenanceClient
+	ClusterMaintenanceClient
 	UserClient
 	ClusterAPIClient
 }

--- a/src/k8s/pkg/client/k8sd/interface.go
+++ b/src/k8s/pkg/client/k8sd/interface.go
@@ -35,6 +35,14 @@ type ConfigClient interface {
 	SetClusterConfig(context.Context, apiv1.SetClusterConfigRequest) error
 }
 
+// ManagementClient implements methods to manage the cluster.
+type ManagementClient interface {
+	// RefreshCertificatesPlan generates a plan to refresh the Kubernetes certificates of the node.
+	RefreshCertificatesPlan(context.Context, apiv1.RefreshCertificatesPlanRequest) (apiv1.RefreshCertificatesPlanResponse, error)
+	// RefreshCertificatesRun refreshes the Kubernetes certificates of the node.
+	RefreshCertificatesRun(context.Context, apiv1.RefreshCertificatesRunRequest) (apiv1.RefreshCertificatesRunResponse, error)
+}
+
 // UserClient implements methods to enable accessing the cluster.
 type UserClient interface {
 	// KubeConfig retrieves a kubeconfig file that can be used to access the cluster.
@@ -51,6 +59,7 @@ type Client interface {
 	ClusterClient
 	StatusClient
 	ConfigClient
+	ManagementClient
 	UserClient
 	ClusterAPIClient
 }

--- a/src/k8s/pkg/client/k8sd/manage.go
+++ b/src/k8s/pkg/client/k8sd/manage.go
@@ -1,0 +1,15 @@
+package k8sd
+
+import (
+	"context"
+
+	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+)
+
+func (c *k8sd) RefreshCertificatesPlan(ctx context.Context, request apiv1.RefreshCertificatesPlanRequest) (apiv1.RefreshCertificatesPlanResponse, error) {
+	return query(ctx, c, "POST", apiv1.RefreshCertificatesPlanRPC, request, &apiv1.RefreshCertificatesPlanResponse{})
+}
+
+func (c *k8sd) RefreshCertificatesRun(ctx context.Context, request apiv1.RefreshCertificatesRunRequest) (apiv1.RefreshCertificatesRunResponse, error) {
+	return query(ctx, c, "POST", apiv1.RefreshCertificatesRunRPC, request, &apiv1.RefreshCertificatesRunResponse{})
+}

--- a/src/k8s/pkg/client/k8sd/mock/mock.go
+++ b/src/k8s/pkg/client/k8sd/mock/mock.go
@@ -34,7 +34,7 @@ type Mock struct {
 	SetClusterConfigCalledWith apiv1.SetClusterConfigRequest
 	SetClusterConfigErr        error
 
-	// k8sd.MaintenanceClient
+	// k8sd.ClusterMaintenanceClient
 	RefreshCertificatesPlanCalledWith apiv1.RefreshCertificatesPlanRequest
 	RefreshCertificatesPlanResponse   apiv1.RefreshCertificatesPlanResponse
 	RefreshCertificatesPlanErr        error

--- a/src/k8s/pkg/client/k8sd/mock/mock.go
+++ b/src/k8s/pkg/client/k8sd/mock/mock.go
@@ -34,7 +34,7 @@ type Mock struct {
 	SetClusterConfigCalledWith apiv1.SetClusterConfigRequest
 	SetClusterConfigErr        error
 
-	// k8sd.ManagementClient
+	// k8sd.MaintenanceClient
 	RefreshCertificatesPlanCalledWith apiv1.RefreshCertificatesPlanRequest
 	RefreshCertificatesPlanResponse   apiv1.RefreshCertificatesPlanResponse
 	RefreshCertificatesPlanErr        error

--- a/src/k8s/pkg/client/k8sd/mock/mock.go
+++ b/src/k8s/pkg/client/k8sd/mock/mock.go
@@ -34,6 +34,14 @@ type Mock struct {
 	SetClusterConfigCalledWith apiv1.SetClusterConfigRequest
 	SetClusterConfigErr        error
 
+	// k8sd.ManagementClient
+	RefreshCertificatesPlanCalledWith apiv1.RefreshCertificatesPlanRequest
+	RefreshCertificatesPlanResponse   apiv1.RefreshCertificatesPlanResponse
+	RefreshCertificatesPlanErr        error
+	RefreshCertificatesRunCalledWith  apiv1.RefreshCertificatesRunRequest
+	RefreshCertificatesRunResponse    apiv1.RefreshCertificatesRunResponse
+	RefreshCertificatesRunErr         error
+
 	// k8sd.UserClient
 	KubeConfigCalledWith apiv1.KubeConfigRequest
 	KubeConfigResponse   apiv1.KubeConfigResponse
@@ -66,6 +74,14 @@ func (m *Mock) NodeStatus(_ context.Context) (apiv1.NodeStatusResponse, bool, er
 }
 func (m *Mock) ClusterStatus(_ context.Context, waitReady bool) (apiv1.ClusterStatusResponse, error) {
 	return m.ClusterStatusResponse, m.ClusterStatusErr
+}
+
+func (m *Mock) RefreshCertificatesPlan(_ context.Context, request apiv1.RefreshCertificatesPlanRequest) (apiv1.RefreshCertificatesPlanResponse, error) {
+	return m.RefreshCertificatesPlanResponse, m.RefreshCertificatesPlanErr
+}
+
+func (m *Mock) RefreshCertificatesRun(_ context.Context, request apiv1.RefreshCertificatesRunRequest) (apiv1.RefreshCertificatesRunResponse, error) {
+	return m.RefreshCertificatesRunResponse, m.RefreshCertificatesRunErr
 }
 
 func (m *Mock) GetClusterConfig(_ context.Context) (apiv1.GetClusterConfigResponse, error) {

--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -132,10 +132,10 @@ func refreshCertsRunControlPlane(s state.State, r *http.Request, snap snap.Snap)
 		return response.InternalError(fmt.Errorf("failed to read kubelet certificate: %w", err))
 	}
 
-	expirationDuration := kubeletCert.NotAfter.Sub(kubeletCert.NotBefore)
+	expirationTimeUNIX := kubeletCert.NotAfter.Unix()
 
 	return response.SyncResponse(true, apiv1.RefreshCertificatesRunResponse{
-		ExpirationSeconds: int(expirationDuration.Seconds()),
+		ExpirationSeconds: int(expirationTimeUNIX),
 	})
 }
 
@@ -283,9 +283,9 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 		return response.InternalError(fmt.Errorf("failed to load kubelet certificate: %w", err))
 	}
 
-	expirationDuration := cert.NotAfter.Sub(cert.NotBefore)
+	expirationTimeUNIX := cert.NotAfter.Unix()
 	return response.SyncResponse(true, apiv1.RefreshCertificatesRunResponse{
-		ExpirationSeconds: int(expirationDuration.Seconds()),
+		ExpirationSeconds: int(expirationTimeUNIX),
 	})
 
 }


### PR DESCRIPTION
## Overview
Add a `refresh-certs` command to refresh certificates for both control plane and worker nodes.
## Rationale
In Proposal 002, we outlined the process for refreshing certificates via the `k8s` command line interface. This allows the snap to refresh certificates for both control plane and worker nodes in the cluster.
## Testing
```
root@t-1:~# k8s refresh-certs --ttl 10mo --extra-sans=10.0.10.10 foo.local
Certificates have been successfully refreshed, and will expire at 26265600.
root@t-1:~# openssl x509 -in /etc/kubernetes/pki/kubelet.crt -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            12:c4:76:9f:58:42:e7:a2:e1:2f:b3:fb:6e:85:48:01
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = kubernetes-ca
        Validity
            Not Before: Aug 23 20:40:39 2024 GMT
            Not After : Jun 23 20:40:39 2025 GMT
        Subject: O = system:nodes, CN = system:node:t-1
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                Public-Key: (2048 bit)
                Modulus:
                    00:e5:ec:c8:51:b7:9c:32:26:05:75:00:b5:39:b0:
                    cc:43:3c:8e:73:60:21:c2:b9:65:2d:c1:c0:f7:24:
                    da:e0:30:2d:8a:76:fd:c8:ad:8b:ed:d3:0a:3b:e6:
                    82:84:99:74:32:8f:e7:5a:da:aa:e6:ba:31:9c:62:
                    11:ef:dd:da:bf:12:27:2f:87:bd:59:26:e1:d2:4f:
                    54:3a:2c:15:a1:e5:07:5a:f0:ad:71:ab:2b:c5:59:
                    8a:6e:f9:44:48:b1:b1:ec:6f:7c:66:20:62:b3:a3:
                    89:75:f1:7a:e4:92:1c:d1:6f:d2:c4:98:41:03:7c:
                    74:90:6f:b6:ed:db:43:46:11:6b:40:66:f3:86:50:
                    fe:64:24:89:0b:51:c0:8b:85:a9:4b:94:60:f7:3d:
                    18:37:78:4f:a9:0f:44:fa:17:58:ad:ca:f7:91:b1:
                    e2:c1:e1:fc:aa:4d:cb:68:a9:b1:ca:28:a7:5d:bc:
                    a4:5a:c3:6d:ab:08:9d:63:9d:3b:f5:a5:a4:12:18:
                    61:49:8b:17:f1:56:16:ef:69:8f:ba:12:98:a5:f0:
                    d4:58:af:3c:68:cd:9b:b1:42:62:ef:b4:89:a9:a7:
                    0e:3d:78:49:47:01:77:cb:14:6e:4d:45:ef:0e:7b:
                    2f:4d:34:a3:4b:39:b5:52:80:cc:a6:57:b5:66:d4:
                    e1:bb
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment, Data Encipherment
            X509v3 Extended Key Usage:
                TLS Web Client Authentication, TLS Web Server Authentication
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Authority Key Identifier:
                7E:77:CB:E4:93:9D:78:3B:06:18:29:30:B8:75:36:B3:E6:C4:5B:64
            X509v3 Subject Alternative Name:
                DNS:t-1, IP Address:10.45.248.29, IP Address:10.152.183.1, IP Address:10.0.10.10, IP Address:127.0.0.1, IP Address:10.1.0.61, IP Address:10.45.248.29, IP Address:0:0:0:0:0:0:0:1, IP Address:FE80:0:0:0:9432:79FF:FE7A:1099, IP Address:FE80:0:0:0:8822:FFFF:FECC:20F4, IP Address:FE80:0:0:0:40D1:A8FF:FE1B:26A4, IP Address:FE80:0:0:0:C425:69FF:FE90:42C8, IP Address:FE80:0:0:0:202B:9EFF:FED5:4830, IP Address:FE80:0:0:0:408D:8DFF:FE39:4EA1, IP Address:FE80:0:0:0:286C:EFFF:FED4:6DC8, IP Address:FE80:0:0:0:64A7:47FF:FE00:3483, IP Address:FE80:0:0:0:216:3EFF:FED5:9F98, IP Address:FE80:0:0:0:216:3EFF:FED1:779C
    Signature Algorithm: sha256WithRSAEncryption
    Signature Value:
        33:25:7a:92:07:af:f7:ef:dc:bd:a5:80:1d:a9:5e:bd:0f:93:
        0e:24:f6:d7:5a:f1:52:69:c9:8e:c7:72:e4:52:74:c8:be:b4:
        1e:b5:d1:d0:70:fb:56:14:c3:37:d7:f9:f4:be:f2:fd:99:4d:
        7b:da:4a:fa:ca:a0:ce:4f:fe:7b:94:eb:54:81:92:14:7a:ec:
        06:45:5b:35:09:94:82:ba:c8:d5:7b:6c:58:61:3b:6d:96:97:
        2d:5d:04:9f:16:45:e9:85:14:5f:90:16:93:67:33:4b:fa:76:
        95:06:a2:3f:77:90:4a:25:9a:37:c8:3a:1b:0e:f9:84:0f:1a:
        3e:42:0d:99:78:82:c4:be:e4:a3:57:1d:0e:f7:ea:00:14:7c:
        67:f3:13:7c:f7:98:72:7f:ef:2c:2f:ae:4c:f7:c7:d0:32:a5:
        47:77:86:c6:b9:d9:50:54:76:78:f4:dd:4d:d1:b6:72:5a:f3:
        3b:87:3a:3f:39:17:ba:1e:0c:0c:5f:69:f0:99:6e:d0:ab:9f:
        49:0d:38:f6:9a:d3:0e:f4:63:52:87:33:3d:54:80:3c:d8:ed:
        dd:20:95:8c:ff:08:f5:24:84:9e:9a:2d:0e:35:28:1d:70:a2:
        7b:e3:01:57:73:76:da:31:b7:c7:00:b7:dd:b4:05:d6:c8:c8:
        ff:3a:0e:7a
```
## Discussion
The `RefreshCertificatesRunResponse` contains the certificate validity period in seconds. However, parsing this from the CLI might show the user an inaccurate expiration date. Therefore, it may be better to return the UNIX timestamp, which would allow the actual date to be encoded in that field.