### PR TITLE
Update cilium version in sync-images.yaml

### DIFF
--- a/build-scripts/hack/sync-images.yaml
+++ b/build-scripts/hack/sync-images.yaml
@@ -2,11 +2,11 @@ sync:
   - source: ghcr.io/canonical/k8s-snap/pause:3.10
     target: '{{ env "MIRROR" }}/canonical/k8s-snap/pause:3.10'
     type: image
-  - source: ghcr.io/canonical/cilium-operator-generic:1.15.2-ck2
-    target: '{{ env "MIRROR" }}/canonical/cilium-operator-generic:1.15.2-ck2'
+  - source: ghcr.io/canonical/cilium-operator-generic:1.16.3-ck0
+    target: '{{ env "MIRROR" }}/canonical/cilium-operator-generic:1.16.3-ck0'
     type: image
-  - source: ghcr.io/canonical/cilium:1.15.2-ck2
-    target: '{{ env "MIRROR" }}/canonical/cilium:1.15.2-ck2'
+  - source: ghcr.io/canonical/cilium:1.16.3-ck0
+    target: '{{ env "MIRROR" }}/canonical/cilium:1.16.3-ck0'
     type: image
   - source: ghcr.io/canonical/coredns:1.11.1-ck4
     target: '{{ env "MIRROR" }}/canonical/coredns:1.11.1-ck4'


### PR DESCRIPTION
Follow-up fix on https://github.com/canonical/k8s-snap/pull/803/files
Adds sync-images version bump.