### PR TITLE
Auto-update components in release-1.31 branch

### DIFF
--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -21,6 +21,7 @@ jobs:
           # Keep main branch up to date
           - main
           # Supported stable release branches
+          - release-1.31
           - release-1.30
 
     steps:


### PR DESCRIPTION
Include the release-1.31 branch in auto-update components job as a part of https://github.com/canonical/k8s-snap/issues/666

Merge after:
* https://github.com/canonical/k8s-snap/pull/667