### PR TITLE
Improve Nightly Test runs to pass

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -61,6 +61,6 @@ jobs:
           name: ${{ env.artifact_name }}
           path: ${{ github.workspace }}/inspection-reports.tar.gz
       - name: Tmate debugging session
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 10

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -3,47 +3,47 @@ name: Nightly Latest/Edge Tests
 on:
   schedule:
     - cron: '0 0 * * *' # Runs every midnight
+  pull_request:
 
 permissions:
   contents: read
 
 jobs:
   test-integration:
-    name: Integration Test ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.releases }}
+    name: Integration Test ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.release }}
     strategy:
       matrix:
         os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
         arch: ["amd64", "arm64"]
-        releases: ["latest/edge"]
+        release: ["latest/edge"]
       fail-fast: false # TODO: remove once arm64 works
 
-    runs-on: ${{ matrix.arch == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-22.04' }}
 
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      - name: Setup Python
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install lxd and tox
         run: |
           sudo apt update
-          sudo apt install -y python3 python3-pip
-      - name: Install tox
-        run: |
-          pip3 install tox==4.13
-      - name: Install lxd
-        run: |
+          sudo apt install -y tox
           sudo snap refresh lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
       - name: Create build directory
         run: mkdir -p build
-      - name: Install $${ matrix.releases }} k8s snap
+      - name: Install ${{ matrix.release }} k8s snap
         run: |
           cd build
-          snap download k8s --channel=${{ matrix.releases }} --basename k8s
+          snap download k8s --channel=${{ matrix.release }} --basename k8s
       - name: Run end to end tests # tox path needs to be specified for arm64
         env:
-          TEST_SNAP: ${{ github.workspace }}/build/k8s-${{ matrix.patch }}.snap
+          TEST_SNAP: ${{ github.workspace }}/build/k8s.snap
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.os }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
@@ -52,4 +52,15 @@ jobs:
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
         run: |
           export PATH="/home/runner/.local/bin:$PATH"
-          cd tests/integration && sg lxd -c 'tox -e integration'
+          cd tests/integration && sg lxd -c 'tox -vve integration'
+      - name: Prepare inspection reports
+        if: failure()
+        run: |
+          tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
+          echo "artifact_name=inspection-reports-${{ matrix.os }}-${{ matrix.arch }}" | sed 's/:/-/g' >> $GITHUB_ENV
+      - name: Upload inspection report artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.artifact_name }}
+          path: ${{ github.workspace }}/inspection-reports.tar.gz

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -18,15 +18,11 @@ jobs:
         release: ["latest/edge"]
       fail-fast: false # TODO: remove once arm64 works
 
-    runs-on: ${{ matrix.arch == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-22.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'Ubuntu_ARM64_4C_16G_01' || 'ubuntu-20.04' }}
 
     steps:
       - name: Checking out repo
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
       - name: Install lxd and tox
         run: |
           sudo apt update
@@ -64,3 +60,7 @@ jobs:
         with:
           name: ${{ env.artifact_name }}
           path: ${{ github.workspace }}/inspection-reports.tar.gz
+      - name: Tmate debugging session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 10

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -3,7 +3,6 @@ name: Nightly Latest/Edge Tests
 on:
   schedule:
     - cron: '0 0 * * *' # Runs every midnight
-  pull_request:
 
 permissions:
   contents: read

--- a/build-scripts/hack/sync-images.yaml
+++ b/build-scripts/hack/sync-images.yaml
@@ -23,8 +23,8 @@ sync:
   - source: ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1
     target: '{{ env "MIRROR" }}/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1'
     type: image
-  - source: ghcr.io/canonical/metrics-server:0.7.0-ck1
-    target: '{{ env "MIRROR" }}/canonical/metrics-server:0.7.0-ck1'
+  - source: ghcr.io/canonical/metrics-server:0.7.0-ck2
+    target: '{{ env "MIRROR" }}/canonical/metrics-server:0.7.0-ck2'
     type: image
   - source: ghcr.io/canonical/rawfile-localpv:0.8.0-ck4
     target: '{{ env "MIRROR" }}/canonical/rawfile-localpv:0.8.0-ck4'

--- a/docs/src/snap/howto/install/offline.md
+++ b/docs/src/snap/howto/install/offline.md
@@ -120,7 +120,7 @@ ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner:v5.0.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer:v1.11.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1
-ghcr.io/canonical/metrics-server:0.7.0-ck1
+ghcr.io/canonical/metrics-server:0.7.0-ck2
 ghcr.io/canonical/rawfile-localpv:0.8.0-ck4
 ```
 

--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/metrics-server"
 
 	// imageTag is the image tag to use for metrics-server.
-	imageTag = "0.7.0-ck1"
+	imageTag = "0.7.0-ck2"
 )

--- a/tests/integration/templates/etcd/etcd.service
+++ b/tests/integration/templates/etcd/etcd.service
@@ -11,6 +11,7 @@
     LimitNOFILE=40000
     TimeoutStartSec=0
 
+    Environment=ETCD_UNSUPPORTED_ARCH=$ARCH
     ExecStart=/tmp/test-etcd/etcd --name $NAME \
     --data-dir /tmp/etcd/s1 \
     --listen-client-urls $CLIENT_URL \

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -15,7 +15,7 @@ ETCD_DIR = MANIFESTS_DIR / "etcd"
 ETCD_URL = os.getenv("ETCD_URL") or "https://github.com/etcd-io/etcd/releases/download"
 
 # ETCD_VERSION is the version of etcd to use.
-ETCD_VERSION = os.getenv("ETCD_VERSION") or "v3.3.8"
+ETCD_VERSION = os.getenv("ETCD_VERSION") or "v3.4.34"
 
 # SNAP is the absolute path to the snap against which we run the integration tests.
 SNAP = os.getenv("TEST_SNAP")

--- a/tests/integration/tests/test_util/etcd.py
+++ b/tests/integration/tests/test_util/etcd.py
@@ -90,6 +90,7 @@ class EtcdCluster:
         ]
 
         substitutes = {
+            "ARCH": instance.arch,
             "NAME": instance.id,
             "IP": ip,
             "CLIENT_URL": f"https://{ip}:2379",
@@ -224,13 +225,14 @@ class EtcdCluster:
                 input=str.encode(src.substitute(substitutes)),
             )
 
+        arch = instance.arch
         instance.exec(
             [
                 "curl",
                 "-L",
-                f"{self.etcd_url}/{self.etcd_version}/etcd-{self.etcd_version}-linux-amd64.tar.gz",
+                f"{self.etcd_url}/{self.etcd_version}/etcd-{self.etcd_version}-linux-{arch}.tar.gz",
                 "-o",
-                f"/tmp/etcd-{self.etcd_version}-linux-amd64.tar.gz",
+                f"/tmp/etcd-{self.etcd_version}-linux-{arch}.tar.gz",
             ]
         )
         instance.exec(["mkdir", "-p", "/tmp/test-etcd"])
@@ -238,7 +240,7 @@ class EtcdCluster:
             [
                 "tar",
                 "xzvf",
-                f"/tmp/etcd-{self.etcd_version}-linux-amd64.tar.gz",
+                f"/tmp/etcd-{self.etcd_version}-linux-{arch}.tar.gz",
                 "-C",
                 "/tmp/test-etcd",
                 "--strip-components=1",

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -2,7 +2,7 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import subprocess
-from functools import partial
+from functools import cached_property, partial
 
 
 class HarnessError(Exception):
@@ -29,6 +29,12 @@ class Instance:
     @property
     def id(self) -> str:
         return self._id
+
+    @cached_property
+    def arch(self) -> str:
+        return self.exec(
+            ["dpkg", "--print-architecture"], text=True, capture_output=True
+        ).stdout.strip()
 
     def __str__(self) -> str:
         return f"{self._h.name}:{self.id}"

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 
 @pytest.mark.node_count(1)
 @pytest.mark.no_setup()
-@pytest.mark.xfail("cilium failures are blocking this from working")
+@pytest.mark.xfail(reason="cilium failures are blocking this from working")
 @pytest.mark.skipif(
     not config.VERSION_UPGRADE_CHANNELS, reason="No upgrade channels configured"
 )
@@ -26,10 +26,7 @@ def test_version_upgrades(instances: List[harness.Instance]):
                 "'recent' requires the number of releases as second argument and the flavour as third argument"
             )
         _, num_channels, flavour = channels
-        arch = cp.exec(
-            ["dpkg", "--print-architecture"], text=True, capture_output=True
-        ).stdout.strip()
-        channels = snap.get_latest_channels(int(num_channels), flavour, arch)
+        channels = snap.get_latest_channels(int(num_channels), flavour, cp.arch)
 
     LOG.info(
         f"Bootstrap node on {channels[0]} and upgrade through channels: {channels[1:]}"

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -1,47 +1,46 @@
 [tox]
-no_package = True
+skipsdist = True
 skip_missing_interpreters = True
 env_list = format, lint, integration
-min_version = 4.0.0
 
 [testenv]
 set_env =
     PYTHONBREAKPOINT=pdb.set_trace
     PY_COLORS=1
-pass_env =
+passenv =
     PYTHONPATH
 
 [testenv:format]
 description = Apply coding style standards to code
-deps = -r {tox_root}/requirements-dev.txt
+deps = -r {toxinidir}/requirements-dev.txt
 commands =
-    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/tests
-    isort {tox_root}/tests --profile=black
-    black {tox_root}/tests
+    licenseheaders -t {toxinidir}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {toxinidir}/tests
+    isort {toxinidir}/tests --profile=black
+    black {toxinidir}/tests
 
 [testenv:lint]
 description = Check code against coding style standards
-deps = -r {tox_root}/requirements-dev.txt
+deps = -r {toxinidir}/requirements-dev.txt
 commands =
-    codespell {tox_root}/tests
-    flake8 {tox_root}/tests
-    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/tests --dry
-    isort {tox_root}/tests --profile=black --check
-    black {tox_root}/tests --check --diff
+    codespell {toxinidir}/tests
+    flake8 {toxinidir}/tests
+    licenseheaders -t {toxinidir}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {toxinidir}/tests --dry
+    isort {toxinidir}/tests --profile=black --check
+    black {toxinidir}/tests --check --diff
 
 [testenv:integration]
 description = Run integration tests
 deps =
-    -r {tox_root}/requirements-test.txt
+    -r {toxinidir}/requirements-test.txt
 commands =
-    pytest -v \
+    pytest -vv \
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \
         --disable-warnings \
         {posargs} \
-        {tox_root}/tests
-pass_env =
+        {toxinidir}/tests
+passenv =
     TEST_*
 
 [flake8]


### PR DESCRIPTION
## Overview

Resolves a number of tests issues the nightly tests were having to run effectively on arm64 and amd64 units. 

## Details
* Changes to the github workflow definition 
    * Use system-wide tox installed through apt for arm64 workers to use
   * Correctly upload the right TEST_SNAP after its downloaded
   * Include inspection reports in failures
   * Add tmate session for remote debugging
* Add support for arm64 in the etcd tests (correct release url, correct systemd file)
* Address pytest syntax issue for use of `pytest.mark.xfail`
* Adjust the testing `tox.ini` to be tox 3 and 4 compatible