### PR TITLE
Add extra SANs to microcluster certificate

### DIFF
--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -21,6 +21,10 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Args:   cmdutil.MaximumNArgs(env, 1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if !opts.worker && len(args) == 0 {
+				cmd.PrintErrln("Error: A node name is required for control-plane nodes.")
+			}
+
 			var name string
 			if len(args) == 1 {
 				name = args[0]

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -175,12 +175,16 @@ func New(cfg Config) (*App, error) {
 func (a *App) Run(ctx context.Context, customHooks *state.Hooks) error {
 	// TODO: consider improving API for overriding hooks.
 	hooks := &state.Hooks{
+		PreInit:       a.onPreInit,
 		PostBootstrap: a.onBootstrap,
 		PostJoin:      a.onPostJoin,
 		PreRemove:     a.onPreRemove,
 		OnStart:       a.onStart,
 	}
 	if customHooks != nil {
+		if customHooks.PreInit != nil {
+			hooks.PreInit = customHooks.PreInit
+		}
 		if customHooks.PostBootstrap != nil {
 			hooks.PostBootstrap = customHooks.PostBootstrap
 		}

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -22,46 +21,8 @@ import (
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
-	"github.com/canonical/lxd/shared"
-	microclusterTypes "github.com/canonical/microcluster/v3/rest/types"
 	"github.com/canonical/microcluster/v3/state"
 )
-
-// onPreInit is called before we bootstrap or join a node.
-func (a *App) onPreInit(ctx context.Context, s state.State, bootstrap bool, initConfig map[string]string) error {
-	err := os.Remove(filepath.Join(s.FileSystem().StateDir, "server.crt"))
-	if err != nil {
-		return fmt.Errorf("failed to remove server.crt: %w", err)
-	}
-
-	err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.key"))
-	if err != nil {
-		return fmt.Errorf("failed to remove server.key: %w", err)
-	}
-
-	cert, err := shared.KeyPairAndCA(
-		s.FileSystem().StateDir,
-		string(microclusterTypes.ServerCertificateName),
-		shared.CertServer,
-		shared.CertOptions{
-			AddHosts:                true,
-			CommonName:              s.Name(),
-			SubjectAlternativeNames: []string{initConfig["cluster_name"]},
-		})
-	if err != nil {
-		return err
-	}
-
-	err = a.client.UpdateCertificate(ctx, microclusterTypes.ServerCertificateName, microclusterTypes.KeyPair{
-		Cert: string(cert.PublicKey()),
-		Key:  string(cert.PrivateKey()),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to update certificate %s: %w", microclusterTypes.ServerCertificateName, err)
-	}
-
-	return nil
-}
 
 // onBootstrap is called after we bootstrap the first cluster node.
 // onBootstrap configures local services then writes the cluster config on the database.

--- a/src/k8s/pkg/k8sd/app/hooks_preinit.go
+++ b/src/k8s/pkg/k8sd/app/hooks_preinit.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/lxd/shared"
+	microclusterTypes "github.com/canonical/microcluster/v3/rest/types"
+	"github.com/canonical/microcluster/v3/state"
+)
+
+// onPreInit is called before we bootstrap or join a node.
+func (a *App) onPreInit(ctx context.Context, s state.State, bootstrap bool, initConfig map[string]string) error {
+	var extraSANs []string
+	if bootstrap {
+		bootstrapConfig, err := utils.MicroclusterBootstrapConfigFromMap(initConfig)
+		if err != nil {
+			return fmt.Errorf("failed to get bootstrap config: %w", err)
+		}
+		extraSANs = bootstrapConfig.ExtraSANs
+	} else {
+		controlPlaneJoinConfig, err := utils.MicroclusterControlPlaneJoinConfigFromMap(initConfig)
+		if err != nil {
+			return fmt.Errorf("failed to get control plane join config: %w", err)
+		}
+		extraSANs = controlPlaneJoinConfig.ExtraSANS
+	}
+
+	err := os.Remove(filepath.Join(s.FileSystem().StateDir, "server.crt"))
+	if err != nil {
+		return fmt.Errorf("failed to remove server.crt: %w", err)
+	}
+
+	err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.key"))
+	if err != nil {
+		return fmt.Errorf("failed to remove server.key: %w", err)
+	}
+
+	cert, err := shared.KeyPairAndCA(
+		s.FileSystem().StateDir,
+		string(microclusterTypes.ServerCertificateName),
+		shared.CertServer,
+		shared.CertOptions{
+			AddHosts:                true,
+			CommonName:              s.Name(),
+			SubjectAlternativeNames: append(extraSANs, s.Name()),
+		})
+	if err != nil {
+		return err
+	}
+
+	err = a.client.UpdateCertificate(ctx, microclusterTypes.ServerCertificateName, microclusterTypes.KeyPair{
+		Cert: string(cert.PublicKey()),
+		Key:  string(cert.PrivateKey()),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update certificate %s: %w", microclusterTypes.ServerCertificateName, err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/app/hooks_preinit.go
+++ b/src/k8s/pkg/k8sd/app/hooks_preinit.go
@@ -24,11 +24,11 @@ func (a *App) onPreInit(ctx context.Context, s state.State, bootstrap bool, init
 	}
 	extraSANs := controlPlaneJoinConfig.ExtraSANS
 
-	if err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.crt")); err != nil {
+	if err := os.Remove(filepath.Join(s.FileSystem().StateDir, "server.crt")); err != nil {
 		return fmt.Errorf("failed to remove server.crt: %w", err)
 	}
 
-	if err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.key")); err != nil {
+	if err := os.Remove(filepath.Join(s.FileSystem().StateDir, "server.key")); err != nil {
 		return fmt.Errorf("failed to remove server.key: %w", err)
 	}
 
@@ -45,7 +45,7 @@ func (a *App) onPreInit(ctx context.Context, s state.State, bootstrap bool, init
 		return err
 	}
 
-	if err = a.client.UpdateCertificate(ctx, microclusterTypes.ServerCertificateName, microclusterTypes.KeyPair{
+	if err := a.client.UpdateCertificate(ctx, microclusterTypes.ServerCertificateName, microclusterTypes.KeyPair{
 		Cert: string(cert.PublicKey()),
 		Key:  string(cert.PrivateKey()),
 	}); err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_preinit.go
+++ b/src/k8s/pkg/k8sd/app/hooks_preinit.go
@@ -24,13 +24,11 @@ func (a *App) onPreInit(ctx context.Context, s state.State, bootstrap bool, init
 	}
 	extraSANs := controlPlaneJoinConfig.ExtraSANS
 
-	err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.crt"))
-	if err != nil {
+	if err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.crt")); err != nil {
 		return fmt.Errorf("failed to remove server.crt: %w", err)
 	}
 
-	err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.key"))
-	if err != nil {
+	if err = os.Remove(filepath.Join(s.FileSystem().StateDir, "server.key")); err != nil {
 		return fmt.Errorf("failed to remove server.key: %w", err)
 	}
 
@@ -47,11 +45,10 @@ func (a *App) onPreInit(ctx context.Context, s state.State, bootstrap bool, init
 		return err
 	}
 
-	err = a.client.UpdateCertificate(ctx, microclusterTypes.ServerCertificateName, microclusterTypes.KeyPair{
+	if err = a.client.UpdateCertificate(ctx, microclusterTypes.ServerCertificateName, microclusterTypes.KeyPair{
 		Cert: string(cert.PublicKey()),
 		Key:  string(cert.PrivateKey()),
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("failed to update certificate %s: %w", microclusterTypes.ServerCertificateName, err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -66,9 +66,11 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 				log.Error(err, "Failed to create Kubernetes client", err)
 			}
 
-			log.Info("Deleting node from Kubernetes cluster")
-			if err := c.DeleteNode(ctx, s.Name()); err != nil {
-				log.Error(err, "Failed to remove Kubernetes node")
+			if c != nil {
+				log.Info("Deleting node from Kubernetes cluster")
+				if err := c.DeleteNode(ctx, s.Name()); err != nil {
+					log.Error(err, "Failed to remove Kubernetes node")
+				}
 			}
 		}
 

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -118,7 +118,9 @@ extra-sans:
         text=True,
     )
 
-    util.wait_until_k8s_ready(cluster_node, instances, node_names={joining_cp.id: "my-node"})
+    util.wait_until_k8s_ready(
+        cluster_node, instances, node_names={joining_cp.id: "my-node"}
+    )
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 2, "nodes should have joined cluster"
 

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -88,9 +88,40 @@ def test_no_remove(instances: List[harness.Instance]):
     assert "control-plane" in util.get_local_node_status(joining_cp)
     assert "worker" in util.get_local_node_status(joining_worker)
 
-    nodes = util.ready_nodes(cluster_node)
-
     cluster_node.exec(["k8s", "remove-node", joining_cp.id])
+    nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 3, "cp node should not have been removed from cluster"
     cluster_node.exec(["k8s", "remove-node", joining_worker.id])
+    nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 3, "worker node should not have been removed from cluster"
+
+
+@pytest.mark.node_count(2)
+def test_join_with_non_hostname_name(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_cp = instances[1]
+
+    out = cluster_node.exec(
+        ["k8s", "get-join-token", "my-token"],
+        capture_output=True,
+        text=True,
+    )
+    join_token = out.stdout.strip()
+
+    join_config = """
+extra-sans:
+- my-token
+"""
+    joining_cp.exec(
+        ["k8s", "join-cluster", join_token, "--name", "my-node", "--file", "-"],
+        input=join_config,
+        text=True,
+    )
+
+    util.wait_until_k8s_ready(cluster_node, instances, node_names={joining_cp.id: "my-node"})
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 2, "nodes should have joined cluster"
+
+    cluster_node.exec(["k8s", "remove-node", "my-node"])
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 1, "cp node should be removed from the cluster"

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -7,7 +7,7 @@ import shlex
 import subprocess
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union, Mapping
 
 from tenacity import (
     RetryCallState,
@@ -141,17 +141,26 @@ def wait_until_k8s_ready(
     instances: List[harness.Instance],
     retries: int = 30,
     delay_s: int = 5,
+    node_names: Mapping[str, str] = {},
 ):
     """
     Validates that the K8s node is in Ready state.
+
+    By default, the hostname of the instances is used as the node name.
+    If the instance name is different from the hostname, the instance name should be passed to the
+    node_names dictionary, e.g. {"instance_id": "node_name"}.
     """
     for instance in instances:
-        host = hostname(instance)
+        if instance.id in node_names:
+            node_name = node_names[instance.id]
+        else:
+            node_name = hostname(instance)
+
         result = (
             stubbornly(retries=retries, delay_s=delay_s)
             .on(control_node)
             .until(lambda p: " Ready" in p.stdout.decode())
-            .exec(["k8s", "kubectl", "get", "node", host, "--no-headers"])
+            .exec(["k8s", "kubectl", "get", "node", node_name, "--no-headers"])
         )
     LOG.info("Kubelet registered successfully!")
     LOG.info("%s", result.stdout.decode())

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -7,7 +7,7 @@ import shlex
 import subprocess
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Union, Mapping
+from typing import Any, Callable, List, Mapping, Optional, Union
 
 from tenacity import (
     RetryCallState,


### PR DESCRIPTION
Microcluster validates that the certificate SANs do match with the name that was created when creating the join token. 
This breaks the CAPI workflow as in that, the noden/hostname is unknown at the time the token is created. 

We can work around this issue by providing extraSANs to the microcluster certificate on init which is done in this PR.

See https://docs.google.com/document/d/1ZcEDgLwy_BroyJr_oqTOyqBsK0mvBt7EB6UCrCxC1mg/edit#heading=h.kavgppauvkj5 for more context.