### PR TITLE
Replace Cilium LoadBalancer with MetalLB

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -79,10 +79,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          detached: true
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -113,6 +109,8 @@ jobs:
         run: |
           tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
           echo "artifact_name=inspection-reports-${{ matrix.os }}" | sed 's/:/-/g' >> $GITHUB_ENV
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Upload inspection report artifact
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -103,14 +103,12 @@ jobs:
           TEST_LXD_IMAGE: ${{ matrix.os }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration -- -k test_loadbalancer'
+          cd tests/integration && sg lxd -c 'tox -e integration'
       - name: Prepare inspection reports
         if: failure()
         run: |
           tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
           echo "artifact_name=inspection-reports-${{ matrix.os }}" | sed 's/:/-/g' >> $GITHUB_ENV
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Upload inspection report artifact
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -79,6 +79,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -103,7 +103,7 @@ jobs:
           TEST_LXD_IMAGE: ${{ matrix.os }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration'
+          cd tests/integration && sg lxd -c 'tox -e integration -- -k test_loadbalancer'
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/src/k8s/pkg/k8sd/features/implementation_default.go
+++ b/src/k8s/pkg/k8sd/features/implementation_default.go
@@ -4,18 +4,20 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/features/cilium"
 	"github.com/canonical/k8s/pkg/k8sd/features/coredns"
 	"github.com/canonical/k8s/pkg/k8sd/features/localpv"
+	"github.com/canonical/k8s/pkg/k8sd/features/metallb"
 	metrics_server "github.com/canonical/k8s/pkg/k8sd/features/metrics-server"
 )
 
 // Default implements the Canonical Kubernetes built-in features.
-// Cilium is used for networking (network + load-balancer + ingress + gateway).
+// Cilium is used for networking (network + ingress + gateway).
+// MetalLB is used for LoadBalancer.
 // CoreDNS is used for DNS.
 // MetricsServer is used for metrics-server.
 // LocalPV Rawfile CSI is used for local-storage.
 var Implementation Interface = &implementation{
 	applyDNS:           coredns.ApplyDNS,
 	applyNetwork:       cilium.ApplyNetwork,
-	applyLoadBalancer:  cilium.ApplyLoadBalancer,
+	applyLoadBalancer:  metallb.ApplyLoadBalancer,
 	applyIngress:       cilium.ApplyIngress,
 	applyGateway:       cilium.ApplyGateway,
 	applyMetricsServer: metrics_server.ApplyMetricsServer,

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -216,7 +216,19 @@ def session_instance(
         bootstrap_config_path,
     )
 
+    instance_default_ip = util.get_default_ip(instance)
+
     instance.exec(["k8s", "bootstrap", "--file", bootstrap_config_path])
+    instance_default_cidr = util.get_default_cidr(instance, instance_default_ip)
+
+    lb_cidr = util.find_suitable_cidr(
+        parent_cidr=instance_default_cidr,
+        excluded_ips=[instance_default_ip],
+    )
+
+    instance.exec(
+        ["k8s", "set", f"load-balancer.cidrs={lb_cidr}", "load-balancer.l2-mode=true"]
+    )
     util.wait_until_k8s_ready(instance, [instance])
     util.wait_for_network(instance)
     util.wait_for_dns(instance)

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -3,6 +3,8 @@
 #
 import json
 import logging
+import subprocess
+import time
 from pathlib import Path
 from typing import List
 
@@ -33,6 +35,37 @@ def get_ingress_service_node_port(p):
         if ingress_http_port:
             return ingress_http_port
     return None
+
+
+def get_external_service_ip(instance: harness.Instance, svcs) -> str:
+    try_count = 0
+    ingress_ip = None
+    while ingress_ip is None and try_count < 5:
+        try_count += 1
+        for svc in svcs:
+            try:
+                ingress_ip = (
+                    instance.exec(
+                        [
+                            "k8s",
+                            "kubectl",
+                            "--namespace",
+                            "kube-system",
+                            "get",
+                            "service",
+                            svc,
+                            "-o=jsonpath='{.status.loadBalancer.ingress[0].ip}'",
+                        ],
+                        capture_output=True,
+                    )
+                    .stdout.decode()
+                    .replace("'", "")
+                )
+            except subprocess.CalledProcessError:
+                ingress_ip = None
+                pass
+        time.sleep(3)
+    return ingress_ip
 
 
 def test_ingress(session_instance: List[harness.Instance]):
@@ -77,3 +110,12 @@ def test_ingress(session_instance: List[harness.Instance]):
     util.stubbornly(retries=5, delay_s=5).on(session_instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"localhost:{ingress_http_port}", "-H", "Host: foo.bar.com"])
+
+    # Test the ingress service via loadbalancer IP
+    ingress_ip = get_external_service_ip(
+        session_instance, ["ck-ingress-contour-envoy", "cilium-ingress"]
+    )
+    assert ingress_ip is not None, "No ingress IP found."
+    util.stubbornly(retries=5, delay_s=5).on(session_instance).until(
+        lambda p: "Welcome to nginx!" in p.stdout.decode()
+    ).exec(["curl", f"{ingress_ip}", "-H", "Host: foo.bar.com"])

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -83,9 +83,6 @@ def test_loadbalancer(instances: List[harness.Instance]):
     )
     service_ip = p.stdout.decode().replace("'", "")
 
-    p = tester_instance.exec(
-        ["curl", service_ip],
-        capture_output=True,
-    )
-
-    assert "Welcome to nginx!" in p.stdout.decode()
+    util.stubbornly(retries=5, delay_s=3).on(tester_instance).until(
+        lambda p: "Welcome to nginx!" in p.stdout.decode()
+    ).exec(["curl", service_ip])

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -1,10 +1,7 @@
 #
 # Copyright 2024 Canonical, Ltd.
 #
-import ipaddress
 import logging
-import subprocess
-import time
 from pathlib import Path
 from typing import List
 
@@ -13,29 +10,6 @@ from test_util import harness, util
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
-
-
-def find_suitable_cidr(parent_cidr: str, excluded_ips: List[str]):
-    net = ipaddress.IPv4Network(parent_cidr, False)
-
-    # Starting from the first IP address from the parent cidr,
-    # we search for a /30 cidr block(4 total ips, 2 available)
-    # that doesn't contain the excluded ips to avoid collisions
-    # /30 because this is the smallest CIDR cilium hands out IPs from
-    for i in range(4, 255, 4):
-        lb_net = ipaddress.IPv4Network(f"{str(net[0]+i)}/30", False)
-
-        contains_excluded = False
-        for excluded in excluded_ips:
-            if ipaddress.ip_address(excluded) in lb_net:
-                contains_excluded = True
-                break
-
-        if contains_excluded:
-            continue
-
-        return str(lb_net)
-    raise RuntimeError("Could not find a suitable CIDR for LoadBalancer services")
 
 
 @pytest.mark.node_count(2)
@@ -49,7 +23,7 @@ def test_loadbalancer(instances: List[harness.Instance]):
 
     instance_default_cidr = util.get_default_cidr(instance, instance_default_ip)
 
-    lb_cidr = find_suitable_cidr(
+    lb_cidr = util.find_suitable_cidr(
         parent_cidr=instance_default_cidr,
         excluded_ips=[instance_default_ip, tester_instance_default_ip],
     )
@@ -115,56 +89,3 @@ def test_loadbalancer(instances: List[harness.Instance]):
     )
 
     assert "Welcome to nginx!" in p.stdout.decode()
-
-    # Try to access the service via Ingress
-    instance.exec(["k8s", "enable", "ingress"])
-    instance.exec(
-        ["k8s", "kubectl", "apply", "-f", "-"],
-        input=Path(MANIFESTS_DIR / "ingress-test.yaml").read_bytes(),
-    )
-    instance.exec(
-        [
-            "k8s",
-            "kubectl",
-            "wait",
-            "--for=condition=ready",
-            "pod",
-            "-l",
-            "run=my-nginx",
-            "--timeout",
-            "180s",
-        ]
-    )
-
-    try_count = 0
-    ingress_ip = None
-    while ingress_ip is None and try_count < 5:
-        try_count += 1
-        for svc in ["ck-ingress-contour-envoy", "cilium-ingress"]:
-            try:
-                ingress_ip = (
-                    instance.exec(
-                        [
-                            "k8s",
-                            "kubectl",
-                            "--namespace",
-                            "kube-system",
-                            "get",
-                            "service",
-                            svc,
-                            "-o=jsonpath='{.status.loadBalancer.ingress[0].ip}'",
-                        ],
-                        capture_output=True,
-                    )
-                    .stdout.decode()
-                    .replace("'", "")
-                )
-            except subprocess.CalledProcessError:
-                ingress_ip = None
-                pass
-        time.sleep(3)
-
-    assert ingress_ip is not None, "No ingress IP found."
-    util.stubbornly(retries=5, delay_s=5).on(tester_instance).until(
-        lambda p: "Welcome to nginx!" in p.stdout.decode()
-    ).exec(["curl", f"{ingress_ip}", "-H", "Host: foo.bar.com"])

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -217,12 +217,12 @@ def wait_until_k8s_ready(
 
 def wait_for_dns(instance: harness.Instance):
     LOG.info("Waiting for DNS to be ready")
-    instance.exec(["k8s", "x-wait-for", "dns"])
+    instance.exec(["k8s", "x-wait-for", "dns", "--timeout", "20m"])
 
 
 def wait_for_network(instance: harness.Instance):
     LOG.info("Waiting for network to be ready")
-    instance.exec(["k8s", "x-wait-for", "network", "--timeout", "10m"])
+    instance.exec(["k8s", "x-wait-for", "network", "--timeout", "20m"])
 
 
 def hostname(instance: harness.Instance) -> str:


### PR DESCRIPTION
This PR replaces the Cilium LoadBalancer with MetalLB in the default Canonical Kubernetes configuration. The Cilium LoadBalancer had a bunch of shortcomings, e.g. IPv6 support.