### PR TITLE
Increase timeouts and log test timestamps

### DIFF
--- a/tests/branch_management/tox.ini
+++ b/tests/branch_management/tox.ini
@@ -38,6 +38,8 @@ commands =
         --tb native \
         --log-cli-level DEBUG \
         --disable-warnings \
+        --log-format "%(asctime)s %(levelname)s %(message)s" \
+        --log-date-format "%Y-%m-%d %H:%M:%S" \
         {posargs} \
         {tox_root}/tests
 pass_env =

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 DIR = Path(__file__).absolute().parent
 
 # The following defaults are used to define how long to wait for a condition to be met.
-DEFAULT_WAIT_RETRIES = int(os.getenv("TEST_DEFAULT_WAIT_RETRIES") or 60)
+DEFAULT_WAIT_RETRIES = int(os.getenv("TEST_DEFAULT_WAIT_RETRIES") or 120)
 DEFAULT_WAIT_DELAY_S = int(os.getenv("TEST_DEFAULT_WAIT_DELAY_S") or 5)
 
 MANIFESTS_DIR = DIR / ".." / ".." / "templates"

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -37,6 +37,8 @@ commands =
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \
+        --log-format "%(asctime)s %(levelname)s %(message)s" \
+        --log-date-format "%Y-%m-%d %H:%M:%S" \
         --disable-warnings \
         {posargs} \
         {toxinidir}/tests


### PR DESCRIPTION
We're waiting about 5 minutes for new nodes to become ready, however sometimes this isn't enough. It can take around one minute just to pull the cilium image.

For this reason, we'll double the test timeouts again.

While at it, we're configuring pytest to log timestamps, which allows us to correlate test logs with the k8s logs.