### PR TITLE
[Release 1.30] Update to arm64 versions of the same images

### DIFF
--- a/src/k8s/pkg/k8sd/features/images.go
+++ b/src/k8s/pkg/k8sd/features/images.go
@@ -4,13 +4,13 @@ const dnsImageRepository = "ghcr.io/canonical/coredns"
 const dnsImageTag = "1.11.1-ck4"
 
 const ciliumAgentImageRepository = "ghcr.io/canonical/cilium"
-const ciliumAgentImageTag = "1.15.2-ck1"
+const ciliumAgentImageTag = "1.15.2-ck2"
 
 const ciliumOperatorImageRepository = "ghcr.io/canonical/cilium-operator"
-const ciliumOperatorImageTag = "1.15.2-ck1"
+const ciliumOperatorImageTag = "1.15.2-ck2"
 
 const storageImageRepository = "ghcr.io/canonical/rawfile-localpv"
-const storageImageTag = "0.8.0-ck5"
+const storageImageTag = "0.8.0-ck4"
 
 const metricsServerImageRepository = "ghcr.io/canonical/metrics-server"
-const metricsServerImageTag = "0.7.0-ck0"
+const metricsServerImageTag = "0.7.0-ck2"


### PR DESCRIPTION
### Overview
None of the 1.30 track snaps operate because the images within those channels don't function on arm64. 

### Details
* Update the images to versions built for arm64 and amd64

