### PR TITLE
WIP: Set all containerd config in config.toml

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -107,7 +107,7 @@ jobs:
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration -- --tags pull_request'
+          cd tests/integration && sg lxd -c 'tox -e integration -- -k test_node_cleanup_new_containerd_path'
       - name: Prepare inspection reports
         if: failure()
         run: |


### PR DESCRIPTION
# Summary

Move all containerd configs to the `config.toml` file instead of CLI flags.

# Rationale

Containerd seems to create the `/run/containerd` folder regardless of the custom state configuration. This was an effort to check if there is a bug in the containerd CLI. 
This did not work but I think that moving the containerd config into one place makes sense regardless.