### PR TITLE
Enable duplicate word check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,14 +16,11 @@ linters:
   - bodyclose
   - canonicalheader
   - copyloopvar
+  - decorder
+  - dogsled
+  - dupword
 
 # TODO(ben): Enable those linters step by step and fix existing issues.
-# - cyclop
-# - decorder
-# - depguard
-# - dogsled
-# - dupl
-# - dupword
 # - durationcheck
 # - err113
 # - errcheck
@@ -329,10 +326,4 @@ issues:
       linters: [ gocritic ]
     - path: "_test\\.go"
       linters:
-        - bodyclose
-        - dupl
-        - funlen
-        - goconst
-        - gosec
-        - noctx
-        - wrapcheck
+        - dupword

--- a/src/k8s/pkg/k8sd/features/contour/chart.go
+++ b/src/k8s/pkg/k8sd/features/contour/chart.go
@@ -39,7 +39,7 @@ var (
 
 	// NOTE: The image version is v1.29.2 instead of 1.28.2
 	// to follow the upstream configuration for the contour gateway provisioner.
-	// ContourGatewayProvisionerEnvoyImageTag is the tag to use for for envoy in the gateway.
+	// ContourGatewayProvisionerEnvoyImageTag is the tag to use for envoy in the gateway.
 	ContourGatewayProvisionerEnvoyImageTag = "v1.29.2"
 
 	// ContourIngressEnvoyImageRepo represents the image to use for the Contour Envoy proxy.


### PR DESCRIPTION
Remove cyclop - we have intentional long code at some places 
Remove depguard - we don't want to deny any package 
Remove dupl - we have duplicate code by intention in some places.