### PR TITLE
[Release 1.30-moonray] Update to arm64 versions of the same images

### DIFF
--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// imageTag is the image tag to use for Rawfile LocalPV CSI.
-	imageTag = "0.8.0-ck5"
+	imageTag = "0.8.0-ck4"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"

--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/metrics-server"
 
 	// imageTag is the image tag to use for metrics-server.
-	imageTag = "0.7.0-ck0"
+	imageTag = "0.7.0-ck2"
 )


### PR DESCRIPTION
### Overview
Use multiarch versions of these images so that one can bootstrap from 1.30-moonray track