### PR TITLE
Add minimum release for upgrade tests

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -45,6 +45,8 @@ jobs:
           # Test the latest (up to) 6 releases for the flavour
           # TODO(ben): upgrade nightly to run all flavours
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
+          # Upgrading from 1.30 is not supported.
+          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
         run: |
           export PATH="/home/runner/.local/bin:$PATH"

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -119,6 +119,11 @@ JUJU_MACHINES = os.getenv("TEST_JUJU_MACHINES") or ""
 VERSION_UPGRADE_CHANNELS = (
     os.environ.get("TEST_VERSION_UPGRADE_CHANNELS", "").strip().split()
 )
+
+# The minimum Kubernetes release to upgrade from (e.g. "1.31")
+# Only relevant when using 'recent' in VERSION_UPGRADE_CHANNELS.
+VERSION_UPGRADE_MIN_RELEASE = os.environ.get("TEST_VERSION_UPGRADE_MIN_RELEASE")
+
 # A list of space-separated channels for which the strict interface tests should be run in sequential order.
 # Alternatively, use 'recent <num> strict' to get the latest <num> channels for strict.
 STRICT_INTERFACE_CHANNELS = (

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -84,7 +84,7 @@ def get_most_stable_channels(
 
         if min_release is not None:
             _min_release = major_minor(min_release)
-            if version_key < _min_release:
+            if _min_release is not None and version_key < _min_release:
                 continue
 
         if version_key not in channel_map or RISK_LEVELS.index(

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -6,7 +6,9 @@ import logging
 import re
 import urllib.error
 import urllib.request
-from typing import List
+from typing import List, Optional
+
+from test_util.util import major_minor
 
 LOG = logging.getLogger(__name__)
 
@@ -60,7 +62,11 @@ def filter_arch_and_flavor(channels: List[dict], arch: str, flavor: str) -> List
 
 
 def get_most_stable_channels(
-    num_of_channels: int, flavor: str, arch: str, include_latest=True
+    num_of_channels: int,
+    flavor: str,
+    arch: str,
+    include_latest: bool = True,
+    min_release: Optional[str] = None,
 ) -> List[str]:
     """Get an ascending list of latest channels based on the number of channels
     flavour and architecture."""
@@ -75,6 +81,11 @@ def get_most_stable_channels(
     channel_map = {}
     for channel, major, minor, risk in arch_flavor_channels:
         version_key = (int(major), int(minor))
+
+        if min_release is not None:
+            _min_release = major_minor(min_release)
+            if version_key < _min_release:
+                continue
 
         if version_key not in channel_map or RISK_LEVELS.index(
             risk

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -26,7 +26,16 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
                 "'recent' requires the number of releases as second argument and the flavour as third argument"
             )
         _, num_channels, flavour = channels
-        channels = snap.get_most_stable_channels(int(num_channels), flavour, cp.arch)
+        channels = snap.get_most_stable_channels(
+            int(num_channels),
+            flavour,
+            cp.arch,
+            min_release=config.VERSION_UPGRADE_MIN_RELEASE,
+        )
+        if len(channels) < 2:
+            pytest.fail(
+                f"Need at least 2 channels to upgrade, got {len(channels)} for flavour {flavour}"
+            )
         current_channel = channels[0]
 
     LOG.info(


### PR DESCRIPTION
Upgrading from 1.30 to 1.31 is not supported due to incompatible changes. The upgrade tests serve as a promotion gate, so we need to have a way to exclude this release from the tests.