### PR TITLE
Add testing level tags

### DIFF
--- a/tests/integration/requirements-test.txt
+++ b/tests/integration/requirements-test.txt
@@ -1,5 +1,6 @@
 coverage[toml]==7.2.5
 pytest==7.3.1
+pytest_tagging==1.5.3
 PyYAML==6.0.1
 tenacity==8.2.3
 pylint==3.2.5

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -13,6 +13,8 @@ from test_util.registry import Registry
 
 LOG = logging.getLogger(__name__)
 
+pytest_plugins = ("pytest_tagging",)
+
 # The following snaps will be downloaded once per test run and preloaded
 # into the harness instances to reduce the number of downloads.
 PRELOADED_SNAPS = ["snapd", "core20"]

--- a/tests/integration/tests/test_util/tags.py
+++ b/tests/integration/tests/test_util/tags.py
@@ -1,0 +1,12 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+from pytest_tagging import combine_tags
+
+PULL_REQUEST = "pull_request"
+NIGHTLY = "nightly"
+WEEKLY = "weekly"
+
+# Those tags can be used for a convenient way to run multiple test levels.
+combine_tags("up_to_nightly", PULL_REQUEST, NIGHTLY)
+combine_tags("up_to_weekly", PULL_REQUEST, NIGHTLY, WEEKLY)


### PR DESCRIPTION
Introduce tags to mark tests for specific testing levels.

In a follow-up PR, the existing tests will be marked and then we can simply run e.g.
```
tox run -e integration -- --tags up_to_nightly
```
to execute all nightly tests.