### PR TITLE
Run all tests for backports or when there are test changes

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -107,7 +107,17 @@ jobs:
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration -- --tags pull_request'
+          tags="pull_request"
+          # Run all tests if there are test changes. In case of a PR, we'll
+          # get a merge commit that includes all changes.
+          if git diff HEAD HEAD~1 --name-only | grep "tests/"; then
+            tags="weekly"
+          fi
+          # Run all tests on backports.
+          if echo ${{ github.base_ref }} | grep "release-"; then
+            tags="weekly"
+          fi
+          cd tests/integration && sg lxd -c 'tox -e integration -- --tags $tags'
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -30,6 +30,8 @@ jobs:
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
+          sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT
+          sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
       - name: Create build directory
         run: mkdir -p build
       - name: Install ${{ matrix.release }} k8s snap

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -17,7 +17,7 @@ jobs:
         release: ["latest/edge"]
       fail-fast: false # TODO: remove once arm64 works
 
-    runs-on: ${{ matrix.arch == 'arm64' && ["self-hosted", "Linux", "ARM64", "jammy", "large"] || ["self-hosted", "Linux", "AMD64", "jammy", "large"] }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-large' }}
 
     steps:
       - name: Checking out repo

--- a/src/k8s/pkg/k8sd/api/cluster_join.go
+++ b/src/k8s/pkg/k8sd/api/cluster_join.go
@@ -37,16 +37,16 @@ func (e *Endpoints) postClusterJoin(s state.State, r *http.Request) response.Res
 
 	joinConfig := struct {
 		// We only care about this field from the entire join config.
-		containerdBaseDir string `yaml:"containerd-base-dir,omitempty"`
+		ContainerdBaseDir string `yaml:"containerd-base-dir,omitempty"`
 	}{}
 
 	if err := yaml.Unmarshal([]byte(req.Config), &joinConfig); err != nil {
 		return response.BadRequest(fmt.Errorf("failed to parse request config: %w", err))
 	}
 
-	if joinConfig.containerdBaseDir != "" {
+	if joinConfig.ContainerdBaseDir != "" {
 		// append k8s-containerd to the given base dir, so we don't flood it with our own folders.
-		e.provider.Snap().SetContainerdBaseDir(filepath.Join(joinConfig.containerdBaseDir, "k8s-containerd"))
+		e.provider.Snap().SetContainerdBaseDir(filepath.Join(joinConfig.ContainerdBaseDir, "k8s-containerd"))
 	}
 
 	config := map[string]string{}

--- a/tests/integration/tests/test_cleanup.py
+++ b/tests/integration/tests/test_cleanup.py
@@ -64,7 +64,9 @@ def test_node_cleanup_new_containerd_path(instances: List[harness.Instance]):
 
     boostrap_config = yaml.safe_load(containerd_path_bootstrap_config)
     new_containerd_paths = [
-        os.path.join(boostrap_config["containerd-base-dir"], "k8s-containerd", p.lstrip("/"))
+        os.path.join(
+            boostrap_config["containerd-base-dir"], "k8s-containerd", p.lstrip("/")
+        )
         for p in CONTAINERD_PATHS
     ]
 


### PR DESCRIPTION
We're adding a few checks to the integration tests workflow. We'll use the "weekly" tag in case of backports (targeting the release-* branches) and whenever there are test changes.
