### PR TITLE
Add annotations for configuring which devices cilium use for routing

### DIFF
--- a/src/k8s/cmd/k8s/k8s_bootstrap_test.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
 	cmdutil "github.com/canonical/k8s/cmd/util"
 	"github.com/canonical/k8s/pkg/utils"
 	. "github.com/onsi/gomega"
@@ -63,8 +64,8 @@ var testCases = []testCase{
 				},
 				CloudProvider: utils.Pointer("external"),
 				Annotations: map[string]string{
-					apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove: "true",
-					apiv1.AnnotationSkipStopServicesOnRemove:          "true",
+					apiv1_annotations.AnnotationSkipCleanupKubernetesNodeOnRemove: "true",
+					apiv1_annotations.AnnotationSkipStopServicesOnRemove:          "true",
 				},
 			},
 			ControlPlaneTaints:                 []string{"node-role.kubernetes.io/control-plane:NoSchedule"},

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -5,7 +5,7 @@ go 1.22.6
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite v1.22.0
-	github.com/canonical/k8s-snap-api v1.0.10
+	github.com/canonical/k8s-snap-api v1.0.11
 	github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230
 	github.com/canonical/microcluster/v3 v3.0.0-20240827143335-f7a4d3984970
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -99,8 +99,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite v1.22.0 h1:DuJmfcREl4gkQJyvZzjl2GHFZROhbPyfdjDRQXpkOyw=
 github.com/canonical/go-dqlite v1.22.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/k8s-snap-api v1.0.10 h1:BoAw4Vr8mR8MWTKeZZxH5LmrF3JYGSZHDv+KEo5ifoU=
-github.com/canonical/k8s-snap-api v1.0.10/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
+github.com/canonical/k8s-snap-api v1.0.11 h1:nGtwrUQBLiaL3HUXFx2gb4kq6qVpl2yNwMwHVX0dEok=
+github.com/canonical/k8s-snap-api v1.0.11/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
 github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230 h1:YOqZ+/14OPZ+/TOXpRHIX3KLT0C+wZVpewKIwlGUmW0=
 github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230/go.mod h1:YVGI7HStOKsV+cMyXWnJ7RaMPaeWtrkxyIPvGWbgACc=
 github.com/canonical/microcluster/v3 v3.0.0-20240827143335-f7a4d3984970 h1:UrnpglbXELlxtufdk6DGDytu2JzyzuS3WTsOwPrkQLI=

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/utils"
@@ -87,7 +88,7 @@ func (e *Endpoints) postClusterRemove(s state.State, r *http.Request) response.R
 		return response.InternalError(fmt.Errorf("failed to get cluster config: %w", err))
 	}
 
-	if _, ok := cfg.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove]; ok {
+	if _, ok := cfg.Annotations[apiv1_annotations.AnnotationSkipCleanupKubernetesNodeOnRemove]; ok {
 		// Explicitly skip removing the node from Kubernetes.
 		log.Info("Skipping Kubernetes worker node removal")
 		return response.SyncResponse(true, nil)

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -61,7 +62,7 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 
 	cfg, err := databaseutil.GetClusterConfig(ctx, s)
 	if err == nil {
-		if _, ok := cfg.Annotations.Get(apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove); !ok {
+		if _, ok := cfg.Annotations.Get(apiv1_annotations.AnnotationSkipCleanupKubernetesNodeOnRemove); !ok {
 			c, err := snap.KubernetesClient("")
 			if err != nil {
 				log.Error(err, "Failed to create Kubernetes client", err)

--- a/src/k8s/pkg/k8sd/features/calico/internal.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal.go
@@ -4,25 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations/calico"
 	"github.com/canonical/k8s/pkg/k8sd/types"
-)
-
-const (
-	annotationAPIServerEnabled             = "k8sd/v1alpha1/calico/apiserver-enabled"
-	annotationEncapsulationV4              = "k8sd/v1alpha1/calico/encapsulation-v4"
-	annotationEncapsulationV6              = "k8sd/v1alpha1/calico/encapsulation-v6"
-	annotationAutodetectionV4FirstFound    = "k8sd/v1alpha1/calico/autodetection-v4/firstFound"
-	annotationAutodetectionV4Kubernetes    = "k8sd/v1alpha1/calico/autodetection-v4/kubernetes"
-	annotationAutodetectionV4Interface     = "k8sd/v1alpha1/calico/autodetection-v4/interface"
-	annotationAutodetectionV4SkipInterface = "k8sd/v1alpha1/calico/autodetection-v4/skipInterface"
-	annotationAutodetectionV4CanReach      = "k8sd/v1alpha1/calico/autodetection-v4/canReach"
-	annotationAutodetectionV4CIDRs         = "k8sd/v1alpha1/calico/autodetection-v4/cidrs"
-	annotationAutodetectionV6FirstFound    = "k8sd/v1alpha1/calico/autodetection-v6/firstFound"
-	annotationAutodetectionV6Kubernetes    = "k8sd/v1alpha1/calico/autodetection-v6/kubernetes"
-	annotationAutodetectionV6Interface     = "k8sd/v1alpha1/calico/autodetection-v6/interface"
-	annotationAutodetectionV6SkipInterface = "k8sd/v1alpha1/calico/autodetection-v6/skipInterface"
-	annotationAutodetectionV6CanReach      = "k8sd/v1alpha1/calico/autodetection-v6/canReach"
-	annotationAutodetectionV6CIDRs         = "k8sd/v1alpha1/calico/autodetection-v6/cidrs"
 )
 
 type config struct {
@@ -82,18 +65,18 @@ func internalConfig(annotations types.Annotations) (config, error) {
 		apiServerEnabled: defaultAPIServerEnabled,
 	}
 
-	if v, ok := annotations.Get(annotationAPIServerEnabled); ok {
+	if v, ok := annotations.Get(apiv1_annotations.AnnotationAPIServerEnabled); ok {
 		c.apiServerEnabled = v == "true"
 	}
 
-	if v, ok := annotations.Get(annotationEncapsulationV4); ok {
+	if v, ok := annotations.Get(apiv1_annotations.AnnotationEncapsulationV4); ok {
 		if err := checkEncapsulation(v); err != nil {
 			return config{}, fmt.Errorf("invalid encapsulation-v4 annotation: %w", err)
 		}
 		c.encapsulationV4 = v
 	}
 
-	if v, ok := annotations.Get(annotationEncapsulationV6); ok {
+	if v, ok := annotations.Get(apiv1_annotations.AnnotationEncapsulationV6); ok {
 		if err := checkEncapsulation(v); err != nil {
 			return config{}, fmt.Errorf("invalid encapsulation-v6 annotation: %w", err)
 		}
@@ -101,12 +84,12 @@ func internalConfig(annotations types.Annotations) (config, error) {
 	}
 
 	v4Map := map[string]string{
-		annotationAutodetectionV4FirstFound:    "firstFound",
-		annotationAutodetectionV4Kubernetes:    "kubernetes",
-		annotationAutodetectionV4Interface:     "interface",
-		annotationAutodetectionV4SkipInterface: "skipInterface",
-		annotationAutodetectionV4CanReach:      "canReach",
-		annotationAutodetectionV4CIDRs:         "cidrs",
+		apiv1_annotations.AnnotationAutodetectionV4FirstFound:    "firstFound",
+		apiv1_annotations.AnnotationAutodetectionV4Kubernetes:    "kubernetes",
+		apiv1_annotations.AnnotationAutodetectionV4Interface:     "interface",
+		apiv1_annotations.AnnotationAutodetectionV4SkipInterface: "skipInterface",
+		apiv1_annotations.AnnotationAutodetectionV4CanReach:      "canReach",
+		apiv1_annotations.AnnotationAutodetectionV4CIDRs:         "cidrs",
 	}
 
 	autodetectionV4, err := parseAutodetectionAnnotations(annotations, v4Map)
@@ -119,12 +102,12 @@ func internalConfig(annotations types.Annotations) (config, error) {
 	}
 
 	v6Map := map[string]string{
-		annotationAutodetectionV6FirstFound:    "firstFound",
-		annotationAutodetectionV6Kubernetes:    "kubernetes",
-		annotationAutodetectionV6Interface:     "interface",
-		annotationAutodetectionV6SkipInterface: "skipInterface",
-		annotationAutodetectionV6CanReach:      "canReach",
-		annotationAutodetectionV6CIDRs:         "cidrs",
+		apiv1_annotations.AnnotationAutodetectionV6FirstFound:    "firstFound",
+		apiv1_annotations.AnnotationAutodetectionV6Kubernetes:    "kubernetes",
+		apiv1_annotations.AnnotationAutodetectionV6Interface:     "interface",
+		apiv1_annotations.AnnotationAutodetectionV6SkipInterface: "skipInterface",
+		apiv1_annotations.AnnotationAutodetectionV6CanReach:      "canReach",
+		apiv1_annotations.AnnotationAutodetectionV6CIDRs:         "cidrs",
 	}
 
 	autodetectionV6, err := parseAutodetectionAnnotations(annotations, v6Map)

--- a/src/k8s/pkg/k8sd/features/calico/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/calico/internal_test.go
@@ -3,6 +3,7 @@ package calico
 import (
 	"testing"
 
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations/calico"
 	. "github.com/onsi/gomega"
 )
 
@@ -26,8 +27,8 @@ func TestInternalConfig(t *testing.T) {
 		{
 			name: "Valid",
 			annotations: map[string]string{
-				annotationAPIServerEnabled: "true",
-				annotationEncapsulationV4:  "IPIP",
+				apiv1_annotations.AnnotationAPIServerEnabled: "true",
+				apiv1_annotations.AnnotationEncapsulationV4:  "IPIP",
 			},
 			expectedConfig: config{
 				apiServerEnabled: true,
@@ -39,15 +40,15 @@ func TestInternalConfig(t *testing.T) {
 		{
 			name: "InvalidEncapsulation",
 			annotations: map[string]string{
-				annotationEncapsulationV4: "Invalid",
+				apiv1_annotations.AnnotationEncapsulationV4: "Invalid",
 			},
 			expectError: true,
 		},
 		{
 			name: "InvalidAPIServerEnabled",
 			annotations: map[string]string{
-				annotationAPIServerEnabled: "invalid",
-				annotationEncapsulationV4:  "VXLAN",
+				apiv1_annotations.AnnotationAPIServerEnabled: "invalid",
+				apiv1_annotations.AnnotationEncapsulationV4:  "VXLAN",
 			},
 			expectedConfig: config{
 				apiServerEnabled: false,
@@ -59,15 +60,15 @@ func TestInternalConfig(t *testing.T) {
 		{
 			name: "MultipleAutodetectionV4",
 			annotations: map[string]string{
-				annotationAutodetectionV4FirstFound: "true",
-				annotationAutodetectionV4Kubernetes: "true",
+				apiv1_annotations.AnnotationAutodetectionV4FirstFound: "true",
+				apiv1_annotations.AnnotationAutodetectionV4Kubernetes: "true",
 			},
 			expectError: true,
 		},
 		{
 			name: "ValidAutodetectionCidrs",
 			annotations: map[string]string{
-				annotationAutodetectionV4CIDRs: "10.1.0.0/16,2001:0db8::/32",
+				apiv1_annotations.AnnotationAutodetectionV4CIDRs: "10.1.0.0/16,2001:0db8::/32",
 			},
 			expectedConfig: config{
 				apiServerEnabled: false,

--- a/src/k8s/pkg/k8sd/features/cilium/internal.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal.go
@@ -1,17 +1,8 @@
 package cilium
 
 import (
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations/cilium"
 	"github.com/canonical/k8s/pkg/k8sd/types"
-)
-
-const (
-	// List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
-	// e.g. k8sd/v1alpha1/cilium/devices="eth+ lxdbr+"
-	annotationDevices = "k8sd/v1alpha1/cilium/devices"
-
-	// Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route
-	// bridge type devices are ingored in automatic selection
-	annotationDirectRoutingDevice = "k8sd/v1alpha1/cilium/direct-routing-device"
 )
 
 type config struct {
@@ -22,11 +13,11 @@ type config struct {
 func internalConfig(annotations types.Annotations) (config, error) {
 	c := config{}
 
-	if v, ok := annotations.Get(annotationDevices); ok {
+	if v, ok := annotations.Get(apiv1_annotations.AnnotationDevices); ok {
 		c.devices = v
 	}
 
-	if v, ok := annotations.Get(annotationDirectRoutingDevice); ok {
+	if v, ok := annotations.Get(apiv1_annotations.AnnotationDirectRoutingDevice); ok {
 		c.directRoutingDevice = v
 	}
 

--- a/src/k8s/pkg/k8sd/features/cilium/internal.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal.go
@@ -1,0 +1,34 @@
+package cilium
+
+import (
+	"github.com/canonical/k8s/pkg/k8sd/types"
+)
+
+const (
+	// List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'
+	// e.g. k8sd/v1alpha1/cilium/devices="eth+ lxdbr+"
+	annotationDevices = "k8sd/v1alpha1/cilium/devices"
+
+	// Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route
+	// bridge type devices are ingored in automatic selection
+	annotationDirectRoutingDevice = "k8sd/v1alpha1/cilium/direct-routing-device"
+)
+
+type config struct {
+	devices             string
+	directRoutingDevice string
+}
+
+func internalConfig(annotations types.Annotations) (config, error) {
+	c := config{}
+
+	if v, ok := annotations.Get(annotationDevices); ok {
+		c.devices = v
+	}
+
+	if v, ok := annotations.Get(annotationDirectRoutingDevice); ok {
+		c.directRoutingDevice = v
+	}
+
+	return c, nil
+}

--- a/src/k8s/pkg/k8sd/features/cilium/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal_test.go
@@ -1,0 +1,54 @@
+package cilium
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestInternalConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		annotations    map[string]string
+		expectedConfig config
+		expectError    bool
+	}{
+		{
+			name:        "Empty",
+			annotations: map[string]string{},
+			expectedConfig: config{
+				devices:             "",
+				directRoutingDevice: "",
+			},
+			expectError: false,
+		},
+		{
+			name: "Valid",
+			annotations: map[string]string{
+				annotationDevices:             "eth+ lxdbr+",
+				annotationDirectRoutingDevice: "eth0",
+			},
+			expectedConfig: config{
+				devices:             "eth+ lxdbr+",
+				directRoutingDevice: "eth0",
+			},
+			expectError: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			annotations := make(map[string]string)
+			for k, v := range tc.annotations {
+				annotations[k] = v
+			}
+
+			parsed, err := internalConfig(annotations)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(parsed).To(Equal(tc.expectedConfig))
+			}
+		})
+	}
+}

--- a/src/k8s/pkg/k8sd/features/cilium/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal_test.go
@@ -3,6 +3,7 @@ package cilium
 import (
 	"testing"
 
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations/cilium"
 	. "github.com/onsi/gomega"
 )
 
@@ -25,8 +26,8 @@ func TestInternalConfig(t *testing.T) {
 		{
 			name: "Valid",
 			annotations: map[string]string{
-				annotationDevices:             "eth+ lxdbr+",
-				annotationDirectRoutingDevice: "eth0",
+				apiv1_annotations.AnnotationDevices:             "eth+ lxdbr+",
+				apiv1_annotations.AnnotationDirectRoutingDevice: "eth0",
 			},
 			expectedConfig: config{
 				devices:             "eth+ lxdbr+",

--- a/src/k8s/pkg/k8sd/features/metrics-server/internal.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/internal.go
@@ -1,10 +1,8 @@
 package metrics_server
 
-import "github.com/canonical/k8s/pkg/k8sd/types"
-
-const (
-	annotationImageRepo = "k8sd/v1alpha1/metrics-server/image-repo"
-	annotationImageTag  = "k8sd/v1alpha1/metrics-server/image-tag"
+import (
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations/metrics-server"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 )
 
 type config struct {
@@ -18,10 +16,10 @@ func internalConfig(annotations types.Annotations) config {
 		imageTag:  imageTag,
 	}
 
-	if v, ok := annotations.Get(annotationImageRepo); ok {
+	if v, ok := annotations.Get(apiv1_annotations.AnnotationImageRepo); ok {
 		config.imageRepo = v
 	}
-	if v, ok := annotations.Get(annotationImageTag); ok {
+	if v, ok := annotations.Get(apiv1_annotations.AnnotationImageTag); ok {
 		config.imageTag = v
 	}
 


### PR DESCRIPTION
Fixes #702

Cilium [excludes](https://github.com/cilium/cilium/pull/17560) `bridge` devices while performing auto detection and suggests providing the selection filtermanually through the `devices` flag if auto detection is not suitable.

This PR adds the `k8sd/v1alpha1/cilium/devices` and `k8sd/v1alpha1/cilium/direct-routing-device` annotations to let users configure which devices(interfaces) can be used by cilium. 

Initially we aimed to override this auto detection and select the device based on the node internal ip however the device names could be different on multiple machines which breaks this assumption. As an alternative we could set the `devices` field with a certain default value with wildcard filters to cover common interface names, e.g. `eth+ lxdbr+ enp+`.