### PR TITLE
Multiarch image support for local storage and metrics-server

### DIFF
--- a/build-scripts/hack/sync-images.yaml
+++ b/build-scripts/hack/sync-images.yaml
@@ -26,6 +26,6 @@ sync:
   - source: ghcr.io/canonical/metrics-server:0.7.0-ck1
     target: '{{ env "MIRROR" }}/canonical/metrics-server:0.7.0-ck1'
     type: image
-  - source: ghcr.io/canonical/rawfile-localpv:0.8.0-ck5
-    target: '{{ env "MIRROR" }}/canonical/rawfile-localpv:0.8.0-ck5'
+  - source: ghcr.io/canonical/rawfile-localpv:0.8.0-ck4
+    target: '{{ env "MIRROR" }}/canonical/rawfile-localpv:0.8.0-ck4'
     type: image

--- a/build-scripts/hack/sync-images.yaml
+++ b/build-scripts/hack/sync-images.yaml
@@ -23,8 +23,8 @@ sync:
   - source: ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1
     target: '{{ env "MIRROR" }}/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1'
     type: image
-  - source: ghcr.io/canonical/metrics-server:0.7.0-ck0
-    target: '{{ env "MIRROR" }}/canonical/metrics-server:0.7.0-ck0'
+  - source: ghcr.io/canonical/metrics-server:0.7.0-ck1
+    target: '{{ env "MIRROR" }}/canonical/metrics-server:0.7.0-ck1'
     type: image
   - source: ghcr.io/canonical/rawfile-localpv:0.8.0-ck5
     target: '{{ env "MIRROR" }}/canonical/rawfile-localpv:0.8.0-ck5'

--- a/docs/src/snap/howto/install/offline.md
+++ b/docs/src/snap/howto/install/offline.md
@@ -120,7 +120,7 @@ ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner:v5.0.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer:v1.11.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1
-ghcr.io/canonical/metrics-server:0.7.0-ck0
+ghcr.io/canonical/metrics-server:0.7.0-ck1
 ghcr.io/canonical/rawfile-localpv:0.8.0-ck5
 ```
 

--- a/docs/src/snap/howto/install/offline.md
+++ b/docs/src/snap/howto/install/offline.md
@@ -121,7 +121,7 @@ ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner:v5.0.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer:v1.11.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1
 ghcr.io/canonical/metrics-server:0.7.0-ck1
-ghcr.io/canonical/rawfile-localpv:0.8.0-ck5
+ghcr.io/canonical/rawfile-localpv:0.8.0-ck4
 ```
 
 A list of images can also be found in the `images.txt` file when unsquashing the

--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// imageTag is the image tag to use for Rawfile LocalPV CSI.
-	imageTag = "0.8.0-ck5"
+	imageTag = "0.8.0-ck4"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"

--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/metrics-server"
 
 	// imageTag is the image tag to use for metrics-server.
-	imageTag = "0.7.0-ck0"
+	imageTag = "0.7.0-ck1"
 )


### PR DESCRIPTION
### Overview

* bumps metrics-server from 0.7.0-ck0  -> 0.7.0-ck1
* bumps rawfile-localpv from 0.8.0-ck5  -> 0.8.0-ck4

### Details
Though it looks odd, i did confirm the rawfile-localpv had its "ck*" revision drop to a smaller number, it is in fact the correct image.  We need to look at the workflow to understand how it managed to generate a lower number than the previous ck5 release.  
