### PR TITLE
Fix certificate refresh and add e2e tests

### DIFF
--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -2,10 +2,14 @@ package api
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/big"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -29,7 +33,11 @@ import (
 )
 
 func (e *Endpoints) postRefreshCertsPlan(s state.State, r *http.Request) response.Response {
-	seed := rand.Intn(math.MaxInt)
+	seedBigInt, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt))
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to generate seed: %w", err))
+	}
+	seed := int(seedBigInt.Int64())
 
 	snap := e.provider.Snap()
 	isWorker, err := snaputil.IsWorker(snap)
@@ -216,6 +224,11 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 	certificates.CACert = clusterConfig.Certificates.GetCACert()
 	certificates.ClientCACert = clusterConfig.Certificates.GetClientCACert()
 
+	k8sdPublicKey, err := pkiutil.LoadRSAPublicKey(clusterConfig.Certificates.GetK8sdPublicKey())
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to load k8sd public key, error: %w", err))
+	}
+
 	g, ctx := errgroup.WithContext(r.Context())
 
 	for _, csr := range []struct {
@@ -272,9 +285,26 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 				return fmt.Errorf("failed to generate CSR for %s: %w", csr.name, err)
 			}
 
+			// Obtain the SHA256 sum of the CSR request.
+			hash := sha256.New()
+			_, err = hash.Write([]byte(csrPEM))
+			if err != nil {
+				return fmt.Errorf("failed to checksum CSR %s, err: %w", csr.name, err)
+			}
+
+			signature, err := rsa.EncryptPKCS1v15(rand.Reader, k8sdPublicKey, hash.Sum(nil))
+			if err != nil {
+				return fmt.Errorf("failed to sign CSR %s, err: %w", csr.name, err)
+			}
+			signatureB64 := base64.StdEncoding.EncodeToString(signature)
+
 			if _, err = client.CertificatesV1().CertificateSigningRequests().Create(ctx, &certv1.CertificateSigningRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: csr.name,
+					Annotations: map[string]string{
+						"k8sd.io/signature": signatureB64,
+						"k8sd.io/node":      snap.Hostname(),
+					},
 				},
 				Spec: certv1.CertificateSigningRequestSpec{
 					Request:    []byte(csrPEM),

--- a/src/k8s/pkg/k8sd/controllers/csrsigning/validate_test.go
+++ b/src/k8s/pkg/k8sd/controllers/csrsigning/validate_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"testing"
 
 	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
@@ -93,7 +94,7 @@ func TestValidateCSREncryption(t *testing.T) {
 				},
 			},
 			expectErr:        true,
-			expectErrMessage: "failed to decrypt signature",
+			expectErrMessage: "failed to decode b64 signature",
 		},
 		{
 			name: "Missing Signature",
@@ -219,5 +220,5 @@ func mustCreateEncryptedSignature(g Gomega, pub *rsa.PublicKey, csrPEM string) s
 	signature, err := rsa.EncryptPKCS1v15(rand.Reader, pub, hash.Sum(nil))
 	g.Expect(err).NotTo(HaveOccurred())
 
-	return string(signature)
+	return base64.StdEncoding.EncodeToString(signature)
 }

--- a/tests/integration/requirements-test.txt
+++ b/tests/integration/requirements-test.txt
@@ -3,3 +3,4 @@ pytest==7.3.1
 PyYAML==6.0.1
 tenacity==8.2.3
 pylint==3.2.5
+cryptography==43.0.3

--- a/tests/integration/templates/bootstrap-csr-auto-approve.yaml
+++ b/tests/integration/templates/bootstrap-csr-auto-approve.yaml
@@ -1,0 +1,9 @@
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  metrics-server:
+    enabled: true
+  annotations:
+    k8sd/v1alpha1/csrsigning/auto-approve: true

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -46,6 +46,6 @@ passenv =
 [flake8]
 max-line-length = 120
 select = E,W,F,C,N
-ignore = W503
+ignore = W503,E231,E226
 exclude = venv,.git,.tox,.tox_env,.venv,build,dist,*.egg_info
 show-source = true


### PR DESCRIPTION
There are few issues that affect the `k8s refresh-certs` command:
* auto-approving CSR requests does not work. K8sd denies the requests since the CSR signature is missing.
* in case of worker nodes, the specified certificate expiry date and additional Subject Alternative Names are ignored.

This PR addresses these issues and adds an e2e test that refreshes control-plane and worker node certificates, validating the resulting certificates.