### PR TITLE
Add Configure Custom Registries How-To

### DIFF
--- a/docs/src/charm/howto/custom-registry.md
+++ b/docs/src/charm/howto/custom-registry.md
@@ -26,7 +26,7 @@ For example, to configure the charm to use a custom registry at
 `mypassword`, set the `containerd_custom_registries` configuration option as
 follows:
 
-```bash
+```
 juju config k8s containerd_custom_registries='[{
     "url": "http://myregistry.example.com:5000",
     "host": "myregistry.example.com:5000",
@@ -39,7 +39,7 @@ Allow the charm to apply the configuration changes and wait for Juju to
 indicate that the changes have been successfully applied. You can monitor the
 progress by running:
 
-```bash
+```
 juju status --watch 2s
 ```
 
@@ -53,21 +53,21 @@ For example, to create a new workload using the `nginx:latest` image that you
 have previously pushed to the `myregistry.example.com:5000` registry, run the
 following command:
 
-```bash
+```
 kubectl run nginx --image=myregistry.example.com:5000/nginx:latest
 ```
 
 To confirm that the image has been pulled from the custom registry and that the
 workload is running, use the following command:
 
-```bash
-kubectl get pod nginx -o jsonpath='{.spec.containers[*].image}{"->"}{.status.containerStatuses[*].ready}
+```
+kubectl get pod nginx -o jsonpath='{.spec.containers[*].image}{"->"}{.status.containerStatuses[*].ready}'
 ```
 
 The output should indicate that the image was pulled from the custom registry
 and that the workload is running.
 
-```bash
+```
 myregistry.example.com:5000/nginx:latest->true
 ```
 

--- a/docs/src/charm/howto/custom-registry.md
+++ b/docs/src/charm/howto/custom-registry.md
@@ -1,0 +1,76 @@
+# Configure a Custom Registry
+
+The `k8s` charm can be configured to use a custom container registry for its
+container images. This is particularly useful if you have a private registry or
+operate in an air-gapped environment where you need to pull images from a
+different registry. This guide will walk you through the steps to set up `k8s`
+charm to pull images from a custom registry.
+
+## Prerequisites
+
+- A running `k8s` charm cluster.
+- Access to a custom container registry from the cluster (e.g., docker registry
+  or Harbor).
+
+## Configure the Charm
+
+To configure the charm to use a custom registry, you need to set the
+`containerd_custom_registries` configuration option. This options allows
+the charm to configure `containerd` to pull images from registries that require
+authentication. This configuration option should be a JSON-formatted array of
+credential objects. For more details on the `containerd_custom_registries`
+option, refer to the [charm configurations] documentation.
+
+For example, to configure the charm to use a custom registry at
+`myregistry.example.com:5000` with the username `myuser` and password
+`mypassword`, set the `containerd_custom_registries` configuration option as
+follows:
+
+```bash
+juju config k8s containerd_custom_registries='[{
+    "url": "http://myregistry.example.com:5000",
+    "host": "myregistry.example.com:5000",
+    "username": "myuser",
+    "password": "mypassword"
+}]'
+```
+
+Allow the charm to apply the configuration changes and wait for Juju to
+indicate that the changes have been successfully applied. You can monitor the
+progress by running:
+
+```bash
+juju status --watch 2s
+```
+
+## Verify the Configuration
+
+Once the charm is configured and active, verify that the custom registry is
+configured correctly by creating a new workload and ensuring that the images
+are being pulled from the custom registry.
+
+For example, to create a new workload using the `nginx:latest` image that you
+have previously pushed to the `myregistry.example.com:5000` registry, run the
+following command:
+
+```bash
+kubectl run nginx --image=myregistry.example.com:5000/nginx:latest
+```
+
+To confirm that the image has been pulled from the custom registry and that the
+workload is running, use the following command:
+
+```bash
+kubectl get pod nginx -o jsonpath='{.spec.containers[*].image}{"->"}{.status.containerStatuses[*].ready}
+```
+
+The output should indicate that the image was pulled from the custom registry
+and that the workload is running.
+
+```bash
+myregistry.example.com:5000/nginx:latest->true
+```
+
+<!-- LINKS -->
+
+[charm configurations]: https://charmhub.io/k8s/configurations

--- a/docs/src/charm/howto/index.md
+++ b/docs/src/charm/howto/index.md
@@ -20,6 +20,7 @@ etcd
 proxy
 cos-lite
 contribute
+custom-registry
 
 ```
 


### PR DESCRIPTION
## Overview
Add a new How-To page to guide users on configuring custom registries for the `k8s` charm.
### Testing
Custom registry on AWS.
```
Name:             nginx
Namespace:        default
Priority:         0
Service Account:  default
Node:             ip-172-31-17-168.ec2.internal/172.31.17.168
Start Time:       Wed, 16 Oct 2024 22:46:08 +0000
Labels:           run=nginx
Annotations:      <none>
Status:           Running
IP:               10.1.0.115
IPs:
  IP:  10.1.0.115
Containers:
  nginx:
    Container ID:   containerd://f729364d3dc2636626b6c971ea1cbe95cb9d6febb39356c132959a862ca8707e
    Image:          52.205.98.73:5043/nginx:latest
    Image ID:       52.205.98.73:5043/nginx@sha256:719b34dba7bd01c795f94b3a6f3a5f1fe7d53bf09e79e355168a17d2e2949cef
    Port:           <none>
    Host Port:      <none>
    State:          Running
      Started:      Wed, 16 Oct 2024 22:46:08 +0000
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-9lwbb (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
Volumes:
  kube-api-access-9lwbb:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  32m   default-scheduler  Successfully assigned default/nginx to ip-172-31-17-168.ec2.internal
  Normal  Pulling    32m   kubelet            Pulling image "52.205.98.73:5043/nginx:latest"
  Normal  Pulled     32m   kubelet            Successfully pulled image "52.205.98.73:5043/nginx:latest" in 57ms (57ms including waiting). Image size: 72939605 bytes.
  Normal  Created    32m   kubelet            Created container nginx
  Normal  Started    32m   kubelet            Started container nginx
  ```
## Related Issues
https://github.com/canonical/k8s-operator/issues/111