### PR TITLE
Ingress default tls secret extra moonray comment

### DIFF
--- a/docs/moonray/howto/index.md
+++ b/docs/moonray/howto/index.md
@@ -14,7 +14,7 @@ Overview <self>
 :glob:
 :titlesonly:
 install
-
+networking/index
 ```
 
 ---

--- a/docs/moonray/howto/networking/default-ingress-mr.md
+++ b/docs/moonray/howto/networking/default-ingress-mr.md
@@ -46,15 +46,16 @@ sudo k8s get ingress
 
 You should see three options:
 
-- `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret that will be used as the default Ingress
-  certificate. The `TLSCertificateDelegation` is created in the `projectcontour-root` namespace.
-  When defining an Ingress object, specify this secret as the default certificate by setting the `secretName`
-  field under `spec.tls`.
+- `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret that will be used
+  as the default Ingress certificate. The `TLSCertificateDelegation` is created in the
+  `projectcontour-root` namespace. When defining an Ingress object, specify this secret as
+  the default certificate by setting the `secretName` field under `spec.tls`.
 - `enable-proxy-protocol`: If set, proxy protocol will be enabled for the Ingress
 
 ### TLS Secret
 
-You can create a TLS secret by following the official [Kubernetes documentation][kubectl-create-secret-tls/].
+You can create a TLS secret by following the official
+[Kubernetes documentation][kubectl-create-secret-tls/].
 Note: remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
 
 Tell Ingress to use your new Ingress certificate:
@@ -63,14 +64,16 @@ Tell Ingress to use your new Ingress certificate:
 sudo k8s set ingress.default-tls-secret=<new-default-tls-secret>
 ```
 
-Replace `<new-default-tls-secret>` with the desired value for your Ingress configuration.
+Replace `<new-default-tls-secret>` with the desired value for your Ingress
+configuration.
 
 ### Proxy Protocol
 
 Enabling the proxy protocol allows passing client connection information to the
 backend service.
 
-Consult the official [Kubernetes documentation on the proxy protocol][proxy-protocol].
+Consult the official
+[Kubernetes documentation on the proxy protocol][proxy-protocol].
 
 Use the following command to enable the proxy protocol:
 
@@ -78,7 +81,8 @@ Use the following command to enable the proxy protocol:
 sudo k8s set ingress.enable-proxy-protocol=<new-enable-proxy-protocol>
 ```
 
-Adjust the value of `<new-enable-proxy-protocol>` with your proxy protocol requirements.
+Adjust the value of `<new-enable-proxy-protocol>` with your proxy protocol
+requirements.
 
 ## Disable Ingress
 

--- a/docs/moonray/howto/networking/default-ingress-mr.md
+++ b/docs/moonray/howto/networking/default-ingress-mr.md
@@ -51,7 +51,8 @@ You should see three options:
   `TLSCertificateDelegation` is created in the `projectcontour-root` namespace.
   When defining an Ingress object, specify this secret as the default
   certificate by setting the `secretName` field under `spec.tls`.
-- `enable-proxy-protocol`: If set, proxy protocol will be enabled for the Ingress
+- `enable-proxy-protocol`: If set, proxy protocol will be enabled for the
+  Ingress.
 
 ### TLS Secret
 

--- a/docs/moonray/howto/networking/default-ingress-mr.md
+++ b/docs/moonray/howto/networking/default-ingress-mr.md
@@ -46,10 +46,11 @@ sudo k8s get ingress
 
 You should see three options:
 
-- `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret that will be used
-  as the default Ingress certificate. The `TLSCertificateDelegation` is created in the
-  `projectcontour-root` namespace. When defining an Ingress object, specify this secret as
-  the default certificate by setting the `secretName` field under `spec.tls`.
+- `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret that
+  will be used as the default Ingress certificate. The
+  `TLSCertificateDelegation` is created in the `projectcontour-root` namespace.
+  When defining an Ingress object, specify this secret as the default
+  certificate by setting the `secretName` field under `spec.tls`.
 - `enable-proxy-protocol`: If set, proxy protocol will be enabled for the Ingress
 
 ### TLS Secret

--- a/docs/moonray/howto/networking/default-ingress-mr.md
+++ b/docs/moonray/howto/networking/default-ingress-mr.md
@@ -1,0 +1,107 @@
+# How to use default Ingress
+
+{{product}} allows you to configure Ingress into your cluster. When
+enabled, it tells your cluster how external HTTP and HTTPS traffic should be
+routed to its services.
+
+## What you'll need
+
+This guide assumes the following:
+
+- You have root or sudo access to the machine
+- You have a bootstrapped {{product}} cluster (see the [Getting
+  Started][getting-started-guide] guide).
+
+## Check Ingress status
+
+Find out whether Ingress is enabled or disabled with the following command:
+
+```
+sudo k8s status
+```
+
+The default state for the cluster is `ingress disabled`.
+
+## Enable Ingress
+
+To enable Ingress, run:
+
+```
+sudo k8s enable ingress
+```
+
+For more information on the command, execute:
+
+```
+sudo k8s help enable
+```
+
+## Configure Ingress
+
+Discover your configuration options by running:
+
+```
+sudo k8s get ingress 
+```
+
+You should see three options:
+
+- `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret that will be used as the default Ingress
+  certificate. The `TLSCertificateDelegation` is created in the `projectcontour-root` namespace.
+  When defining an Ingress object, specify this secret as the default certificate by setting the `secretName`
+  field under `spec.tls`.
+- `enable-proxy-protocol`: If set, proxy protocol will be enabled for the Ingress
+
+### TLS Secret
+
+You can create a TLS secret by following the official [Kubernetes documentation][kubectl-create-secret-tls/].
+Note: remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
+
+Tell Ingress to use your new Ingress certificate:
+
+```
+sudo k8s set ingress.default-tls-secret=<new-default-tls-secret>
+```
+
+Replace `<new-default-tls-secret>` with the desired value for your Ingress configuration.
+
+### Proxy Protocol
+
+Enabling the proxy protocol allows passing client connection information to the
+backend service.
+
+Consult the official [Kubernetes documentation on the proxy protocol][proxy-protocol].
+
+Use the following command to enable the proxy protocol:
+
+```
+sudo k8s set ingress.enable-proxy-protocol=<new-enable-proxy-protocol>
+```
+
+Adjust the value of `<new-enable-proxy-protocol>` with your proxy protocol requirements.
+
+## Disable Ingress
+
+You can `disable` the built-in ingress:
+
+``` {warning} Disabling Ingress may impact external access to services within
+    your cluster.
+    Ensure that you have alternative configurations in place before disabling Ingress.
+```
+
+```
+sudo k8s disable ingress
+```
+
+For more information on this command, run:
+
+```
+sudo k8s help disable
+```
+
+<!-- LINKS -->
+
+[kubectl-create-secret-tls/]: https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_tls/
+[proxy-protocol]: https://kubernetes.io/docs/reference/networking/service-protocols/#protocol-proxy-special
+[getting-started-guide]: /snap/tutorial/getting-started
+[kubectl-guide]: /snap/tutorial/kubectl

--- a/docs/moonray/howto/networking/default-ingress-mr.md
+++ b/docs/moonray/howto/networking/default-ingress-mr.md
@@ -46,7 +46,7 @@ sudo k8s get ingress
 
 You should see three options:
 
-- `enabled`: If set to true, Ingress is enabled
+
 - `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret that
   will be used as the default Ingress certificate. The
   `TLSCertificateDelegation` is created in the `projectcontour-root` namespace.
@@ -61,9 +61,7 @@ You should see three options:
 
 You can create a TLS secret by following the official
 [Kubernetes documentation][kubectl-create-secret-tls/].
-```{note}
 Please remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
-```
 
 Tell Ingress to use your new Ingress certificate:
 

--- a/docs/moonray/howto/networking/default-ingress-mr.md
+++ b/docs/moonray/howto/networking/default-ingress-mr.md
@@ -51,6 +51,8 @@ You should see three options:
   `TLSCertificateDelegation` is created in the `projectcontour-root` namespace.
   When defining an Ingress object, specify this secret as the default
   certificate by setting the `secretName` field under `spec.tls`.
+  For further information, see the
+  [TLS Certificate Delegation guide][tls-delegation] guide.
 - `enable-proxy-protocol`: If set, proxy protocol will be enabled for the
   Ingress.
 
@@ -111,3 +113,4 @@ sudo k8s help disable
 [proxy-protocol]: https://kubernetes.io/docs/reference/networking/service-protocols/#protocol-proxy-special
 [getting-started-guide]: /snap/tutorial/getting-started
 [kubectl-guide]: /snap/tutorial/kubectl
+[tls-delegation]: https://projectcontour.io/docs/main/config/tls-delegation/

--- a/docs/moonray/howto/networking/default-ingress-mr.md
+++ b/docs/moonray/howto/networking/default-ingress-mr.md
@@ -20,7 +20,7 @@ Find out whether Ingress is enabled or disabled with the following command:
 sudo k8s status
 ```
 
-The default state for the cluster is `ingress disabled`.
+Please ensure that Ingress is enabled on your cluster.
 
 ## Enable Ingress
 
@@ -46,6 +46,7 @@ sudo k8s get ingress
 
 You should see three options:
 
+- `enabled`: If set to true, Ingress is enabled
 - `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret that
   will be used as the default Ingress certificate. The
   `TLSCertificateDelegation` is created in the `projectcontour-root` namespace.
@@ -60,7 +61,9 @@ You should see three options:
 
 You can create a TLS secret by following the official
 [Kubernetes documentation][kubectl-create-secret-tls/].
-Note: remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
+```{note}
+Please remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
+```
 
 Tell Ingress to use your new Ingress certificate:
 

--- a/docs/moonray/howto/networking/index.md
+++ b/docs/moonray/howto/networking/index.md
@@ -11,9 +11,5 @@ how to configure and use key capabilities of {{product}}.
 ```{toctree}
 :titlesonly:
 
-/snap/howto/networking/default-dns.md
-/snap/howto/networking/default-network.md
-/snap/howto/networking/default-ingress-mr.md
-/snap/howto/networking/default-loadbalancer.md
-/snap/howto/networking/dualstack.md
+default-ingress-mr.md
 ```

--- a/docs/moonray/howto/networking/index.md
+++ b/docs/moonray/howto/networking/index.md
@@ -13,6 +13,6 @@ how to configure and use key capabilities of {{product}}.
 
 /snap/howto/networking/default-dns.md
 /snap/howto/networking/default-network.md
-/snap/howto/networking/default-ingress.md
+/snap/howto/networking/default-ingress-mr.md
 /snap/howto/networking/default-loadbalancer.md
 ```

--- a/docs/moonray/howto/networking/index.md
+++ b/docs/moonray/howto/networking/index.md
@@ -1,0 +1,18 @@
+# Networking
+
+```{toctree}
+:hidden:
+Networking <self>
+```
+
+Networking is a core part of a working Kubernetes cluster. These topics cover
+how to configure and use key capabilities of {{product}}.
+
+```{toctree}
+:titlesonly:
+
+/snap/howto/networking/default-dns.md
+/snap/howto/networking/default-network.md
+/snap/howto/networking/default-ingress.md
+/snap/howto/networking/default-loadbalancer.md
+```

--- a/docs/moonray/howto/networking/index.md
+++ b/docs/moonray/howto/networking/index.md
@@ -15,4 +15,5 @@ how to configure and use key capabilities of {{product}}.
 /snap/howto/networking/default-network.md
 /snap/howto/networking/default-ingress-mr.md
 /snap/howto/networking/default-loadbalancer.md
+/snap/howto/networking/dualstack.md
 ```

--- a/docs/src/snap/howto/index.md
+++ b/docs/src/snap/howto/index.md
@@ -16,7 +16,6 @@ Overview <self>
 
 install/index
 networking/index
-networking/dualstack
 storage/index
 external-datastore
 proxy

--- a/docs/src/snap/howto/networking/default-ingress.md
+++ b/docs/src/snap/howto/networking/default-ingress.md
@@ -56,9 +56,7 @@ You should see three options:
 
 You can create a TLS secret by following the official
 [Kubernetes documentation][kubectl-create-secret-tls/].
-```{note}
 Please remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
-```
 
 Tell Ingress to use your new Ingress certificate:
 

--- a/docs/src/snap/howto/networking/default-ingress.md
+++ b/docs/src/snap/howto/networking/default-ingress.md
@@ -20,7 +20,7 @@ Find out whether Ingress is enabled or disabled with the following command:
 sudo k8s status
 ```
 
-The default state for the cluster is `ingress disabled`.
+Please ensure that Ingress is enabled on your cluster.
 
 ## Enable Ingress
 
@@ -46,6 +46,7 @@ sudo k8s get ingress
 
 You should see three options:
 
+- `enabled`: If set to true, Ingress is enabled
 - `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret in
   the kube-system namespace that will be used as the default Ingress
   certificate
@@ -53,8 +54,11 @@ You should see three options:
 
 ### TLS Secret
 
-You can create a TLS secret by following the official [Kubernetes documentation][kubectl-create-secret-tls/].
-Note: remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
+You can create a TLS secret by following the official
+[Kubernetes documentation][kubectl-create-secret-tls/].
+```{note}
+Please remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
+```
 
 Tell Ingress to use your new Ingress certificate:
 
@@ -62,14 +66,16 @@ Tell Ingress to use your new Ingress certificate:
 sudo k8s set ingress.default-tls-secret=<new-default-tls-secret>
 ```
 
-Replace `<new-default-tls-secret>` with the desired value for your Ingress configuration.
+Replace `<new-default-tls-secret>` with the desired value for your Ingress
+configuration.
 
 ### Proxy Protocol
 
 Enabling the proxy protocol allows passing client connection information to the
 backend service.
 
-Consult the official [Kubernetes documentation on the proxy protocol][proxy-protocol].
+Consult the official
+[Kubernetes documentation on the proxy protocol][proxy-protocol].
 
 Use the following command to enable the proxy protocol:
 
@@ -77,7 +83,8 @@ Use the following command to enable the proxy protocol:
 sudo k8s set ingress.enable-proxy-protocol=<new-enable-proxy-protocol>
 ```
 
-Adjust the value of `<new-enable-proxy-protocol>` with your proxy protocol requirements.
+Adjust the value of `<new-enable-proxy-protocol>` with your proxy protocol
+requirements.
 
 ## Disable Ingress
 

--- a/docs/src/snap/howto/networking/index.md
+++ b/docs/src/snap/howto/networking/index.md
@@ -15,4 +15,5 @@ how to configure and use key capabilities of {{product}}.
 /snap/howto/networking/default-network.md
 /snap/howto/networking/default-ingress.md
 /snap/howto/networking/default-loadbalancer.md
+/snap/howto/networking/dualstack.md
 ```


### PR DESCRIPTION
This PR adds some additional context around contour's default tls secret configuration, as it is slightly different from cilium's.
Moonray: https://canonical-moonray--656.com.readthedocs.build/656/