### PR TITLE
Update dualstack.md

### DIFF
--- a/docs/src/snap/howto/networking/dualstack.md
+++ b/docs/src/snap/howto/networking/dualstack.md
@@ -148,4 +148,3 @@ See upstream reference: [kube-apiserver validation][kube-apiserver-test]
 <!-- LINKS -->
 
 [kube-apiserver-test]: https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/validation_test.go#L435
-)

--- a/docs/src/snap/howto/networking/dualstack.md
+++ b/docs/src/snap/howto/networking/dualstack.md
@@ -142,3 +142,5 @@ limitations regarding CIDR size:
 Using a smaller value than `/108` for service CIDRs
 may cause issues like failure to initialize the IPv6 allocator. This is due
 to the CIDR size being too large for Kubernetes to handle efficiently.
+
+See upstream reference: https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/validation_test.go#L435

--- a/docs/src/snap/howto/networking/dualstack.md
+++ b/docs/src/snap/howto/networking/dualstack.md
@@ -139,6 +139,6 @@ When setting up dual-stack networking, it is important to consider the
 limitations regarding CIDR size:
 
 - **/108 is the maximum size for the Service CIDR**
-Using a smaller valuethan `/108` for service CIDRs
+Using a smaller value than `/108` for service CIDRs
 may cause issues like failure to initialize the IPv6 allocator. This is due
 to the CIDR size being too large for Kubernetes to handle efficiently.

--- a/docs/src/snap/howto/networking/dualstack.md
+++ b/docs/src/snap/howto/networking/dualstack.md
@@ -138,6 +138,6 @@ cluster bootstrap process. The key configuration parameters are:
 When setting up dual-stack networking, it is important to consider the
 limitations regarding CIDR size:
 
-- **/64 is too large for the Service CIDR**: Using a `/64` CIDR for services
+- **/108 is the maximum size for the Service CIDR**: Using a smaller value than `/108` for service CIDRs
 may cause issues like failure to initialize the IPv6 allocator. This is due
 to the CIDR size being too large for Kubernetes to handle efficiently.

--- a/docs/src/snap/howto/networking/dualstack.md
+++ b/docs/src/snap/howto/networking/dualstack.md
@@ -138,6 +138,7 @@ cluster bootstrap process. The key configuration parameters are:
 When setting up dual-stack networking, it is important to consider the
 limitations regarding CIDR size:
 
-- **/108 is the maximum size for the Service CIDR**: Using a smaller value than `/108` for service CIDRs
+- **/108 is the maximum size for the Service CIDR**
+Using a smaller valuethan `/108` for service CIDRs
 may cause issues like failure to initialize the IPv6 allocator. This is due
 to the CIDR size being too large for Kubernetes to handle efficiently.

--- a/docs/src/snap/howto/networking/dualstack.md
+++ b/docs/src/snap/howto/networking/dualstack.md
@@ -143,4 +143,9 @@ Using a smaller value than `/108` for service CIDRs
 may cause issues like failure to initialize the IPv6 allocator. This is due
 to the CIDR size being too large for Kubernetes to handle efficiently.
 
-See upstream reference: https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/validation_test.go#L435
+See upstream reference: [kube-apiserver validation][kube-apiserver-test]
+
+<!-- LINKS -->
+
+[kube-apiserver-test]: https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/validation_test.go#L435
+)


### PR DESCRIPTION
We have determined that /108 is the maximum supported size. Cluster fails to bootstrap with /64 and /96.