### PR TITLE
Add docs page for IPv6-only

### DIFF
--- a/docs/src/snap/howto/networking/index.md
+++ b/docs/src/snap/howto/networking/index.md
@@ -16,4 +16,5 @@ how to configure and use key capabilities of {{product}}.
 /snap/howto/networking/default-ingress.md
 /snap/howto/networking/default-loadbalancer.md
 /snap/howto/networking/dualstack.md
+/snap/howto/networking/ipv6.md
 ```

--- a/docs/src/snap/howto/networking/ipv6.md
+++ b/docs/src/snap/howto/networking/ipv6.md
@@ -1,0 +1,145 @@
+# How to Setup an IPv6-Only Cluster
+
+An IPv6-only Kubernetes cluster operates exclusively using IPv6 addresses,
+without support for IPv4. This configuration is ideal for environments that
+are transitioning away from IPv4 or want to take full advantage of IPv6's
+expanded address space. In this document, we’ll guide you through setting up
+an IPv6-only cluster, including key configurations and necessary checks
+to ensure proper setup.
+
+## Prerequisites
+
+Before setting up an IPv6-only cluster, ensure that:
+
+- Your environment supports IPv6.
+- Network infrastructure, such as routers, firewalls, and DNS, are configured
+to handle IPv6 traffic.
+- Any underlying infrastructure (e.g., cloud providers, bare metal setups)
+must be IPv6-compatible.
+
+## Setting Up an IPv6-Only Cluster
+
+The process of creating an IPv6-only cluster involves specifying only IPv6
+CIDRs for Pods and Services during the bootstrap process. Unlike dual-stack,
+only IPv6 CIDRs are used.
+
+1. **Bootstrap Kubernetes with IPv6 CIDRs**
+
+You can start by bootstrapping the Kubernetes cluster and providing only IPv6
+CIDRs for pods and services:
+
+```bash
+sudo k8s bootstrap --timeout 10m --interactive
+```
+
+When prompted, set the Pod and Service CIDRs to IPv6 ranges. For example:
+
+```
+Please set the Pod CIDR: [fd01::/108]
+Please set the Service CIDR: [fd98::/108]
+```
+
+Alternatively, these values can be configured in a bootstrap configuration file
+(`bootstrap-config.yaml`):
+
+```yaml
+pod-cidr: fd01::/108
+service-cidr: fd98::/108
+```
+
+Then, use the configuration file during the bootstrapping process:
+
+```bash
+sudo k8s bootstrap --file bootstrap-config.yaml
+```
+
+2. **Verify Pod and Service Creation**
+
+Once the cluster is up, verify that all pods are running:
+
+```sh
+sudo k8s kubectl get pods -A
+```
+
+Test the IPv6-only cluster by deploying a pod and exposing it via a service:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-ipv6
+spec:
+  selector:
+    matchLabels:
+      run: nginx-ipv6
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: nginx-ipv6
+    spec:
+      containers:
+      - name: nginx-ipv6
+        image: rocks.canonical.com/cdk/diverdane/nginxipv6:1.0.0
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-ipv6
+  labels:
+    run: nginx-ipv6
+spec:
+  type: NodePort
+  ipFamilies:
+  - IPv6
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: nginx-ipv6
+```
+
+3. **Check IPv6 Connectivity**
+
+Retrieve the service details to confirm an IPv6 address is assigned:
+
+```sh
+sudo k8s kubectl get service nginx-ipv6 -n default
+```
+
+The output should show the service’s IPv6 address:
+
+```
+NAME         TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+nginx-ipv6   NodePort   fd98::7534    <none>        80:32248/TCP   2m
+```
+
+Use the assigned IPv6 address to test connectivity:
+
+```bash
+curl http://[fd98::7534]/
+```
+
+If the Nginx server responds, IPv6 connectivity is working properly.
+
+## IPv6-Only Cluster Considerations
+
+1. **Service and Pod CIDR Sizing**
+
+Use `/108` as the maximum size for Service CIDRs. Larger ranges (e.g., `/64`)
+may lead to allocation errors or Kubernetes failing to initialize the IPv6
+address allocator.
+
+2. **Ingress and DNS**
+
+When setting up an IPv6-only cluster, ensure that your ingress controllers and
+DNS configurations are properly configured for IPv6, as many setups default to
+IPv4.
+
+3. **External IPv6 Access**
+
+Verify that your external networking supports IPv6, especially if
+your applications need to communicate beyond the cluster.
+Ensure firewalls and load balancers are IPv6-compatible.

--- a/docs/src/snap/howto/networking/ipv6.md
+++ b/docs/src/snap/howto/networking/ipv6.md
@@ -61,7 +61,9 @@ Once the cluster is up, verify that all pods are running:
 sudo k8s kubectl get pods -A
 ```
 
-Deploy a pod with an nginx web-server and expose it via a service to verify connectivity of the IPv6-only cluster:
+Deploy a pod with an nginx web-server and expose it via a service to verify
+connectivity of the IPv6-only cluster. For that, create a manifest file
+`nginx-ipv6.yaml` with the following content:
 
 ```yaml
 apiVersion: apps/v1
@@ -101,6 +103,12 @@ spec:
     run: nginx-ipv6
 ```
 
+Deploy it with:
+
+```sh
+sudo k8s kubectl apply -f nginx-ipv6.yaml
+```
+
 3. **Verify IPv6 Connectivity**
 
 Retrieve the service details to confirm an IPv6 address is assigned:
@@ -122,24 +130,13 @@ Use the assigned IPv6 address to test connectivity:
 curl http://[fd98::7534]/
 ```
 
-A welcome message from the nginx web-server is displayed when IPv6 connectivity is set up correctly.
+A welcome message from the nginx web-server is displayed when IPv6
+connectivity is set up correctly.
 
 ## IPv6-Only Cluster Considerations
 
-1. **Service and Pod CIDR Sizing**
+**Service and Pod CIDR Sizing**
 
 Use `/108` as the maximum size for Service CIDRs. Larger ranges (e.g., `/64`)
 may lead to allocation errors or Kubernetes failing to initialize the IPv6
 address allocator.
-
-2. **Ingress and DNS**
-
-When setting up an IPv6-only cluster, ensure that your ingress controllers and
-DNS configurations are properly configured for IPv6, as many setups default to
-IPv4.
-
-3. **External IPv6 Access**
-
-Verify that your external networking supports IPv6, especially if
-your applications need to communicate beyond the cluster.
-Ensure firewalls and load balancers are IPv6-compatible.

--- a/docs/src/snap/howto/networking/ipv6.md
+++ b/docs/src/snap/howto/networking/ipv6.md
@@ -3,7 +3,7 @@
 An IPv6-only Kubernetes cluster operates exclusively using IPv6 addresses,
 without support for IPv4. This configuration is ideal for environments that
 are transitioning away from IPv4 or want to take full advantage of IPv6's
-expanded address space. In this document, we’ll guide you through setting up
+expanded address space. This document, explains how to set up
 an IPv6-only cluster, including key configurations and necessary checks
 to ensure proper setup.
 
@@ -14,7 +14,7 @@ Before setting up an IPv6-only cluster, ensure that:
 - Your environment supports IPv6.
 - Network infrastructure, such as routers, firewalls, and DNS, are configured
 to handle IPv6 traffic.
-- Any underlying infrastructure (e.g., cloud providers, bare metal setups)
+- Any underlying infrastructure (e.g. cloud providers, bare metal setups)
 must be IPv6-compatible.
 
 ## Setting Up an IPv6-Only Cluster
@@ -25,14 +25,14 @@ only IPv6 CIDRs are used.
 
 1. **Bootstrap Kubernetes with IPv6 CIDRs**
 
-You can start by bootstrapping the Kubernetes cluster and providing only IPv6
+Start by bootstrapping the Kubernetes cluster and providing only IPv6
 CIDRs for pods and services:
 
 ```bash
 sudo k8s bootstrap --timeout 10m --interactive
 ```
 
-When prompted, set the Pod and Service CIDRs to IPv6 ranges. For example:
+When prompted, set the pod and service CIDRs to IPv6 ranges. For example:
 
 ```
 Please set the Pod CIDR: [fd01::/108]
@@ -40,14 +40,14 @@ Please set the Service CIDR: [fd98::/108]
 ```
 
 Alternatively, these values can be configured in a bootstrap configuration file
-(`bootstrap-config.yaml`):
+named `bootstrap-config.yaml` in this example:
 
 ```yaml
 pod-cidr: fd01::/108
 service-cidr: fd98::/108
 ```
 
-Then, use the configuration file during the bootstrapping process:
+Specify the configuration file during the bootstrapping process:
 
 ```bash
 sudo k8s bootstrap --file bootstrap-config.yaml
@@ -61,7 +61,7 @@ Once the cluster is up, verify that all pods are running:
 sudo k8s kubectl get pods -A
 ```
 
-Test the IPv6-only cluster by deploying a pod and exposing it via a service:
+Deploy a pod with an nginx web-server and expose it via a service to verify connectivity of the IPv6-only cluster:
 
 ```yaml
 apiVersion: apps/v1
@@ -101,7 +101,7 @@ spec:
     run: nginx-ipv6
 ```
 
-3. **Check IPv6 Connectivity**
+3. **Verify IPv6 Connectivity**
 
 Retrieve the service details to confirm an IPv6 address is assigned:
 
@@ -109,7 +109,7 @@ Retrieve the service details to confirm an IPv6 address is assigned:
 sudo k8s kubectl get service nginx-ipv6 -n default
 ```
 
-The output should show the service’s IPv6 address:
+Obtain the service’s IPv6 address from the output:
 
 ```
 NAME         TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
@@ -122,7 +122,7 @@ Use the assigned IPv6 address to test connectivity:
 curl http://[fd98::7534]/
 ```
 
-If the Nginx server responds, IPv6 connectivity is working properly.
+A welcome message from the nginx web-server is displayed when IPv6 connectivity is set up correctly.
 
 ## IPv6-Only Cluster Considerations
 

--- a/docs/src/snap/howto/networking/ipv6.md
+++ b/docs/src/snap/howto/networking/ipv6.md
@@ -20,7 +20,7 @@ must be IPv6-compatible.
 ## Setting Up an IPv6-Only Cluster
 
 The process of creating an IPv6-only cluster involves specifying only IPv6
-CIDRs for Pods and Services during the bootstrap process. Unlike dual-stack,
+CIDRs for pods and services during the bootstrap process. Unlike dual-stack,
 only IPv6 CIDRs are used.
 
 1. **Bootstrap Kubernetes with IPv6 CIDRs**
@@ -62,7 +62,7 @@ sudo k8s kubectl get pods -A
 ```
 
 Deploy a pod with an nginx web-server and expose it via a service to verify
-connectivity of the IPv6-only cluster. For that, create a manifest file
+connectivity of the IPv6-only cluster. Create a manifest file
 `nginx-ipv6.yaml` with the following content:
 
 ```yaml
@@ -103,7 +103,7 @@ spec:
     run: nginx-ipv6
 ```
 
-Deploy it with:
+Deploy the web-server and its service by running:
 
 ```sh
 sudo k8s kubectl apply -f nginx-ipv6.yaml


### PR DESCRIPTION
This is quite similar to the dualstack documentation setup.