### PR TITLE
Checks k8s-related port availability in PreInitChecks

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -232,7 +232,7 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s state.State, encodedT
 	}
 
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, false); err != nil {
 		return fmt.Errorf("pre-init checks failed for worker node: %w", err)
 	}
 
@@ -420,7 +420,7 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 	cfg.Certificates.K8sdPrivateKey = utils.Pointer(certificates.K8sdPrivateKey)
 
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, true); err != nil {
 		return fmt.Errorf("pre-init checks failed for bootstrap node: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -231,8 +231,14 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s state.State, encodedT
 		Annotations: response.Annotations,
 	}
 
+	serviceConfigs := types.K8sServiceConfigs{
+		IsControlPlane:         false,
+		ExtraNodeKubeletArgs:   joinConfig.ExtraNodeKubeletArgs,
+		ExtraNodeKubeProxyArgs: joinConfig.ExtraNodeKubeProxyArgs,
+	}
+
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg, false); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs); err != nil {
 		return fmt.Errorf("pre-init checks failed for worker node: %w", err)
 	}
 
@@ -419,8 +425,16 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 	cfg.Certificates.K8sdPublicKey = utils.Pointer(certificates.K8sdPublicKey)
 	cfg.Certificates.K8sdPrivateKey = utils.Pointer(certificates.K8sdPrivateKey)
 
+	serviceConfigs := types.K8sServiceConfigs{
+		IsControlPlane:                     true,
+		ExtraNodeKubeSchedulerArgs:         bootstrapConfig.ExtraNodeKubeSchedulerArgs,
+		ExtraNodeKubeControllerManagerArgs: bootstrapConfig.ExtraNodeKubeControllerManagerArgs,
+		ExtraNodeKubeletArgs:               bootstrapConfig.ExtraNodeKubeletArgs,
+		ExtraNodeKubeProxyArgs:             bootstrapConfig.ExtraNodeKubeProxyArgs,
+	}
+
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg, true); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs); err != nil {
 		return fmt.Errorf("pre-init checks failed for bootstrap node: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -232,13 +232,12 @@ func (a *App) onBootstrapWorkerNode(ctx context.Context, s state.State, encodedT
 	}
 
 	serviceConfigs := types.K8sServiceConfigs{
-		IsControlPlane:         false,
 		ExtraNodeKubeletArgs:   joinConfig.ExtraNodeKubeletArgs,
 		ExtraNodeKubeProxyArgs: joinConfig.ExtraNodeKubeProxyArgs,
 	}
 
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs, false); err != nil {
 		return fmt.Errorf("pre-init checks failed for worker node: %w", err)
 	}
 
@@ -426,7 +425,6 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 	cfg.Certificates.K8sdPrivateKey = utils.Pointer(certificates.K8sdPrivateKey)
 
 	serviceConfigs := types.K8sServiceConfigs{
-		IsControlPlane:                     true,
 		ExtraNodeKubeSchedulerArgs:         bootstrapConfig.ExtraNodeKubeSchedulerArgs,
 		ExtraNodeKubeControllerManagerArgs: bootstrapConfig.ExtraNodeKubeControllerManagerArgs,
 		ExtraNodeKubeletArgs:               bootstrapConfig.ExtraNodeKubeletArgs,
@@ -434,7 +432,7 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 	}
 
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs, true); err != nil {
 		return fmt.Errorf("pre-init checks failed for bootstrap node: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -138,7 +138,7 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 	}
 
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, true); err != nil {
 		return fmt.Errorf("pre-init checks failed for joining node: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -139,7 +139,6 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 	}
 
 	serviceConfigs := types.K8sServiceConfigs{
-		IsControlPlane:                     true,
 		ExtraNodeKubeSchedulerArgs:         joinConfig.ExtraNodeKubeSchedulerArgs,
 		ExtraNodeKubeControllerManagerArgs: joinConfig.ExtraNodeKubeControllerManagerArgs,
 		ExtraNodeKubeletArgs:               joinConfig.ExtraNodeKubeletArgs,
@@ -147,7 +146,7 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 	}
 
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs, true); err != nil {
 		return fmt.Errorf("pre-init checks failed for joining node: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -9,6 +9,7 @@ import (
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/control"
@@ -137,8 +138,16 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to initialize control plane certificates: %w", err)
 	}
 
+	serviceConfigs := types.K8sServiceConfigs{
+		IsControlPlane:                     true,
+		ExtraNodeKubeSchedulerArgs:         joinConfig.ExtraNodeKubeSchedulerArgs,
+		ExtraNodeKubeControllerManagerArgs: joinConfig.ExtraNodeKubeControllerManagerArgs,
+		ExtraNodeKubeletArgs:               joinConfig.ExtraNodeKubeletArgs,
+		ExtraNodeKubeProxyArgs:             joinConfig.ExtraNodeKubeProxyArgs,
+	}
+
 	// Pre-init checks
-	if err := snap.PreInitChecks(ctx, cfg, true); err != nil {
+	if err := snap.PreInitChecks(ctx, cfg, serviceConfigs); err != nil {
 		return fmt.Errorf("pre-init checks failed for joining node: %w", err)
 	}
 

--- a/src/k8s/pkg/k8sd/types/k8s_service_configs.go
+++ b/src/k8s/pkg/k8sd/types/k8s_service_configs.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"net"
+)
+
+const (
+	// Default values for Kubernetes services.
+	KubeControllerManagerPort = "10257"
+	KubeSchedulerPort         = "10259"
+	KubeletPort               = "10250"
+	KubeletHealthzPort        = "10248"
+	KubeletReadOnlyPort       = "10255"
+	KubeProxyHealthzPort      = "10256"
+	KubeProxyMetricsPort      = "10249"
+)
+
+type K8sServiceConfigs struct {
+	IsControlPlane                     bool
+	ExtraNodeKubeControllerManagerArgs map[string]*string
+	ExtraNodeKubeSchedulerArgs         map[string]*string
+	ExtraNodeKubeletArgs               map[string]*string
+	ExtraNodeKubeProxyArgs             map[string]*string
+}
+
+func (s *K8sServiceConfigs) GetKubeControllerManagerPort() string {
+	return getConfigOrDefault(s.ExtraNodeKubeControllerManagerArgs, "--secure-port", KubeControllerManagerPort)
+}
+
+func (s *K8sServiceConfigs) GetKubeSchedulerPort() string {
+	return getConfigOrDefault(s.ExtraNodeKubeSchedulerArgs, "--secure-port", KubeSchedulerPort)
+}
+
+func (s *K8sServiceConfigs) GetKubeletPort() string {
+	return getConfigOrDefault(s.ExtraNodeKubeletArgs, "--port", KubeletPort)
+}
+
+func (s *K8sServiceConfigs) GetKubeletHealthzPort() string {
+	return getConfigOrDefault(s.ExtraNodeKubeletArgs, "--healthz-port", KubeletHealthzPort)
+}
+
+func (s *K8sServiceConfigs) GetKubeletReadOnlyPort() string {
+	return getConfigOrDefault(s.ExtraNodeKubeletArgs, "--read-only-port", KubeletReadOnlyPort)
+}
+
+func (s *K8sServiceConfigs) GetKubeProxyHealthzPort() (string, error) {
+	address := getConfigOrDefault(s.ExtraNodeKubeProxyArgs, "--healthz-bind-address", "")
+	if address == "" {
+		return KubeProxyHealthzPort, nil
+	}
+	_, port, err := net.SplitHostPort(address)
+	return port, err
+}
+
+func (s *K8sServiceConfigs) GetKubeProxyMetricsPort() (string, error) {
+	address := getConfigOrDefault(s.ExtraNodeKubeProxyArgs, "--metrics-bind-address", "")
+	if address == "" {
+		return KubeProxyMetricsPort, nil
+	}
+	_, port, err := net.SplitHostPort(address)
+	return port, err
+}
+
+func getConfigOrDefault(serviceArgs map[string]*string, optionName, defaultValue string) string {
+	if serviceArgs == nil {
+		return defaultValue
+	} else if val, ok := serviceArgs[optionName]; !ok || val == nil {
+		return defaultValue
+	} else {
+		return *val
+	}
+}

--- a/src/k8s/pkg/k8sd/types/k8s_service_configs.go
+++ b/src/k8s/pkg/k8sd/types/k8s_service_configs.go
@@ -16,7 +16,6 @@ const (
 )
 
 type K8sServiceConfigs struct {
-	IsControlPlane                     bool
 	ExtraNodeKubeControllerManagerArgs map[string]*string
 	ExtraNodeKubeSchedulerArgs         map[string]*string
 	ExtraNodeKubeletArgs               map[string]*string

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -66,5 +66,5 @@ type Snap interface {
 
 	K8sdClient(address string) (k8sd.Client, error) // k8sd client
 
-	PreInitChecks(ctx context.Context, config types.ClusterConfig) error // pre-init checks before k8s-snap can start
+	PreInitChecks(ctx context.Context, config types.ClusterConfig, isControlPlane bool) error // pre-init checks before k8s-snap can start
 }

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -66,5 +66,5 @@ type Snap interface {
 
 	K8sdClient(address string) (k8sd.Client, error) // k8sd client
 
-	PreInitChecks(ctx context.Context, config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs) error // pre-init checks before k8s-snap can start
+	PreInitChecks(ctx context.Context, config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs, isControlPlane bool) error // pre-init checks before k8s-snap can start
 }

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -66,5 +66,5 @@ type Snap interface {
 
 	K8sdClient(address string) (k8sd.Client, error) // k8sd client
 
-	PreInitChecks(ctx context.Context, config types.ClusterConfig, isControlPlane bool) error // pre-init checks before k8s-snap can start
+	PreInitChecks(ctx context.Context, config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs) error // pre-init checks before k8s-snap can start
 }

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -245,7 +245,7 @@ func (s *Snap) SnapctlSet(ctx context.Context, args ...string) error {
 	return s.SnapctlSetErr
 }
 
-func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig) error {
+func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, isControlPlane bool) error {
 	s.PreInitChecksCalledWith = append(s.PreInitChecksCalledWith, config)
 	return s.PreInitChecksErr
 }

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -245,7 +245,7 @@ func (s *Snap) SnapctlSet(ctx context.Context, args ...string) error {
 	return s.SnapctlSetErr
 }
 
-func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, isControlPlane bool) error {
+func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs) error {
 	s.PreInitChecksCalledWith = append(s.PreInitChecksCalledWith, config)
 	return s.PreInitChecksErr
 }

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -245,7 +245,7 @@ func (s *Snap) SnapctlSet(ctx context.Context, args ...string) error {
 	return s.SnapctlSetErr
 }
 
-func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs) error {
+func (s *Snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs, isControlPlane bool) error {
 	s.PreInitChecksCalledWith = append(s.PreInitChecksCalledWith, config)
 	return s.PreInitChecksErr
 }

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -396,7 +396,7 @@ func checkK8sServicePorts(config types.ClusterConfig, serviceConfigs types.K8sSe
 		if open, err := utils.IsLocalPortOpen(port); err != nil {
 			// Could not open port due to error.
 			allErrors = append(allErrors, fmt.Errorf("could not check port %s (needed by: %s): %w", port, service, err))
-		} else if open {
+		} else if !open {
 			allErrors = append(allErrors, fmt.Errorf("port %s (needed by: %s) is already in use.", port, service))
 		}
 	}

--- a/src/k8s/pkg/snap/snap_test.go
+++ b/src/k8s/pkg/snap/snap_test.go
@@ -144,7 +144,7 @@ func TestSnap(t *testing.T) {
 		conf := types.ClusterConfig{}
 		serviceConfigs := types.K8sServiceConfigs{}
 
-		err = snap.PreInitChecks(context.Background(), conf, serviceConfigs)
+		err = snap.PreInitChecks(context.Background(), conf, serviceConfigs, true)
 		g.Expect(err).To(Not(HaveOccurred()))
 		expectedCalls := []string{}
 		for _, binary := range []string{"kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy", "kubelet"} {
@@ -163,7 +163,7 @@ func TestSnap(t *testing.T) {
 			g.Expect(err).To(Not(HaveOccurred()))
 			defer l.Close()
 
-			err = snap.PreInitChecks(context.Background(), conf, serviceConfigs)
+			err = snap.PreInitChecks(context.Background(), conf, serviceConfigs, true)
 			g.Expect(err).To(HaveOccurred())
 		})
 
@@ -177,7 +177,7 @@ func TestSnap(t *testing.T) {
 			f.Close()
 			defer os.Remove(f.Name())
 
-			err = snap.PreInitChecks(context.Background(), conf, serviceConfigs)
+			err = snap.PreInitChecks(context.Background(), conf, serviceConfigs, true)
 			g.Expect(err).To(HaveOccurred())
 		})
 
@@ -185,7 +185,7 @@ func TestSnap(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.PreInitChecks(context.Background(), conf, serviceConfigs)
+			err := snap.PreInitChecks(context.Background(), conf, serviceConfigs, true)
 			g.Expect(err).To(HaveOccurred())
 		})
 	})

--- a/src/k8s/pkg/utils/checks/checks.go
+++ b/src/k8s/pkg/utils/checks/checks.go
@@ -1,0 +1,59 @@
+package checks
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/utils"
+)
+
+// CheckK8sServicePorts verifies that the Kubernetes-related ports are free to be used.
+// The ports checked depends on whether a node is a control plane node, or a worker node.
+func CheckK8sServicePorts(config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs, isControlPlane bool) error {
+	var allErrors []error
+	ports := map[string]string{
+		// Default values from official Kubernetes documentation.
+		"kubelet":           serviceConfigs.GetKubeletPort(),
+		"kubelet-healthz":   serviceConfigs.GetKubeletHealthzPort(),
+		"kubelet-read-only": serviceConfigs.GetKubeletReadOnlyPort(),
+		"k8s-dqlite":        strconv.Itoa(config.Datastore.GetK8sDqlitePort()),
+		"loadbalancer":      strconv.Itoa(config.LoadBalancer.GetBGPPeerPort()),
+	}
+
+	if port, err := serviceConfigs.GetKubeProxyHealthzPort(); err != nil {
+		allErrors = append(allErrors, err)
+	} else {
+		ports["kube-proxy-healhz"] = port
+	}
+
+	if port, err := serviceConfigs.GetKubeProxyMetricsPort(); err != nil {
+		allErrors = append(allErrors, err)
+	} else {
+		ports["kube-proxy-metrics"] = port
+	}
+
+	if isControlPlane {
+		ports["kube-apiserver"] = strconv.Itoa(config.APIServer.GetSecurePort())
+		ports["kube-scheduler"] = serviceConfigs.GetKubeSchedulerPort()
+		ports["kube-controller-manager"] = serviceConfigs.GetKubeControllerManagerPort()
+	} else {
+		ports["kube-apiserver-proxy"] = strconv.Itoa(config.APIServer.GetSecurePort())
+	}
+
+	for service, port := range ports {
+		if port == "0" {
+			// Some ports may be set to 0 in order to disable them. No need to check.
+			continue
+		}
+		if open, err := utils.IsLocalPortOpen(port); err != nil {
+			// Could not open port due to error.
+			allErrors = append(allErrors, fmt.Errorf("could not check port %s (needed by: %s): %w", port, service, err))
+		} else if !open {
+			allErrors = append(allErrors, fmt.Errorf("port %s (needed by: %s) is already in use.", port, service))
+		}
+	}
+
+	return errors.Join(allErrors...)
+}

--- a/src/k8s/pkg/utils/net.go
+++ b/src/k8s/pkg/utils/net.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// IsLocalPortOpen checks if the given local port is already open or not.
+func IsLocalPortOpen(port int) (bool, error) {
+	if err := checkPort("localhost", port, 500*time.Millisecond); err == nil {
+		return true, nil
+	} else if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, syscall.ECONNREFUSED) {
+		return false, nil
+	} else {
+		// could not open due to error, couldn't check.
+		return false, err
+	}
+}
+
+func checkPort(host string, port int, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeout)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}

--- a/src/k8s/pkg/utils/net.go
+++ b/src/k8s/pkg/utils/net.go
@@ -4,13 +4,12 @@ import (
 	"errors"
 	"net"
 	"os"
-	"strconv"
 	"syscall"
 	"time"
 )
 
 // IsLocalPortOpen checks if the given local port is already open or not.
-func IsLocalPortOpen(port int) (bool, error) {
+func IsLocalPortOpen(port string) (bool, error) {
 	if err := checkPort("localhost", port, 500*time.Millisecond); err == nil {
 		return true, nil
 	} else if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, syscall.ECONNREFUSED) {
@@ -21,8 +20,8 @@ func IsLocalPortOpen(port int) (bool, error) {
 	}
 }
 
-func checkPort(host string, port int, timeout time.Duration) error {
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, strconv.Itoa(port)), timeout)
+func checkPort(host, port string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
``PreInitChecks`` is called on bootstrap or when joining another Kubernetes cluster. Kubernetes and its services open up several ports; if they're already in use, we cannot progress.

Adding these checks will make these error cases more explainable to the user, rather than a generic bootstrap / join error.

Sample error:

```
sudo k8s bootstrap
Bootstrapping the cluster. This may take a few seconds, please wait.
Error: Failed to bootstrap the cluster.

The error was: failed to POST /k8sd/cluster: failed to bootstrap new cluster: Failed to run post-bootstrap actions: pre-init checks failed for bootstrap node: Encountered error(s) while verifying port availability for Kubernetes services: Port 10250 (needed by: kubelet) is already in use.
Port 10249 (needed by: kube-proxy-metrics) is already in use.
```