### PR TITLE
Allow tests to override how long wait for slower clouds providers to pull images

### DIFF
--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -123,7 +123,9 @@ def test_ipv6_only_on_dualstack_infra(instances: List[harness.Instance]):
         )
 
     # This might take a while
-    util.stubbornly(retries=30, delay_s=20).until(util.ready_nodes(main) == 3)
+    util.stubbornly(retries=config.DEFAULT_WAIT_RETRIES, delay_s=20).until(
+        util.ready_nodes(main) == 3
+    )
 
 
 @pytest.mark.node_count(3)
@@ -190,4 +192,6 @@ def test_ipv6_only_on_ipv6_infra(instances: List[harness.Instance]):
         )
 
     # This might take a while
-    util.stubbornly(retries=30, delay_s=20).until(util.ready_nodes(main) == 3)
+    util.stubbornly(retries=config.DEFAULT_WAIT_RETRIES, delay_s=20).until(
+        util.ready_nodes(main) == 3
+    )

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 DIR = Path(__file__).absolute().parent
 
+# The following defaults are used to define how long to wait for a condition to be met.
+DEFAULT_WAIT_RETRIES = os.getenv("TEST_DEFAULT_WAIT_RETRIES") or 30
+DEFAULT_WAIT_DELAY_S = os.getenv("TEST_DEFAULT_WAIT_DELAY_S") or 5
+
 MANIFESTS_DIR = DIR / ".." / ".." / "templates"
 
 # ETCD_DIR contains all templates required to setup an etcd database.

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -183,8 +183,8 @@ def setup_k8s_snap(
 def wait_until_k8s_ready(
     control_node: harness.Instance,
     instances: List[harness.Instance],
-    retries: int = 30,
-    delay_s: int = 5,
+    retries: int = config.DEFAULT_WAIT_RETRIES,
+    delay_s: int = config.DEFAULT_WAIT_DELAY_S,
     node_names: Mapping[str, str] = {},
 ):
     """


### PR DESCRIPTION
### Overview
* GH runners may be quick, but others may be slower
* how long to wait for k8s_ready can differ on these cloud substrates, the tests should be adjustable

### Detail
* using OS env vars to set the RETRIES and DELAY_S for various clouds
* `wait_until_k8s_ready` will default to be `150s`, but can be extended to wait longer or shorter