### PR TITLE
Certificate reference page

### DIFF
--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -2,18 +2,11 @@
 
 #### 1. **Root CAs**
 
-| **Common Name (CN)**         | **Usage**                            | **Path on Disk**                     | **Used For**                              |
+| **Common Name**         | **Usage**                            | **Path on Disk**                     | **Used For**                              |
 |------------------------------|--------------------------------------|--------------------------------------|-------------------------------------------|
 | `kubernetes-ca`               | General Kubernetes CA               | `/etc/kubernetes/pki/ca.crt`         | Signing all Kubernetes-related certificates |
-| `etcd-ca`                     | CA for etcd                         | `/etc/kubernetes/pki/etcd/ca.crt`    | Signing certificates for etcd communication |
 | `kubernetes-front-proxy-ca`   | CA for front-end proxy              | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy |
-
-#### 2. **Service Account Keys**
-
-| **Key File**         | **Usage**                   | **Path on Disk**                   | **Used For**                            |
-|----------------------|-----------------------------|------------------------------------|-----------------------------------------|
-| `sa.key`             | Service Account Private Key | `/etc/kubernetes/pki/sa.key`       | Signing service account tokens         |
-| `sa.pub`             | Service Account Public Key  | `/etc/kubernetes/pki/sa.pub`       | Verifying service account tokens       |
+| `client-ca`                   | CA for client certificates          | `/etc/kubernetes/pki/client-ca.crt` | Signing certificates for the client |
 
 #### 3. **Certificates Used by the API Server**
 
@@ -40,15 +33,3 @@
 | `controller-manager.conf`          | Controller Manager Client Config       | `/etc/kubernetes/controller-manager.conf`  | Communication with the API server            |
 | `scheduler.conf`                   | Scheduler Client Config                | `/etc/kubernetes/scheduler.conf`           | Communication with the API server            |
 | `kubelet.conf`                     | Kubelet Client Config                  | `/etc/kubernetes/kubelet.conf`             | Node registration and communication with API server |
-
-#### 6. **Paths for Key and Certificate Pairs**
-
-| **Component**                 | **Key Path**                                   | **Certificate Path**                           | **Used By**                  |
-|-------------------------------|-----------------------------------------------|------------------------------------------------|------------------------------|
-| `etcd-ca`                     | `/etc/kubernetes/pki/etcd/ca.key`             | `/etc/kubernetes/pki/etcd/ca.crt`              | etcd                         |
-| `kube-apiserver-etcd-client`  | `/etc/kubernetes/pki/apiserver-etcd-client.key` | `/etc/kubernetes/pki/apiserver-etcd-client.crt` | kube-apiserver               |
-| `kubernetes-ca`               | `/etc/kubernetes/pki/ca.key`                  | `/etc/kubernetes/pki/ca.crt`                   | kube-apiserver, kube-controller-manager |
-| `kube-apiserver`              | `/etc/kubernetes/pki/apiserver.key`           | `/etc/kubernetes/pki/apiserver.crt`            | kube-apiserver               |
-| `kube-apiserver-kubelet-client` | `/etc/kubernetes/pki/apiserver-kubelet-client.key` | `/etc/kubernetes/pki/apiserver-kubelet-client.crt` | kube-apiserver               |
-| `front-proxy-ca`              | `/etc/kubernetes/pki/front-proxy-ca.key`      | `/etc/kubernetes/pki/front-proxy-ca.crt`       | kube-apiserver, kube-controller-manager |
-| `front-proxy-client`          | `/etc/kubernetes/pki/front-proxy-client.key`  | `/etc/kubernetes/pki/front-proxy-client.crt`   | kube-apiserver               |

--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -1,5 +1,6 @@
 # Cluster Certificates
-
+This reference page provides an overview of certificate authorities (CAs), certificates and 
+configuration directories in use by a {{ product }} cluster. 
 ## **CertificateAuthorities (CA)**
 
 | **Common Name**              | **Usage**                            | **Path on Disk**                         | **Used For**                                |

--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -39,6 +39,9 @@ their issuance.
 
 ## Configuration Files for Kubernetes Components
 
+The following tables provide an overview of the configuration files used to
+communicate with the cluster services.
+
 ### Control-plane node
 
 Control-plane nodes use the following configuration files.

--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -1,0 +1,54 @@
+### Kubernetes Cluster Certificates Reference Page
+
+#### 1. **Root CAs**
+
+| **Common Name (CN)**         | **Usage**                            | **Path on Disk**                     | **Used For**                              |
+|------------------------------|--------------------------------------|--------------------------------------|-------------------------------------------|
+| `kubernetes-ca`               | General Kubernetes CA               | `/etc/kubernetes/pki/ca.crt`         | Signing all Kubernetes-related certificates |
+| `etcd-ca`                     | CA for etcd                         | `/etc/kubernetes/pki/etcd/ca.crt`    | Signing certificates for etcd communication |
+| `kubernetes-front-proxy-ca`   | CA for front-end proxy              | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy |
+
+#### 2. **Service Account Keys**
+
+| **Key File**         | **Usage**                   | **Path on Disk**                   | **Used For**                            |
+|----------------------|-----------------------------|------------------------------------|-----------------------------------------|
+| `sa.key`             | Service Account Private Key | `/etc/kubernetes/pki/sa.key`       | Signing service account tokens         |
+| `sa.pub`             | Service Account Public Key  | `/etc/kubernetes/pki/sa.pub`       | Verifying service account tokens       |
+
+#### 3. **Certificates Used by the API Server**
+
+| **Common Name (CN)**            | **Usage**                     | **Path on Disk**                       | **Used For**                              |
+|---------------------------------|-------------------------------|----------------------------------------|-------------------------------------------|
+| `kube-apiserver`                | Server                        | `/etc/kubernetes/pki/apiserver.crt`    | Securing the API server endpoint          |
+| `kube-apiserver-kubelet-client` | Client                        | `/etc/kubernetes/pki/apiserver-kubelet-client.crt` | API server communication with kubelets    |
+| `kube-apiserver-etcd-client`    | Client                        | `/etc/kubernetes/pki/apiserver-etcd-client.crt` | API server communication with etcd        |
+| `front-proxy-client`            | Client                        | `/etc/kubernetes/pki/front-proxy-client.crt` | API server communication with the front-proxy |
+
+#### 4. **Certificates Used by etcd**
+
+| **Common Name (CN)**        | **Usage**              | **Path on Disk**                         | **Used For**                               |
+|-----------------------------|------------------------|------------------------------------------|--------------------------------------------|
+| `kube-etcd`                 | Server, Client         | `/etc/kubernetes/pki/etcd/server.crt`    | Securing communication with etcd           |
+| `kube-etcd-peer`            | Server, Client         | `/etc/kubernetes/pki/etcd/peer.crt`      | Securing communication between etcd peers  |
+| `kube-etcd-healthcheck-client` | Client               | `/etc/kubernetes/pki/etcd/healthcheck-client.crt` | Health checks on etcd |
+
+#### 5. **Certificates for Kubernetes Components**
+
+| **Config File**                    | **Usage**                              | **Path on Disk**                           | **Used For**                                 |
+|------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|
+| `admin.conf`                       | Administrator Client Config            | `/etc/kubernetes/admin.conf`               | Admin access to the cluster                  |
+| `controller-manager.conf`          | Controller Manager Client Config       | `/etc/kubernetes/controller-manager.conf`  | Communication with the API server            |
+| `scheduler.conf`                   | Scheduler Client Config                | `/etc/kubernetes/scheduler.conf`           | Communication with the API server            |
+| `kubelet.conf`                     | Kubelet Client Config                  | `/etc/kubernetes/kubelet.conf`             | Node registration and communication with API server |
+
+#### 6. **Paths for Key and Certificate Pairs**
+
+| **Component**                 | **Key Path**                                   | **Certificate Path**                           | **Used By**                  |
+|-------------------------------|-----------------------------------------------|------------------------------------------------|------------------------------|
+| `etcd-ca`                     | `/etc/kubernetes/pki/etcd/ca.key`             | `/etc/kubernetes/pki/etcd/ca.crt`              | etcd                         |
+| `kube-apiserver-etcd-client`  | `/etc/kubernetes/pki/apiserver-etcd-client.key` | `/etc/kubernetes/pki/apiserver-etcd-client.crt` | kube-apiserver               |
+| `kubernetes-ca`               | `/etc/kubernetes/pki/ca.key`                  | `/etc/kubernetes/pki/ca.crt`                   | kube-apiserver, kube-controller-manager |
+| `kube-apiserver`              | `/etc/kubernetes/pki/apiserver.key`           | `/etc/kubernetes/pki/apiserver.crt`            | kube-apiserver               |
+| `kube-apiserver-kubelet-client` | `/etc/kubernetes/pki/apiserver-kubelet-client.key` | `/etc/kubernetes/pki/apiserver-kubelet-client.crt` | kube-apiserver               |
+| `front-proxy-ca`              | `/etc/kubernetes/pki/front-proxy-ca.key`      | `/etc/kubernetes/pki/front-proxy-ca.crt`       | kube-apiserver, kube-controller-manager |
+| `front-proxy-client`          | `/etc/kubernetes/pki/front-proxy-client.key`  | `/etc/kubernetes/pki/front-proxy-client.crt`   | kube-apiserver               |

--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -1,18 +1,29 @@
-# Cluster Certificates
-This reference page provides an overview of certificate authorities (CAs), certificates and 
-configuration directories in use by a {{ product }} cluster. 
-## **CertificateAuthorities (CA)**
+# Cluster Certificates and Configuration Directories
 
-| **Common Name**              | **Usage**                            | **Path on Disk**                         | **Used For**                                |
-|------------------------------|--------------------------------------|------------------------------------------|---------------------------------------------|
+This reference page provides an overview of certificate authorities (CAs),
+certificates and configuration directories in use by a {{ product }} cluster.
+
+## Certificate Authorities (CAs)
+
+This table outlines the common certificate authorities (CAs) used in a
+Kubernetes environment, detailing their specific purposes, usage,
+and locations on the disk.
+
+| **Common Name**                            | **Purpose** | **File Location**  | **Primary Function**          |
+|--------------------------------------------|-----------|----------------------|-------------------------------|
 | `kubernetes-ca`               | General Kubernetes CA               | `/etc/kubernetes/pki/ca.crt`             | Signing all Kubernetes-related certificates |
 | `kubernetes-front-proxy-ca`   | CA for front-end proxy              | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy    |
 | `client-ca`                   | CA for client certificates          | `/etc/kubernetes/pki/client-ca.crt`      | Signing certificates for the client         |
 
 
-## **Certificates**
+## Certificates
 
-| **Common Name**                            | **Usage** | **Path on Disk**                                     | **Used For**                                                     | **Signed By**               |
+This table provides an overview of the certificates currently in use,
+including their roles, storage paths, and the entities responsible for
+their issuance.
+
+
+| **Common Name**                            | **Purpose** | **File Location**  | **Primary Function**            | **Signed By**               |
 |--------------------------------------------|-----------|------------------------------------------------------|------------------------------------------------------------------|-----------------------------|
 | `kube-apiserver`                           | Server    | `/etc/kubernetes/pki/apiserver.crt`                  | Securing the API server endpoint                                 | `kubernetes-ca`             |
 | `apiserver-kubelet-client`            | Client    | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`   | API server communication with kubelets                           | `kubernetes-ca-client`      |
@@ -26,11 +37,13 @@ configuration directories in use by a {{ product }} cluster.
 | `root@$hostname`                          | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8sd nodes | `self-signed`      |
 
 
-## **Configurations for Kubernetes Components**
+## Configuration Files for Kubernetes Components
 
 ### Control-plane node
 
-| **Config File**                    | **Usage**                              | **Path on Disk**                           | **Used For**                                 |
+Control-plane nodes use the following configuration files.
+
+| **Configuration File**             | **Purpose**                            | **File Location**                          | **Primary Function**                                 |
 |------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|
 | `admin.conf`                       | Administrator Client Config            | `/etc/kubernetes/admin.conf`               | Admin access to the cluster                  |
 | `controller-manager.conf`          | Controller Manager Client Config       | `/etc/kubernetes/controller-manager.conf`  | Communication with the API server            |
@@ -40,7 +53,9 @@ configuration directories in use by a {{ product }} cluster.
 
 ### Worker node
 
-| **Config File**                    | **Usage**                              | **Path on Disk**                           | **Used For**                                 |
+Worker nodes use the following configuration files.
+
+| **Configuration File**             | **Purpose**                            | **File Location**                          | **Primary Function**                                 |
 |------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|
 | `proxy.conf`                       | Proxy Client Config                    | `/etc/kubernetes/proxy.conf`               | Communication with the API server            |
 | `kubelet.conf`                     | Kubelet Client Config                  | `/etc/kubernetes/kubelet.conf`             | Node registration and communication with API server |

--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -17,9 +17,9 @@
 | `kube-apiserver-kubelet-client`            | Client    | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`   | API server communication with kubelets                           | `kubernetes-ca-client`      |
 | `kube-apiserver-etcd-client`               | Client    | `/etc/kubernetes/pki/apiserver-etcd-client.crt`      | API server communication with etcd                               | `kubernetes-ca-client`      |
 | `front-proxy-client`                       | Client    | `/etc/kubernetes/pki/front-proxy-client.crt`         | API server communication with the front-proxy                    | `kubernetes-front-proxy-ca` |
-| `kube-controller-manager`                  | Client    | `/etc/kubernetes/pki/controller-manager.crt`         | Communication between the controller manager and the API server  | `kubernetes-ca-client`      |
-| `kube-scheduler`                           | Client    | `/etc/kubernetes/pki/scheduler.crt`                  | Communication between the scheduler and the API server           | `kubernetes-ca-client`      |
-| `kube-proxy`                               | Client    | `/etc/kubernetes/pki/proxy.crt`                      | Communication between kube-proxy and the API server              | `kubernetes-ca-client`      |
+| `system:kube-controller-manager`                  | Client    | `/etc/kubernetes/pki/controller-manager.crt`         | Communication between the controller manager and the API server  | `kubernetes-ca-client`      |
+| `system:kube-scheduler`                           | Client    | `/etc/kubernetes/pki/scheduler.crt`                  | Communication between the scheduler and the API server           | `kubernetes-ca-client`      |
+| `system:kube-proxy`                               | Client    | `/etc/kubernetes/pki/proxy.crt`                      | Communication between kube-proxy and the API server              | `kubernetes-ca-client`      |
 | `system:node:$hostname`                    | Client    | `/etc/kubernetes/pki/kubelet-client.crt`             | Authentication of kubelets to the API server                     | `kubernetes-ca-client`      |
 | `k8s-dqlite`                               | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`| Communication between k8s-dqlite nodes and API server            | `self-signed`               |
 | `root@$hostname`                          | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8sd nodes | `self-signed`      |

--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -1,6 +1,6 @@
-### Kubernetes Cluster Certificates Reference Page
+### Cluster Certificates
 
-#### 1. **Root CAs**
+#### 1. **CertificateAuthorities (CA)**
 
 | **Common Name**         | **Usage**                            | **Path on Disk**                     | **Used For**                              |
 |------------------------------|--------------------------------------|--------------------------------------|-------------------------------------------|
@@ -8,24 +8,24 @@
 | `kubernetes-front-proxy-ca`   | CA for front-end proxy              | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy |
 | `client-ca`                   | CA for client certificates          | `/etc/kubernetes/pki/client-ca.crt` | Signing certificates for the client |
 
-#### 3. **Certificates Used by the API Server**
 
-| **Common Name (CN)**            | **Usage**                     | **Path on Disk**                       | **Used For**                              |
-|---------------------------------|-------------------------------|----------------------------------------|-------------------------------------------|
-| `kube-apiserver`                | Server                        | `/etc/kubernetes/pki/apiserver.crt`    | Securing the API server endpoint          |
-| `kube-apiserver-kubelet-client` | Client                        | `/etc/kubernetes/pki/apiserver-kubelet-client.crt` | API server communication with kubelets    |
-| `kube-apiserver-etcd-client`    | Client                        | `/etc/kubernetes/pki/apiserver-etcd-client.crt` | API server communication with etcd        |
-| `front-proxy-client`            | Client                        | `/etc/kubernetes/pki/front-proxy-client.crt` | API server communication with the front-proxy |
+#### 2. **Certificates**
 
-#### 4. **Certificates Used by etcd**
+| **Common Name**                       | **Usage** | **Path on Disk**                                     | **Used For**                                                     | **Signed By**               |
+|--------------------------------------------|-----------|------------------------------------------------------|------------------------------------------------------------------|-----------------------------|
+| `kube-apiserver`                           | Server    | `/etc/kubernetes/pki/apiserver.crt`                  | Securing the API server endpoint                                 | `kubernetes-ca`             |
+| `kube-apiserver-kubelet-client`            | Client    | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`   | API server communication with kubelets                           | `kubernetes-ca-client`      |
+| `kube-apiserver-etcd-client`               | Client    | `/etc/kubernetes/pki/apiserver-etcd-client.crt`      | API server communication with etcd                               | `kubernetes-ca-client`      |
+| `front-proxy-client`                       | Client    | `/etc/kubernetes/pki/front-proxy-client.crt`         | API server communication with the front-proxy                    | `kubernetes-front-proxy-ca` |
+| `kube-controller-manager`                  | Client    | `/etc/kubernetes/pki/controller-manager.crt`         | Communication between the controller manager and the API server  | `kubernetes-ca-client`      |
+| `kube-scheduler`                           | Client    | `/etc/kubernetes/pki/scheduler.crt`                  | Communication between the scheduler and the API server           | `kubernetes-ca-client`      |
+| `kube-proxy`                               | Client    | `/etc/kubernetes/pki/proxy.crt`                      | Communication between kube-proxy and the API server              | `kubernetes-ca-client`      |
+| `system:node:$hostname`                    | Client    | `/etc/kubernetes/pki/kubelet-client.crt`             | Authentication of kubelets to the API server                     | `kubernetes-ca-client`      |
+| `k8s-dqlite`             | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8s-dqlite nodes and API server | `self-signed`      |
+| `root@$hostname`             | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8sd nodes | `self-signed`      |
 
-| **Common Name (CN)**        | **Usage**              | **Path on Disk**                         | **Used For**                               |
-|-----------------------------|------------------------|------------------------------------------|--------------------------------------------|
-| `kube-etcd`                 | Server, Client         | `/etc/kubernetes/pki/etcd/server.crt`    | Securing communication with etcd           |
-| `kube-etcd-peer`            | Server, Client         | `/etc/kubernetes/pki/etcd/peer.crt`      | Securing communication between etcd peers  |
-| `kube-etcd-healthcheck-client` | Client               | `/etc/kubernetes/pki/etcd/healthcheck-client.crt` | Health checks on etcd |
 
-#### 5. **Certificates for Kubernetes Components**
+#### 5. **Configurations for Kubernetes Components**
 
 | **Config File**                    | **Usage**                              | **Path on Disk**                           | **Used For**                                 |
 |------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|

--- a/docs/src/snap/reference/certificates.md
+++ b/docs/src/snap/reference/certificates.md
@@ -1,17 +1,17 @@
-### Cluster Certificates
+# Cluster Certificates
 
-#### 1. **CertificateAuthorities (CA)**
+## **CertificateAuthorities (CA)**
 
-| **Common Name**         | **Usage**                            | **Path on Disk**                     | **Used For**                              |
-|------------------------------|--------------------------------------|--------------------------------------|-------------------------------------------|
-| `kubernetes-ca`               | General Kubernetes CA               | `/etc/kubernetes/pki/ca.crt`         | Signing all Kubernetes-related certificates |
-| `kubernetes-front-proxy-ca`   | CA for front-end proxy              | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy |
-| `client-ca`                   | CA for client certificates          | `/etc/kubernetes/pki/client-ca.crt` | Signing certificates for the client |
+| **Common Name**              | **Usage**                            | **Path on Disk**                         | **Used For**                                |
+|------------------------------|--------------------------------------|------------------------------------------|---------------------------------------------|
+| `kubernetes-ca`               | General Kubernetes CA               | `/etc/kubernetes/pki/ca.crt`             | Signing all Kubernetes-related certificates |
+| `kubernetes-front-proxy-ca`   | CA for front-end proxy              | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy    |
+| `client-ca`                   | CA for client certificates          | `/etc/kubernetes/pki/client-ca.crt`      | Signing certificates for the client         |
 
 
-#### 2. **Certificates**
+## **Certificates**
 
-| **Common Name**                       | **Usage** | **Path on Disk**                                     | **Used For**                                                     | **Signed By**               |
+| **Common Name**                            | **Usage** | **Path on Disk**                                     | **Used For**                                                     | **Signed By**               |
 |--------------------------------------------|-----------|------------------------------------------------------|------------------------------------------------------------------|-----------------------------|
 | `kube-apiserver`                           | Server    | `/etc/kubernetes/pki/apiserver.crt`                  | Securing the API server endpoint                                 | `kubernetes-ca`             |
 | `kube-apiserver-kubelet-client`            | Client    | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`   | API server communication with kubelets                           | `kubernetes-ca-client`      |
@@ -21,15 +21,25 @@
 | `kube-scheduler`                           | Client    | `/etc/kubernetes/pki/scheduler.crt`                  | Communication between the scheduler and the API server           | `kubernetes-ca-client`      |
 | `kube-proxy`                               | Client    | `/etc/kubernetes/pki/proxy.crt`                      | Communication between kube-proxy and the API server              | `kubernetes-ca-client`      |
 | `system:node:$hostname`                    | Client    | `/etc/kubernetes/pki/kubelet-client.crt`             | Authentication of kubelets to the API server                     | `kubernetes-ca-client`      |
-| `k8s-dqlite`             | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8s-dqlite nodes and API server | `self-signed`      |
-| `root@$hostname`             | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8sd nodes | `self-signed`      |
+| `k8s-dqlite`                               | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`| Communication between k8s-dqlite nodes and API server            | `self-signed`               |
+| `root@$hostname`                          | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8sd nodes | `self-signed`      |
 
 
-#### 5. **Configurations for Kubernetes Components**
+## **Configurations for Kubernetes Components**
+
+### Control-plane node
 
 | **Config File**                    | **Usage**                              | **Path on Disk**                           | **Used For**                                 |
 |------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|
 | `admin.conf`                       | Administrator Client Config            | `/etc/kubernetes/admin.conf`               | Admin access to the cluster                  |
 | `controller-manager.conf`          | Controller Manager Client Config       | `/etc/kubernetes/controller-manager.conf`  | Communication with the API server            |
 | `scheduler.conf`                   | Scheduler Client Config                | `/etc/kubernetes/scheduler.conf`           | Communication with the API server            |
+| `kubelet.conf`                     | Kubelet Client Config                  | `/etc/kubernetes/kubelet.conf`             | Node registration and communication with API server |
+| `proxy.conf`                       | Proxy Client Config                    | `/etc/kubernetes/proxy.conf`               | Communication with the API server            |
+
+### Worker node
+
+| **Config File**                    | **Usage**                              | **Path on Disk**                           | **Used For**                                 |
+|------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|
+| `proxy.conf`                       | Proxy Client Config                    | `/etc/kubernetes/proxy.conf`               | Communication with the API server            |
 | `kubelet.conf`                     | Kubelet Client Config                  | `/etc/kubernetes/kubelet.conf`             | Node registration and communication with API server |

--- a/docs/src/snap/reference/index.md
+++ b/docs/src/snap/reference/index.md
@@ -13,6 +13,7 @@ Overview <self>
 
 releases
 commands
+certificates
 bootstrap-config-reference
 proxy
 troubleshooting

--- a/src/k8s/pkg/k8sd/pki/control_plane.go
+++ b/src/k8s/pkg/k8sd/pki/control_plane.go
@@ -46,7 +46,7 @@ type ControlPlanePKI struct {
 	// [client] CN=system:node:$hostname, O=system:nodes (signed by kubernetes-ca-client)
 	KubeletClientCert, KubeletClientKey string
 
-	// [client] CN=kube-apiserver-kubelet-client, O=system:masters (signed by kubernetes-ca-client)
+	// [client] CN=apiserver-kubelet-client, O=system:masters (signed by kubernetes-ca-client)
 	APIServerKubeletClientCert, APIServerKubeletClientKey string
 
 	// Keypair used to verify authenticity of cluster messages (e.g. for configmap/k8sd-config)

--- a/src/k8s/pkg/k8sd/pki/k8sdqlite.go
+++ b/src/k8s/pkg/k8sd/pki/k8sdqlite.go
@@ -18,7 +18,7 @@ type K8sDqlitePKI struct {
 	notBefore         time.Time // notBefore date for the generated certificates
 	notAfter          time.Time // not after date (expiration date) for the generated certificates
 
-	// CN=k8s-dqlite, DNS=hostname, IP=127.0.0.1 (self-signed)
+	// CN=k8s, DNS=hostname, IP=127.0.0.1 (self-signed)
 	K8sDqliteCert, K8sDqliteKey string
 }
 


### PR DESCRIPTION
Adds an overview of all certificates used by Canonical K8s

https://canonical-ubuntu-documentation-library--632.com.readthedocs.build/canonical-kubernetes/632/snap/reference/certificates/