### PR TITLE
Fix conflict using manual trivy and the trivy action

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -163,6 +163,9 @@ jobs:
           cp trivy-k8s-repo-scan--results.sarif ./manual-trivy/sarifs/
       - name: Run Trivy vulnerability scanner on the snap
         run: |
+          for var in $(env | grep -o '^TRIVY_[^=]*'); do
+            unset "$var"
+          done
           cp build/k8s.snap .
           unsquashfs k8s.snap
           ./manual-trivy/trivy rootfs ./squashfs-root/ --format sarif > ./manual-trivy/sarifs/snap.sarif

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -144,10 +144,12 @@ jobs:
           path: build
       - name: Setup Trivy vulnerability scanner
         run: |
-          mkdir -p sarifs
+          mkdir -p manual-trivy/sarifs
+          pushd manual-trivy
           VER=$(curl --silent -qI https://github.com/aquasecurity/trivy/releases/latest | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}');
           wget https://github.com/aquasecurity/trivy/releases/download/${VER}/trivy_${VER#v}_Linux-64bit.tar.gz
           tar -zxvf ./trivy_${VER#v}_Linux-64bit.tar.gz
+          popd
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@master
         with:
@@ -158,13 +160,13 @@ jobs:
           severity: "MEDIUM,HIGH,CRITICAL"
       - name: Gather Trivy repo scan results
         run: |
-          cp trivy-k8s-repo-scan--results.sarif ./sarifs/
+          cp trivy-k8s-repo-scan--results.sarif ./manual-trivy/sarifs/
       - name: Run Trivy vulnerability scanner on the snap
         run: |
           cp build/k8s.snap .
           unsquashfs k8s.snap
-          ./trivy rootfs ./squashfs-root/ --format sarif > sarifs/snap.sarif
+          ./manual-trivy/trivy rootfs ./squashfs-root/ --format sarif > ./manual-trivy/sarifs/snap.sarif
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: "sarifs"
+          sarif_file: "./manual-trivy/sarifs"


### PR DESCRIPTION
### Overview
Resolve a conflict trying to run trivy manually and using the trivy-action

### Details
The `trivy-action` clones itself into a directory called `trivy` overwriting the binary just downloaded in that same spot. 
By moving the downloaded file to another directory, they don't' conflict 