### PR TITLE
Change busybox image registry to avoid rate limit errors

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -109,7 +109,7 @@ jobs:
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
-          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}]'
+          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
           cd tests/integration && sg lxd -c 'tox -e integration'
       - name: Prepare inspection reports

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -48,7 +48,7 @@ jobs:
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
-          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}]'
+          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
           export PATH="/home/runner/.local/bin:$PATH"
           cd tests/integration && sg lxd -c 'tox -vve integration'

--- a/tests/integration/templates/gateway-test.yaml
+++ b/tests/integration/templates/gateway-test.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: my-nginx
-        image: nginx
+        image: ghcr.io/containerd/nginx:1.27.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/templates/ingress-test.yaml
+++ b/tests/integration/templates/ingress-test.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: my-nginx
-        image: nginx
+        image: ghcr.io/containerd/nginx:1.27.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/templates/loadbalancer-test.yaml
+++ b/tests/integration/templates/loadbalancer-test.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: my-nginx
-        image: nginx
+        image: ghcr.io/containerd/nginx:1.27.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/templates/nginx-pod.yaml
+++ b/tests/integration/templates/nginx-pod.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   containers:
     - name: nginx
-      image: nginx:latest
+      image: ghcr.io/containerd/nginx:1.27.0
   restartPolicy: Always

--- a/tests/integration/templates/storage-setup.yaml
+++ b/tests/integration/templates/storage-setup.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
     - name: storage-writer-container
-      image: busybox
+      image: ghcr.io/containerd/busybox:1.28
       command:
         ["/bin/sh", "-c", "while true; do echo LOREM IPSUM $(date) | tee -a /mnt/dates; sleep 2; done"]
       volumeMounts:

--- a/tests/integration/templates/storage-test.yaml
+++ b/tests/integration/templates/storage-test.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: storage-reader-container
-      image: busybox
+      image: ghcr.io/containerd/busybox:1.28
       command:
         ["/bin/sh", "-c", "while true; do tail -1 /mnt/dates; sleep 2; done"]
       volumeMounts:

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -23,7 +23,7 @@ def test_dns(instances: List[harness.Instance]):
             "kubectl",
             "run",
             "busybox",
-            "--image=busybox:1.28",
+            "--image=ghcr.io/containerd/busybox:1.28",
             "--restart=Never",
             "--",
             "sleep",

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -154,6 +154,11 @@ USE_LOCAL_MIRROR = (os.getenv("TEST_USE_LOCAL_MIRROR") or "1") == "1"
 DEFAULT_MIRROR_LIST = [
     {"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io"},
     {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io"},
+    {
+        "name": "rocks.canonical.com",
+        "port": 5002,
+        "remote": "https://rocks.canonical.com/cdk",
+    },
 ]
 
 # Local mirror configuration.


### PR DESCRIPTION
Our tests use busybox and nginx images from dockerhub, however the CI jobs often fail due to rate limit errors.

We'll use images from GHCR instead, where the CI jobs are authenticated.

While at it, we'll configure our registry mirror to cache images from rocks.canonical.com.