### PR TITLE
[Backport 1.31] Fix install by revision in integration tests (#865)

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -175,9 +175,9 @@ def setup_k8s_snap(
         snap_path = (tmp_path / "k8s.snap").as_posix()
         instance.send_file(which_snap, snap_path)
         cmd += ["--dangerous", snap_path]
-    elif snap_revision := _as_int(which_snap):
+    elif _as_int(which_snap):
         LOG.info("Install k8s snap by revision")
-        cmd += [config.SNAP_NAME, "--revision", snap_revision]
+        cmd += [config.SNAP_NAME, "--revision", which_snap]
     elif "/" in which_snap or which_snap in RISKS:
         LOG.info("Install k8s snap by specific channel: %s", which_snap)
         cmd += [config.SNAP_NAME, "--channel", which_snap]


### PR DESCRIPTION
The integration test backport needs to be backported because the promotion CI uses the integration test of the corresponding release branch.
If a 1.31 snap should be promoted, then the 1.31 integration tests suite is executed. 
See https://github.com/canonical/canonical-kubernetes-release-ci/pull/14