### PR TITLE
[quick fix] capi tutorial getting-started.md

### DIFF
--- a/docs/src/capi/tutorial/getting-started.md
+++ b/docs/src/capi/tutorial/getting-started.md
@@ -31,7 +31,6 @@ providers:
   - name: ck8s
     type: ControlPlaneProvider
     url: "https://github.com/canonical/cluster-api-k8s/releases/latest/control-plane-components.yaml"
-    type: "ControlPlaneProvider"
 ```
 
 ### Set up a management cluster


### PR DESCRIPTION
In clusterclt providers there is a duplicate ControlPlaneProvider type. This PR removes that duplicate

KU-1468