### PR TITLE
Add timeout to integration tests LXD container removal

### DIFF
--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -230,10 +230,10 @@ class LXDHarness(Harness):
         try:
             # There are cases where the instance is not deleted properly and this command is stuck.
             # A timeout prevents this.
-            run(["lxc", "rm", instance_id, "--force", "--debug"], timeout=60*5)
+            run(["lxc", "rm", instance_id, "--force", "--debug"], timeout=60 * 5)
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"failed to delete instance {instance_id}") from e
-        except subprocess.TimeoutExpired as e:
+        except subprocess.TimeoutExpired:
             LOG.warning("LXC container removal timed out.")
             pass
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -228,9 +228,14 @@ class LXDHarness(Harness):
             raise HarnessError(f"unknown instance {instance_id}")
 
         try:
-            run(["lxc", "rm", instance_id, "--force", "--debug"])
+            # There are cases where the instance is not deleted properly and this command is stuck.
+            # A timeout prevents this.
+            run(["lxc", "rm", instance_id, "--force", "--debug"], timeout=60*5)
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"failed to delete instance {instance_id}") from e
+        except subprocess.TimeoutExpired as e:
+            LOG.warning("LXC container removal timed out.")
+            pass
 
         self.instances.discard(instance_id)
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -228,7 +228,7 @@ class LXDHarness(Harness):
             raise HarnessError(f"unknown instance {instance_id}")
 
         try:
-            run(["lxc", "rm", instance_id, "--force"])
+            run(["lxc", "rm", instance_id, "--force", "--debug"])
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"failed to delete instance {instance_id}") from e
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -230,7 +230,10 @@ class LXDHarness(Harness):
         try:
             # There are cases where the instance is not deleted properly and this command is stuck.
             # A timeout prevents this.
-            run(["lxc", "rm", instance_id, "--force", "--debug"], timeout=60 * 5)
+            # TODO(ben): This is a workaround for an issue that arises because of our use of
+            # privileged containers. We eventually move away from this (not supported >24.10)
+            # which should also fix this issue and make this timeout unnecessary.
+            run(["lxc", "rm", instance_id, "--force"], timeout=60 * 5)
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"failed to delete instance {instance_id}") from e
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
Sometimes the removing an LXD container is stuck forever. Adding a timeout prevents the CI from hanging indefinitely in this case.
It is very likely that this happens because of how we configure the LXD profile. Since this will undergo significant changes in the future, I did not dig too deeply into this issue.
https://discourse.ubuntu.com/t/lxd-containers-not-removed-in-ci-even-with-force-flag/49039