### PR TITLE
Add IPv6-only support for moonray

### DIFF
--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -86,6 +86,8 @@ jobs:
           export TEST_SUBSTRATE=lxd
           export TEST_LXD_IMAGE=${{ matrix.os }}
           export TEST_INSPECTION_REPORTS_DIR="$HOME/inspection-reports"
+          # IPv6-only is only supported on moonray
+          [[ ${{ matrix.patch }}== "moonray" ]] && export TEST_IPV6_ONLY="true"
           cd tests/integration && sg lxd -c 'tox -e integration'
       - name: Prepare inspection reports
         if: failure()

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -87,7 +87,9 @@ jobs:
           export TEST_LXD_IMAGE=${{ matrix.os }}
           export TEST_INSPECTION_REPORTS_DIR="$HOME/inspection-reports"
           # IPv6-only is only supported on moonray
-          [[ ${{ matrix.patch }}== "moonray" ]] && export TEST_IPV6_ONLY="true"
+          if [[ "${{ matrix.patch }}" == "moonray" ]]; then
+            export TEST_IPV6_ONLY="true"
+          fi
           cd tests/integration && sg lxd -c 'tox -e integration'
       - name: Prepare inspection reports
         if: failure()

--- a/src/k8s/pkg/client/kubernetes/endpoints.go
+++ b/src/k8s/pkg/client/kubernetes/endpoints.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/canonical/k8s/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -40,7 +41,13 @@ func (c *Client) GetKubeAPIServerEndpoints(ctx context.Context) ([]string, error
 		}
 		for _, addr := range subset.Addresses {
 			if addr.IP != "" {
-				addresses = append(addresses, fmt.Sprintf("%s:%d", addr.IP, portNumber))
+				var address string
+				if utils.IsIPv4(addr.IP) {
+					address = addr.IP
+				} else {
+					address = fmt.Sprintf("[%s]", addr.IP)
+				}
+				addresses = append(addresses, fmt.Sprintf("%s:%d", address, portNumber))
 			}
 		}
 	}

--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -263,10 +263,10 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 	}
 
 	// Kubeconfigs
-	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), "[::1]:6443", certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
 		return response.InternalError(fmt.Errorf("failed to generate kubelet kubeconfig: %w", err))
 	}
-	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), "[::1]:6443", certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
 		return response.InternalError(fmt.Errorf("failed to generate kube-proxy kubeconfig: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -126,7 +126,7 @@ func refreshCertsRunControlPlane(s state.State, r *http.Request, snap snap.Snap)
 		return response.InternalError(fmt.Errorf("failed to write control plane certificates: %w", err))
 	}
 
-	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), clusterConfig.APIServer.GetSecurePort(), *certificates, localhostAddress); err != nil {
+	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), localhostAddress, clusterConfig.APIServer.GetSecurePort(), *certificates); err != nil {
 		return response.InternalError(fmt.Errorf("failed to generate control plane kubeconfigs: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -81,6 +81,13 @@ func refreshCertsRunControlPlane(s state.State, r *http.Request, snap snap.Snap)
 		return response.InternalError(fmt.Errorf("failed to parse node IP address %q", s.Address().Hostname()))
 	}
 
+	var localhostAddress string
+	if nodeIP.To4() == nil {
+		localhostAddress = "[::1]"
+	} else {
+		localhostAddress = "127.0.0.1"
+	}
+
 	serviceIPs, err := utils.GetKubernetesServiceIPsFromServiceCIDRs(clusterConfig.Network.GetServiceCIDR())
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to get IP address(es) from ServiceCIDR %q: %w", clusterConfig.Network.GetServiceCIDR(), err))
@@ -119,7 +126,7 @@ func refreshCertsRunControlPlane(s state.State, r *http.Request, snap snap.Snap)
 		return response.InternalError(fmt.Errorf("failed to write control plane certificates: %w", err))
 	}
 
-	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), clusterConfig.APIServer.GetSecurePort(), *certificates); err != nil {
+	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), clusterConfig.APIServer.GetSecurePort(), *certificates, localhostAddress); err != nil {
 		return response.InternalError(fmt.Errorf("failed to generate control plane kubeconfigs: %w", err))
 	}
 
@@ -262,9 +269,16 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 		return response.InternalError(fmt.Errorf("failed to write worker PKI: %w", err))
 	}
 
-	localhostAddress, err := utils.GetLocalhostAddress(clusterConfig.Network.GetPodCIDR(), clusterConfig.Network.GetServiceCIDR())
-	if err != nil {
-		return response.InternalError(fmt.Errorf("failed to get localhost address"))
+	nodeIP := net.ParseIP(s.Address().Hostname())
+	if nodeIP == nil {
+		return response.InternalError(fmt.Errorf("failed to parse node IP address %q", s.Address().Hostname()))
+	}
+
+	var localhostAddress string
+	if nodeIP.To4() == nil {
+		localhostAddress = "[::1]"
+	} else {
+		localhostAddress = "127.0.0.1"
 	}
 
 	// Kubeconfigs

--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -262,11 +262,16 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 		return response.InternalError(fmt.Errorf("failed to write worker PKI: %w", err))
 	}
 
+	localhostAddress, err := utils.GetLocalhostAddress(clusterConfig.Network.GetPodCIDR(), clusterConfig.Network.GetServiceCIDR())
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to get localhost address"))
+	}
+
 	// Kubeconfigs
-	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), "[::1]:6443", certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), fmt.Sprintf("%s:6443", localhostAddress), certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
 		return response.InternalError(fmt.Errorf("failed to generate kubelet kubeconfig: %w", err))
 	}
-	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), "[::1]:6443", certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), fmt.Sprintf("%s:6443", localhostAddress), certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
 		return response.InternalError(fmt.Errorf("failed to generate kube-proxy kubeconfig: %w", err))
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -409,7 +409,7 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 	}
 
 	// Generate kubeconfigs
-	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), cfg.APIServer.GetSecurePort(), *certificates, localhostAddress); err != nil {
+	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), localhostAddress, cfg.APIServer.GetSecurePort(), *certificates); err != nil {
 		return fmt.Errorf("failed to generate kubeconfigs: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -179,10 +179,10 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s state.State, encodedT
 	}
 
 	// Kubeconfigs
-	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), "[::1]:6443", certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
 		return fmt.Errorf("failed to generate kubelet kubeconfig: %w", err)
 	}
-	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), "127.0.0.1:6443", certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), "[::1]:6443", certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
 		return fmt.Errorf("failed to generate kube-proxy kubeconfig: %w", err)
 	}
 
@@ -296,7 +296,7 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 		// NOTE: Default certificate expiration is set to 20 years.
 		certificates := pki.NewK8sDqlitePKI(pki.K8sDqlitePKIOpts{
 			Hostname:          s.Name(),
-			IPSANs:            []net.IP{{127, 0, 0, 1}},
+			IPSANs:            []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 			NotBefore:         notBefore,
 			NotAfter:          notBefore.AddDate(20, 0, 0),
 			AllowSelfSignedCA: true,
@@ -402,7 +402,7 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 	// Configure datastore
 	switch cfg.Datastore.GetType() {
 	case "k8s-dqlite":
-		if err := setup.K8sDqlite(snap, fmt.Sprintf("%s:%d", nodeIP.String(), cfg.Datastore.GetK8sDqlitePort()), nil, bootstrapConfig.ExtraNodeK8sDqliteArgs); err != nil {
+		if err := setup.K8sDqlite(snap, fmt.Sprintf("[%s]:%d", nodeIP.String(), cfg.Datastore.GetK8sDqlitePort()), nil, bootstrapConfig.ExtraNodeK8sDqliteArgs); err != nil {
 			return fmt.Errorf("failed to configure k8s-dqlite: %w", err)
 		}
 	case "external":

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -64,7 +64,7 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		// NOTE: Default certificate expiration is set to 20 years.
 		certificates := pki.NewK8sDqlitePKI(pki.K8sDqlitePKIOpts{
 			Hostname:  s.Name(),
-			IPSANs:    []net.IP{{127, 0, 0, 1}},
+			IPSANs:    []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 			NotBefore: notBefore,
 			NotAfter:  notBefore.AddDate(20, 0, 0),
 		})

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -147,7 +147,7 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to write control plane certificates: %w", err)
 	}
 
-	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), cfg.APIServer.GetSecurePort(), *certificates, localhostAddress); err != nil {
+	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), localhostAddress, cfg.APIServer.GetSecurePort(), *certificates); err != nil {
 		return fmt.Errorf("failed to generate kubeconfigs: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -158,10 +158,16 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		}
 		cluster := make([]string, len(members))
 		for _, member := range members {
-			cluster = append(cluster, fmt.Sprintf("%s:%d", member.Address.Addr(), cfg.Datastore.GetK8sDqlitePort()))
+			var address string
+			if member.Address.Addr().Is6() {
+				address = fmt.Sprintf("[%s]", member.Address.Addr().String())
+			} else {
+				address = member.Address.Addr().String()
+			}
+			cluster = append(cluster, fmt.Sprintf("%s:%d", address, cfg.Datastore.GetK8sDqlitePort()))
 		}
 
-		address := fmt.Sprintf("%s:%d", nodeIP.String(), cfg.Datastore.GetK8sDqlitePort())
+		address := fmt.Sprintf("%s:%d", utils.ToIPString(nodeIP), cfg.Datastore.GetK8sDqlitePort())
 		if err := setup.K8sDqlite(snap, address, cluster, joinConfig.ExtraNodeK8sDqliteArgs); err != nil {
 			return fmt.Errorf("failed to configure k8s-dqlite with address=%s cluster=%v: %w", address, cluster, err)
 		}

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -91,10 +91,6 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, _ type
 			"enabled": true,
 		},
 		"disableEnvoyVersionCheck": true,
-		/* 		"routingMode":              "native",
-		   		"enableIpMasqAgent":        false,
-		   		"enableIpv6Masquerade":     true,
-		   		"ipv6NativeRoutingCIDR":    ipv6CIDR, */
 	}
 
 	if snap.Strict() {

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -91,6 +91,10 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, cfg types.Network, _ type
 			"enabled": true,
 		},
 		"disableEnvoyVersionCheck": true,
+		/* 		"routingMode":              "native",
+		   		"enableIpMasqAgent":        false,
+		   		"enableIpv6Masquerade":     true,
+		   		"ipv6NativeRoutingCIDR":    ipv6CIDR, */
 	}
 
 	if snap.Strict() {

--- a/src/k8s/pkg/k8sd/pki/k8sdqlite.go
+++ b/src/k8s/pkg/k8sd/pki/k8sdqlite.go
@@ -64,7 +64,7 @@ func (c *K8sDqlitePKI) CompleteCertificates() error {
 			return fmt.Errorf("k8s-dqlite certificate not specified and generating self-signed certificates is not allowed")
 		}
 
-		template, err := pkiutil.GenerateCertificate(pkix.Name{CommonName: "k8s"}, c.notBefore, c.notAfter, false, append(c.dnsSANs, c.hostname), append(c.ipSANs, net.IP{127, 0, 0, 1}))
+		template, err := pkiutil.GenerateCertificate(pkix.Name{CommonName: "k8s"}, c.notBefore, c.notAfter, false, append(c.dnsSANs, c.hostname), append(c.ipSANs, net.ParseIP("127.0.0.1"), net.ParseIP("::1")))
 		if err != nil {
 			return fmt.Errorf("failed to generate k8s-dqlite certificate: %w", err)
 		}

--- a/src/k8s/pkg/k8sd/pki/worker.go
+++ b/src/k8s/pkg/k8sd/pki/worker.go
@@ -48,7 +48,7 @@ func (c *ControlPlanePKI) CompleteWorkerNodePKI(hostname string, nodeIP net.IP, 
 			c.notAfter,
 			false,
 			[]string{hostname},
-			[]net.IP{{127, 0, 0, 1}, nodeIP},
+			[]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1"), nodeIP},
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate kubelet certificate for hostname=%s address=%s: %w", hostname, nodeIP.String(), err)

--- a/src/k8s/pkg/k8sd/setup/containerd.go
+++ b/src/k8s/pkg/k8sd/setup/containerd.go
@@ -53,7 +53,7 @@ func defaultContainerdConfig(
 
 		"plugins": map[string]any{
 			"io.containerd.grpc.v1.cri": map[string]any{
-				"stream_server_address":       "127.0.0.1",
+				"stream_server_address":       "::1",
 				"stream_server_port":          "0",
 				"enable_selinux":              false,
 				"sandbox_image":               pauseImage,

--- a/src/k8s/pkg/k8sd/setup/containerd.go
+++ b/src/k8s/pkg/k8sd/setup/containerd.go
@@ -53,7 +53,7 @@ func defaultContainerdConfig(
 
 		"plugins": map[string]any{
 			"io.containerd.grpc.v1.cri": map[string]any{
-				"stream_server_address":       "::1",
+				"stream_server_address":       "127.0.0.1",
 				"stream_server_port":          "0",
 				"enable_selinux":              false,
 				"sandbox_image":               pauseImage,

--- a/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
@@ -20,7 +20,7 @@ func K8sAPIServerProxy(snap snap.Snap, servers []string, extraArgs map[string]*s
 	if _, err := snaputil.UpdateServiceArguments(snap, "k8s-apiserver-proxy", map[string]string{
 		"--endpoints":  configFile,
 		"--kubeconfig": filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
-		"--listen":     "127.0.0.1:6443",
+		"--listen":     "[::1]:6443",
 	}, nil); err != nil {
 		return fmt.Errorf("failed to write arguments file: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
@@ -17,10 +17,17 @@ func K8sAPIServerProxy(snap snap.Snap, servers []string, extraArgs map[string]*s
 		return fmt.Errorf("failed to write proxy configuration file: %w", err)
 	}
 
+	var localhostAddress string
+	if utils.IsIPv4(servers[0]) {
+		localhostAddress = "127.0.0.1"
+	} else {
+		localhostAddress = "[::1]"
+	}
+
 	if _, err := snaputil.UpdateServiceArguments(snap, "k8s-apiserver-proxy", map[string]string{
 		"--endpoints":  configFile,
 		"--kubeconfig": filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"),
-		"--listen":     "[::1]:6443",
+		"--listen":     fmt.Sprintf("%s:6443", localhostAddress),
 	}, nil); err != nil {
 		return fmt.Errorf("failed to write arguments file: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
@@ -17,10 +17,8 @@ func K8sAPIServerProxy(snap snap.Snap, servers []string, extraArgs map[string]*s
 		return fmt.Errorf("failed to write proxy configuration file: %w", err)
 	}
 
-	var localhostAddress string
-	if utils.IsIPv4(servers[0]) {
-		localhostAddress = "127.0.0.1"
-	} else {
+	localhostAddress := "127.0.0.1"
+	if len(servers) > 0 && !utils.IsIPv4(servers[0]) {
 		localhostAddress = "[::1]"
 	}
 

--- a/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy.go
@@ -11,15 +11,10 @@ import (
 )
 
 // K8sAPIServerProxy prepares configuration for k8s-apiserver-proxy.
-func K8sAPIServerProxy(snap snap.Snap, servers []string, extraArgs map[string]*string) error {
+func K8sAPIServerProxy(snap snap.Snap, servers []string, localhostAddress string, extraArgs map[string]*string) error {
 	configFile := filepath.Join(snap.ServiceExtraConfigDir(), "k8s-apiserver-proxy.json")
 	if err := proxy.WriteEndpointsConfig(servers, configFile); err != nil {
 		return fmt.Errorf("failed to write proxy configuration file: %w", err)
-	}
-
-	localhostAddress := "127.0.0.1"
-	if len(servers) > 0 && !utils.IsIPv4(servers[0]) {
-		localhostAddress = "[::1]"
 	}
 
 	if _, err := snaputil.UpdateServiceArguments(snap, "k8s-apiserver-proxy", map[string]string{

--- a/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy_test.go
+++ b/src/k8s/pkg/k8sd/setup/k8s_apiserver_proxy_test.go
@@ -27,7 +27,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 
 		s := mustSetupSnapAndDirectories(t, setK8sApiServerMock)
 
-		g.Expect(setup.K8sAPIServerProxy(s, nil, nil)).To(Succeed())
+		g.Expect(setup.K8sAPIServerProxy(s, nil, "127.0.0.1", nil)).To(Succeed())
 
 		tests := []struct {
 			key         string
@@ -61,7 +61,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 			"--listen":       nil, // This should trigger a delete
 			"--my-extra-arg": utils.Pointer("my-extra-val"),
 		}
-		g.Expect(setup.K8sAPIServerProxy(s, nil, extraArgs)).To(Succeed())
+		g.Expect(setup.K8sAPIServerProxy(s, nil, "127.0.0.1", extraArgs)).To(Succeed())
 
 		tests := []struct {
 			key         string
@@ -98,7 +98,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setK8sApiServerMock)
 
 		s.Mock.ServiceExtraConfigDir = "nonexistent"
-		g.Expect(setup.K8sAPIServerProxy(s, nil, nil)).ToNot(Succeed())
+		g.Expect(setup.K8sAPIServerProxy(s, nil, "127.0.0.1", nil)).ToNot(Succeed())
 	})
 
 	t.Run("MissingServiceArgumentsDir", func(t *testing.T) {
@@ -107,7 +107,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 		s := mustSetupSnapAndDirectories(t, setK8sApiServerMock)
 
 		s.Mock.ServiceArgumentsDir = "nonexistent"
-		g.Expect(setup.K8sAPIServerProxy(s, nil, nil)).ToNot(Succeed())
+		g.Expect(setup.K8sAPIServerProxy(s, nil, "127.0.0.1", nil)).ToNot(Succeed())
 	})
 
 	t.Run("JSONFileContent", func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestK8sApiServerProxy(t *testing.T) {
 		endpoints := []string{"192.168.0.1", "192.168.0.2", "192.168.0.3"}
 		fileName := filepath.Join(s.Mock.ServiceExtraConfigDir, "k8s-apiserver-proxy.json")
 
-		g.Expect(setup.K8sAPIServerProxy(s, endpoints, nil)).To(Succeed())
+		g.Expect(setup.K8sAPIServerProxy(s, endpoints, "127.0.0.1", nil)).To(Succeed())
 
 		b, err := os.ReadFile(fileName)
 		g.Expect(err).NotTo(HaveOccurred())

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -88,7 +88,7 @@ func KubeAPIServer(snap snap.Snap, nodeIP net.IP, serviceCIDR string, authWebhoo
 	}
 
 	if nodeIP != nil && !nodeIP.IsLoopback() {
-		args["--advertise-address"] = utils.ToIPString(nodeIP)
+		args["--advertise-address"] = nodeIP.String()
 	}
 
 	switch datastore.GetType() {

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -88,7 +88,7 @@ func KubeAPIServer(snap snap.Snap, nodeIP net.IP, serviceCIDR string, authWebhoo
 	}
 
 	if nodeIP != nil && !nodeIP.IsLoopback() {
-		args["--advertise-address"] = nodeIP.String()
+		args["--advertise-address"] = utils.ToIPString(nodeIP)
 	}
 
 	switch datastore.GetType() {

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -12,12 +12,7 @@ import (
 )
 
 // KubeProxy configures kube-proxy on the local node.
-func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR string, extraArgs map[string]*string) error {
-	localhostAddress, err := utils.GetLocalhostAddress(podCIDR, "")
-	if err != nil {
-		return fmt.Errorf("failed to get locahost address: %w", err)
-	}
-
+func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR string, localhostAddress string, extraArgs map[string]*string) error {
 	serviceArgs := map[string]string{
 		"--cluster-cidr":         podCIDR,
 		"--healthz-bind-address": fmt.Sprintf("%s:10256", localhostAddress),

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -13,9 +13,14 @@ import (
 
 // KubeProxy configures kube-proxy on the local node.
 func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR string, extraArgs map[string]*string) error {
+	localhostAddress, err := utils.GetLocalhostAddress(podCIDR, "")
+	if err != nil {
+		return fmt.Errorf("failed to get locahost address: %w", err)
+	}
+
 	serviceArgs := map[string]string{
 		"--cluster-cidr":         podCIDR,
-		"--healthz-bind-address": "[::1]:10256",
+		"--healthz-bind-address": fmt.Sprintf("%s:10256", localhostAddress),
 		"--kubeconfig":           filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"),
 		"--profiling":            "false",
 	}

--- a/src/k8s/pkg/k8sd/setup/kube_proxy.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy.go
@@ -15,7 +15,7 @@ import (
 func KubeProxy(ctx context.Context, snap snap.Snap, hostname string, podCIDR string, extraArgs map[string]*string) error {
 	serviceArgs := map[string]string{
 		"--cluster-cidr":         podCIDR,
-		"--healthz-bind-address": "127.0.0.1",
+		"--healthz-bind-address": "[::1]:10256",
 		"--kubeconfig":           filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"),
 		"--profiling":            "false",
 	}

--- a/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_proxy_test.go
@@ -31,7 +31,7 @@ func TestKubeProxy(t *testing.T) {
 	g.Expect(setup.EnsureAllDirectories(s)).To(BeNil())
 
 	t.Run("Args", func(t *testing.T) {
-		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16", nil)).To(BeNil())
+		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16", "127.0.0.1", nil)).To(BeNil())
 
 		for key, expectedVal := range map[string]string{
 			"--cluster-cidr":           "10.1.0.0/16",
@@ -55,7 +55,7 @@ func TestKubeProxy(t *testing.T) {
 			"--healthz-bind-address": nil,
 			"--my-extra-arg":         utils.Pointer("my-extra-val"),
 		}
-		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16", extraArgs)).To(BeNil())
+		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16", "127.0.0.1", extraArgs)).To(BeNil())
 
 		for key, expectedVal := range map[string]string{
 			"--cluster-cidr":           "10.1.0.0/16",
@@ -80,7 +80,7 @@ func TestKubeProxy(t *testing.T) {
 
 	s.Mock.OnLXD = true
 	t.Run("ArgsOnLXD", func(t *testing.T) {
-		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16", nil)).To(BeNil())
+		g.Expect(setup.KubeProxy(context.Background(), s, "myhostname", "10.1.0.0/16", "127.0.0.1", nil)).To(BeNil())
 
 		for key, expectedVal := range map[string]string{
 			"--conntrack-max-per-core": "0",
@@ -103,7 +103,7 @@ func TestKubeProxy(t *testing.T) {
 		s.Mock.ServiceArgumentsDir = filepath.Join(dir, "k8s")
 
 		g.Expect(setup.EnsureAllDirectories(s)).To(BeNil())
-		g.Expect(setup.KubeProxy(context.Background(), s, "dev", "10.1.0.0/16", nil)).To(BeNil())
+		g.Expect(setup.KubeProxy(context.Background(), s, "dev", "10.1.0.0/16", "127.0.0.1", nil)).To(BeNil())
 
 		val, err := snaputil.GetServiceArgument(s, "kube-proxy", "--hostname-override")
 		g.Expect(err).To(BeNil())

--- a/src/k8s/pkg/k8sd/setup/kubelet.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet.go
@@ -80,7 +80,7 @@ func kubelet(snap snap.Snap, hostname string, nodeIP net.IP, clusterDNS string, 
 		args["--cluster-domain"] = clusterDomain
 	}
 	if nodeIP != nil && !nodeIP.IsLoopback() {
-		args["--node-ip"] = nodeIP.String()
+		args["--node-ip"] = utils.ToIPString(nodeIP)
 	}
 	if _, err := snaputil.UpdateServiceArguments(snap, "kubelet", args, nil); err != nil {
 		return fmt.Errorf("failed to render arguments file: %w", err)

--- a/src/k8s/pkg/k8sd/setup/util_kubeconfig.go
+++ b/src/k8s/pkg/k8sd/setup/util_kubeconfig.go
@@ -57,7 +57,7 @@ func KubeconfigString(url string, caPEM string, crtPEM string, keyPEM string) (s
 }
 
 // SetupControlPlaneKubeconfigs writes kubeconfig files for the control plane components.
-func SetupControlPlaneKubeconfigs(kubeConfigDir string, securePort int, pki pki.ControlPlanePKI) error {
+func SetupControlPlaneKubeconfigs(kubeConfigDir string, securePort int, pki pki.ControlPlanePKI, localhostAddress string) error {
 	for _, kubeconfig := range []struct {
 		file string
 		crt  string
@@ -69,7 +69,7 @@ func SetupControlPlaneKubeconfigs(kubeConfigDir string, securePort int, pki pki.
 		{file: "scheduler.conf", crt: pki.KubeSchedulerClientCert, key: pki.KubeSchedulerClientKey},
 		{file: "kubelet.conf", crt: pki.KubeletClientCert, key: pki.KubeletClientKey},
 	} {
-		if err := Kubeconfig(filepath.Join(kubeConfigDir, kubeconfig.file), fmt.Sprintf("[::1]:%d", securePort), pki.CACert, kubeconfig.crt, kubeconfig.key); err != nil {
+		if err := Kubeconfig(filepath.Join(kubeConfigDir, kubeconfig.file), fmt.Sprintf("%s:%d", localhostAddress, securePort), pki.CACert, kubeconfig.crt, kubeconfig.key); err != nil {
 			return fmt.Errorf("failed to write kubeconfig %s: %w", kubeconfig.file, err)
 		}
 	}

--- a/src/k8s/pkg/k8sd/setup/util_kubeconfig.go
+++ b/src/k8s/pkg/k8sd/setup/util_kubeconfig.go
@@ -69,7 +69,7 @@ func SetupControlPlaneKubeconfigs(kubeConfigDir string, securePort int, pki pki.
 		{file: "scheduler.conf", crt: pki.KubeSchedulerClientCert, key: pki.KubeSchedulerClientKey},
 		{file: "kubelet.conf", crt: pki.KubeletClientCert, key: pki.KubeletClientKey},
 	} {
-		if err := Kubeconfig(filepath.Join(kubeConfigDir, kubeconfig.file), fmt.Sprintf("127.0.0.1:%d", securePort), pki.CACert, kubeconfig.crt, kubeconfig.key); err != nil {
+		if err := Kubeconfig(filepath.Join(kubeConfigDir, kubeconfig.file), fmt.Sprintf("[::1]:%d", securePort), pki.CACert, kubeconfig.crt, kubeconfig.key); err != nil {
 			return fmt.Errorf("failed to write kubeconfig %s: %w", kubeconfig.file, err)
 		}
 	}

--- a/src/k8s/pkg/k8sd/setup/util_kubeconfig.go
+++ b/src/k8s/pkg/k8sd/setup/util_kubeconfig.go
@@ -57,7 +57,7 @@ func KubeconfigString(url string, caPEM string, crtPEM string, keyPEM string) (s
 }
 
 // SetupControlPlaneKubeconfigs writes kubeconfig files for the control plane components.
-func SetupControlPlaneKubeconfigs(kubeConfigDir string, securePort int, pki pki.ControlPlanePKI, localhostAddress string) error {
+func SetupControlPlaneKubeconfigs(kubeConfigDir string, localhostAddress string, securePort int, pki pki.ControlPlanePKI) error {
 	for _, kubeconfig := range []struct {
 		file string
 		crt  string

--- a/src/k8s/pkg/proxy/userspace.go
+++ b/src/k8s/pkg/proxy/userspace.go
@@ -27,6 +27,8 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"github.com/canonical/k8s/pkg/utils"
 )
 
 type remote struct {
@@ -78,7 +80,8 @@ func (tp *tcpproxy) Run() error {
 		tp.MonitorInterval = 5 * time.Minute
 	}
 	for _, srv := range tp.Endpoints {
-		addr := fmt.Sprintf("%s:%d", srv.Target, srv.Port)
+		ip := net.ParseIP(srv.Target)
+		addr := fmt.Sprintf("%s:%d", utils.ToIPString(ip), srv.Port)
 		tp.remotes = append(tp.remotes, &remote{srv: srv, addr: addr})
 	}
 

--- a/src/k8s/pkg/utils/cidr.go
+++ b/src/k8s/pkg/utils/cidr.go
@@ -126,41 +126,10 @@ func ParseCIDRs(CIDRstring string) (string, string, error) {
 	return ipv4CIDR, ipv6CIDR, nil
 }
 
-// GetLocalhostAddress returns the localhost address based on the given pod and service CIDRs.
-// In IPv6-only mode, the IPv6 localhost address is returned. Otherwise the IPv4 localhost address is returned.
-func GetLocalhostAddress(podCIDR string, serviceCIDR string) (string, error) {
-	if podCIDR == "" && serviceCIDR == "" {
-		return "", fmt.Errorf("both pod and service CIDRs are empty")
-	}
-
-	var podIPv4, serviceIPv4 string
-	var err error
-
-	if podCIDR != "" {
-		podIPv4, _, err = ParseCIDRs(podCIDR)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse pod CIDR: %w", err)
-		}
-	}
-
-	if serviceCIDR != "" {
-		serviceIPv4, _, err = ParseCIDRs(serviceCIDR)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse service CIDR: %w", err)
-		}
-	}
-
-	if (podCIDR == "" || podIPv4 != "") && (serviceCIDR == "" || serviceIPv4 != "") {
-		return "127.0.0.1", nil
-	}
-
-	return "[::1]", nil
-}
-
 // IsIPv4 returns true if the address is a valid IPv4 address, false otherwise.
+// The address may contain a port number.
 func IsIPv4(address string) bool {
-	ipPort := strings.Split(address, ":")
-	ip := ipPort[0]
+	ip := strings.Split(address, ":")[0]
 	parsedIP := net.ParseIP(ip)
 	return parsedIP != nil && parsedIP.To4() != nil
 }

--- a/src/k8s/pkg/utils/cidr.go
+++ b/src/k8s/pkg/utils/cidr.go
@@ -125,3 +125,47 @@ func ParseCIDRs(CIDRstring string) (string, string, error) {
 	}
 	return ipv4CIDR, ipv6CIDR, nil
 }
+
+// GetLocalhostAddress returns the localhost address based on the given pod and service CIDRs.
+// In IPv6-only mode, the IPv6 localhost address is returned. Otherwise the IPv4 localhost address is returned.
+func GetLocalhostAddress(podCIDR string, serviceCIDR string) (string, error) {
+	var podIPv4, serviceIPv4 string
+	var err error
+
+	if podCIDR != "" {
+		podIPv4, _, err = ParseCIDRs(podCIDR)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse pod CIDR: %w", err)
+		}
+	}
+
+	if serviceCIDR != "" {
+		serviceIPv4, _, err = ParseCIDRs(serviceCIDR)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse service CIDR: %w", err)
+		}
+	}
+
+	if (podCIDR == "" || podIPv4 != "") && (serviceCIDR == "" || serviceIPv4 != "") {
+		return "127.0.0.1", nil
+	}
+
+	return "[::1]", nil
+}
+
+// IsIPv4 returns true if the address is a valid IPv4 address, false otherwise.
+func IsIPv4(address string) bool {
+	ipPort := strings.Split(address, ":")
+	ip := ipPort[0]
+	parsedIP := net.ParseIP(ip)
+	return parsedIP != nil && parsedIP.To4() != nil
+}
+
+// ToIPString returns the string representation of an IP address.
+// If the IP address is an IPv6 address, it is enclosed in square brackets.
+func ToIPString(ip net.IP) string {
+	if ip.To4() != nil {
+		return ip.String()
+	}
+	return "[" + ip.String() + "]"
+}

--- a/src/k8s/pkg/utils/cidr.go
+++ b/src/k8s/pkg/utils/cidr.go
@@ -129,6 +129,10 @@ func ParseCIDRs(CIDRstring string) (string, string, error) {
 // GetLocalhostAddress returns the localhost address based on the given pod and service CIDRs.
 // In IPv6-only mode, the IPv6 localhost address is returned. Otherwise the IPv4 localhost address is returned.
 func GetLocalhostAddress(podCIDR string, serviceCIDR string) (string, error) {
+	if podCIDR == "" && serviceCIDR == "" {
+		return "", fmt.Errorf("both pod and service CIDRs are empty")
+	}
+
 	var podIPv4, serviceIPv4 string
 	var err error
 

--- a/src/k8s/pkg/utils/cidr_test.go
+++ b/src/k8s/pkg/utils/cidr_test.go
@@ -165,40 +165,7 @@ func TestParseCIDRs(t *testing.T) {
 	}
 }
 
-func TestGetLocalhostAddress(t *testing.T) {
-	tests := []struct {
-		podCIDR     string
-		serviceCIDR string
-		expected    string
-		expectErr   bool
-	}{
-		{"192.168.0.0/16", "10.96.0.0/12", "127.0.0.1", false},
-		{"192.168.0.0/16", "", "127.0.0.1", false},
-		{"", "10.96.0.0/12", "127.0.0.1", false},
-		{"fd01::/10", "fd98::/108", "[::1]", false},
-		{"fd01::/10", "", "[::1]", false},
-		{"", "fd98::/108", "[::1]", false},
-		{"", "", "", true},                      // Empty podCIDR and serviceCIDR
-		{"invalid", "10.96.0.0/12", "", true},   // Invalid podCIDR
-		{"192.168.0.0/16", "invalid", "", true}, // Invalid serviceCIDR
-	}
-
-	for _, tc := range tests {
-		g := NewWithT(t)
-		addr, err := utils.GetLocalhostAddress(tc.podCIDR, tc.serviceCIDR)
-
-		if tc.expectErr {
-			g.Expect(err).To(HaveOccurred())
-		} else {
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(addr).To(Equal(tc.expected))
-		}
-	}
-}
-
 func TestIsIPv4(t *testing.T) {
-	RegisterTestingT(t)
-
 	tests := []struct {
 		address  string
 		expected bool
@@ -206,19 +173,20 @@ func TestIsIPv4(t *testing.T) {
 		{"192.168.1.1:80", true},
 		{"127.0.0.1", true},
 		{"::1", false},
-		{"[fe80::1%eth0]:80", false},
+		{"[fe80::1]:80", false},
 		{"256.256.256.256", false}, // Invalid IPv4 address
 	}
 
 	for _, tc := range tests {
-		result := utils.IsIPv4(tc.address)
-		Expect(result).To(Equal(tc.expected))
+		t.Run(tc.address, func(t *testing.T) {
+			g := NewWithT(t)
+			result := utils.IsIPv4(tc.address)
+			g.Expect(result).To(Equal(tc.expected))
+		})
 	}
 }
 
 func TestToIPString(t *testing.T) {
-	RegisterTestingT(t)
-
 	tests := []struct {
 		ip       net.IP
 		expected string
@@ -230,7 +198,10 @@ func TestToIPString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		result := utils.ToIPString(tc.ip)
-		Expect(result).To(Equal(tc.expected))
+		t.Run(tc.expected, func(t *testing.T) {
+			g := NewWithT(t)
+			result := utils.ToIPString(tc.ip)
+			g.Expect(result).To(Equal(tc.expected))
+		})
 	}
 }

--- a/tests/integration/templates/bootstrap-ipv6-only.yaml
+++ b/tests/integration/templates/bootstrap-ipv6-only.yaml
@@ -1,0 +1,16 @@
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+    cluster-domain: cluster.local
+  local-storage:
+    enabled: true
+    local-path: /storage/path
+    default: false
+  gateway:
+    enabled: true
+  metrics-server:
+    enabled: true
+pod-cidr: fd01::/108
+service-cidr: fd98::/108

--- a/tests/integration/templates/etcd/etcd-tls.conf
+++ b/tests/integration/templates/etcd/etcd-tls.conf
@@ -17,7 +17,7 @@
     subjectAltName = @alt_names
 
     [alt_names]
-    IP.1 = 127.0.0.1
-    IP.2 = $IP 
+    IP.1 = [::1]
+    IP.2 = $IP
     DNS.1 = localhost
     DNS.2 = $NAME

--- a/tests/integration/templates/etcd/etcd-tls.conf
+++ b/tests/integration/templates/etcd/etcd-tls.conf
@@ -17,7 +17,7 @@
     subjectAltName = @alt_names
 
     [alt_names]
-    IP.1 = [::1]
+    IP.1 = 127.0.0.1
     IP.2 = $IP
     DNS.1 = localhost
     DNS.2 = $NAME

--- a/tests/integration/templates/nginx-ipv6-only.yaml
+++ b/tests/integration/templates/nginx-ipv6-only.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: nginxipv6
-        image: rocks.canonical.com/cdk/diverdane/nginxipv6:1.0.0
+        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/templates/nginx-ipv6-only.yaml
+++ b/tests/integration/templates/nginx-ipv6-only.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginxipv6
+spec:
+  selector:
+    matchLabels:
+      run: nginxipv6
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: nginxipv6
+    spec:
+      containers:
+      - name: nginxipv6
+        image: rocks.canonical.com/cdk/diverdane/nginxipv6:1.0.0
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-ipv6
+  labels:
+    run: nginxipv6
+spec:
+  type: NodePort
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: nginxipv6

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
+import os
 from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import List
 
@@ -61,6 +62,10 @@ def test_dualstack(instances: List[harness.Instance]):
 @pytest.mark.node_count(3)
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.dualstack()
+@pytest.mark.skipif(
+    os.getenv("TEST_IPV6_ONLY") in ["false", None],
+    reason="IPv6 is currently only supported for moonray/calico",
+)
 def test_ipv6_only(instances: List[harness.Instance]):
     main = instances[0]
     joining_cp = instances[1]

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -56,3 +56,50 @@ def test_dualstack(instances: List[harness.Instance]):
         util.stubbornly(retries=3, delay_s=1).on(main).exec(
             ["curl", address], shell=True
         )
+
+
+@pytest.mark.node_count(1)
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-ipv6-only.yaml").read_text()
+)
+@pytest.mark.dualstack()
+def test_dualstack(instances: List[harness.Instance]):
+    main = instances[0]
+    dualstack_config = (config.MANIFESTS_DIR / "nginx-dualstack.yaml").read_text()
+
+    # Deploy nginx with dualstack service
+    main.exec(
+        ["k8s", "kubectl", "apply", "-f", "-"], input=str.encode(dualstack_config)
+    )
+    addresses = (
+        util.stubbornly(retries=5, delay_s=3)
+        .on(main)
+        .exec(
+            [
+                "k8s",
+                "kubectl",
+                "get",
+                "svc",
+                "nginx-dualstack",
+                "-o",
+                "jsonpath='{.spec.clusterIPs[*]}'",
+            ],
+            text=True,
+            capture_output=True,
+        )
+        .stdout
+    )
+
+    for ip in addresses.split():
+        addr = ip_address(ip.strip("'"))
+        if isinstance(addr, IPv6Address):
+            address = f"http://[{str(addr)}]"
+        elif isinstance(addr, IPv4Address):
+            address = f"http://{str(addr)}"
+        else:
+            pytest.fail(f"Unknown IP address type: {addr}")
+
+        # need to shell out otherwise this runs into permission errors
+        util.stubbornly(retries=3, delay_s=1).on(main).exec(
+            ["curl", address], shell=True
+        )

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -63,13 +63,17 @@ def test_dualstack(instances: List[harness.Instance]):
     (config.MANIFESTS_DIR / "bootstrap-ipv6-only.yaml").read_text()
 )
 @pytest.mark.dualstack()
-def test_dualstack(instances: List[harness.Instance]):
+def test_ipv6_only(instances: List[harness.Instance]):
     main = instances[0]
-    dualstack_config = (config.MANIFESTS_DIR / "nginx-dualstack.yaml").read_text()
+    ipv6_config = (config.MANIFESTS_DIR / "nginx-ipv6-only.yaml").read_text()
 
-    # Deploy nginx with dualstack service
+    # TODO: add --address <ipv6> to the `--address` flag
+    # TODO: Disable ipv4 for this lxc containe
+
+
+    # Deploy nginx with ipv6 service
     main.exec(
-        ["k8s", "kubectl", "apply", "-f", "-"], input=str.encode(dualstack_config)
+        ["k8s", "kubectl", "apply", "-f", "-"], input=str.encode(ipv6_config)
     )
     addresses = (
         util.stubbornly(retries=5, delay_s=3)
@@ -80,7 +84,7 @@ def test_dualstack(instances: List[harness.Instance]):
                 "kubectl",
                 "get",
                 "svc",
-                "nginx-dualstack",
+                "nginx-ipv6",
                 "-o",
                 "jsonpath='{.spec.clusterIPs[*]}'",
             ],
@@ -95,7 +99,7 @@ def test_dualstack(instances: List[harness.Instance]):
         if isinstance(addr, IPv6Address):
             address = f"http://[{str(addr)}]"
         elif isinstance(addr, IPv4Address):
-            address = f"http://{str(addr)}"
+            assert False, "IPv4 address found in IPv6-only cluster"
         else:
             pytest.fail(f"Unknown IP address type: {addr}")
 


### PR DESCRIPTION
Adds support for IPv6-only support on moonray. For the default k8s-snap this is not yet supported as Cilium loadbalancer does not support IPv6-only.

Most of the changes basically only ensure that the IPv6 address is properly put into brackets. We use different representations of IPs across the codebase (e.g. string, or net.IP or Addr by microcluster) so we cannot just simply use the same approach everywhere.