### PR TITLE
Check kubernetes services are running as expected after bootstrapping / joining

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -178,10 +178,10 @@ k8s::common::execute_service() {
 
   k8s::common::setup_env
 
+  set -xe
   # Source arguments and substitute environment variables. Will fail if we cannot read the file.
   declare -a args="($(cat "${SNAP_COMMON}/args/${service_name}"))"
 
-  set -xe
   exec "${SNAP}/bin/${service_name}" "${args[@]}"
 }
 

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -236,5 +236,12 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to wait for kube-apiserver to become ready: %w", err)
 	}
 
+	log.Info("API server is ready - waiting for control plane services")
+	if err := waitControlPlaneServices(ctx, snap); err != nil {
+		log.Error(err, "Not all control plane services entered an active state. Stopping control plane services.")
+		return err
+	}
+
+	log.Info("Control plane node services are ready")
 	return nil
 }

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -19,9 +19,10 @@ type Snap interface {
 	GID() int         // GID is the group ID to set on config files.
 	Hostname() string // Hostname is the name of the node.
 
-	StartService(ctx context.Context, serviceName string) error   // snapctl start $service
-	StopService(ctx context.Context, serviceName string) error    // snapctl stop $service
-	RestartService(ctx context.Context, serviceName string) error // snapctl restart $service
+	StartService(ctx context.Context, serviceName string) error              // snapctl start $service
+	StopService(ctx context.Context, serviceName string) error               // snapctl stop $service
+	RestartService(ctx context.Context, serviceName string) error            // snapctl restart $service
+	GetServiceState(ctx context.Context, serviceName string) (string, error) // systemctl is-running $service
 
 	SnapctlGet(ctx context.Context, args ...string) ([]byte, error) // snapctl get $args...
 	SnapctlSet(ctx context.Context, args ...string) error           // snapctl set $args...

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -99,6 +99,10 @@ func (s *Snap) RestartService(ctx context.Context, name string) error {
 	return s.RestartServiceErr
 }
 
+func (s *Snap) GetServiceState(ctx context.Context, name string) (string, error) {
+	return "active", nil
+}
+
 func (s *Snap) Refresh(ctx context.Context, opts types.RefreshOpts) (string, error) {
 	if len(s.RefreshCalledWith) == 0 {
 		s.RefreshCalledWith = []types.RefreshOpts{opts}

--- a/src/k8s/pkg/snap/mock/runner.go
+++ b/src/k8s/pkg/snap/mock/runner.go
@@ -11,11 +11,22 @@ type Runner struct {
 	CalledWithCommand []string
 	Err               error
 	Log               bool
+	RunOutput         string
 }
 
 // Run is a mock implementation of CommandRunner.
 func (m *Runner) Run(ctx context.Context, command []string, opts ...func(*exec.Cmd)) error {
 	m.CalledWithCommand = append(m.CalledWithCommand, strings.Join(command, " "))
 	m.CalledWithCtx = ctx
+
+	// In some cases, it is expected to get the command's stdout.
+	cmd := &exec.Cmd{}
+	for _, o := range opts {
+                o(cmd)
+        }
+	if m.RunOutput != "" {
+		cmd.Stdout.Write([]byte(m.RunOutput))
+	}
+
 	return m.Err
 }

--- a/src/k8s/pkg/snap/pebble_test.go
+++ b/src/k8s/pkg/snap/pebble_test.go
@@ -54,6 +54,48 @@ func TestPebble(t *testing.T) {
 		})
 	})
 
+	t.Run("GetServiceState", func(t *testing.T) {
+		g := NewWithT(t)
+		mockRunner := &mock.Runner{
+			RunOutput: "Service  Startup  Current   Since\ntest-service  enabled  active  -",
+		}
+		snap := snap.NewPebble(snap.PebbleOpts{
+			SnapDir:    "testdir",
+			RunCommand: mockRunner.Run,
+		})
+
+		state, err := snap.GetServiceState(context.Background(), "test-service")
+
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(state).To(Equal("active"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("testdir/bin/pebble services test-service"))
+
+		t.Run("run error", func(t *testing.T) {
+			g := NewWithT(t)
+			mockRunner.Err = fmt.Errorf("some error")
+
+			_, err := snap.GetServiceState(context.Background(), "test-service")
+
+			g.Expect(err).To(HaveOccurred())
+		})
+
+		t.Run("invalid output", func(t *testing.T) {
+			g := NewWithT(t)
+
+			mockRunner.RunOutput = "Service  Startup  Current   Since"
+			_, err := snap.GetServiceState(context.Background(), "test-service")
+			g.Expect(err).To(HaveOccurred())
+
+			mockRunner.RunOutput = "Service  Startup  Current   Since\nFoo"
+			_, err = snap.GetServiceState(context.Background(), "test-service")
+			g.Expect(err).To(HaveOccurred())
+
+			mockRunner.RunOutput = "Service  Startup  Current   Since\ntest-service enabled foo -"
+			_, err = snap.GetServiceState(context.Background(), "test-service")
+			g.Expect(err).To(HaveOccurred())
+		})
+	})
+
 	t.Run("Restart", func(t *testing.T) {
 		g := NewWithT(t)
 		mockRunner := &mock.Runner{}

--- a/src/k8s/pkg/snap/service.go
+++ b/src/k8s/pkg/snap/service.go
@@ -13,3 +13,11 @@ func serviceName(serviceName string) string {
 	}
 	return fmt.Sprintf("k8s.%s", serviceName)
 }
+
+// systemdServiceName infers the name of the systemd service from the service name.
+func systemdServiceName(serviceName string) string {
+	if strings.HasPrefix(serviceName, "snap.k8s.") {
+		return serviceName
+	}
+	return fmt.Sprintf("snap.k8s.%s", serviceName)
+}

--- a/tests/integration/templates/bootstrap-foo-lish-arg.yaml
+++ b/tests/integration/templates/bootstrap-foo-lish-arg.yaml
@@ -1,0 +1,3 @@
+# Contains the bootstrap configuration for the test ensuring k8s services start as expected.
+extra-node-kubelet-args:
+  --foo: "lish"

--- a/tests/integration/tests/test_bootstrap.py
+++ b/tests/integration/tests/test_bootstrap.py
@@ -4,7 +4,7 @@
 from typing import List
 
 import pytest
-from test_util import harness, tags
+from test_util import config, harness, tags
 
 
 @pytest.mark.node_count(1)
@@ -15,3 +15,23 @@ def test_microk8s_installed(instances: List[harness.Instance]):
     instance.exec("snap install microk8s --classic".split())
     result = instance.exec("k8s bootstrap".split(), capture_output=True, check=False)
     assert "Error: microk8s snap is installed" in result.stderr.decode()
+
+
+@pytest.mark.node_count(1)
+@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.tags(tags.NIGHTLY)
+def test_k8s_service_invalid_extra_args(instances: List[harness.Instance]):
+    instance = instances[0]
+    foo_lish_bootstrap_config = (
+        config.MANIFESTS_DIR / "bootstrap-foo-lish-arg.yaml"
+    ).read_text()
+
+    result = instance.exec(
+        ["k8s", "bootstrap", "--file", "-"],
+        input=str.encode(foo_lish_bootstrap_config),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert "expected kubelet to be in state active" in result.stderr


### PR DESCRIPTION
Currently, we're doing only a few checks that would ensure a successful installation of the k8s-snap (the containerd path is free for us to use, the ports meant for Kubernetes services are free, binaries are sane).

However, due to various reasons, the bootstrap / join process can still succeed, even if some of the services are not running (e.g.: invalid extra service arguments given in the bootstrap config, leading to a service to fail due to an unknown or invalid argument). At the moment, we're only verifying that `kube-apiserver` is accessible.

We're adding a few checks that the Kubernetes services are not stopped / failed after we've started them.

Adds integration test for this scenario.