### PR TITLE
Increase test timeouts

### DIFF
--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -113,7 +113,7 @@ def test_gateway(instances: List[harness.Instance]):
     # Get gateway node port
     gateway_http_port = None
     result = (
-        util.stubbornly(retries=7, delay_s=3)
+        util.stubbornly(retries=10, delay_s=3)
         .on(instance)
         .until(lambda p: get_gateway_service_node_port(p) is not None)
         .exec(["k8s", "kubectl", "get", "service", "-o", "json"])
@@ -123,12 +123,12 @@ def test_gateway(instances: List[harness.Instance]):
     assert gateway_http_port is not None, "No Gateway nodePort found."
 
     # Test the Gateway service via loadbalancer IP.
-    util.stubbornly(retries=5, delay_s=5).on(instance).until(
+    util.stubbornly(retries=10, delay_s=5).on(instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"localhost:{gateway_http_port}"])
 
     gateway_ip = get_external_service_ip(instance)
     assert gateway_ip is not None, "No Gateway IP found."
-    util.stubbornly(retries=5, delay_s=5).on(instance).until(
+    util.stubbornly(retries=10, delay_s=5).on(instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"{gateway_ip}", "-H", "Host: foo.bar.com"])

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -126,7 +126,7 @@ def test_ingress(instances: List[harness.Instance]):
         ]
     )
 
-    util.stubbornly(retries=5, delay_s=5).on(instance).until(
+    util.stubbornly(retries=10, delay_s=5).on(instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"localhost:{ingress_http_port}", "-H", "Host: foo.bar.com"])
 
@@ -139,6 +139,6 @@ def test_ingress(instances: List[harness.Instance]):
         ],
     )
     assert ingress_ip is not None, "No ingress IP found."
-    util.stubbornly(retries=5, delay_s=5).on(instance).until(
+    util.stubbornly(retries=10, delay_s=5).on(instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"{ingress_ip}", "-H", "Host: foo.bar.com"])

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -62,12 +62,12 @@ def test_loadbalancer(instances: List[harness.Instance]):
         ]
     )
 
-    util.stubbornly(retries=5, delay_s=2).on(instance).until(
+    util.stubbornly(retries=10, delay_s=2).on(instance).until(
         lambda p: "my-nginx" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "service", "-o", "json"])
 
     p = (
-        util.stubbornly(retries=5, delay_s=3)
+        util.stubbornly(retries=10, delay_s=3)
         .on(instance)
         .until(lambda p: len(p.stdout.decode().replace("'", "")) > 0)
         .exec(
@@ -83,6 +83,6 @@ def test_loadbalancer(instances: List[harness.Instance]):
     )
     service_ip = p.stdout.decode().replace("'", "")
 
-    util.stubbornly(retries=5, delay_s=3).on(tester_instance).until(
+    util.stubbornly(retries=20, delay_s=3).on(tester_instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", service_ip])

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -59,6 +59,6 @@ def test_network(instances: List[harness.Instance]):
     assert len(out["items"]) > 0, "No NGINX pod found"
     podIP = out["items"][0]["status"]["podIP"]
 
-    util.stubbornly(retries=5, delay_s=5).on(instance).until(
+    util.stubbornly(retries=10, delay_s=5).on(instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", "-s", f"http://{podIP}"])

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -53,7 +53,7 @@ def test_dualstack(instances: List[harness.Instance]):
             pytest.fail(f"Unknown IP address type: {addr}")
 
         # need to shell out otherwise this runs into permission errors
-        util.stubbornly(retries=3, delay_s=1).on(main).exec(
+        util.stubbornly(retries=10, delay_s=1).on(main).exec(
             ["curl", address], shell=True
         )
 
@@ -113,7 +113,7 @@ def test_ipv6_only_on_dualstack_infra(instances: List[harness.Instance]):
             pytest.fail(f"Unknown IP address type: {addr}")
 
         # need to shell out otherwise this runs into permission errors
-        util.stubbornly(retries=3, delay_s=1).on(main).exec(
+        util.stubbornly(retries=10, delay_s=1).on(main).exec(
             ["curl", address], shell=True
         )
 


### PR DESCRIPTION
A few tests occasionally time out while waiting for load balancer addresses to become available.

We'll bump these timeouts to avoid flaky tests.

```
______________________________ test_loadbalancer _______________________________
Traceback (most recent call last):
  File "/home/ubuntu/actions-runner/_work/k8s-snap/k8s-snap/tests/integration/.tox/integration/lib/python3.10/site-packages/tenacity/__init__.py", line 382, in __call__
    result = fn(*args, **kwargs)
  File "/home/ubuntu/actions-runner/_work/k8s-snap/k8s-snap/tests/integration/tests/test_util/util.py", line 103, in exec
    resp = self._run(command_args, **command_kwds)
  File "/home/ubuntu/actions-runner/_work/k8s-snap/k8s-snap/tests/integration/tests/test_util/harness/lxd.py", line 221, in exec
    return run(
  File "/home/ubuntu/actions-runner/_work/k8s-snap/k8s-snap/tests/integration/tests/test_util/util.py", line 37, in run
    return subprocess.run(command, **kwargs)
  File "/home/ubuntu/actions-runner/_work/_tool/Python/3.10.15/x64/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['lxc', 'shell', 'k8s-integration-7bfaaf-35', '--', 'bash', '-c', 'curl 10.224.189.4']' returned non-zero exit status 7.
```