### PR TITLE
Fix registry mirror log collection

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -44,9 +44,12 @@ def _generate_inspection_report(h: harness.Harness, instance_id: str):
     )
 
     (inspection_path / instance_id).mkdir(parents=True, exist_ok=True)
-    (inspection_path / instance_id / "inspection_report_logs.txt").write_text(
-        result.stdout
-    )
+    report_log = inspection_path / instance_id / "inspection_report_logs.txt"
+    with report_log.open("w") as f:
+        f.write("stdout:\n")
+        f.write(result.stdout)
+        f.write("stderr:\n")
+        f.write(result.stderr)
 
     try:
         h.pull_file(

--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -2,12 +2,13 @@
 # Copyright 2024 Canonical, Ltd.
 #
 import logging
+from pathlib import Path
 from string import Template
 from typing import List, Optional
 
 from test_util import config
 from test_util.harness import Harness, Instance
-from test_util.util import get_default_ip
+from test_util.util import get_default_ip, setup_k8s_snap
 
 LOG = logging.getLogger(__name__)
 
@@ -79,6 +80,8 @@ class Registry:
         self._ip = get_default_ip(self.instance)
 
         self.add_mirrors()
+
+        setup_k8s_snap(self.instance, Path("/"))
 
     def get_configured_mirrors(self) -> List[Mirror]:
         mirrors: List[Mirror] = []


### PR DESCRIPTION
The registry mirror instance doesn't currently include the k8s snap, which is why the log collection script is missing.

This commit will install the k8s snap on the mirror instance and also capture the "inspect.sh" stderr output.