### PR TITLE
Correct microcluster schema migration order

### DIFF
--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -18,11 +18,9 @@ var (
 	SchemaExtensions = []schema.Update{
 		schemaApplyMigration("kubernetes-auth-tokens", "000-create.sql"),
 		schemaApplyMigration("cluster-configs", "000-create.sql"),
-
 		schemaApplyMigration("worker-tokens", "000-create.sql"),
-		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
-
 		schemaApplyMigration("feature-status", "000-feature-status.sql"),
+		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
 	}
 
 	//go:embed sql/migrations


### PR DESCRIPTION
## Description
Migrations should be applied in the correct order with the latest migration being applied last.
Microcluster counts the migrations we have done. 

Changing the order can lead to mistakes: 
We previously apply schemaApplyMigration("feature-status", "000-feature-status.sql") at schema count 5, then we add in schemaApplyMigration("worker-tokens", "001-add-expiry.sql") at schema count 5, leading us to re-apply feature-status in count 6 when migrating the schema.

For instance, this issue occurred migrating moonray: https://github.com/canonical/k8s-snap/blob/archive/release-1.30-moonray/src/k8s/pkg/k8sd/database/schema.go