### PR TITLE
Add unit tests for token validator endpoints

### DIFF
--- a/src/k8s/pkg/k8sd/api/node_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/node_access_handler_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateNodeTokenAccessHandler(t *testing.T) {
+	g := NewWithT(t)
+
+	const tokenFileName = "tmp-token-file"
+	const tokenHeaderName = "X-Node-Token"
+
+	tempDir := os.TempDir()
+	defer os.RemoveAll(tempDir)
+
+	for _, tc := range []struct {
+		tokenHeaderContent string
+		tokenFileContent   string
+		expectErr          bool
+		createFile         bool
+	}{
+		{
+			tokenHeaderContent: "node-token",
+			tokenFileContent:   "node-token",
+			createFile:         true,
+		},
+		{
+			tokenHeaderContent: "node-token",
+			tokenFileContent:   "different-node-token",
+			expectErr:          true,
+			createFile:         true,
+		},
+		{
+			tokenHeaderContent: "",
+			tokenFileContent:   "node-token",
+			expectErr:          true,
+			createFile:         true,
+		},
+		{
+			tokenHeaderContent: "node-token",
+			tokenFileContent:   "node-token",
+			expectErr:          true,
+		},
+	} {
+		var err error
+		if tc.createFile {
+			err = os.WriteFile(path.Join(tempDir, tokenFileName), []byte(tc.tokenFileContent), 0o644)
+			g.Expect(err).To(BeNil())
+		}
+
+		e := &Endpoints{
+			context: context.Background(),
+			provider: &mock.Provider{
+				SnapFn: func() snap.Snap {
+					return &mock.Snap{
+						Mock: mock.Mock{
+							NodeTokenFile: path.Join(tempDir, tokenFileName),
+						},
+					}
+				},
+			},
+		}
+
+		req := &http.Request{
+			Header: make(http.Header),
+		}
+		req.Header.Set(tokenHeaderName, tc.tokenHeaderContent)
+
+		handler := e.ValidateNodeTokenAccessHandler(tokenHeaderName)
+		valid, resp := handler(nil, req)
+
+		os.Remove(path.Join(tempDir, tokenFileName))
+
+		if tc.expectErr {
+			g.Expect(valid).To(BeFalse())
+			g.Expect(resp).NotTo(BeNil())
+		} else {
+			g.Expect(valid).To(BeTrue())
+			g.Expect(resp).To(BeNil())
+		}
+	}
+}

--- a/src/k8s/pkg/k8sd/api/node_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/node_access_handler_test.go
@@ -27,33 +27,33 @@ func TestValidateNodeTokenAccessHandler(t *testing.T) {
 		createFile         bool
 	}{
 		{
-			name:               "Header and file token match",
+			name:               "header and file token match",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "node-token",
 			createFile:         true,
 		},
 		{
-			name:               "Header and file token differ",
+			name:               "header and file token differ",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "different-node-token",
 			expectErr:          true,
 			createFile:         true,
 		},
 		{
-			name:               "Missing header token",
+			name:               "missing header token",
 			tokenHeaderContent: "",
 			tokenFileContent:   "node-token",
 			expectErr:          true,
 			createFile:         true,
 		},
 		{
-			name:               "Missing token file",
+			name:               "missing token file",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "node-token",
 			expectErr:          true,
 		},
 		{
-			name:               "Missing token in token file",
+			name:               "missing token in token file",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "",
 			expectErr:          true,

--- a/src/k8s/pkg/snap/mock/provider.go
+++ b/src/k8s/pkg/snap/mock/provider.go
@@ -1,0 +1,39 @@
+package mock
+
+import (
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/microcluster/v2/microcluster"
+)
+
+type Provider struct {
+	MicroClusterFn                     func() *microcluster.MicroCluster
+	SnapFn                             func() snap.Snap
+	NotifyUpdateNodeConfigControllerFn func()
+	NotifyFeatureControllerFn          func(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool)
+}
+
+func (p *Provider) MicroCluster() *microcluster.MicroCluster {
+	if p.MicroClusterFn != nil {
+		return p.MicroClusterFn()
+	}
+	return nil
+}
+
+func (p *Provider) Snap() snap.Snap {
+	if p.SnapFn != nil {
+		return p.SnapFn()
+	}
+	return nil
+}
+
+func (p *Provider) NotifyUpdateNodeConfigController() {
+	if p.NotifyUpdateNodeConfigControllerFn != nil {
+		p.NotifyUpdateNodeConfigControllerFn()
+	}
+}
+
+func (p *Provider) NotifyFeatureController(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool) {
+	if p.NotifyFeatureControllerFn != nil {
+		p.NotifyFeatureControllerFn(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns)
+	}
+}


### PR DESCRIPTION
* Add unit tests for the ValidateNodeTokenAccessHandler and ValidateCAPIAuthTokenAccessHandler.
* Add mock for Provider interface