### PR TITLE
Fix lint and sbom jobs

### DIFF
--- a/build-scripts/hack/generate-sbom.py
+++ b/build-scripts/hack/generate-sbom.py
@@ -139,13 +139,15 @@ def k8s_snap_c_dqlite_components(manifest, extra_files):
 def rock_cilium(manifest, extra_files):
     LOG.info("Generating SBOM info for Cilium rocks")
 
+    cilium_version = "1.15.2"
+
     with util.git_repo(CILIUM_ROCK_REPO, CILIUM_ROCK_TAG) as d:
         rock_repo_commit = util.parse_output(["git", "rev-parse", "HEAD"], cwd=d)
-        rockcraft = (d / "cilium/rockcraft.yaml").read_text()
-        operator_rockcraft = (d / "cilium-operator-generic/rockcraft.yaml").read_text()
+        rockcraft = (d / f"{cilium_version}/cilium/rockcraft.yaml").read_text()
+        operator_rockcraft = (d / f"{cilium_version}/cilium-operator-generic/rockcraft.yaml").read_text()
 
-        extra_files["cilium/rockcraft.yaml"] = rockcraft
-        extra_files["cilium-operator-generic/rockcraft.yaml"] = operator_rockcraft
+        extra_files[f"{cilium_version}/cilium/rockcraft.yaml"] = rockcraft
+        extra_files[f"{cilium_version}/cilium-operator-generic/rockcraft.yaml"] = operator_rockcraft
 
         rockcraft_yaml = yaml.safe_load(rockcraft)
         repo_url = rockcraft_yaml["parts"]["cilium"]["source"]
@@ -169,10 +171,10 @@ def rock_cilium(manifest, extra_files):
         },
         "language": "go",
         "details": [
-            "cilium/rockcraft.yaml",
+            f"{cilium_version}/cilium/rockcraft.yaml",
             "cilium/go.mod",
             "cilium/go.sum",
-            "cilium-operator-generic/rockcraft.yaml",
+            f"{cilium_version}/cilium-operator-generic/rockcraft.yaml",
             "cilium-operator-generic/go.mod",
             "cilium-operator-generic/go.sum",
         ],

--- a/build-scripts/patches/strict/0001-Strict-patch.patch
+++ b/build-scripts/patches/strict/0001-Strict-patch.patch
@@ -299,7 +299,7 @@ index 3e54d68..295c458 100644
 +    #  * list mounts
 +    #
 +    # https://paste.ubuntu.com/p/WscCCfnvGH/plain/
-+    # https://paste.ubuntu.com/p/sSnJVvZkrr/plain/ 
++    # https://paste.ubuntu.com/p/sSnJVvZkrr/plain/
 +    #
 +    # LOG.info("Waiting for shims to go away...")
 +    # stubbornly(retries=20, delay_s=5).on(instance).until(


### PR DESCRIPTION
We need to remove a trailing whitespace that was added by mistake as it breaks the linting job.

At the same time, the cilium rockcraft.yaml location changed after introducing a new version, for which reason we need to update the sbom generation script.