### PR TITLE
Skip Go/K8s test suite when docs are changed

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -2,6 +2,8 @@ name: Go
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - main
       - autoupdate/strict
@@ -10,6 +12,8 @@ on:
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
       - 'autoupdate/sync/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -2,11 +2,15 @@ name: Informing Integration Tests
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - main
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/sync/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,6 +2,8 @@ name: Integration Tests
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - main
       - autoupdate/strict
@@ -10,6 +12,8 @@ on:
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
       - 'autoupdate/sync/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -2,6 +2,8 @@ name: Python
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - main
       - autoupdate/strict
@@ -10,6 +12,8 @@ on:
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
       - 'autoupdate/sync/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -2,6 +2,8 @@ name: SBOM
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - main
       - autoupdate/strict
@@ -10,6 +12,8 @@ on:
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
       - 'autoupdate/sync/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently, when docs are changed PR triggers all builds including code test which is unnecessary. This PR adds additional logic to workflows to skip builds when changes are only in the docs directory.

KU-1154
