### PR TITLE
[Backport release-1.31] Microcluster Migration History Restoration

### DIFF
--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -18,9 +18,11 @@ var (
 	SchemaExtensions = []schema.Update{
 		schemaApplyMigration("kubernetes-auth-tokens", "000-create.sql"),
 		schemaApplyMigration("cluster-configs", "000-create.sql"),
+		schemaApplyMigration("worker-nodes", "000-create.sql"),
 		schemaApplyMigration("worker-tokens", "000-create.sql"),
 		schemaApplyMigration("feature-status", "000-feature-status.sql"),
 		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
+		schemaApplyMigration("worker-nodes", "001-delete.sql"),
 	}
 
 	//go:embed sql/migrations

--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -18,11 +18,9 @@ var (
 	SchemaExtensions = []schema.Update{
 		schemaApplyMigration("kubernetes-auth-tokens", "000-create.sql"),
 		schemaApplyMigration("cluster-configs", "000-create.sql"),
-
 		schemaApplyMigration("worker-tokens", "000-create.sql"),
-		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
-
 		schemaApplyMigration("feature-status", "000-feature-status.sql"),
+		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
 	}
 
 	//go:embed sql/migrations

--- a/src/k8s/pkg/k8sd/database/sql/migrations/worker-nodes/000-create.sql
+++ b/src/k8s/pkg/k8sd/database/sql/migrations/worker-nodes/000-create.sql
@@ -2,4 +2,4 @@ CREATE TABLE worker_nodes (
   id                   INTEGER   PRIMARY  KEY    AUTOINCREMENT  NOT  NULL,
   name                 TEXT      NOT      NULL,
   UNIQUE(name)
-);
+)

--- a/src/k8s/pkg/k8sd/database/sql/migrations/worker-nodes/001-delete.sql
+++ b/src/k8s/pkg/k8sd/database/sql/migrations/worker-nodes/001-delete.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS worker_nodes


### PR DESCRIPTION
# Microcluster Migration History Restoration
This PR backports the correction of our Microcluster migrations into 1.31.
Two PRs are backported: #689 #676. One corrects the order and the other properly drops a table instead of removing the migration.