### PR TITLE
Do not stop Kubernetes services on node removal if annotation is set.

### DIFF
--- a/docs/src/snap/reference/annotations.md
+++ b/docs/src/snap/reference/annotations.md
@@ -7,6 +7,7 @@ the bootstrap configuration.
 | Name                                                          | Description                                                                                                                                                                                                                                       | Values          |
 |---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
 | `k8sd/v1alpha/lifecycle/skip-cleanup-kubernetes-node-on-remove` | If set, only microcluster and file cleanup are performed.  This is helpful when an external controller (e.g., CAPI) manages the Kubernetes node lifecycle. By default,  k8sd will remove the Kubernetes node when it is removed from the cluster. | "true"\|"false" |
+| `k8sd/v1alpha/lifecycle/skip-stop-services-on-remove` | If set, the k8s services will not be stopped on the leaving node when removing the node. This is helpful when an external controller (e.g., CAPI) manages the Kubernetes node lifecycle. By default, all services are stopped on leaving nodes. | "true"\|"false" |
 
 <!-- Links -->
 

--- a/src/k8s/cmd/k8s/k8s_bootstrap_test.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap_test.go
@@ -62,7 +62,10 @@ var testCases = []testCase{
 					Enabled: utils.Pointer(true),
 				},
 				CloudProvider: utils.Pointer("external"),
-				Annotations:   map[string]string{apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove: "true"},
+				Annotations: map[string]string{
+					apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove: "true",
+					apiv1.AnnotationSkipStopServicesOnRemove:          "true",
+				},
 			},
 			ControlPlaneTaints:                 []string{"node-role.kubernetes.io/control-plane:NoSchedule"},
 			PodCIDR:                            utils.Pointer("10.100.0.0/16"),

--- a/src/k8s/cmd/k8s/testdata/bootstrap-config-full.yaml
+++ b/src/k8s/cmd/k8s/testdata/bootstrap-config-full.yaml
@@ -23,6 +23,7 @@ cluster-config:
   cloud-provider: external
   annotations:
     k8sd/v1alpha/lifecycle/skip-cleanup-kubernetes-node-on-remove: true
+    k8sd/v1alpha/lifecycle/skip-stop-services-on-remove: true
 control-plane-taints:
 - node-role.kubernetes.io/control-plane:NoSchedule
 pod-cidr: 10.100.0.0/16

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -5,7 +5,7 @@ go 1.22.6
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite v1.22.0
-	github.com/canonical/k8s-snap-api v1.0.5
+	github.com/canonical/k8s-snap-api v1.0.6
 	github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230
 	github.com/canonical/microcluster/v3 v3.0.0-20240827143335-f7a4d3984970
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -99,8 +99,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite v1.22.0 h1:DuJmfcREl4gkQJyvZzjl2GHFZROhbPyfdjDRQXpkOyw=
 github.com/canonical/go-dqlite v1.22.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/k8s-snap-api v1.0.5 h1:49bgi6CGtFjCPweeTz55Sv/waKgCl6ftx4BqXt3RI9k=
-github.com/canonical/k8s-snap-api v1.0.5/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
+github.com/canonical/k8s-snap-api v1.0.6 h1:hUJ59ol9romwUz82bYIumitobcuBQwKjWMnge1AhGzM=
+github.com/canonical/k8s-snap-api v1.0.6/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
 github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230 h1:YOqZ+/14OPZ+/TOXpRHIX3KLT0C+wZVpewKIwlGUmW0=
 github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230/go.mod h1:YVGI7HStOKsV+cMyXWnJ7RaMPaeWtrkxyIPvGWbgACc=
 github.com/canonical/microcluster/v3 v3.0.0-20240827143335-f7a4d3984970 h1:UrnpglbXELlxtufdk6DGDytu2JzyzuS3WTsOwPrkQLI=

--- a/src/k8s/pkg/k8sd/api/worker.go
+++ b/src/k8s/pkg/k8sd/api/worker.go
@@ -86,5 +86,6 @@ func (e *Endpoints) postWorkerInfo(s state.State, r *http.Request) response.Resp
 		KubeProxyClientCert: workerCertificates.KubeProxyClientCert,
 		KubeProxyClientKey:  workerCertificates.KubeProxyClientKey,
 		K8sdPublicKey:       cfg.Certificates.GetK8sdPublicKey(),
+		Annotations:         cfg.Annotations,
 	})
 }

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -28,7 +28,6 @@ import (
 // onBootstrap is called after we bootstrap the first cluster node.
 // onBootstrap configures local services then writes the cluster config on the database.
 func (a *App) onBootstrap(ctx context.Context, s state.State, initConfig map[string]string) error {
-
 	// NOTE(neoaggelos): context timeout is passed over configuration, so that hook failures are propagated to the client
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -213,6 +212,7 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s state.State, encodedT
 			CACert:        utils.Pointer(response.CACert),
 			ClientCACert:  utils.Pointer(response.ClientCACert),
 		},
+		Annotations: response.Annotations,
 	}
 
 	// Pre-init checks

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -61,7 +61,7 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 
 	cfg, err := databaseutil.GetClusterConfig(ctx, s)
 	if err == nil {
-		if _, ok := cfg.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove]; !ok {
+		if _, ok := cfg.Annotations.Get(apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove); !ok {
 			c, err := snap.KubernetesClient("")
 			if err != nil {
 				log.Error(err, "Failed to create Kubernetes client", err)
@@ -130,7 +130,7 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 		log.Error(err, "failed to cleanup control plane certificates")
 	}
 
-	if _, ok := cfg.Annotations[apiv1.AnnotationSkipStopServicesOnRemove]; !ok {
+	if _, ok := cfg.Annotations.Get(apiv1.AnnotationSkipStopServicesOnRemove); !ok {
 		log.Info("Stopping worker services")
 		if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
 			log.Error(err, "Failed to stop worker services")

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -59,7 +59,8 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 		log.Error(err, "Failed to wait for node to finish microcluster join before removing. Continuing with the cleanup...")
 	}
 
-	if cfg, err := databaseutil.GetClusterConfig(ctx, s); err == nil {
+	cfg, err := databaseutil.GetClusterConfig(ctx, s)
+	if err == nil {
 		if _, ok := cfg.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove]; !ok {
 			c, err := snap.KubernetesClient("")
 			if err != nil {
@@ -124,20 +125,22 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 		log.Error(err, "Failed to unmark node as worker")
 	}
 
-	/* 	log.Info("Stopping worker services")
-	   	if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
-	   		log.Error(err, "Failed to stop worker services")
-	   	} */
-
 	log.Info("Cleaning up control plane certificates")
 	if _, err := setup.EnsureControlPlanePKI(snap, &pki.ControlPlanePKI{}); err != nil {
 		log.Error(err, "failed to cleanup control plane certificates")
 	}
 
-	/* 	log.Info("Stopping control plane services")
-	   	if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
-	   		log.Error(err, "Failed to stop control-plane services")
-	   	} */
+	if _, ok := cfg.Annotations[apiv1.AnnotationSkipStopServicesOnRemove]; !ok {
+		log.Info("Stopping worker services")
+		if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
+			log.Error(err, "Failed to stop worker services")
+		}
+
+		log.Info("Stopping control plane services")
+		if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
+			log.Error(err, "Failed to stop control-plane services")
+		}
+	}
 
 	return nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -124,20 +124,20 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 		log.Error(err, "Failed to unmark node as worker")
 	}
 
-	log.Info("Stopping worker services")
-	if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
-		log.Error(err, "Failed to stop worker services")
-	}
+	/* 	log.Info("Stopping worker services")
+	   	if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
+	   		log.Error(err, "Failed to stop worker services")
+	   	} */
 
 	log.Info("Cleaning up control plane certificates")
 	if _, err := setup.EnsureControlPlanePKI(snap, &pki.ControlPlanePKI{}); err != nil {
 		log.Error(err, "failed to cleanup control plane certificates")
 	}
 
-	log.Info("Stopping control plane services")
-	if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
-		log.Error(err, "Failed to stop control-plane services")
-	}
+	/* 	log.Info("Stopping control plane services")
+	   	if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
+	   		log.Error(err, "Failed to stop control-plane services")
+	   	} */
 
 	return nil
 }

--- a/tests/integration/templates/bootstrap-skip-service-stop.yaml
+++ b/tests/integration/templates/bootstrap-skip-service-stop.yaml
@@ -1,0 +1,9 @@
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  metrics-server:
+    enabled: true
+  annotations:
+    k8sd/v1alpha/lifecycle/skip-stop-services-on-remove: true

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -137,7 +137,13 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
     ).stdout.split("\n")[1:-1]
     print(services)
     for service in services:
-        for expected_active_service in ["containerd", "k8sd", "kubelet", "kube-proxy", "k8s-apiserver-proxy"]:
+        for expected_active_service in [
+            "containerd",
+            "k8sd",
+            "kubelet",
+            "kube-proxy",
+            "k8s-apiserver-proxy",
+        ]:
             if expected_active_service in service:
                 assert (
                     " active " in service


### PR DESCRIPTION
Requires https://github.com/canonical/k8s-snap-api/pull/8 - will update api version tag for the snap afterwards.

By default, all services on a leaving node are stopped. This PR adds logic to skip this step if the `k8sd/v1alpha/lifecycle/skip-stop-services-on-remove` annotation is set. 

This is required for Cluster API to properly drain nodes. See

Also adds an integration test to validate that this works as expected.