### PR TITLE
Add min-tls-version flag

### DIFF
--- a/src/k8s/pkg/k8sd/setup/kube_apiserver.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver.go
@@ -85,6 +85,7 @@ func KubeAPIServer(snap snap.Snap, securePort int, nodeIP net.IP, serviceCIDR st
 		"--service-cluster-ip-range":                 serviceCIDR,
 		"--tls-cert-file":                            filepath.Join(snap.KubernetesPKIDir(), "apiserver.crt"),
 		"--tls-cipher-suites":                        strings.Join(apiserverTLSCipherSuites, ","),
+		"--tls-min-version":                          "VersionTLS12",
 		"--tls-private-key-file":                     filepath.Join(snap.KubernetesPKIDir(), "apiserver.key"),
 	}
 

--- a/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_apiserver_test.go
@@ -63,6 +63,7 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--service-cluster-ip-range", expectedVal: "10.0.0.0/24"},
 			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
 			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", filepath.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
 			{key: "--request-timeout", expectedVal: "300s"},
@@ -123,6 +124,7 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--service-cluster-ip-range", expectedVal: "10.0.0.0/24"},
 			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
 			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", filepath.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
 		}
@@ -178,6 +180,7 @@ func TestKubeAPIServer(t *testing.T) {
 			{key: "--service-cluster-ip-range", expectedVal: "10.0.0.0/24"},
 			{key: "--tls-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.crt")},
 			{key: "--tls-cipher-suites", expectedVal: apiserverTLSCipherSuites},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 			{key: "--tls-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "apiserver.key")},
 			{key: "--etcd-servers", expectedVal: fmt.Sprintf("unix://%s", filepath.Join(s.Mock.K8sDqliteStateDir, "k8s-dqlite.sock"))},
 			{key: "--request-timeout", expectedVal: "300s"},

--- a/src/k8s/pkg/k8sd/setup/kube_controller_manager.go
+++ b/src/k8s/pkg/k8sd/setup/kube_controller_manager.go
@@ -22,6 +22,7 @@ func KubeControllerManager(snap snap.Snap, extraArgs map[string]*string) error {
 		"--root-ca-file":                     filepath.Join(snap.KubernetesPKIDir(), "ca.crt"),
 		"--service-account-private-key-file": filepath.Join(snap.KubernetesPKIDir(), "serviceaccount.key"),
 		"--terminated-pod-gc-threshold":      "12500",
+		"--tls-min-version":                  "VersionTLS12",
 		"--use-service-account-credentials":  "true",
 	}
 	// enable cluster-signing if certificates are available

--- a/src/k8s/pkg/k8sd/setup/kube_controller_manager_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_controller_manager_test.go
@@ -47,6 +47,7 @@ func TestKubeControllerManager(t *testing.T) {
 			{key: "--root-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--service-account-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
 			{key: "--cluster-signing-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--cluster-signing-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.key")},
@@ -95,6 +96,7 @@ func TestKubeControllerManager(t *testing.T) {
 			{key: "--root-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--service-account-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
 		}
 		for _, tc := range tests {
@@ -148,6 +150,7 @@ func TestKubeControllerManager(t *testing.T) {
 			{key: "--root-ca-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--service-account-private-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "serviceaccount.key")},
 			{key: "--terminated-pod-gc-threshold", expectedVal: "12500"},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 			{key: "--use-service-account-credentials", expectedVal: "true"},
 			{key: "--cluster-signing-cert-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.crt")},
 			{key: "--cluster-signing-key-file", expectedVal: filepath.Join(s.Mock.KubernetesPKIDir, "ca.key")},

--- a/src/k8s/pkg/k8sd/setup/kube_scheduler.go
+++ b/src/k8s/pkg/k8sd/setup/kube_scheduler.go
@@ -18,6 +18,7 @@ func KubeScheduler(snap snap.Snap, extraArgs map[string]*string) error {
 		"--leader-elect-lease-duration": "30s",
 		"--leader-elect-renew-deadline": "15s",
 		"--profiling":                   "false",
+		"--tls-min-version":             "VersionTLS12",
 	}, nil); err != nil {
 		return fmt.Errorf("failed to render arguments file: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/setup/kube_scheduler_test.go
+++ b/src/k8s/pkg/k8sd/setup/kube_scheduler_test.go
@@ -39,6 +39,7 @@ func TestKubeScheduler(t *testing.T) {
 			{key: "--leader-elect-lease-duration", expectedVal: "30s"},
 			{key: "--leader-elect-renew-deadline", expectedVal: "15s"},
 			{key: "--profiling", expectedVal: "false"},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -79,6 +80,7 @@ func TestKubeScheduler(t *testing.T) {
 			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "scheduler.conf")},
 			{key: "--leader-elect-renew-deadline", expectedVal: "15s"},
 			{key: "--profiling", expectedVal: "true"},
+			{key: "--tls-min-version", expectedVal: "VersionTLS12"},
 			{key: "--my-extra-arg", expectedVal: "my-extra-val"},
 		}
 		for _, tc := range tests {


### PR DESCRIPTION
DISA requires a TLS version of 1.2 as a minimum.