### PR TITLE
Cleanup left-over iptables rules from kubeproxy and cilium

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -46,6 +46,8 @@ k8s::common::is_strict() {
 # Cleanup configuration left by the network feature
 k8s::remove::network() {
   k8s::common::setup_env
+  
+  "${SNAP}/bin/kube-proxy" --cleanup || true
 
   k8s::cmd::k8s x-cleanup network || true
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -164,6 +164,7 @@ parts:
       - ethtool
       - hostname
       - iproute2
+      - ipset
       - kmod
       - libatm1
       - libnss-resolve

--- a/src/k8s/pkg/k8sd/features/cilium/cleanup.go
+++ b/src/k8s/pkg/k8sd/features/cilium/cleanup.go
@@ -27,11 +27,8 @@ func CleanupNetwork(ctx context.Context, snap snap.Snap) error {
 
 		lines := strings.Split(string(out), "\n")
 		for i, line := range lines {
-			for _, word := range []string{"cilium", "kube", "CILIUM", "KUBE"} {
-				if strings.Contains(line, word) {
-					lines[i] = ""
-					break
-				}
+			if strings.Contains(strings.ToLower(line), "cilium") {
+				lines[i] = ""
 			}
 		}
 

--- a/src/k8s/pkg/k8sd/features/cilium/cleanup.go
+++ b/src/k8s/pkg/k8sd/features/cilium/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/canonical/k8s/pkg/snap"
 )
@@ -15,6 +16,29 @@ func CleanupNetwork(ctx context.Context, snap snap.Snap) error {
 	if _, err := os.Stat("/opt/cni/bin/cilium-dbg"); err == nil {
 		if err := exec.CommandContext(ctx, "/opt/cni/bin/cilium-dbg", "cleanup", "--all-state", "--force").Run(); err != nil {
 			return fmt.Errorf("cilium-dbg cleanup failed: %w", err)
+		}
+	}
+
+	for _, cmd := range []string{"iptables", "ip6tables", "iptables-legacy", "ip6tables-legacy"} {
+		out, err := exec.Command(fmt.Sprintf("%s-save", cmd)).Output()
+		if err != nil {
+			return fmt.Errorf("failed to read iptables rules: %w", err)
+		}
+
+		lines := strings.Split(string(out), "\n")
+		for i, line := range lines {
+			for _, word := range []string{"cilium", "kube", "CILIUM", "KUBE"} {
+				if strings.Contains(line, word) {
+					lines[i] = ""
+					break
+				}
+			}
+		}
+
+		restore := exec.Command(fmt.Sprintf("%s-restore", cmd))
+		restore.Stdin = strings.NewReader(strings.Join(lines, "\n"))
+		if err := restore.Run(); err != nil {
+			return fmt.Errorf("failed to restore iptables rules: %w", err)
 		}
 	}
 


### PR DESCRIPTION
`cilium-dbg` seems to clean up interfaces, bpf programs, network namespaces properly. Seems like we are leaking some iptables rules so added a cleanup step for left-over iptables rules from kubeproxy and cilium.

