### PR TITLE
Mirror `libtirpc` to Launchpad

### DIFF
--- a/src/k8s/hack/env.sh
+++ b/src/k8s/hack/env.sh
@@ -2,7 +2,7 @@
 
 ## Component repositories
 REPO_MUSL="https://git.launchpad.net/musl"
-REPO_LIBTIRPC="https://salsa.debian.org/debian/libtirpc.git"
+REPO_LIBTIRPC="https://git.launchpad.net/libtirpc"
 REPO_LIBNSL="https://github.com/thkukuk/libnsl.git"
 REPO_LIBUV="https://github.com/libuv/libuv.git"
 REPO_LIBLZ4="https://github.com/lz4/lz4.git"


### PR DESCRIPTION
## Overview
We have seen some issues recently while cloning the `libtirpc` repo from debian. This pull request points the build scripts to our Launchpad mirror.