### PR TITLE
revert spelling change

### DIFF
--- a/docs/src/_parts/bootstrap_config.md
+++ b/docs/src/_parts/bootstrap_config.md
@@ -189,7 +189,7 @@ If omitted defaults to `true`.
 Sets the cloud provider to be used by the cluster.
 
 When this is set as `external`, node will wait for an external cloud provider to
-do cloud specific setup and finish node initialisation.
+do cloud specific setup and finish node initialization.
 
 Possible values: `external`.
 


### PR DESCRIPTION
Revert a spelling change in https://github.com/canonical/k8s-snap/commit/79f3145c038b1b5901264720a1c06daf0969517d that causes the `make go.doc` command to make a change during the workflow, which fails the subsequent `git diff` check.