### PR TITLE
Validate ports in PreInitChecks

### DIFF
--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -344,8 +344,7 @@ func (s *snap) PreInitChecks(ctx context.Context, config types.ClusterConfig) er
 		for _, address := range []string{"127.0.0.1", "0.0.0.0"} {
 			listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", address, port))
 			if err != nil {
-				listener.Close()
-				return fmt.Errorf("couldn't bind to required address %s. Is it in use?", address)
+				return fmt.Errorf("couldn't bind to required address %s:%d. Is it in use?", address, port)
 			}
 			listener.Close()
 		}


### PR DESCRIPTION
This function runs before any of the k8s binaries are started, it's the right place to validate that the api-server, kubelet, etc. ports are available.

Note: containerd doesn't seem to use a consistent port, which complicates checking if it's port is available.
Note: When a port is in use, I sometimes get a `The error was: failed to POST /k8sd/cluster: Post "http://control.socket/1.0/k8sd/cluster": EOF` error before the validation happens. I'm investigating this.