### PR TITLE
use lxd 5.21/stable snap

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -31,7 +31,7 @@ jobs:
           pip3 install tox==4.13
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.19/stable
+          sudo snap refresh lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'


### PR DESCRIPTION
Nightly edge CI workflow is failing due to lxd 5.19/stable not being available.  Update to lxd 5.21/stable.

KU-1576: fixes #669.