### PR TITLE
Use test-level tags in CI

### DIFF
--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -94,7 +94,7 @@ jobs:
           TEST_FLAVOR: ${{ matrix.patch }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration'
+          cd tests/integration && sg lxd -c 'tox -e integration -- --tags pull_request'
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -111,7 +111,7 @@ jobs:
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration'
+          cd tests/integration && sg lxd -c 'tox -e integration -- --tags pull_request'
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -51,7 +51,7 @@ jobs:
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
           export PATH="/home/runner/.local/bin:$PATH"
-          cd tests/integration && sg lxd -c 'tox -vve integration'
+          cd tests/integration && sg lxd -c 'tox -vve integration -- --tags up_to_nightly '
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Generator, Iterator, List, Optional, Union
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 from test_util.etcd import EtcdCluster
 from test_util.registry import Registry
 
@@ -30,8 +30,8 @@ def pytest_itemcollected(item):
         tag.args[0] in tags.TEST_LEVELS for tag in marked_tags
     ):
         pytest.fail(
-            f"The test {item.nodeid} does not have one of the test level tags ({", ".join(tags.TEST_LEVELS)})."
-            f"Please add at least one test-level tag using @pytest.mark.tags."
+            f"The test {item.nodeid} does not have one of the test level tags."
+            f"Please add at least one test-level tag using @pytest.mark.tags ({tags.TEST_LEVELS})."
         )
 
 

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -19,6 +19,7 @@ pytest_plugins = ("pytest_tagging",)
 # into the harness instances to reduce the number of downloads.
 PRELOADED_SNAPS = ["snapd", "core20"]
 
+
 def pytest_collection_modifyitems(config, items):
     """
     A hook to ensure all tests have at least one tag before execution.
@@ -36,6 +37,7 @@ def pytest_collection_modifyitems(config, items):
             f"The following tests do not have any tags: {', '.join(untagged_tests)}. "
             f"Please add at least one tag using @pytest.mark.tags."
         )
+
 
 def _harness_clean(h: harness.Harness):
     "Clean up created instances within the test harness."

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Generator, Iterator, List, Optional, Union
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 from test_util.etcd import EtcdCluster
 from test_util.registry import Registry
 
@@ -20,22 +20,18 @@ pytest_plugins = ("pytest_tagging",)
 PRELOADED_SNAPS = ["snapd", "core20"]
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_itemcollected(item):
     """
     A hook to ensure all tests have at least one tag before execution.
     """
-    untagged_tests = []
-
-    for item in items:
-        # Check for tags in the pytest.mark attributes
-        tags = [mark for mark in item.iter_markers(name="tags")]
-        if not tags:
-            untagged_tests.append(item.nodeid)
-
-    if untagged_tests:
+    # Check for tags in the pytest.mark attributes
+    marked_tags = [mark for mark in item.iter_markers(name="tags")]
+    if not marked_tags or not any(
+        tag.args[0] in tags.TEST_LEVELS for tag in marked_tags
+    ):
         pytest.fail(
-            f"The following tests do not have any tags: {', '.join(untagged_tests)}. "
-            f"Please add at least one tag using @pytest.mark.tags."
+            f"The test {item.nodeid} does not have one of the test level tags ({", ".join(tags.TEST_LEVELS)})."
+            f"Please add at least one test-level tag using @pytest.mark.tags."
         )
 
 

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -19,6 +19,23 @@ pytest_plugins = ("pytest_tagging",)
 # into the harness instances to reduce the number of downloads.
 PRELOADED_SNAPS = ["snapd", "core20"]
 
+def pytest_collection_modifyitems(config, items):
+    """
+    A hook to ensure all tests have at least one tag before execution.
+    """
+    untagged_tests = []
+
+    for item in items:
+        # Check for tags in the pytest.mark attributes
+        tags = [mark for mark in item.iter_markers(name="tags")]
+        if not tags:
+            untagged_tests.append(item.nodeid)
+
+    if untagged_tests:
+        pytest.fail(
+            f"The following tests do not have any tags: {', '.join(untagged_tests)}. "
+            f"Please add at least one tag using @pytest.mark.tags."
+        )
 
 def _harness_clean(h: harness.Harness):
     "Clean up created instances within the test harness."

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -80,14 +80,13 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
     services = joining_cp.exec(
         ["snap", "services", "k8s"], capture_output=True, text=True
     ).stdout.split("\n")[1:-1]
-    print(services)
     for service in services:
         if "k8s-apiserver-proxy" in service:
             assert (
                 " inactive " in service
             ), "apiserver proxy should be inactive on control-plane"
         else:
-            assert " active " in service, "service should be active"
+            assert " active " in service, f"'{service}' should be active"
 
     cluster_node.exec(["k8s", "remove-node", worker.id])
     nodes = util.ready_nodes(cluster_node)
@@ -95,7 +94,6 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
     services = worker.exec(
         ["snap", "services", "k8s"], capture_output=True, text=True
     ).stdout.split("\n")[1:-1]
-    print(services)
     for service in services:
         for expected_active_service in [
             "containerd",

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -1,0 +1,115 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+import datetime
+import logging
+import os
+import subprocess
+import tempfile
+from typing import List
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from test_util import config, harness, util, tags
+
+LOG = logging.getLogger(__name__)
+
+@pytest.mark.node_count(3)
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-no-k8s-node-remove.yaml").read_text()
+)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_no_remove(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_cp = instances[1]
+    joining_worker = instances[2]
+
+    join_token = util.get_join_token(cluster_node, joining_cp)
+    join_token_worker = util.get_join_token(cluster_node, joining_worker, "--worker")
+    util.join_cluster(joining_cp, join_token)
+    util.join_cluster(joining_worker, join_token_worker)
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 3, "nodes should have joined cluster"
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_cp)
+    assert "worker" in util.get_local_node_status(joining_worker)
+
+    # TODO: k8sd sometimes fails when requested to remove nodes immediately
+    # after bootstrapping the cluster. It seems that it takes a little
+    # longer for trust store changes to be propagated to all nodes, which
+    # should probably be fixed on the microcluster side.
+    #
+    # For now, we'll perform some retries.
+    #
+    #   failed to POST /k8sd/cluster/remove: failed to delete cluster member
+    #   k8s-integration-c1aee0-2: No truststore entry found for node with name
+    #   "k8s-integration-c1aee0-2"
+    util.stubbornly(retries=3, delay_s=5).on(cluster_node).exec(
+        ["k8s", "remove-node", joining_cp.id]
+    )
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 3, "cp node should not have been removed from cluster"
+    cluster_node.exec(["k8s", "remove-node", joining_worker.id])
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 3, "worker node should not have been removed from cluster"
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-skip-service-stop.yaml").read_text()
+)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_cp = instances[1]
+    worker = instances[2]
+
+    join_token = util.get_join_token(cluster_node, joining_cp)
+    util.join_cluster(joining_cp, join_token)
+
+    join_token_worker = util.get_join_token(cluster_node, worker, "--worker")
+    util.join_cluster(worker, join_token_worker)
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+
+    # TODO: skip retrying this once the microcluster trust store issue is addressed.
+    util.stubbornly(retries=3, delay_s=5).on(cluster_node).exec(
+        ["k8s", "remove-node", joining_cp.id]
+    )
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 2, "cp node should have been removed from the cluster"
+    services = joining_cp.exec(
+        ["snap", "services", "k8s"], capture_output=True, text=True
+    ).stdout.split("\n")[1:-1]
+    print(services)
+    for service in services:
+        if "k8s-apiserver-proxy" in service:
+            assert (
+                " inactive " in service
+            ), "apiserver proxy should be inactive on control-plane"
+        else:
+            assert " active " in service, "service should be active"
+
+    cluster_node.exec(["k8s", "remove-node", worker.id])
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 1, "worker node should have been removed from the cluster"
+    services = worker.exec(
+        ["snap", "services", "k8s"], capture_output=True, text=True
+    ).stdout.split("\n")[1:-1]
+    print(services)
+    for service in services:
+        for expected_active_service in [
+            "containerd",
+            "k8sd",
+            "kubelet",
+            "kube-proxy",
+            "k8s-apiserver-proxy",
+        ]:
+            if expected_active_service in service:
+                assert (
+                    " active " in service
+                ), f"{expected_active_service} should be active on worker"

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -1,19 +1,14 @@
 #
 # Copyright 2024 Canonical, Ltd.
 #
-import datetime
 import logging
-import os
-import subprocess
-import tempfile
 from typing import List
 
 import pytest
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
+
 
 @pytest.mark.node_count(3)
 @pytest.mark.bootstrap_config(

--- a/tests/integration/tests/test_bootstrap.py
+++ b/tests/integration/tests/test_bootstrap.py
@@ -4,11 +4,12 @@
 from typing import List
 
 import pytest
-from test_util import harness
+from test_util import harness, tags
 
 
 @pytest.mark.node_count(1)
 @pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.tags(tags.NIGHTLY)
 def test_microk8s_installed(instances: List[harness.Instance]):
     instance = instances[0]
     instance.exec("snap install microk8s --classic".split())

--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -7,7 +7,7 @@ import platform
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CI
     os.getenv("TEST_CILIUM_E2E") in ["false", None],
     reason="Test is known to be flaky on GitHub Actions",
 )
+@pytest.mark.tags(tags.WEEKLY)
 def test_cilium_e2e(instances: List[harness.Instance]):
     instance = instances[0]
     instance.exec(["bash", "-c", "mkdir -p ~/.kube"])

--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -7,7 +7,7 @@ import platform
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_cleanup.py
+++ b/tests/integration/tests/test_cleanup.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import harness, util, tags
+from test_util import harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_cleanup.py
+++ b/tests/integration/tests/test_cleanup.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import harness, util
+from test_util import harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
@@ -18,6 +18,7 @@ CONTAINERD_PATHS = [
 
 
 @pytest.mark.node_count(1)
+@pytest.mark.tags(tags.NIGHTLY)
 def test_node_cleanup(instances: List[harness.Instance], tmp_path):
     instance = instances[0]
     util.wait_for_dns(instance)

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -11,7 +11,7 @@ from typing import List
 import pytest
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 
@@ -98,8 +98,6 @@ def test_worker_nodes(instances: List[harness.Instance]):
     ] and other_joining_node.id in [
         node["metadata"]["name"] for node in nodes
     ], f"only {cluster_node.id} should be left in cluster"
-
-
 
 
 @pytest.mark.node_count(3)

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -11,12 +11,13 @@ from typing import List
 import pytest
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(2)
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_control_plane_nodes(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_node = instances[1]
@@ -41,6 +42,7 @@ def test_control_plane_nodes(instances: List[harness.Instance]):
 
 @pytest.mark.node_count(2)
 @pytest.mark.snap_versions([util.previous_track(config.SNAP), config.SNAP])
+@pytest.mark.tags(tags.NIGHTLY)
 def test_mixed_version_join(instances: List[harness.Instance]):
     """Test n versioned node joining a n-1 versioned cluster."""
     cluster_node = instances[0]  # bootstrapped on the previous channel
@@ -65,6 +67,7 @@ def test_mixed_version_join(instances: List[harness.Instance]):
 
 
 @pytest.mark.node_count(3)
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_worker_nodes(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_node = instances[1]
@@ -97,105 +100,10 @@ def test_worker_nodes(instances: List[harness.Instance]):
     ], f"only {cluster_node.id} should be left in cluster"
 
 
-@pytest.mark.node_count(3)
-@pytest.mark.bootstrap_config(
-    (config.MANIFESTS_DIR / "bootstrap-no-k8s-node-remove.yaml").read_text()
-)
-def test_no_remove(instances: List[harness.Instance]):
-    cluster_node = instances[0]
-    joining_cp = instances[1]
-    joining_worker = instances[2]
-
-    join_token = util.get_join_token(cluster_node, joining_cp)
-    join_token_worker = util.get_join_token(cluster_node, joining_worker, "--worker")
-    util.join_cluster(joining_cp, join_token)
-    util.join_cluster(joining_worker, join_token_worker)
-
-    util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "nodes should have joined cluster"
-
-    assert "control-plane" in util.get_local_node_status(cluster_node)
-    assert "control-plane" in util.get_local_node_status(joining_cp)
-    assert "worker" in util.get_local_node_status(joining_worker)
-
-    # TODO: k8sd sometimes fails when requested to remove nodes immediately
-    # after bootstrapping the cluster. It seems that it takes a little
-    # longer for trust store changes to be propagated to all nodes, which
-    # should probably be fixed on the microcluster side.
-    #
-    # For now, we'll perform some retries.
-    #
-    #   failed to POST /k8sd/cluster/remove: failed to delete cluster member
-    #   k8s-integration-c1aee0-2: No truststore entry found for node with name
-    #   "k8s-integration-c1aee0-2"
-    util.stubbornly(retries=3, delay_s=5).on(cluster_node).exec(
-        ["k8s", "remove-node", joining_cp.id]
-    )
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "cp node should not have been removed from cluster"
-    cluster_node.exec(["k8s", "remove-node", joining_worker.id])
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "worker node should not have been removed from cluster"
 
 
 @pytest.mark.node_count(3)
-@pytest.mark.bootstrap_config(
-    (config.MANIFESTS_DIR / "bootstrap-skip-service-stop.yaml").read_text()
-)
-def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
-    cluster_node = instances[0]
-    joining_cp = instances[1]
-    worker = instances[2]
-
-    join_token = util.get_join_token(cluster_node, joining_cp)
-    util.join_cluster(joining_cp, join_token)
-
-    join_token_worker = util.get_join_token(cluster_node, worker, "--worker")
-    util.join_cluster(worker, join_token_worker)
-
-    util.wait_until_k8s_ready(cluster_node, instances)
-
-    # TODO: skip retrying this once the microcluster trust store issue is addressed.
-    util.stubbornly(retries=3, delay_s=5).on(cluster_node).exec(
-        ["k8s", "remove-node", joining_cp.id]
-    )
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 2, "cp node should have been removed from the cluster"
-    services = joining_cp.exec(
-        ["snap", "services", "k8s"], capture_output=True, text=True
-    ).stdout.split("\n")[1:-1]
-    print(services)
-    for service in services:
-        if "k8s-apiserver-proxy" in service:
-            assert (
-                " inactive " in service
-            ), "apiserver proxy should be inactive on control-plane"
-        else:
-            assert " active " in service, "service should be active"
-
-    cluster_node.exec(["k8s", "remove-node", worker.id])
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 1, "worker node should have been removed from the cluster"
-    services = worker.exec(
-        ["snap", "services", "k8s"], capture_output=True, text=True
-    ).stdout.split("\n")[1:-1]
-    print(services)
-    for service in services:
-        for expected_active_service in [
-            "containerd",
-            "k8sd",
-            "kubelet",
-            "kube-proxy",
-            "k8s-apiserver-proxy",
-        ]:
-            if expected_active_service in service:
-                assert (
-                    " active " in service
-                ), f"{expected_active_service} should be active on worker"
-
-
-@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.NIGHTLY)
 def test_join_with_custom_token_name(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_cp = instances[1]
@@ -254,6 +162,7 @@ extra-sans:
 @pytest.mark.bootstrap_config(
     (config.MANIFESTS_DIR / "bootstrap-csr-auto-approve.yaml").read_text()
 )
+@pytest.mark.tags(tags.NIGHTLY)
 def test_cert_refresh(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_worker = instances[1]

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -4,7 +4,7 @@
 from typing import List
 
 import pytest
-from test_util import harness, util, tags
+from test_util import harness, tags, util
 
 
 @pytest.mark.node_count(3)

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -4,10 +4,11 @@
 from typing import List
 
 import pytest
-from test_util import harness, util
+from test_util import harness, util, tags
 
 
 @pytest.mark.node_count(3)
+@pytest.mark.tags(tags.NIGHTLY)
 def test_wrong_token_race(instances: List[harness.Instance]):
     cluster_node = instances[0]
 

--- a/tests/integration/tests/test_config_propagation.py
+++ b/tests/integration/tests/test_config_propagation.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import harness, util, tags
+from test_util import harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_config_propagation.py
+++ b/tests/integration/tests/test_config_propagation.py
@@ -5,12 +5,13 @@ import logging
 from typing import List
 
 import pytest
-from test_util import harness, util
+from test_util import harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(3)
+@pytest.mark.tags(tags.NIGHTLY)
 def test_config_propagation(instances: List[harness.Instance]):
     initial_node = instances[0]
     joining_cplane_node = instances[1]

--- a/tests/integration/tests/test_control_plane_taints.py
+++ b/tests/integration/tests/test_control_plane_taints.py
@@ -6,7 +6,7 @@ import time
 from typing import List
 
 import pytest
-from test_util import harness, util
+from test_util import harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
@@ -15,6 +15,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.bootstrap_config(
     'control-plane-taints: ["node-role.kubernetes.io/control-plane:NoSchedule"]'
 )
+@pytest.mark.tags(tags.NIGHTLY)
 def test_control_plane_taints(instances: List[harness.Instance]):
     k8s_instance = instances[0]
     retries = 10

--- a/tests/integration/tests/test_control_plane_taints.py
+++ b/tests/integration/tests/test_control_plane_taints.py
@@ -6,7 +6,7 @@ import time
 from typing import List
 
 import pytest
-from test_util import harness, util, tags
+from test_util import harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -5,12 +5,13 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_dns(instances: List[harness.Instance]):
     instance = instances[0]
     util.wait_until_k8s_ready(instance, [instance])

--- a/tests/integration/tests/test_etcd.py
+++ b/tests/integration/tests/test_etcd.py
@@ -7,7 +7,7 @@ from typing import List
 
 import pytest
 import yaml
-from test_util import harness, util, tags
+from test_util import harness, tags, util
 from test_util.etcd import EtcdCluster
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/tests/test_etcd.py
+++ b/tests/integration/tests/test_etcd.py
@@ -7,7 +7,7 @@ from typing import List
 
 import pytest
 import yaml
-from test_util import harness, util
+from test_util import harness, util, tags
 from test_util.etcd import EtcdCluster
 
 LOG = logging.getLogger(__name__)
@@ -16,6 +16,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.node_count(1)
 @pytest.mark.etcd_count(1)
 @pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.tags(tags.NIGHTLY)
 def test_etcd(instances: List[harness.Instance], etcd_cluster: EtcdCluster):
     k8s_instance = instances[0]
 

--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
@@ -69,6 +69,7 @@ def get_external_service_ip(instance: harness.Instance) -> str:
 
 
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_gateway(instances: List[harness.Instance]):
     instance = instances[0]
     instance_default_ip = util.get_default_ip(instance)

--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
@@ -74,6 +74,7 @@ def get_external_service_ip(instance: harness.Instance, service_namespace) -> st
 
 
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_ingress(instances: List[harness.Instance]):
     instance = instances[0]
     instance_default_ip = util.get_default_ip(instance)

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import harness, util, tags
+from test_util import harness, tags, util
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -6,13 +6,14 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import harness, util
+from test_util import harness, util, tags
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(2)
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_loadbalancer(instances: List[harness.Instance]):
     instance = instances[0]
 

--- a/tests/integration/tests/test_metrics_server.py
+++ b/tests/integration/tests/test_metrics_server.py
@@ -5,12 +5,13 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_metrics_server(instances: List[harness.Instance]):
     instance = instances[0]
     util.wait_until_k8s_ready(instance, [instance])

--- a/tests/integration/tests/test_metrics_server.py
+++ b/tests/integration/tests/test_metrics_server.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -7,13 +7,14 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_network(instances: List[harness.Instance]):
     instance = instances[0]
     util.wait_until_k8s_ready(instance, [instance])

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -6,7 +6,7 @@ from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -6,7 +6,7 @@ from ipaddress import IPv4Address, IPv6Address, ip_address
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
@@ -16,6 +16,7 @@ LOG = logging.getLogger(__name__)
     (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
 )
 @pytest.mark.dualstack()
+@pytest.mark.tags(tags.NIGHTLY)
 def test_dualstack(instances: List[harness.Instance]):
     main = instances[0]
     dualstack_config = (config.MANIFESTS_DIR / "nginx-dualstack.yaml").read_text()
@@ -61,6 +62,7 @@ def test_dualstack(instances: List[harness.Instance]):
 @pytest.mark.node_count(3)
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.network_type("dualstack")
+@pytest.mark.tags(tags.NIGHTLY)
 def test_ipv6_only_on_dualstack_infra(instances: List[harness.Instance]):
     main = instances[0]
     joining_cp = instances[1]

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -8,7 +8,7 @@ import subprocess
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 
 LOG = logging.getLogger(__name__)
 
@@ -30,6 +30,7 @@ STATUS_PATTERNS = [
 @pytest.mark.bootstrap_config(
     (config.MANIFESTS_DIR / "bootstrap-smoke.yaml").read_text()
 )
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_smoke(instances: List[harness.Instance]):
     instance = instances[0]
 

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -8,7 +8,7 @@ import subprocess
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_storage.py
+++ b/tests/integration/tests/test_storage.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util
+from test_util import config, harness, util, tags
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)
@@ -23,6 +23,7 @@ def check_pvc_bound(p: subprocess.CompletedProcess) -> bool:
 
 
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
+@pytest.mark.tags(tags.PULL_REQUEST)
 def test_storage(instances: List[harness.Instance]):
     instance = instances[0]
     util.wait_until_k8s_ready(instance, [instance])

--- a/tests/integration/tests/test_storage.py
+++ b/tests/integration/tests/test_storage.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, util, tags
+from test_util import config, harness, tags, util
 from test_util.config import MANIFESTS_DIR
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, snap, util
+from test_util import config, harness, snap, util, tags
 
 LOG = logging.getLogger(__name__)
 
@@ -15,6 +15,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.skipif(
     not config.STRICT_INTERFACE_CHANNELS, reason="No strict channels configured"
 )
+@pytest.mark.tags(tags.NIGHTLY)
 def test_strict_interfaces(instances: List[harness.Instance], tmp_path):
     channels = config.STRICT_INTERFACE_CHANNELS
     cp = instances[0]

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, snap, util, tags
+from test_util import config, harness, snap, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.skipif(
     not config.STRICT_INTERFACE_CHANNELS, reason="No strict channels configured"
 )
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.WEEKLY)
 def test_strict_interfaces(instances: List[harness.Instance], tmp_path):
     channels = config.STRICT_INTERFACE_CHANNELS
     cp = instances[0]

--- a/tests/integration/tests/test_util/tags.py
+++ b/tests/integration/tests/test_util/tags.py
@@ -3,7 +3,6 @@
 #
 from pytest_tagging import combine_tags
 
-
 PULL_REQUEST = "pull_request"
 NIGHTLY = "nightly"
 WEEKLY = "weekly"

--- a/tests/integration/tests/test_util/tags.py
+++ b/tests/integration/tests/test_util/tags.py
@@ -3,9 +3,12 @@
 #
 from pytest_tagging import combine_tags
 
+
 PULL_REQUEST = "pull_request"
 NIGHTLY = "nightly"
 WEEKLY = "weekly"
+
+TEST_LEVELS = [PULL_REQUEST, NIGHTLY, WEEKLY]
 
 # Those tags can be used for a convenient way to run multiple test levels.
 combine_tags("up_to_nightly", PULL_REQUEST, NIGHTLY)

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, snap, util, tags
+from test_util import config, harness, snap, tags, util
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -5,7 +5,7 @@ import logging
 from typing import List
 
 import pytest
-from test_util import config, harness, snap, util
+from test_util import config, harness, snap, util, tags
 
 LOG = logging.getLogger(__name__)
 
@@ -15,6 +15,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.skipif(
     not config.VERSION_UPGRADE_CHANNELS, reason="No upgrade channels configured"
 )
+@pytest.mark.tags(tags.NIGHTLY)
 def test_version_upgrades(instances: List[harness.Instance], tmp_path):
     channels = config.VERSION_UPGRADE_CHANNELS
     cp = instances[0]


### PR DESCRIPTION
# Summary

Adds a test level to each integration test and use them in the CI

# Rationale
The integration tests for each PR take way too long and test a lot of things that are very unlikely to break. It is sufficient to run those in the nightly test runs or even weekly (e.g. for conformance tests).

# Changes
* Assigns a test level to each integration test 
* ensures that the integration tests fail if a tag is missing for a test.
* minor refactoring to ensure pull_request level tests and nightly tests are not in the same file
* Use tags in the CI

Note that there is currently no weekly CI but I already added the tag for it. This is work for later.

