### PR TITLE
Adds configurable containerd base dir during bootstrap / join

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -99,6 +99,7 @@ k8s::remove::containerd() {
 
   # only remove containerd if the snap was already bootstrapped.
   # this is to prevent removing containerd when it is not installed by the snap.
+  # NOTE: do NOT include .containerd-base-dir! By default, it will contain "/".
   for file in "containerd-socket-path" "containerd-config-dir" "containerd-root-dir" "containerd-cni-bin-dir"; do
     if [ -f "$SNAP_COMMON/lock/$file" ]; then
       rm -rf $(cat "$SNAP_COMMON/lock/$file")

--- a/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
+++ b/src/k8s/pkg/k8sd/api/cluster_bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
@@ -38,6 +39,12 @@ func (e *Endpoints) postClusterBootstrap(_ state.State, r *http.Request) respons
 
 	if status.Ready {
 		return response.BadRequest(fmt.Errorf("cluster is already bootstrapped"))
+	}
+
+	// If not set, leave the default base dir location.
+	if req.Config.ContainerdBaseDir != "" {
+		// append k8s-containerd to the given base dir, so we don't flood it with our own folders.
+		e.provider.Snap().SetContainerdBaseDir(filepath.Join(req.Config.ContainerdBaseDir, "k8s-containerd"))
 	}
 
 	// NOTE(neoaggelos): microcluster adds an implicit 30 second timeout if no context deadline is set.

--- a/src/k8s/pkg/k8sd/setup/containerd.go
+++ b/src/k8s/pkg/k8sd/setup/containerd.go
@@ -173,6 +173,7 @@ func saveSnapContainerdPaths(s snap.Snap) error {
 		"containerd-config-dir":  s.ContainerdConfigDir(),
 		"containerd-root-dir":    s.ContainerdRootDir(),
 		"containerd-cni-bin-dir": s.CNIBinDir(),
+		snap.ContainerdBaseDir:   s.GetContainerdBaseDir(),
 	}
 
 	for filename, content := range m {

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -39,6 +39,8 @@ type Snap interface {
 	EtcdPKIDir() string          // /etc/kubernetes/pki/etcd
 	KubeletRootDir() string      // /var/lib/kubelet
 
+	SetContainerdBaseDir(baseDir string) // sets the containerd base directory.
+	GetContainerdBaseDir() string        // gets the containerd base directory.
 	ContainerdConfigDir() string         // classic confinement: /etc/containerd, strict confinement: /var/snap/k8s/common/etc/containerd
 	ContainerdExtraConfigDir() string    // classic confinement: /etc/containerd/conf.d, strict confinement: /var/snap/k8s/common/etc/containerd/conf.d
 	ContainerdRegistryConfigDir() string // classic confinement: /etc/containerd/hosts.d, strict confinement: /var/snap/k8s/common/etc/containerd/hosts.d

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -30,6 +30,7 @@ type Mock struct {
 	ContainerdConfigDir         string
 	ContainerdExtraConfigDir    string
 	ContainerdRegistryConfigDir string
+	ContainerdBaseDir           string
 	ContainerdRootDir           string
 	ContainerdSocketDir         string
 	ContainerdSocketPath        string
@@ -129,6 +130,14 @@ func (s *Snap) GID() int {
 
 func (s *Snap) Hostname() string {
 	return s.Mock.Hostname
+}
+
+func (s *Snap) SetContainerdBaseDir(baseDir string) {
+	s.Mock.ContainerdBaseDir = baseDir
+}
+
+func (s *Snap) GetContainerdBaseDir() string {
+	return s.Mock.ContainerdBaseDir
 }
 
 func (s *Snap) ContainerdConfigDir() string {

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -24,6 +24,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	ContainerdBaseDir = ".containerd-base-dir"
+)
+
 type SnapOpts struct {
 	SnapInstanceName  string
 	SnapDir           string
@@ -171,6 +175,14 @@ func (s *snap) Hostname() string {
 		return "dev"
 	}
 	return hostname
+}
+
+func (s *snap) SetContainerdBaseDir(baseDir string) {
+	s.containerdBaseDir = baseDir
+}
+
+func (s *snap) GetContainerdBaseDir() string {
+	return s.containerdBaseDir
 }
 
 func (s *snap) ContainerdConfigDir() string {
@@ -349,7 +361,8 @@ func (s *snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, se
 	if _, err := os.Stat(s.ContainerdSocketDir()); err == nil {
 		return fmt.Errorf("The path '%s' required for the containerd socket already exists. "+
 			"This may mean that another service is already using that path, and it conflicts with the k8s snap. "+
-			"Please make sure that there is no other service installed that uses the same path, and remove the existing directory.", s.ContainerdSocketDir())
+			"Please make sure that there is no other service installed that uses the same path, and remove the existing directory."+
+			"(dev-only): You can change the default k8s containerd base path with the containerd-base-dir option in the bootstrap / join-cluster config file.", s.ContainerdSocketDir())
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("Encountered an error while checking '%s': %w", s.ContainerdSocketDir(), err)
 	}

--- a/tests/integration/templates/bootstrap-containerd-path.yaml
+++ b/tests/integration/templates/bootstrap-containerd-path.yaml
@@ -1,0 +1,2 @@
+# Contains the bootstrap configuration for the containerd-related paths test.
+containerd-base-dir: /home/ubuntu

--- a/tests/integration/tests/test_cleanup.py
+++ b/tests/integration/tests/test_cleanup.py
@@ -2,19 +2,21 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
+import os
 from typing import List
 
 import pytest
-from test_util import harness, tags, util
+import yaml
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 
 CONTAINERD_PATHS = [
     "/etc/containerd",
-    "/opt/cni/bin",
     "/run/containerd",
     "/var/lib/containerd",
 ]
+CNI_PATH = "/opt/cni/bin"
 
 
 @pytest.mark.node_count(1)
@@ -27,11 +29,65 @@ def test_node_cleanup(instances: List[harness.Instance], tmp_path):
     util.remove_k8s_snap(instance)
 
     # Check that the containerd-related folders are removed on snap removal.
+    all_paths = CONTAINERD_PATHS + [CNI_PATH]
     process = instance.exec(
-        ["ls", *CONTAINERD_PATHS], capture_output=True, text=True, check=False
+        ["ls", *all_paths], capture_output=True, text=True, check=False
     )
-    for path in CONTAINERD_PATHS:
+    for path in all_paths:
         assert f"cannot access '{path}': No such file or directory" in process.stderr
 
     util.setup_k8s_snap(instance, tmp_path)
     instance.exec(["k8s", "bootstrap"])
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.tags(tags.NIGHTLY)
+def test_node_cleanup_new_containerd_path(instances: List[harness.Instance]):
+    main = instances[0]
+    joiner = instances[1]
+
+    containerd_path_bootstrap_config = (
+        config.MANIFESTS_DIR / "bootstrap-containerd-path.yaml"
+    ).read_text()
+
+    main.exec(
+        ["k8s", "bootstrap", "--file", "-"],
+        input=str.encode(containerd_path_bootstrap_config),
+    )
+
+    join_token = util.get_join_token(main, joiner)
+    joiner.exec(
+        ["k8s", "join-cluster", join_token, "--file", "-"],
+        input=str.encode(containerd_path_bootstrap_config),
+    )
+
+    boostrap_config = yaml.safe_load(containerd_path_bootstrap_config)
+    new_containerd_paths = [
+        os.path.join(boostrap_config["containerd-base-dir"], "k8s-containerd", p)
+        for p in CONTAINERD_PATHS
+    ]
+    for instance in instances:
+        # Check that the containerd-related folders are not in the default locations.
+        process = instance.exec(
+            ["ls", *CONTAINERD_PATHS], capture_output=True, text=True, check=False
+        )
+        for path in CONTAINERD_PATHS:
+            assert (
+                f"cannot access '{path}': No such file or directory" in process.stderr
+            )
+
+        # Check that the containerd-related folders are in the new locations.
+        # If one of them is missing, this should have a non-zero exit code.
+        instance.exec(["ls", *new_containerd_paths], check=True)
+
+    for instance in instances:
+        # Check that the containerd-related folders are not in the new locations after snap removal.
+        util.remove_k8s_snap(instance)
+        process = instance.exec(
+            ["ls", *new_containerd_paths], capture_output=True, text=True, check=False
+        )
+        for path in new_containerd_paths:
+            assert (
+                f"cannot access '{path}': No such file or directory" in process.stderr
+            )


### PR DESCRIPTION
Adds configurable containerd base dir during bootstrap / join

Currently, for the classic k8s snap, the default locations for the containerd-related files are:

```
- /etc/containerd/
- /run/containerd/
- /var/lib/containerd/
```

These paths can conflict with other containerd installations on the host (e.g. from docker), meaning that the k8s snap cannot be installed. In a developer's usecase, we shouldn't require the other services to be disabled, but we can allow the k8s snap's containerd to be installed in a different location during bootstrap / node join.

Adds the ``--containerd-base-dir`` option for k8s bootstrap and join-cluster commands. If not given, the snap's default paths will be used instead. After the node was initialized, save the containerd base location in a file, so we can properly reference it later / on restart.

Depends-On: https://github.com/canonical/k8s-snap-api/pull/19