### PR TITLE
x-snap-config: Do not check if node is part of the cluster

### DIFF
--- a/src/k8s/cmd/k8s/k8s_x_snapd_config.go
+++ b/src/k8s/cmd/k8s/k8s_x_snapd_config.go
@@ -64,11 +64,7 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
 			defer cancel()
 			if err := control.WaitUntilReady(ctx, func() (bool, error) {
-				_, partOfCluster, err := client.NodeStatus(cmd.Context())
-				if !partOfCluster {
-					cmd.PrintErrf("Node is not part of a cluster: %v\n", err)
-					env.Exit(1)
-				}
+				_, _, err := client.NodeStatus(cmd.Context())
 				return err == nil, nil
 			}); err != nil {
 				cmd.PrintErrf("Error: k8sd did not come up in time: %v\n", err)


### PR DESCRIPTION
Follow-up fix for: https://github.com/canonical/k8s-snap/pull/633

In the mentioned PR, we wait until k8sd is up to sync the config. We exit early if the node is not part of a cluster. However, a closer look at the implementation of `NodeStatus` shows that this would skip any error that we wait for:

```
func (c *k8sd) NodeStatus(ctx context.Context) (apiv1.NodeStatusResponse, bool, error) {
	response, err := query(ctx, c, "GET", apiv1.NodeStatusRPC, nil, &apiv1.NodeStatusResponse{})
	if err != nil {
		// Error 503 means the node is not initialized yet
		var statusErr api.StatusError
		if errors.As(err, &statusErr) {
			if statusErr.Status() == http.StatusServiceUnavailable {
				return apiv1.NodeStatusResponse{}, false, nil
			}
		}

		return apiv1.NodeStatusResponse{}, false, err <- Returns partOfCluster == false if an error happens. 
	}

	return response, true, nil
}
```

This PR removes the wrong check.