### PR TITLE
How-to Openstack Integration

### DIFF
--- a/docs/src/charm/howto/index.md
+++ b/docs/src/charm/howto/index.md
@@ -16,6 +16,7 @@ Overview <self>
 
 charm
 install-lxd
+openstack
 Integrate with etcd <etcd>
 Integrate with ceph-csi <ceph-csi>
 proxy

--- a/docs/src/charm/howto/openstack.md
+++ b/docs/src/charm/howto/openstack.md
@@ -67,7 +67,7 @@ A modified overlay template can look like this:
 ```yaml
 applications:
   kubeapi-load-balancer: null
-  kubernetes-control-plane:
+  k8s:
     options:
       allow-privileged: "true"
   openstack-integrator:
@@ -85,8 +85,8 @@ applications:
       - 0 
 relations:
   - [openstack-cloud-controller:certificates,            easyrsa:client]
-  - [openstack-cloud-controller:kube-control,            kubernetes-control-plane:kube-control]
-  - [openstack-cloud-controller:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+  - [openstack-cloud-controller:kube-control,            k8s:kube-control]
+  - [openstack-cloud-controller:external-cloud-provider, k8s:external-cloud-provider]
   - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
   - [easyrsa:client,                                     cinder-csi:certificates]
   - [k8s:kube-control,              cinder-csi:kube-control]

--- a/docs/src/charm/howto/openstack.md
+++ b/docs/src/charm/howto/openstack.md
@@ -1,120 +1,79 @@
 # Integrating with OpenStack
 
 This guide explains how to integrate {{product}} with the OpenStack cloud
-platform.
+platform. The `openstack-integrator` charm simplifies working with {{product}}
+on OpenStack. Using the credentials provided to Juju, it acts as a proxy between
+{{product}} and the underlying cloud, granting permissions to dynamically
+create, for example, Cinder volumes.
 
 ## Prerequisites
 
 To follow this guide, you will need:
 
 - An [OpenStack][openstack] cloud environment.
-- Juju set-up as the deployment tool for Openstack. Please refer to
-  [Juju and Openstack][juju-openstack] documentation for more information.
-- A Juju [controller][controller] with [access][credentials] to the OpenStack 
-  cloud environment.
-- A Juju [model][model] for deploying {{product}} on OpenStack.
+- The installation requires Octavia to be available both to support Kubernetes
+  LoadBalancer services and to support the creation of a load balancer for the
+  Kubernetes API.
 - A valid [proxy configuration][proxy] in constrained environments.
 
-## Deploying {{product}} on OpenStack
-
+## Installing {{product}} on OpenStack
 
 To deploy the {{product}} [bundle][bundle] on OpenStack you need an overlay
-bundle which serves as an extension of the core bundle. The overlay bundle
-contains the necessary configuration to deploy {{product}} on OpenStack.
-Applications are deployed through the overlay and relations are established
-between the applications. These include the openstack integrator, cloud
+bundle which serves as an extension of the core bundle. Through the overlay,
+applications are deployed and relations are established between the
+applications. These include the openstack integrator, cloud
 controller, and cinder-csi charm.
+
+### OpenStack Overlay Configurations:
 
 Refer to the base overlay [openstack-overlay.yaml][openstack-overlay] and
 modify it as needed.
 
-### OpenStack Overlay Configurations:
-
-Run `openstack project list` to retrieve your project id and include the
-[project id][project] in the overlay template:
-
 ```yaml
 applications:
-  openstack-integrator:
-    options:
-      project-id: <my-openstack-project-id>
-```
-
-
-Adjust [easyrsa][easyrsa] to avoid creating an LXD machine:
-
-```yaml
-applications:
-  easyrsa:
-    to:
-      - 0
-```
-
-If your set-up includes a load-balancer add the following:
-
-```yaml
-relations:
-  - [k8s:loadbalancer-external, openstack-integrator:lb-consumers]
-```
-
-```yaml
-applications:
-  kubeapi-load-balancer: null 
-```
-
-A modified overlay template can look like this:
-
-```yaml
-applications:
-  kubeapi-load-balancer: null
-  k8s:
-    options:
-      allow-privileged: "true"
   openstack-integrator:
     charm: openstack-integrator
     num_units: 1
     trust: true
-    options:
-      project-id: <my-openstack-project-id>
+    base: ubuntu@22.04
   openstack-cloud-controller:
     charm: openstack-cloud-controller
   cinder-csi:
     charm: cinder-csi
-  easyrsa: 
-    to:   
-      - 0 
 relations:
-  - [openstack-cloud-controller:certificates,            easyrsa:client]
   - [openstack-cloud-controller:kube-control,            k8s:kube-control]
+  - [cinder-csi:kube-control,                            k8s:kube-control]
   - [openstack-cloud-controller:external-cloud-provider, k8s:external-cloud-provider]
   - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
-  - [easyrsa:client,                                     cinder-csi:certificates]
-  - [k8s:kube-control,              cinder-csi:kube-control]
-  - [openstack-integrator:clients,                       cinder-csi:openstack]
-  - [k8s:loadbalancer-external,     openstack-integrator:lb-consumers]
+  - [cinder-csi:openstack,                               openstack-integrator:clients]
 ```
 
 ### Deploying the Overlay Template
 
 Deploy the {{product}} bundle on OpenStack using the modified overlay:
 
-```bash
-juju deploy canonical-kubernetes --overlay openstack-overlay.yaml --trust
+```
+juju deploy canonical-kubernetes --overlay ~/path/openstack-overlay.yaml --trust
+```
+
+...and remember to fetch the configuration file!
+
+```
+juju ssh k8s/0 -- cat config > ~/.kube/config
 ```
 
 The {{product}} bundle is now deployed and integrated with OpenStack. Run 
 `juju status --watch 1s` to monitor the deployment. It is possible that your
 deployment will take a few minutes until all the components are up and running.
 
+```{note}
+Resources allocated by Kubernetes or the integrator are usually cleaned up automatically when no longer needed. However, it is recommended to periodically, and particularly after tearing down a cluster, use the OpenStack administration tools to make sure all unused resources have been successfully released. 
+```
+
+
+
 <!-- LINKS -->
 [openstack]: https://www.openstack.org/
-[project]: https://docs.openstack.org/python-openstackclient/queens/cli/command-objects/project.html
-[juju-openstack]: https://juju.is/docs/juju/openstack
-[controller]: https://juju.is/docs/juju/manage-controllers
-[model]: https://juju.is/docs/juju/manage-models
 [proxy]: https://documentation.ubuntu.com/canonical-kubernetes/main/src/charm/howto/proxy/
-[credentials]: https://juju.is/docs/juju/manage-credentials
 [bundle]: https://github.com/canonical/k8s-bundles/blob/main/main/bundle.yaml
-[openstack-overlay]: https://github.com/canonical/k8s-bundles/blob/main/main/overlays/openstack-overlay.yaml 
-<!-- TODO add overlay template to repo-->
-[easyrsa]: https://easy-rsa.readthedocs.io/en/latest/
+[openstack-overlay]: https://github.com/canonical/k8s-bundles/blob/main/overlays/openstack.yaml

--- a/docs/src/charm/howto/openstack.md
+++ b/docs/src/charm/howto/openstack.md
@@ -1,0 +1,104 @@
+# Integrating with OpenStack
+
+This guide explains how to integrate {{product}} with the OpenStack cloud
+platform.
+
+## Prerequisites
+
+To follow this guide, you will need:
+
+- An [OpenStack][openstack] cloud environment.
+- Juju set-up as the deployment tool for Openstack. Please refer to
+  [Juju and Openstack][juju-openstack] documentation for more information.
+- An OpenStack [project][project] with the necessary permissions to deploy
+  {{product}}.
+- A juju [controller][controller] with [access][credentials] to the OpenStack 
+  cloud environment.
+- A juju [model][model] for deploying {{product}} on OpenStack.
+- Configured [proxy configuration][proxy] in constrained environments.
+
+## Deploying {{product}} on OpenStack
+
+
+To deploy the {{product}} [bundle][bundle] on OpenStack you need an overlay
+bundle which serves as an extension of the core bundle. The overlay bundle
+contains the necessary configuration to deploy {{product}} on OpenStack.
+
+Refer to the base overlay [openstack-lb-overlay.yaml][openstack-overlay] and
+modify it as needed.
+
+### OpenStack overlay configurations:
+
+Run `openstack project list` to retrieve your project id and include the
+[project id][project] in the overlay template:
+
+```yaml
+applications:
+  openstack-integrator:
+    options:
+      project-id: <my-openstack-project-id>
+```
+
+
+Adjust [easyrsa][easyrsa] to avoid creating an LXD machine:
+
+```yaml
+applications:
+  easyrsa:
+    to:
+      - 0
+```
+
+The modified overlay template should look like this:
+
+```yaml
+applications:
+  kubeapi-load-balancer: null
+  kubernetes-control-plane:
+    options:
+      allow-privileged: "true"
+  openstack-integrator:
+    charm: openstack-integrator
+    num_units: 1
+    trust: true
+    options:
+      project-id: <my-openstack-project-id>
+  openstack-cloud-controller:
+    charm: openstack-cloud-controller
+  cinder-csi:
+    charm: cinder-csi
+  easyrsa: 
+    to:   
+      - 0 
+relations:
+  - [openstack-cloud-controller:certificates,            easyrsa:client]
+  - [openstack-cloud-controller:kube-control,            kubernetes-control-plane:kube-control]
+  - [openstack-cloud-controller:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+  - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
+  - [easyrsa:client,                                     cinder-csi:certificates]
+  - [kubernetes-control-plane:kube-control,              cinder-csi:kube-control]
+  - [openstack-integrator:clients,                       cinder-csi:openstack]
+  - [kubernetes-control-plane:loadbalancer-external,     openstack-integrator:lb-consumers]
+```
+
+Deploy the {{product}} bundle on OpenStack using the modified overlay:
+
+```bash
+juju deploy canonical-kubernetes --overlay openstack-lb-overlay.yaml --trust
+```
+
+The {{product}} bundle is now deployed and integrated with OpenStack. Run 
+`juju status --watch 1s` to monitor the deployment. It is possible that your
+deployment will take a few minutes until all the components are up and running.
+
+<!-- LINKS -->
+[openstack]: https://www.openstack.org/
+[project]: https://docs.openstack.org/python-openstackclient/queens/cli/command-objects/project.html
+[juju-openstack]: https://juju.is/docs/juju/openstack
+[controller]: https://juju.is/docs/juju/manage-controllers
+[model]: https://juju.is/docs/juju/manage-models
+[proxy]: https://documentation.ubuntu.com/canonical-kubernetes/main/src/charm/howto/proxy/
+[credentials]: https://juju.is/docs/juju/manage-credentials
+[bundle]: https://juju.is/docs/juju/bundle
+[openstack-overlay]: https://github.com/charmed-kubernetes/bundle/blob/main/overlays/openstack-lb-overlay.yaml
+[easyrsa]: https://easy-rsa.readthedocs.io/en/latest/

--- a/docs/src/charm/howto/openstack.md
+++ b/docs/src/charm/howto/openstack.md
@@ -11,9 +11,8 @@ create, for example, Cinder volumes.
 To follow this guide, you will need:
 
 - An [OpenStack][openstack] cloud environment.
-- The installation requires Octavia to be available both to support Kubernetes
-  LoadBalancer services and to support the creation of a load balancer for the
-  Kubernetes API.
+- Octavia available both to support Kubernetes LoadBalancer services and to
+  support the creation of a load balancer for the Kubernetes API.
 - A valid [proxy configuration][proxy] in constrained environments.
 
 ## Installing {{product}} on OpenStack
@@ -59,7 +58,7 @@ juju deploy canonical-kubernetes --overlay ~/path/openstack-overlay.yaml --trust
 ...and remember to fetch the configuration file!
 
 ```
-juju ssh k8s/0 -- cat config > ~/.kube/config
+juju run k8s/leader get-kubeconfig | yq eval '.kubeconfig' > kubeconfig
 ```
 
 The {{product}} bundle is now deployed and integrated with OpenStack. Run 


### PR DESCRIPTION
## How-to Openstack Integration

This PR adds docs: how to integrate Canonical K8s with the Openstack cloud it is deployed on, by adding a layer.