### PR TITLE
Set default k8s snap track for registry

### DIFF
--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -81,7 +81,11 @@ class Registry:
 
         self.add_mirrors()
 
-        setup_k8s_snap(self.instance, Path("/"))
+        # Setup the k8s snap on the instance.
+        # Use the latest/edge/classic channel as this version is only used to collect logs.
+        # This would fail if the `TEST_SNAP` environment variable is not set which however has
+        # valid use cases, e.g. in the promotion scenarios.
+        setup_k8s_snap(self.instance, Path("/"), "latest/edge/classic")
 
     def get_configured_mirrors(self) -> List[Mirror]:
         mirrors: List[Mirror] = []


### PR DESCRIPTION
# Summary
The registry setup fails if we do not set config.SNAP. However, there a valid use cases, e.g. promotion tests in which a snap is not set. We don't really care about the concrete snap version that is deployed on the registry as it is only used to collect inspection reports.

This caused the Promotion CI to fail: https://github.com/canonical/canonical-kubernetes-release-ci/actions/runs/12041142807/job/33572453089

# Rationale

Recently, we [added](https://github.com/canonical/k8s-snap/pull/799) a registry/mirror to the integration tests to not run into rate limits when pulling images and to reduce the overall test time. 
In the first version, this registry - which runs as a separate container - did not include the k8s-snap (it does not need it to function). However, because of that we could not get inspection reports from that container which are relevant e.g. for proxy issues. Thus, the snap was added in https://github.com/canonical/k8s-snap/pull/839. This addition implicitly assumed that `config.SNAP` is always set, which is not the case in some scenarios mentioned above.