### PR TITLE
Fix TiCS action's permission error

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -2,8 +2,6 @@ name: Security and quality nightly scan
 
 on:
   pull_request:
-  # schedule:
-  #   - cron: '0 10 * * *'
 
 permissions:
   contents: read
@@ -28,6 +26,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{matrix.branch}}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -55,7 +55,7 @@ jobs:
           mv ./coverage.xml ./.coverage/
 
           # Install the TICS and staticcheck
-          go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
           . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
 
           # We need to have our project built
@@ -66,7 +66,7 @@ jobs:
           sudo make clean
           go build -a ./...
 
-          TICSQServer -project k8s-snap -tmpdir /tmp/tics -branchdir $HOME/work/k8s-snap/k8s-snap/
+          TICSQServer -project k8s-snap -tmpdir /tmp/tics -branchdir $HOME/work/k8s-snap/k8s-snap/ -log 5 -st
 
   Trivy:
     permissions:

--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -1,7 +1,8 @@
 name: Security and quality nightly scan
 
 on:
-  pull_request:
+  schedule:
+    - cron: '0 10 * * *'
 
 permissions:
   contents: read
@@ -67,7 +68,7 @@ jobs:
           sudo make clean
           go build -a ./...
 
-          TICSQServer -project k8s-snap -tmpdir /tmp/tics -branchdir $HOME/work/k8s-snap/k8s-snap/ -log 5 -st
+          TICSQServer -project k8s-snap -tmpdir /tmp/tics -branchdir $HOME/work/k8s-snap/k8s-snap/
 
   Trivy:
     permissions:

--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -1,12 +1,13 @@
 name: Security and quality nightly scan
 
 on:
-  schedule:
-    - cron: '0 10 * * *'
+  pull_request:
+  # schedule:
+  #   - cron: '0 10 * * *'
 
 permissions:
   contents: read
- 
+
 jobs:
   TICS:
     permissions:
@@ -47,7 +48,7 @@ jobs:
 
           # TICS requires us to have the test results in cobertura xml format under the
           # directory use below
-          make go.unit
+          sudo make go.unit
           go install github.com/boumenot/gocover-cobertura@latest
           gocover-cobertura < coverage.txt > coverage.xml
           mkdir .coverage
@@ -62,7 +63,7 @@ jobs:
           # will try to build parts of the project itself
           sudo add-apt-repository -y ppa:dqlite/dev
           sudo apt install dqlite-tools libdqlite-dev -y
-          make clean
+          sudo make clean
           go build -a ./...
 
           TICSQServer -project k8s-snap -tmpdir /tmp/tics -branchdir $HOME/work/k8s-snap/k8s-snap/

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -128,6 +128,13 @@ jobs:
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          # We run into rate limiting issues if we don't authenticate
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checking out repo
         uses: actions/checkout@v4
       - name: Fetch snap


### PR DESCRIPTION
`make go.unit` has to be run with elevated privileges since we now change the owner of /opt/cni/bin to root. See https://github.com/canonical/k8s-snap/blob/a2c00fb6be9951f582e139d83d97ad1dceb4ec13/src/k8s/pkg/k8sd/setup/directories.go#L72 

This operation fails if `make go.unit` is run as a regular user.