### PR TITLE
Fix microk8s snap check

### DIFF
--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -56,11 +56,8 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			}
 			microk8sInfo, err := snapdClient.GetSnapInfo("microk8s")
 			if err != nil {
-				cmd.PrintErrln("Error: failed to check if microk8s is installed: %w", err)
-				env.Exit(1)
-				return
-			}
-			if microk8sInfo.StatusCode == 200 && microk8sInfo.HasInstallDate() {
+				cmd.PrintErrln("Warning: failed to check if microk8s is installed: %w", err)
+			} else if microk8sInfo.StatusCode == 200 && microk8sInfo.HasInstallDate() {
 				cmd.PrintErrln("Error: microk8s snap is installed. Please remove it using the following command and try again:\n\n  sudo snap remove microk8s")
 				env.Exit(1)
 				return


### PR DESCRIPTION
During bootstrap, we're checking if microk8s is installed. If so, we're throwing an error, asking the user to uninstall microk8s first.

The problem is that this check fails when running the CAPI tests under Docker.

```
  k8s bootstrap --name '' --address :2380 --file /capi/etc/config.yaml
  Error: failed to check if microk8s is installed: %w failed to get
  snapd snap info: Get "http://localhost/v2/snaps/microk8s": dial unix
  /run/snapd.socket: connect: no such file or directory
  : exited with status: 1,
```

We'll change the code to log a warning instead of throwing an error when it's unable to check the microk8s snap status.