### PR TITLE
Create more tests on branches and recipes

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -59,7 +61,7 @@ jobs:
         run: pip install tox
       - name: Run branch_management tests
         run: |
-          tox -c tests/branch_management -e integration
+          tox -c tests/branch_management -e test
 
   test-integration:
     name: Test ${{ matrix.os }}

--- a/tests/branch_management/tests/conftest.py
+++ b/tests/branch_management/tests/conftest.py
@@ -2,26 +2,71 @@
 # Copyright 2024 Canonical, Ltd.
 #
 from pathlib import Path
+from typing import Optional
 
 import pytest
 import requests
 import semver
 
+STABLE_URL = "https://dl.k8s.io/release/stable.txt"
+RELEASE_URL = "https://dl.k8s.io/release/stable-{}.{}.txt"
 
-@pytest.fixture
-def upstream_release() -> semver.VersionInfo:
+
+def _upstream_release_exists(ver: semver.Version) -> Optional[semver.Version]:
+    """Return true if the major.minor release exists"""
+    r = requests.get(RELEASE_URL.format(ver.major, ver.minor))
+    if r.status_code == 200:
+        return semver.Version.parse(r.content.decode().lstrip("v"))
+
+
+def _get_max_minor(rev: semver.Version) -> semver.Version:
+    """
+    Get the latest minor release of the provided major.
+
+    For example if you use 1 as major you will get back X where X gives you latest 1.XX release.
+    """
+    out = semver.Version(rev.major, 0, 0)
+    while rev := _upstream_release_exists(rev):
+        out = rev
+        rev = semver.Version(rev.major, rev.minor + 1, 0)
+    return out
+
+
+def _previous_release(ver: semver.Version) -> semver.Version:
+    if ver.minor != 0:
+        ver = semver.Version(ver.major, ver.minor - 1, 0)
+        ver = _upstream_release_exists(ver)
+    else:
+        ver = semver.Version(ver.major, 0, 0)
+        ver = _get_max_minor(ver)
+    return ver
+
+
+@pytest.fixture(scope="session")
+def stable_release() -> semver.Version:
     """Return the latest stable k8s in the release series"""
-    release_url = "https://dl.k8s.io/release/stable.txt"
-    r = requests.get(release_url)
+    r = requests.get(STABLE_URL)
     r.raise_for_status()
     return semver.Version.parse(r.content.decode().lstrip("v"))
 
 
-@pytest.fixture
-def current_release() -> semver.VersionInfo:
+@pytest.fixture(scope="session")
+def current_release() -> semver.Version:
     """Return the current branch k8s version"""
     ver_file = (
         Path(__file__).parent / "../../../build-scripts/components/kubernetes/version"
     )
     version = ver_file.read_text().strip()
     return semver.Version.parse(version.lstrip("v"))
+
+
+@pytest.fixture
+def prior_stable_release(stable_release) -> semver.Version:
+    """Return the prior release to the upstream stable"""
+    return _previous_release(stable_release)
+
+
+@pytest.fixture
+def prior_release(current_release) -> semver.Version:
+    """Return the prior release to the current release"""
+    return _previous_release(current_release)

--- a/tests/branch_management/tox.ini
+++ b/tests/branch_management/tox.ini
@@ -30,12 +30,11 @@ commands =
     black {tox_root}/tests --check --diff
 
 [testenv:test]
-description = Run integration tests
+description = Run branch management tests
 deps =
     -r {tox_root}/requirements-test.txt
 commands =
     pytest -v \
-        --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \
         --disable-warnings \


### PR DESCRIPTION
### Overview
* Confirm that branches are available both in launchpad and github for the stable_release, the previous_stable and the current_release
* Raises awareness that stable releases needs a release branch

### Details
* Represents a clean-up/adjustment due to the track map policy changes
* Verifies that upstream stable, upstream previous stable, and this current version all have a stable release branch in Github and Launchpad
* Verify the tip recipes always exist (regardless of stable version)
* GH action must checkout with `depth:0` so it can "see" all the remote branches