### PR TITLE
Switch COS Lite How-To to use the `k8s-operator` charm

### DIFF
--- a/docs/src/charm/howto/cos-lite.md
+++ b/docs/src/charm/howto/cos-lite.md
@@ -10,7 +10,7 @@ Observability Stack). This guide will help you integrate a COS Lite
 deployment with a {{product}} deployment.
 
 This document assumes that you have a controller with an installation of
-Canonical Kubernetes. If you have not yet installed {{product}}, please see
+{{product}}. If you have not yet installed {{product}}, please see
 ["Installing {{product}}"][how-to-install].
 
 ## Preparing a platform for COS Lite
@@ -55,7 +55,7 @@ KUBECONFIG=./kubeconfig juju add-k8s k8s-cloud
 
 ## Deploying COS Lite on the K8s cloud
 
-On the COS cloud, create a new model and deploy the `cos-lite` bundle:
+On the K8s cloud, create a new model and deploy the `cos-lite` bundle:
 
 ```
 juju add-model cos-lite k8s-cloud

--- a/docs/src/charm/howto/cos-lite.md
+++ b/docs/src/charm/howto/cos-lite.md
@@ -9,15 +9,15 @@ first-class integration between {{product}} and COS Lite (Canonical
 Observability Stack). This guide will help you integrate a COS Lite
 deployment with a {{product}} deployment.
 
-This document assumes you have a controller with an installation of Canonical
-Kubernetes. If you have not yet installed {{product}}, please see
+This document assumes that you have a controller with an installation of
+Canonical Kubernetes. If you have not yet installed {{product}}, please see
 ["Installing {{product}}"][how-to-install].
 
 ## Preparing a platform for COS Lite
 
 If you are unfamiliar with Juju models, the documentation can be found
-[here][juju-models]. In this section, we'll be adding a new model to keep
-observability separate from the Kubernetes model.
+[here][juju-models]. This section adds a new model to keep observability
+separate from the Kubernetes model.
 
 First, create a new model to act as a deployment cloud for COS Lite:
 
@@ -25,8 +25,8 @@ First, create a new model to act as a deployment cloud for COS Lite:
 juju add-model --config logging-config='<root>=DEBUG' cos-cluster
 ```
 
-We also set the logging level to DEBUG so that helpful debug information is
-shown when you use `juju debug-log` (see [juju debug-log][juju-debug-log]).
+Set the logging level to DEBUG so that helpful debug information is shown when
+you use `juju debug-log` (see [juju debug-log][juju-debug-log]).
 
 Next, deploy your observability cluster using the `k8s` charm:
 
@@ -34,11 +34,12 @@ Next, deploy your observability cluster using the `k8s` charm:
 juju deploy k8s --constraints="mem=8G cores=4 root-disk=30G"
 ```
 
-```{note} Make sure to enable the local-storage and load-balancer features for
-the `k8s` charm. These are essential for the COS Lite to function correctly.
+```{note} local-storage and load-balancer are essential features for the COS
+Lite to function correctly. You can enable these features using the charm
+configuration [options][k8s-config].
 ```
 
-Once the cluster is `active/idle` state, export the kubeconfig file:
+Once the cluster is in the `active/idle` state, export the kubeconfig file:
 
 ```
 juju run k8s/leader get-kubeconfig | yq eval '.kubeconfig' > kubeconfig
@@ -73,7 +74,7 @@ Use `juju status --relations` to verify that both `grafana` and `prometheus`
 offerings are listed.
 
 At this stage, you’ve set up a Kubernetes cluster, registered it as a Juju
-cloud, and deployed COS Lite on it. This creates tow models on the same
+cloud, and deployed COS Lite on it. This creates two models on the same
 controller.
 
 ## Integrating COS Lite with {{product}}
@@ -140,3 +141,4 @@ you can head over to the [COS Lite documentation][cos-lite-docs].
 [juju-models]: https://juju.is/docs/juju/model
 [juju-debug-log]: https://juju.is/docs/juju/juju-debug-log
 [cross-model-integration]: https://juju.is/docs/juju/relation#heading--cross-model
+[k8s-config]: https://charmhub.io/k8s/configurations

--- a/docs/src/charm/howto/cos-lite.md
+++ b/docs/src/charm/howto/cos-lite.md
@@ -19,54 +19,49 @@ If you are unfamiliar with Juju models, the documentation can be found
 [here][juju-models]. In this section, we'll be adding a new model to keep
 observability separate from the Kubernetes model.
 
-First, create a MicroK8s model to act as a deployment cloud for COS Lite:
+First, create a new model to act as a deployment cloud for COS Lite:
 
 ```
-juju add-model --config logging-config='<root>=DEBUG' microk8s-ubuntu
+juju add-model --config logging-config='<root>=DEBUG' cos-cluster
 ```
 
 We also set the logging level to DEBUG so that helpful debug information is
 shown when you use `juju debug-log` (see [juju debug-log][juju-debug-log]).
 
-Use the Ubuntu charm to deploy an application named `microk8s`:
+Next, deploy your observability cluster using the `k8s` charm:
 
 ```
-juju deploy ubuntu microk8s --series=focal --constraints="mem=8G cores=4 root-disk=30G"
+juju deploy k8s --constraints="mem=8G cores=4 root-disk=30G"
 ```
 
-Deploy MicroK8s on Ubuntu by accessing the unit you created at the last step
-with `juju ssh microk8s/0` and following the 
-[Install MicroK8s][how-to-install-MicroK8s] guide for configuration.
-
-```{note} Make sure to enable the hostpath-storage and MetalLB addons for 
-MicroK8s.
+```{note} Make sure to enable the local-storage and load-balancer features for
+the `k8s` charm. These are essential for the COS Lite to function correctly.
 ```
 
-Export the MicroK8s kubeconfig file to your current directory after
-configuration:
+Once the cluster is `active/idle` state, export the kubeconfig file:
 
 ```
-juju ssh microk8s/0 -- microk8s config > microk8s-config.yaml
+juju run k8s/leader get-kubeconfig | yq eval '.kubeconfig' > kubeconfig
 ```
 
-Register MicroK8s as a Juju cloud using add-k8s (see ["juju
+Register this cluster as a Juju cloud using add-k8s (see ["juju
 add-k8s"][add-k8s] for details on the add-k8s
 command):
 
 ```
-KUBECONFIG=microk8s-config.yaml juju add-k8s microk8s-cloud
+KUBECONFIG=./kubeconfig juju add-k8s k8s-cloud
 ```
 
-## Deploying COS Lite on the MicroK8s cloud
+## Deploying COS Lite on the K8s cloud
 
-On the MicroK8s cloud, create a new model and deploy the `cos-lite` bundle:
+On the COS cloud, create a new model and deploy the `cos-lite` bundle:
 
 ```
-juju add-model cos-lite microk8s-cloud
+juju add-model cos-lite k8s-cloud
 juju deploy cos-lite
 ```
 
-Make COS Lite’s endpoints available for 
+Make the COS Lite endpoints available for
 [cross-model integration][cross-model-integration]:
 
 ```
@@ -77,9 +72,9 @@ juju offer prometheus:receive-remote-write
 Use `juju status --relations` to verify that both `grafana` and `prometheus`
 offerings are listed.
 
-At this point, you’ve established a MicroK8s model on Ubuntu and incorporated
-it into Juju as a Kubernetes cloud. You then used this cloud as a substrate for
-the COS Lite deployment. You therefore have 2 models on the same controller.
+At this stage, you’ve set up a Kubernetes cluster, registered it as a Juju
+cloud, and deployed COS Lite on it. This creates tow models on the same
+controller.
 
 ## Integrating COS Lite with {{product}}
 
@@ -145,4 +140,3 @@ you can head over to the [COS Lite documentation][cos-lite-docs].
 [juju-models]: https://juju.is/docs/juju/model
 [juju-debug-log]: https://juju.is/docs/juju/juju-debug-log
 [cross-model-integration]: https://juju.is/docs/juju/relation#heading--cross-model
-[how-to-install-MicroK8s]: https://microk8s.io/docs/getting-started


### PR DESCRIPTION
## Overview
Update the `Integrating with COS Lite` How-To guide to use the `k8s-operator` charm as the deployment substrate instead of the MicroK8s snap.