### PR TITLE
retries and delay_s values should be ints

### DIFF
--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -7,8 +7,8 @@ from pathlib import Path
 DIR = Path(__file__).absolute().parent
 
 # The following defaults are used to define how long to wait for a condition to be met.
-DEFAULT_WAIT_RETRIES = os.getenv("TEST_DEFAULT_WAIT_RETRIES") or 30
-DEFAULT_WAIT_DELAY_S = os.getenv("TEST_DEFAULT_WAIT_DELAY_S") or 5
+DEFAULT_WAIT_RETRIES = int(os.getenv("TEST_DEFAULT_WAIT_RETRIES") or 30)
+DEFAULT_WAIT_DELAY_S = int(os.getenv("TEST_DEFAULT_WAIT_DELAY_S") or 5)
 
 MANIFESTS_DIR = DIR / ".." / ".." / "templates"
 


### PR DESCRIPTION
these should be treated like integers not strings


```
____________________________ test_version_upgrades _____________________________
Traceback (most recent call last):
  File "/tmp/tmpzr1bsedy/tests/integration/tests/test_version_upgrades.py", line 40, in test_version_upgrades
    util.wait_until_k8s_ready(cp, instances)
  File "/tmp/tmpzr1bsedy/tests/integration/tests/test_util/util.py", line 207, in wait_until_k8s_ready
    .exec(["k8s", "kubectl", "get", "node", node_name, "--no-headers"])
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/actions-runner/_work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/.tox/integration/lib/python3.12/site-packages/tenacity/__init__.py", line 289, in wrapped_f
    return self(f, *args, **kw)
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/actions-runner/_work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/.tox/integration/lib/python3.12/site-packages/tenacity/__init__.py", line 379, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/actions-runner/_work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/.tox/integration/lib/python3.12/site-packages/tenacity/__init__.py", line 320, in iter
    if self.stop(retry_state):
       ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/actions-runner/_work/canonical-kubernetes-release-ci/canonical-kubernetes-release-ci/.tox/integration/lib/python3.12/site-packages/tenacity/stop.py", line 91, in __call__
    return retry_state.attempt_number >= self.max_attempt_number
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'int' and 'str'
```