### PR TITLE
Removes lingering CSI plugin volume mounts on snap removal

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -60,17 +60,20 @@ k8s::remove::containers() {
   # delete cni network namespaces
   ip netns list | cut -f1 -d' ' | grep -- "^cni-" | xargs -n1 -r -t ip netns delete || true
 
-  # unmount NFS volumes forcefully, as unmounting them normally may hang otherwise.
+  # unmount Pod NFS volumes forcefully, as unmounting them normally may hang otherwise.
   cat /proc/mounts | grep /run/containerd/io.containerd. | grep "nfs[34]" | cut -f2 -d' ' | xargs -r -t umount -f || true
   cat /proc/mounts | grep /var/lib/kubelet/pods | grep "nfs[34]" | cut -f2 -d' ' | xargs -r -t umount -f || true
 
-  # unmount volumes
+  # unmount Pod volumes gracefully.
   cat /proc/mounts | grep /run/containerd/io.containerd. | cut -f2 -d' ' | xargs -r -t umount || true
   cat /proc/mounts | grep /var/lib/kubelet/pods | cut -f2 -d' ' | xargs -r -t umount || true
 
-  # umount lingering volumes by force, to prevent potential volume leaks.
+  # unmount lingering Pod volumes by force, to prevent potential volume leaks.
   cat /proc/mounts | grep /run/containerd/io.containerd. | cut -f2 -d' ' | xargs -r -t umount -f || true
   cat /proc/mounts | grep /var/lib/kubelet/pods | cut -f2 -d' ' | xargs -r -t umount -f || true
+
+  # unmount various volumes exposed by CSI plugin drivers.
+  cat /proc/mounts | grep /var/lib/kubelet/plugins | cut -f2 -d' ' | xargs -r -t umount -f || true
 
   # remove kubelet plugin sockets, as we don't have the containers associated with them anymore,
   # so kubelet won't try to access inexistent plugins on reinstallation.


### PR DESCRIPTION
At the moment, we're unmounting the mounted Pod volumes (``/var/lib/kubelet/pods``) from the system when we remove the snap. However, there may still be volume mounts from certain CSI drivers like Longhorn still mounted (``/var/lib/kubelet/plugins``).

This commit addresses this issue.

Example leaked mounts from Longhorn:

```
cat /proc/mounts | grep /var/lib/kubelet
/dev/longhorn/pvc-14f3eced-66bb-4adc-9c12-d7edcbe80bc0 /var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/b337ad411e8b121b6c392afc3578ff72103fdefddae0524b9b8459b1706259a1/globalmount ext4 rw,relatime 0 0
10.152.183.200:/pvc-8a8d1b75-aada-4360-ac44-315751149fe7 /var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/183ab2cffd14d3869ddd02e1d7b9fb3307b69a3bd3f8fef6f9224e1636496c15/globalmount nfs4 rw,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,softerr,softreval,noresvport,proto=tcp,timeo=600,retrans=5,sec=sys,clientaddr=172.25.255.244,local_lock=none,addr=10.152.183.200 0 0
```