### PR TITLE
Pass localhost address from the start hook instead of embedding into cluster config

### DIFF
--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -3,10 +3,12 @@ package app
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	mctypes "github.com/canonical/microcluster/v3/rest/types"
 )
 
 func startControlPlaneServices(ctx context.Context, snap snap.Snap, datastore string) error {
@@ -57,4 +59,23 @@ func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 	}
 
 	return nil
+}
+
+func DetermineLocalhostAddress(clusterMembers []mctypes.ClusterMember) (string, error) {
+	// Check if any of the cluster members have an IPv6 address, if so return "::1"
+	// if one member has an IPv6 address, other members should also have IPv6 interfaces
+	for _, clusterMember := range clusterMembers {
+		memberAddress := clusterMember.Address.Addr().String()
+		nodeIP := net.ParseIP(memberAddress)
+		if nodeIP == nil {
+			return "", fmt.Errorf("failed to parse node IP address %q", memberAddress)
+		}
+
+		if nodeIP.To4() == nil {
+			return "::1", nil
+		}
+	}
+
+	// If no IPv6 addresses are found this means the cluster is IPv4 only
+	return "127.0.0.1", nil
 }

--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -72,7 +72,7 @@ func DetermineLocalhostAddress(clusterMembers []mctypes.ClusterMember) (string, 
 		}
 
 		if nodeIP.To4() == nil {
-			return "::1", nil
+			return "[::1]", nil
 		}
 	}
 

--- a/src/k8s/pkg/k8sd/app/cluster_util_test.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util_test.go
@@ -1,0 +1,120 @@
+package app_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/k8sd/app"
+	mctypes "github.com/canonical/microcluster/v3/rest/types"
+	. "github.com/onsi/gomega"
+)
+
+func TestDetermineLocalhostAddress(t *testing.T) {
+	t.Run("IPv4Only", func(t *testing.T) {
+		g := NewWithT(t)
+
+		mockMembers := []mctypes.ClusterMember{
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node1",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("10.1.0.1:1234"),
+					},
+				},
+			},
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node2",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("10.1.0.2:1234"),
+					},
+				},
+			},
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node3",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("10.1.0.3:1234"),
+					},
+				},
+			},
+		}
+
+		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(localhostAddress).To(Equal("127.0.0.1"))
+	})
+
+	t.Run("IPv6Only", func(t *testing.T) {
+		g := NewWithT(t)
+
+		mockMembers := []mctypes.ClusterMember{
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node1",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("[fda1:8e75:b6ef::]:1234"),
+					},
+				},
+			},
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node2",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("[fd51:d664:aca3::]:1234"),
+					},
+				},
+			},
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node3",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("[fda3:c11d:3cda::]:1234"),
+					},
+				},
+			},
+		}
+
+		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(localhostAddress).To(Equal("::1"))
+	})
+
+	t.Run("IPv4_IPv6_Mixed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		mockMembers := []mctypes.ClusterMember{
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node1",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("10.1.0.1:1234"),
+					},
+				},
+			},
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node2",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("[fd51:d664:aca3::]:1234"),
+					},
+				},
+			},
+			{
+				ClusterMemberLocal: mctypes.ClusterMemberLocal{
+					Name: "node3",
+					Address: mctypes.AddrPort{
+						AddrPort: netip.MustParseAddrPort("10.1.0.3:1234"),
+					},
+				},
+			},
+		}
+
+		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(localhostAddress).To(Equal("::1"))
+	})
+}

--- a/src/k8s/pkg/k8sd/app/cluster_util_test.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util_test.go
@@ -79,7 +79,7 @@ func TestDetermineLocalhostAddress(t *testing.T) {
 		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
 
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(localhostAddress).To(Equal("::1"))
+		g.Expect(localhostAddress).To(Equal("[::1]"))
 	})
 
 	t.Run("IPv4_IPv6_Mixed", func(t *testing.T) {
@@ -115,6 +115,6 @@ func TestDetermineLocalhostAddress(t *testing.T) {
 		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
 
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(localhostAddress).To(Equal("::1"))
+		g.Expect(localhostAddress).To(Equal("[::1]"))
 	})
 }

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -307,8 +307,6 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 		localhostAddress = "127.0.0.1"
 	}
 
-	cfg.Network.LocalhostAddress = utils.Pointer(localhostAddress)
-
 	// Create directories
 	if err := setup.EnsureAllDirectories(snap); err != nil {
 		return fmt.Errorf("failed to create directories: %w", err)

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"database/sql"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
@@ -73,21 +72,12 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 					return "", fmt.Errorf("failed to get cluster members: %w", err)
 				}
 
-				// Check if any of the cluster members have an IPv6 address, if so return "::1"
-				// if one member has an IPv6 address, other members should also have IPv6 interfaces
-				for _, clusterMember := range clusterMembers {
-					nodeIP := net.ParseIP(clusterMember.Address.Addr().String())
-					if nodeIP == nil {
-						return "", fmt.Errorf("failed to parse node IP address %q", s.Address().Hostname())
-					}
-
-					if nodeIP.To4() == nil {
-						return "::1", nil
-					}
+				localhostAddress, err := DetermineLocalhostAddress(clusterMembers)
+				if err != nil {
+					return "", fmt.Errorf("failed to determine localhost address: %w", err)
 				}
 
-				// If no IPv6 addresses are found this means the cluster is IPv4 only
-				return "127.0.0.1", nil
+				return localhostAddress, nil
 			},
 			func(ctx context.Context, dnsIP string) error {
 				if err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {

--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -82,7 +82,7 @@ func (c *FeatureController) Run(
 	go c.reconcileLoop(ctx, getClusterConfig, setFeatureStatus, features.Network, c.triggerNetworkCh, c.reconciledNetworkCh, func(cfg types.ClusterConfig) (types.FeatureStatus, error) {
 		localhostAddress, err := getLocalhostAddress()
 		if err != nil {
-			return types.FeatureStatus{Enabled: cfg.Network.GetEnabled(), Message: "failed to determine the localhost address"}, fmt.Errorf("failed to get localhost address: %w", err)
+			return types.FeatureStatus{Enabled: false, Message: "failed to determine the localhost address"}, fmt.Errorf("failed to get localhost address: %w", err)
 		}
 		return features.Implementation.ApplyNetwork(ctx, c.snap, localhostAddress, cfg.APIServer, cfg.Network, cfg.Annotations)
 	})

--- a/src/k8s/pkg/k8sd/features/calico/network.go
+++ b/src/k8s/pkg/k8sd/features/calico/network.go
@@ -23,7 +23,7 @@ const (
 // deployment.
 // ApplyNetwork returns an error if anything fails. The error is also wrapped in the .Message field of the
 // returned FeatureStatus.
-func ApplyNetwork(ctx context.Context, snap snap.Snap, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
+func ApplyNetwork(ctx context.Context, snap snap.Snap, _ string, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
 	m := snap.HelmClient()
 
 	if !network.GetEnabled() {

--- a/src/k8s/pkg/k8sd/features/calico/network_test.go
+++ b/src/k8s/pkg/k8sd/features/calico/network_test.go
@@ -45,7 +45,7 @@ func TestDisabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
@@ -74,7 +74,7 @@ func TestDisabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -107,7 +107,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -132,7 +132,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -160,7 +160,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
 
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
@@ -191,7 +191,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeTrue())

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -31,7 +31,7 @@ var (
 // deployment.
 // ApplyNetwork returns an error if anything fails. The error is also wrapped in the .Message field of the
 // returned FeatureStatus.
-func ApplyNetwork(ctx context.Context, snap snap.Snap, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
+func ApplyNetwork(ctx context.Context, snap snap.Snap, localhostAddress string, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
 	m := snap.HelmClient()
 
 	if !network.GetEnabled() {
@@ -124,7 +124,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, apiserver types.APIServer
 		"disableEnvoyVersionCheck": true,
 		// socketLB requires an endpoint to the apiserver that's not managed by the kube-proxy
 		// so we point to the localhost:secureport to talk to either the kube-apiserver or the kube-apiserver-proxy
-		"k8sServiceHost": network.GetLocalhostAddress(),
+		"k8sServiceHost": localhostAddress,
 		"k8sServicePort": apiserver.GetSecurePort(),
 		// This flag enables the runtime device detection which is set to true by default in Cilium 1.16+
 		"enableRuntimeDeviceDetection": true,

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -3,6 +3,7 @@ package cilium
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/canonical/k8s/pkg/client/helm"
 	"github.com/canonical/k8s/pkg/k8sd/types"
@@ -124,7 +125,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, localhostAddress string, 
 		"disableEnvoyVersionCheck": true,
 		// socketLB requires an endpoint to the apiserver that's not managed by the kube-proxy
 		// so we point to the localhost:secureport to talk to either the kube-apiserver or the kube-apiserver-proxy
-		"k8sServiceHost": localhostAddress,
+		"k8sServiceHost": strings.Trim(localhostAddress, "[]"), // Cilium already adds the brackets for ipv6 addresses, so we need to remove them
 		"k8sServicePort": apiserver.GetSecurePort(),
 		// This flag enables the runtime device detection which is set to true by default in Cilium 1.16+
 		"enableRuntimeDeviceDetection": true,

--- a/src/k8s/pkg/k8sd/features/cilium/network_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network_test.go
@@ -46,7 +46,7 @@ func TestNetworkDisabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
@@ -76,7 +76,7 @@ func TestNetworkDisabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -109,7 +109,7 @@ func TestNetworkEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -128,15 +128,14 @@ func TestNetworkEnabled(t *testing.T) {
 			},
 		}
 		network := types.Network{
-			Enabled:          ptr.To(true),
-			LocalhostAddress: ptr.To("127.0.0.1"),
-			PodCIDR:          ptr.To("192.0.2.0/24,2001:db8::/32"),
+			Enabled: ptr.To(true),
+			PodCIDR: ptr.To("192.0.2.0/24,2001:db8::/32"),
 		}
 		apiserver := types.APIServer{
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, annotations)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, annotations)
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeTrue())
@@ -163,15 +162,14 @@ func TestNetworkEnabled(t *testing.T) {
 			},
 		}
 		network := types.Network{
-			Enabled:          ptr.To(true),
-			LocalhostAddress: ptr.To("127.0.0.1"),
-			PodCIDR:          ptr.To("192.0.2.0/24,2001:db8::/32"),
+			Enabled: ptr.To(true),
+			PodCIDR: ptr.To("192.0.2.0/24,2001:db8::/32"),
 		}
 		apiserver := types.APIServer{
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, annotations)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, annotations)
 
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
@@ -205,9 +203,8 @@ func TestNetworkMountPath(t *testing.T) {
 				},
 			}
 			network := types.Network{
-				Enabled:          ptr.To(true),
-				LocalhostAddress: ptr.To("127.0.0.1"),
-				PodCIDR:          ptr.To("192.0.2.0/24,2001:db8::/32"),
+				Enabled: ptr.To(true),
+				PodCIDR: ptr.To("192.0.2.0/24,2001:db8::/32"),
 			}
 			apiserver := types.APIServer{
 				SecurePort: ptr.To(6443),
@@ -219,7 +216,7 @@ func TestNetworkMountPath(t *testing.T) {
 				return tc.name, nil
 			}
 
-			status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+			status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 			g.Expect(err).To(HaveOccurred())
 			g.Expect(err).To(MatchError(mountPathErr))
@@ -247,15 +244,14 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			},
 		}
 		network := types.Network{
-			Enabled:          ptr.To(true),
-			LocalhostAddress: ptr.To("127.0.0.1"),
-			PodCIDR:          ptr.To("192.0.2.0/24,2001:db8::/32"),
+			Enabled: ptr.To(true),
+			PodCIDR: ptr.To("192.0.2.0/24,2001:db8::/32"),
 		}
 		apiserver := types.APIServer{
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err).To(MatchError(mountErr))
@@ -281,9 +277,8 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			},
 		}
 		network := types.Network{
-			Enabled:          ptr.To(true),
-			LocalhostAddress: ptr.To("127.0.0.1"),
-			PodCIDR:          ptr.To("192.0.2.0/24,2001:db8::/32"),
+			Enabled: ptr.To(true),
+			PodCIDR: ptr.To("192.0.2.0/24,2001:db8::/32"),
 		}
 		apiserver := types.APIServer{
 			SecurePort: ptr.To(6443),
@@ -291,7 +286,7 @@ func TestNetworkMountPropagationType(t *testing.T) {
 		logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
 		ctx := klog.NewContext(context.Background(), logger)
 
-		status, err := ApplyNetwork(ctx, snapM, apiserver, network, nil)
+		status, err := ApplyNetwork(ctx, snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -321,15 +316,14 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			},
 		}
 		network := types.Network{
-			Enabled:          ptr.To(true),
-			LocalhostAddress: ptr.To("127.0.0.1"),
-			PodCIDR:          ptr.To("192.0.2.0/24,2001:db8::/32"),
+			Enabled: ptr.To(true),
+			PodCIDR: ptr.To("192.0.2.0/24,2001:db8::/32"),
 		}
 		apiserver := types.APIServer{
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -353,15 +347,14 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			},
 		}
 		network := types.Network{
-			Enabled:          ptr.To(true),
-			LocalhostAddress: ptr.To("127.0.0.1"),
-			PodCIDR:          ptr.To("192.0.2.0/24,2001:db8::/32"),
+			Enabled: ptr.To(true),
+			PodCIDR: ptr.To("192.0.2.0/24,2001:db8::/32"),
 		}
 		apiserver := types.APIServer{
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := ApplyNetwork(context.Background(), snapM, apiserver, network, nil)
+		status, err := ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())

--- a/src/k8s/pkg/k8sd/features/interface.go
+++ b/src/k8s/pkg/k8sd/features/interface.go
@@ -12,7 +12,7 @@ type Interface interface {
 	// ApplyDNS is used to configure the DNS feature on Canonical Kubernetes.
 	ApplyDNS(context.Context, snap.Snap, types.DNS, types.Kubelet, types.Annotations) (types.FeatureStatus, string, error)
 	// ApplyNetwork is used to configure the network feature on Canonical Kubernetes.
-	ApplyNetwork(context.Context, snap.Snap, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
+	ApplyNetwork(context.Context, snap.Snap, string, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	// ApplyLoadBalancer is used to configure the load-balancer feature on Canonical Kubernetes.
 	ApplyLoadBalancer(context.Context, snap.Snap, types.LoadBalancer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	// ApplyIngress is used to configure the ingress controller feature on Canonical Kubernetes.
@@ -28,7 +28,7 @@ type Interface interface {
 // implementation implements Interface.
 type implementation struct {
 	applyDNS           func(context.Context, snap.Snap, types.DNS, types.Kubelet, types.Annotations) (types.FeatureStatus, string, error)
-	applyNetwork       func(context.Context, snap.Snap, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
+	applyNetwork       func(context.Context, snap.Snap, string, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	applyLoadBalancer  func(context.Context, snap.Snap, types.LoadBalancer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	applyIngress       func(context.Context, snap.Snap, types.Ingress, types.Network, types.Annotations) (types.FeatureStatus, error)
 	applyGateway       func(context.Context, snap.Snap, types.Gateway, types.Network, types.Annotations) (types.FeatureStatus, error)
@@ -40,8 +40,8 @@ func (i *implementation) ApplyDNS(ctx context.Context, snap snap.Snap, dns types
 	return i.applyDNS(ctx, snap, dns, kubelet, annotations)
 }
 
-func (i *implementation) ApplyNetwork(ctx context.Context, snap snap.Snap, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
-	return i.applyNetwork(ctx, snap, apiserver, network, annotations)
+func (i *implementation) ApplyNetwork(ctx context.Context, snap snap.Snap, localhostAddress string, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
+	return i.applyNetwork(ctx, snap, localhostAddress, apiserver, network, annotations)
 }
 
 func (i *implementation) ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.LoadBalancer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {

--- a/src/k8s/pkg/k8sd/types/cluster_config_merge.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_merge.go
@@ -46,7 +46,6 @@ func MergeClusterConfig(existing ClusterConfig, new ClusterConfig) (ClusterConfi
 		// network
 		{name: "pod CIDR", val: &config.Network.PodCIDR, old: existing.Network.PodCIDR, new: new.Network.PodCIDR},
 		{name: "service CIDR", val: &config.Network.ServiceCIDR, old: existing.Network.ServiceCIDR, new: new.Network.ServiceCIDR},
-		{name: "localhost address", val: &config.Network.LocalhostAddress, old: existing.Network.LocalhostAddress, new: new.Network.LocalhostAddress},
 		// apiserver
 		{name: "kube-apiserver authorization mode", val: &config.APIServer.AuthorizationMode, old: existing.APIServer.AuthorizationMode, new: new.APIServer.AuthorizationMode, allowChange: true},
 		// kubelet

--- a/src/k8s/pkg/k8sd/types/cluster_config_network.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_network.go
@@ -1,14 +1,12 @@
 package types
 
 type Network struct {
-	Enabled          *bool   `json:"enabled,omitempty"`
-	PodCIDR          *string `json:"pod-cidr,omitempty"`
-	ServiceCIDR      *string `json:"service-cidr,omitempty"`
-	LocalhostAddress *string `json:"localhost-address,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
+	PodCIDR     *string `json:"pod-cidr,omitempty"`
+	ServiceCIDR *string `json:"service-cidr,omitempty"`
 }
 
-func (c Network) GetEnabled() bool            { return getField(c.Enabled) }
-func (c Network) GetPodCIDR() string          { return getField(c.PodCIDR) }
-func (c Network) GetServiceCIDR() string      { return getField(c.ServiceCIDR) }
-func (c Network) GetLocalhostAddress() string { return getField(c.LocalhostAddress) }
-func (c Network) Empty() bool                 { return c == Network{} }
+func (c Network) GetEnabled() bool       { return getField(c.Enabled) }
+func (c Network) GetPodCIDR() string     { return getField(c.PodCIDR) }
+func (c Network) GetServiceCIDR() string { return getField(c.ServiceCIDR) }
+func (c Network) Empty() bool            { return c == Network{} }


### PR DESCRIPTION
Pass localhost address from the start hook instead of embedding into cluster config.
