### PR TITLE
k8sd snapd config sync: Wait for k8sd to come up

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,7 +4,8 @@
 
 k8s::common::setup_env
 
-# disable snap set/get by default
+# disable snap set/get on startup as k8sd is not up yet.
+# the sync will be enabled in the bootstrap hook.
 k8s::cmd::k8s x-snapd-config disable
 
 # k8s has a REST interface to initialize a cluster.

--- a/src/k8s/cmd/k8s/k8s_x_snapd_config.go
+++ b/src/k8s/cmd/k8s/k8s_x_snapd_config.go
@@ -66,7 +66,7 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			if err := control.WaitUntilReady(ctx, func() (bool, error) {
 				_, partOfCluster, err := client.NodeStatus(cmd.Context())
 				if !partOfCluster {
-					cmd.PrintErrf("Node is not part of a cluster: %v\n", err.Error())
+					cmd.PrintErrf("Node is not part of a cluster: %v\n", err)
 					env.Exit(1)
 				}
 				return err == nil, nil

--- a/src/k8s/cmd/k8s/k8s_x_snapd_config.go
+++ b/src/k8s/cmd/k8s/k8s_x_snapd_config.go
@@ -1,12 +1,20 @@
 package k8s
 
 import (
+	"context"
+	"time"
+
 	cmdutil "github.com/canonical/k8s/cmd/util"
+	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
 	"github.com/spf13/cobra"
 )
 
 func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+	var opts struct {
+		timeout time.Duration
+	}
+
 	disableCmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable the use of snap get/set to manage the cluster configuration",
@@ -41,17 +49,34 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
-			switch mode.Orb {
-			case "none":
+			if mode.Orb == "none" {
 				cmd.PrintErrln("Warning: meta.orb is none, skipping reconcile actions")
 				return
-			case "k8sd":
-				client, err := env.Snap.K8sdClient("")
-				if err != nil {
-					cmd.PrintErrf("Error: failed to create k8sd client: %v\n", err)
+			}
+
+			client, err := env.Snap.K8sdClient("")
+			if err != nil {
+				cmd.PrintErrf("Error: failed to create k8sd client: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			defer cancel()
+			if err := control.WaitUntilReady(ctx, func() (bool, error) {
+				_, partOfCluster, err := client.NodeStatus(cmd.Context())
+				if !partOfCluster {
+					cmd.PrintErrf("Node is not part of a cluster: %v\n", err.Error())
 					env.Exit(1)
-					return
 				}
+				return err == nil, nil
+			}); err != nil {
+				cmd.PrintErrf("Error: Node did not come up in time: %v\n", err)
+				env.Exit(1)
+			}
+
+			switch mode.Orb {
+			case "k8sd":
 				response, err := client.GetClusterConfig(cmd.Context())
 				if err != nil {
 					cmd.PrintErrf("Error: failed to retrieve cluster configuration: %v\n", err)
@@ -64,12 +89,6 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 					return
 				}
 			case "snapd":
-				client, err := env.Snap.K8sdClient("")
-				if err != nil {
-					cmd.PrintErrf("Error: failed to create k8sd client: %v\n", err)
-					env.Exit(1)
-					return
-				}
 				if err := snapdconfig.SetK8sdFromSnapd(cmd.Context(), client, env.Snap); err != nil {
 					cmd.PrintErrf("Error: failed to update k8sd state: %v\n", err)
 					env.Exit(1)
@@ -85,6 +104,8 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 		},
 	}
+	reconcileCmd.Flags().DurationVar(&opts.timeout, "timeout", 1*time.Minute, "maximum time to wait")
+
 	cmd := &cobra.Command{
 		Use:    "x-snapd-config",
 		Short:  "Manage snapd configuration",

--- a/src/k8s/cmd/k8s/k8s_x_snapd_config.go
+++ b/src/k8s/cmd/k8s/k8s_x_snapd_config.go
@@ -71,7 +71,7 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				}
 				return err == nil, nil
 			}); err != nil {
-				cmd.PrintErrf("Error: Node did not come up in time: %v\n", err)
+				cmd.PrintErrf("Error: k8sd did not come up in time: %v\n", err)
 				env.Exit(1)
 			}
 


### PR DESCRIPTION
We have machinery in place to sync the k8sd configuration with snapd config. This is reconciled via `k8s x-snapd-config config`. The reconciliation is triggered on every config change and in the snap `configure` hook. 

This causes issues on refresh because `k8sd` may not be up yet after restart and cause:
```
buntu@juju-32b103-6:~$ sudo snap refresh k8s
2024-08-28T14:51:52Z INFO Waiting for "snap.k8s.kube-apiserver.service" to stop.
error: cannot perform the following tasks:
- Run configure hook of "k8s" snap if present (run hook "configure": Error: failed to update k8sd state: failed to update k8s configuration: failed to PUT /k8sd/cluster/config: Database is not yet initialized)
```

This PR fixes this issue by making sure that `k8sd` is up before performing the reconciliation. 
```
k8s-snap on  bschimke95/meta-orb-snapd [$!] took 17,1s …
➜ sudo snap refresh k8s --channel=latest/edge/x-snapd-config --classic
2024-08-28T17:55:18+02:00 INFO Waiting for "snap.k8s.kube-apiserver.service" to stop.
k8s (edge/x-snapd-config) v1.30.3 from Canonical✓ refreshed
```
 
Note that this is not an issue on bootstrap because we disable the sync in that time and just enabled it in the bootstrap hook.
