### PR TITLE
Test file creation in CNI dir

### DIFF
--- a/src/k8s/pkg/k8sd/setup/directories.go
+++ b/src/k8s/pkg/k8sd/setup/directories.go
@@ -82,5 +82,11 @@ func ensureCniBinDir(cniBinDir string) error {
 		}
 	}
 
+	f, err := os.CreateTemp(cniBinDir, "test*.txt")
+	if err != nil {
+		return fmt.Errorf("failed create file in %q: %w", cniBinDir, err)
+	}
+	defer os.Remove(f.Name())
+
 	return nil
 }


### PR DESCRIPTION
We are currently checking if the permissions on the CNI directory are appropriate, but this is not sufficient in some cases. This pr adds an additional check for the CNI directory by writing a temporary file.

KU-2099