### PR TITLE
Adds DrainConnectionsTimeout microcluster configuration

### DIFF
--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -1,6 +1,8 @@
 package k8sd
 
 import (
+	"time"
+
 	cmdutil "github.com/canonical/k8s/cmd/util"
 	"github.com/canonical/k8s/pkg/k8sd/app"
 	"github.com/canonical/k8s/pkg/log"
@@ -19,6 +21,7 @@ var rootCmdOpts struct {
 	disableFeatureController            bool
 	disableUpdateNodeConfigController   bool
 	disableCSRSigningController         bool
+	drainConnectionsTimeout             time.Duration
 }
 
 func addCommands(root *cobra.Command, group *cobra.Group, commands ...*cobra.Command) {
@@ -55,6 +58,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				DisableUpdateNodeConfigController:   rootCmdOpts.disableUpdateNodeConfigController,
 				DisableFeatureController:            rootCmdOpts.disableFeatureController,
 				DisableCSRSigningController:         rootCmdOpts.disableCSRSigningController,
+				DrainConnectionsTimeout:             rootCmdOpts.drainConnectionsTimeout,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd: %v", err)
@@ -88,6 +92,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 
 	cmd.Flags().Uint("port", 0, "Default port for the HTTP API")
 	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")
+	cmd.Flags().DurationVar(&rootCmdOpts.drainConnectionsTimeout, "drain-connection-timeout", 10*time.Second, "amount of time to allow for all connections to drain when shutting down")
 
 	cmd.AddCommand(newSqlCmd(env))
 

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"context"
+	"time"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
 	"github.com/canonical/microcluster/v2/rest"
@@ -15,7 +16,7 @@ type Endpoints struct {
 
 // New creates a new API server instance.
 // Context is the context to use for the API servers endpoints.
-func New(ctx context.Context, provider Provider) map[string]rest.Server {
+func New(ctx context.Context, provider Provider, drainConnectionsTimeout time.Duration) map[string]rest.Server {
 	k8sd := &Endpoints{
 		context:  ctx,
 		provider: provider,
@@ -31,6 +32,7 @@ func New(ctx context.Context, provider Provider) map[string]rest.Server {
 					Endpoints:  k8sd.Endpoints(),
 				},
 			},
+			DrainConnectionsTimeout: drainConnectionsTimeout,
 		},
 	}
 }


### PR DESCRIPTION
In microcluster, there is now a configuration that allows us to drain any current connections before shutting down the unix / http servers.

Note that the servers will also be shut down when removing a node, or if bootstrapping or joining a node fails. If we're not waiting for the connection to drain, we may close current connections before managing to write a response to the clients, resulting in them getting EOF errors.