### PR TITLE
Enable upgrade tests on PRs

### DIFF
--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -91,6 +91,11 @@ jobs:
           TEST_LXD_IMAGE: ${{ matrix.os }}
           TEST_FLAVOR: ${{ matrix.patch }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+          # Test the latest (up to) 6 releases for the flavour
+          # TODO(ben): upgrade nightly to run all flavours
+          TEST_VERSION_UPGRADE_CHANNELS: "recent 6 ${{ matrix.patch }}"
+          # Upgrading from 1.30 is not supported.
+          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
         run: |
           # IPv6-only is only supported on moonray
           if [[ "${{ matrix.patch }}" == "moonray" ]]; then

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -102,6 +102,11 @@ jobs:
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ matrix.os }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+          # Test the latest (up to) 6 releases for the flavour
+          # TODO(ben): upgrade nightly to run all flavours
+          TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
+          # Upgrading from 1.30 is not supported.
+          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
         run: |
           cd tests/integration && sg lxd -c 'tox -e integration'
       - name: Prepare inspection reports

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
+import time
 from typing import List
 
 import pytest
@@ -51,6 +52,11 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
         cp.exec(
             ["snap", "refresh", config.SNAP_NAME, "--channel", channel, "--classic"]
         )
+
+        # After the upgrade and restart, the ready states of e.g. the CNI pods
+        # might be incorrect and need some time to run into timeouts and settle.
+        time.sleep(5)
+
         util.wait_until_k8s_ready(cp, instances)
         current_channel = channel
         LOG.info(f"Upgraded {cp.id} on channel {channel}")


### PR DESCRIPTION
This can only be merged after 1.31 is populated with the current main, otherwise the upgrade test fails.