### PR TITLE
remove kroki and replace with SVGS for now

### DIFF
--- a/docs/canonicalk8s/.sphinx/requirements.txt
+++ b/docs/canonicalk8s/.sphinx/requirements.txt
@@ -18,6 +18,5 @@ sphinx-notfound-page
 sphinx-tabs
 sphinxcontrib-jquery
 sphinxcontrib-svg2pdfconverter[CairoSVG]
-sphinxcontrib.kroki
 sphinxext-opengraph
 watchfiles

--- a/docs/canonicalk8s/custom_conf.py
+++ b/docs/canonicalk8s/custom_conf.py
@@ -167,7 +167,6 @@ custom_extensions = [
     'canonical.terminal-output',
     'notfound.extension',
     'sphinxcontrib.cairosvgconverter', 
-    'sphinxcontrib.kroki',
     ]
 
 # Add custom required Python modules that must be added to the
@@ -179,7 +178,6 @@ custom_extensions = [
 # sphinxext-opengraph
 custom_required_modules = [
     'sphinxcontrib-svg2pdfconverter[CairoSVG]',
-    'sphinxcontrib.kroki'
 ]
 
 # Add files or directories that should be excluded from processing.

--- a/docs/src/_parts/template-explanation
+++ b/docs/src/_parts/template-explanation
@@ -15,11 +15,6 @@ The documentation also supports various diagrams-as-code options. We
 prefer to use UML-style diagrams, but you can also use Mermaid or many
 other types.
 
-Diagrams like this are processed using the 'kroki' directive:
-
-```{kroki} ../../assets/ck-cluster.puml
-```
-
 ## Links
 
 Explanations frequently include links to other documents. In particular, please

--- a/docs/src/snap/explanation/clustering.md
+++ b/docs/src/snap/explanation/clustering.md
@@ -18,8 +18,7 @@ and scheduling of workloads.
 
 This is the overview of a {{product}} cluster:
 
-```{kroki} ../../assets/ck-cluster.puml
-```
+![cluster6][]
 
 ## The Role of `k8sd` in Kubernetes Clustering
 
@@ -68,6 +67,10 @@ entire life-cycle. Their components include:
 - **Kube-Proxy (kube-proxy)**: Manages network communication within the cluster.
 - **Container Runtime**: The software responsible for running containers. In
     {{product}} the runtime is `containerd`.
+
+<!-- IMAGES -->
+
+[cluster6]: https://assets.ubuntu.com/v1/e6d02e9c-cluster6.svg
 
 <!-- LINKS -->
 

--- a/docs/src/snap/explanation/ingress.md
+++ b/docs/src/snap/explanation/ingress.md
@@ -54,8 +54,7 @@ that routes traffic from outside of your cluster to services inside of your clus
 Please do not confuse this with the Kubernetes Service LoadBalancer type
 which operates at layer 4 and routes traffic directly to individual pods.
 
-```{kroki} ../../assets/ingress.puml
-```
+![cluster6][]
 
 With {{product}}, enabling Ingress is easy:
 See the [default Ingress guide][Ingress].
@@ -72,6 +71,10 @@ the responsibility of implementation falls upon you.
 
 You will need to create the Ingress resource,
 outlining rules that direct traffic to your application's Kubernetes service.
+
+<!-- IMAGES -->
+
+[cluster6]: https://assets.ubuntu.com/v1/e6d02e9c-cluster6.svg
 
 <!-- LINKS -->
 

--- a/docs/src/snap/reference/architecture.md
+++ b/docs/src/snap/reference/architecture.md
@@ -10,8 +10,7 @@ current design of {{product}}, following the [C4 model].
 This overview of {{product}} demonstrates the interactions of
 Kubernetes with users and with other systems.
 
-```{kroki} ../../assets/overview.puml
-```
+![cluster2][]
 
 Two actors interact with the Kubernetes snap:
 
@@ -52,8 +51,7 @@ distribution. We have identified the following:
 
 Looking more closely at what is contained within the K8s snap itself:
 
-```{kroki} ../../assets/k8s-container.puml
-```
+![cluster3][]
 
 The `k8s` snap distribution includes the following:
 
@@ -74,8 +72,7 @@ The `k8s` snap distribution includes the following:
 K8sd is the component that implements and exposes the operations functionality
 needed for managing the Kubernetes cluster.
 
-```{kroki} ../../assets/k8sd-component.puml
-```
+![cluster4][]
 
 At the core of the `k8sd` functionality we have the cluster manager that is
 responsible for configuring the services, workload and features we deem
@@ -107,8 +104,7 @@ This functionality is exposed via the following interfaces:
 Canonical `k8s` Charms encompass two primary components: the [`k8s` charm][K8s
 charm] and the [`k8s-worker` charm][K8s-worker charm].
 
-```{kroki} ../../assets/charms-architecture.puml
-```
+![cluster1][]
 
 Charms are instantiated on a machine as a Juju unit, and a collection of units
 constitutes an application. Both `k8s` and `k8s-worker` units are responsible
@@ -140,6 +136,12 @@ and the sharing of observability data with the [`Canonical Observability Stack
 (COS)`][COS docs]. This modular and integrated approach facilitates a robust
 and flexible {{product}} deployment managed through Juju.
 
+<!-- IMAGES -->
+
+[cluster1]: https://assets.ubuntu.com/v1/dfc43753-cluster1.svg
+[cluster2]: https://assets.ubuntu.com/v1/0e486a5d-cluster2.svg
+[cluster3]: https://assets.ubuntu.com/v1/24fd1773-cluster3.svg
+[cluster4]: https://assets.ubuntu.com/v1/24fd1773-cluster4.svg
 
 <!-- LINKS -->
 [C4 model]:           https://c4model.com/

--- a/docs/tools/custom_conf.py
+++ b/docs/tools/custom_conf.py
@@ -145,7 +145,7 @@ custom_linkcheck_anchors_ignore_for_url = [
 ## Use them to extend the default features.
 
 # Add extensions
-custom_extensions = ['sphinxcontrib.kroki',  ]
+custom_extensions = [ ]
 
 # Add MyST extensions
 custom_myst_extensions = []


### PR DESCRIPTION
Kroki causes issues with:
 - rate limiting as we are too lazy to host this ourselves
 - build problems on different versions of Python
 
 This PR removes the kroki extension, the directives in the text and replaces with static SVG images until we determine a better replacement.