### PR TITLE
Enable gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,16 +32,14 @@ linters:
   # - funlen - TODO(ben): maybe consider later; needs some refactoring
   - gci
   - ginkgolinter
+  - gocheckcompilerdirectives
+  # - gochecknoglobals - TODO(ben): We have some global vars, maybe refactor later as this sounds like a useful linter
+  - gochecksumtype
+  # - goconst - TODO(ben): Consider moving consts into separate package
+  - gocritic
 
 
 # TODO(ben): Enable those linters step by step and fix existing issues.
-# - gocheckcompilerdirectives
-# - gochecknoglobals
-# - gochecknoinits
-# - gochecksumtype
-# - gocognit
-# - goconst
-# - gocritic
 # - gocyclo
 # - godot
 # - godox
@@ -329,3 +327,4 @@ issues:
         - dupword
         - err113
         - forcetypeassert
+        - goconst

--- a/src/k8s/cmd/util/hooks.go
+++ b/src/k8s/cmd/util/hooks.go
@@ -25,15 +25,15 @@ func getFileOwnerAndGroup(filePath string) (uid, gid uint32, err error) {
 
 // ValidateRootOwnership checks if the specified path is owned by the root user and root group.
 func ValidateRootOwnership(path string) (err error) {
-	UID, GID, err := getFileOwnerAndGroup(path)
+	uid, gid, err := getFileOwnerAndGroup(path)
 	if err != nil {
 		return err
 	}
-	if UID != 0 {
-		return fmt.Errorf("owner of %s is user with UID %d expected 0", path, UID)
+	if uid != 0 {
+		return fmt.Errorf("owner of %s is user with UID %d expected 0", path, uid)
 	}
-	if GID != 0 {
-		return fmt.Errorf("owner of %s is group with GID %d expected 0", path, GID)
+	if gid != 0 {
+		return fmt.Errorf("owner of %s is group with GID %d expected 0", path, gid)
 	}
 	return nil
 }

--- a/src/k8s/pkg/docgen/json_struct.go
+++ b/src/k8s/pkg/docgen/json_struct.go
@@ -36,7 +36,7 @@ func MarkdownFromJsonStruct(i any, projectDir string) (string, error) {
 
 	var out strings.Builder
 	for _, field := range fields {
-		outFieldType := strings.Replace(field.TypeName, "*", "", -1)
+		outFieldType := strings.ReplaceAll(field.TypeName, "*", "")
 		entry := fmt.Sprintf(entryTemplate, field.FullJsonPath, outFieldType, field.Docstring)
 		out.WriteString(entry)
 	}

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
@@ -71,8 +71,7 @@ func (c *ControlPlaneConfigurationController) Run(ctx context.Context, getCluste
 
 func (c *ControlPlaneConfigurationController) reconcile(ctx context.Context, config types.ClusterConfig) error {
 	// kube-apiserver: external datastore
-	switch config.Datastore.GetType() {
-	case "external":
+	if config.Datastore.GetType() == "external" {
 		// certificates
 		certificatesChanged, err := setup.EnsureExtDatastorePKI(c.snap, &pki.ExternalDatastorePKI{
 			DatastoreCACert:     config.Datastore.GetExternalCACert(),

--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -28,7 +28,7 @@ var (
 		ManifestPath: filepath.Join("charts", "gateway-api-1.0.0.tgz"),
 	}
 
-	//chartGatewayClass represents a manifest to deploy a GatewayClass called ck-gateway.
+	// chartGatewayClass represents a manifest to deploy a GatewayClass called ck-gateway.
 	chartGatewayClass = helm.InstallableChart{
 		Name:         "ck-gateway-class",
 		Namespace:    "default",

--- a/src/k8s/pkg/k8sd/features/cilium/ingress_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/ingress_test.go
@@ -27,7 +27,7 @@ func TestIngress(t *testing.T) {
 		applyChanged   bool
 		ingressEnabled bool
 		helmErr        error
-		//then
+		// then
 		statusMsg     string
 		statusEnabled bool
 	}{

--- a/src/k8s/pkg/k8sd/features/cilium/loadbalancer.go
+++ b/src/k8s/pkg/k8sd/features/cilium/loadbalancer.go
@@ -50,19 +50,20 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 		}, err
 	}
 
-	if loadbalancer.GetBGPMode() {
+	switch {
+	case loadbalancer.GetBGPMode():
 		return types.FeatureStatus{
 			Enabled: true,
 			Version: CiliumAgentImageTag,
 			Message: fmt.Sprintf(lbEnabledMsgTmpl, "BGP"),
 		}, nil
-	} else if loadbalancer.GetL2Mode() {
+	case loadbalancer.GetL2Mode():
 		return types.FeatureStatus{
 			Enabled: true,
 			Version: CiliumAgentImageTag,
 			Message: fmt.Sprintf(lbEnabledMsgTmpl, "L2"),
 		}, nil
-	} else {
+	default:
 		return types.FeatureStatus{
 			Enabled: true,
 			Version: CiliumAgentImageTag,
@@ -198,7 +199,7 @@ func waitForRequiredLoadBalancerCRDs(ctx context.Context, snap snap.Snap, bgpMod
 		requiredCount := len(requiredCRDs)
 		for _, resource := range resources.APIResources {
 			if _, ok := requiredCRDs[resource.Name]; ok {
-				requiredCount = requiredCount - 1
+				requiredCount--
 			}
 		}
 		return requiredCount == 0, nil

--- a/src/k8s/pkg/k8sd/features/metallb/loadbalancer.go
+++ b/src/k8s/pkg/k8sd/features/metallb/loadbalancer.go
@@ -47,19 +47,20 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 		}, err
 	}
 
-	if loadbalancer.GetBGPMode() {
+	switch {
+	case loadbalancer.GetBGPMode():
 		return types.FeatureStatus{
 			Enabled: true,
 			Version: ControllerImageTag,
 			Message: fmt.Sprintf(enabledMsgTmpl, "BGP"),
 		}, nil
-	} else if loadbalancer.GetL2Mode() {
+	case loadbalancer.GetL2Mode():
 		return types.FeatureStatus{
 			Enabled: true,
 			Version: ControllerImageTag,
 			Message: fmt.Sprintf(enabledMsgTmpl, "L2"),
 		}, nil
-	} else {
+	default:
 		return types.FeatureStatus{
 			Enabled: true,
 			Version: ControllerImageTag,

--- a/src/k8s/pkg/k8sd/features/metrics-server/metrics_server_test.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/metrics_server_test.go
@@ -79,11 +79,12 @@ func TestApplyMetricsServer(t *testing.T) {
 				HaveField("Chart.Namespace", Equal("kube-system")),
 				HaveField("State", Equal(tc.expectState)),
 			)))
-			if errors.Is(tc.helmError, helmErr) {
+			switch {
+			case errors.Is(tc.helmError, helmErr):
 				g.Expect(status.Message).To(ContainSubstring(helmErr.Error()))
-			} else if tc.config.GetEnabled() {
+			case tc.config.GetEnabled():
 				g.Expect(status.Message).To(Equal("enabled"))
-			} else {
+			default:
 				g.Expect(status.Message).To(Equal("disabled"))
 			}
 		})

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -200,7 +200,7 @@ func (s *Snap) SnapctlGet(ctx context.Context, args ...string) ([]byte, error) {
 	return s.Mock.SnapctlGet[strings.Join(args, " ")], s.SnapctlGetErr
 }
 func (s *Snap) SnapctlSet(ctx context.Context, args ...string) error {
-	s.SnapctlSetCalledWith = append(s.SnapctlGetCalledWith, args)
+	s.SnapctlSetCalledWith = append(s.SnapctlSetCalledWith, args)
 	return s.SnapctlSetErr
 }
 func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig) error {

--- a/src/k8s/pkg/utils/cidr.go
+++ b/src/k8s/pkg/utils/cidr.go
@@ -167,8 +167,8 @@ func GetDefaultAddress() (ipv4, ipv6 string, err error) {
 }
 
 // SplitCIDRStrings parses the given CIDR string and returns the respective IPv4 and IPv6 CIDRs.
-func SplitCIDRStrings(CIDRstring string) (string, string, error) {
-	clusterCIDRs := strings.Split(CIDRstring, ",")
+func SplitCIDRStrings(cidrString string) (string, string, error) {
+	clusterCIDRs := strings.Split(cidrString, ",")
 	if v := len(clusterCIDRs); v != 1 && v != 2 {
 		return "", "", fmt.Errorf("invalid CIDR list: %v", clusterCIDRs)
 	}

--- a/src/k8s/pkg/utils/pki/load.go
+++ b/src/k8s/pkg/utils/pki/load.go
@@ -64,8 +64,7 @@ func LoadRSAPublicKey(keyPEM string) (*rsa.PublicKey, error) {
 	if pb == nil {
 		return nil, fmt.Errorf("failed to parse PEM block")
 	}
-	switch pb.Type {
-	case "PUBLIC KEY":
+	if pb.Type == "PUBLIC KEY" {
 		parsed, err := x509.ParsePKIXPublicKey(pb.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse public key: %w", err)
@@ -86,8 +85,7 @@ func LoadCertificateRequest(csrPEM string) (*x509.CertificateRequest, error) {
 	if pb == nil {
 		return nil, fmt.Errorf("failed to parse certificate request PEM")
 	}
-	switch pb.Type {
-	case "CERTIFICATE REQUEST":
+	if pb.Type == "CERTIFICATE REQUEST" {
 		parsed, err := x509.ParseCertificateRequest(pb.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse certificate request: %w", err)


### PR DESCRIPTION
`gochecknoglobals` and `goconst` require some refactoring. Let's consider them later.