### PR TITLE
Fix cilium ingress, Refactor string literals

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/ingress.go
+++ b/src/k8s/pkg/k8sd/features/cilium/ingress.go
@@ -12,6 +12,14 @@ import (
 const (
 	IngressDeleteFailedMsgTmpl = "Failed to delete Cilium Ingress, the error was: %v"
 	IngressDeployFailedMsgTmpl = "Failed to deploy Cilium Ingress, the error was: %v"
+
+	IngressOptionEnabled                          = "enabled"
+	IngressOptionLoadBalancerMode                 = "loadbalancerMode"
+	IngressOptionLoadBalancerModeShared           = "shared" // loadbalancerMode: "shared"
+	IngressOptionDefaultSecretName                = "defaultSecretName"
+	IngressOptionDefaultSecretNamespace           = "defaultSecretNamespace"
+	IngressOptionDefaultSecretNamespaceKubeSystem = "kube-system" // defaultSecretNamespace: "kube-system"
+	IngressOptionEnableProxyProtocol              = "enableProxyProtocol"
 )
 
 // ApplyIngress assumes that the managed Cilium CNI is already installed on the cluster. It will fail if that is not the case.
@@ -24,25 +32,25 @@ const (
 // returned FeatureStatus.
 func ApplyIngress(ctx context.Context, snap snap.Snap, ingress types.Ingress, network types.Network, _ types.Annotations) (types.FeatureStatus, error) {
 	m := snap.HelmClient()
-
 	var values map[string]any
 	if ingress.GetEnabled() {
 		values = map[string]any{
 			"ingressController": map[string]any{
-				"enabled":                true,
-				"loadbalancerMode":       "shared",
-				"defaultSecretNamespace": "kube-system",
-				"defaultTLSSecret":       ingress.GetDefaultTLSSecret(),
-				"enableProxyProtocol":    ingress.GetEnableProxyProtocol(),
+				IngressOptionEnabled:                true,
+				IngressOptionLoadBalancerMode:       IngressOptionLoadBalancerModeShared,
+				IngressOptionDefaultSecretNamespace: IngressOptionDefaultSecretNamespaceKubeSystem,
+				IngressOptionDefaultSecretName:      ingress.GetDefaultTLSSecret(),
+				IngressOptionEnableProxyProtocol:    ingress.GetEnableProxyProtocol(),
 			},
 		}
 	} else {
 		values = map[string]any{
 			"ingressController": map[string]any{
-				"enabled":                false,
-				"defaultSecretNamespace": "",
-				"defaultSecretName":      "",
-				"enableProxyProtocol":    false,
+				IngressOptionEnabled:                false,
+				IngressOptionLoadBalancerMode:       "",
+				IngressOptionDefaultSecretNamespace: "",
+				IngressOptionDefaultSecretName:      "",
+				IngressOptionEnableProxyProtocol:    false,
 			},
 		}
 	}


### PR DESCRIPTION
### Overview
- Fixed Cilium ingress chart options according to https://github.com/cilium/cilium/blob/f221719170636b0e0da2c7b8227c18967a1201c8/install/kubernetes/cilium/values.yaml#L765-L774:
    - `defaultTLSSecret` was replaced by `defaultSecretName`
- Refactored string literals and added constants

### Note to reviewer
The `DefaultTLSSecret` field in the `Ingress` type is not changed because Contour ingress is using that field as well:
- https://github.com/canonical/k8s-snap/blob/main/src/k8s/pkg/k8sd/features/contour/ingress.go#L130-L132
- https://github.com/canonical/k8s-snap/blob/main/k8s/manifests/charts/ck-ingress-tls/templates/tlscertificatedelegation.yaml#L8
- https://github.com/canonical/k8s-snap/blob/main/k8s/manifests/charts/ck-ingress-tls/values.yaml#L4