### PR TITLE
Remove stray TRIVY_* env vars for a manual run of trivy

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -114,6 +114,9 @@ jobs:
           snap download k8s --channel ${{ matrix.channel }}
           mv ./k8s*.snap ./k8s.snap
           unsquashfs k8s.snap
+          for var in $(env | grep -o '^TRIVY_[^=]*'); do
+            unset "$var"
+          done
           ./trivy rootfs ./squashfs-root/ --format sarif > sarifs/snap.sarif
       - name: Get HEAD sha
         run: |


### PR DESCRIPTION
Similar to https://github.com/canonical/k8s-snap/pull/752

just for nightly runs