### PR TITLE
implement TestValidateCAPIAuthTokenAccessHandler

### DIFF
--- a/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/canonical/k8s/pkg/k8sd/api"
 	"github.com/canonical/k8s/pkg/k8sd/database"
-	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	testenv "github.com/canonical/k8s/pkg/utils/microcluster"
 	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
@@ -60,7 +60,7 @@ func TestValidateCAPIAuthTokenAccessHandler(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+			testenv.WithState(t, func(ctx context.Context, s state.State) {
 				var err error
 				if tc.tokenDBContent != "" {
 					err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {

--- a/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
@@ -72,9 +72,9 @@ func TestValidateCAPIAuthTokenAccessHandler(t *testing.T) {
 				req := &http.Request{
 					Header: make(http.Header),
 				}
-				req.Header.Set(api.CAPITokenHeaderName, tc.tokenHeaderContent)
+				req.Header.Set("capi-auth-token", tc.tokenHeaderContent)
 
-				handler := api.ValidateCAPIAuthTokenAccessHandler(api.CAPITokenHeaderName)
+				handler := api.ValidateCAPIAuthTokenAccessHandler("capi-auth-token")
 				valid, resp := handler(s, req)
 
 				if tc.expectErr {

--- a/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
@@ -72,9 +72,9 @@ func TestValidateCAPIAuthTokenAccessHandler(t *testing.T) {
 				req := &http.Request{
 					Header: make(http.Header),
 				}
-				req.Header.Set("Authorization", tc.tokenHeaderContent)
+				req.Header.Set(api.CAPITokenHeaderName, tc.tokenHeaderContent)
 
-				handler := api.ValidateCAPIAuthTokenAccessHandler("Authorization")
+				handler := api.ValidateCAPIAuthTokenAccessHandler(api.CAPITokenHeaderName)
 				valid, resp := handler(s, req)
 
 				if tc.expectErr {

--- a/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
@@ -72,9 +72,9 @@ func TestValidateCAPIAuthTokenAccessHandler(t *testing.T) {
 				req := &http.Request{
 					Header: make(http.Header),
 				}
-				req.Header.Set("capi-auth-token", tc.tokenHeaderContent)
+				req.Header.Set("Capi-Auth-Token", tc.tokenHeaderContent)
 
-				handler := api.ValidateCAPIAuthTokenAccessHandler("capi-auth-token")
+				handler := api.ValidateCAPIAuthTokenAccessHandler("Capi-Auth-Token")
 				valid, resp := handler(s, req)
 
 				if tc.expectErr {

--- a/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/capi_access_handler_test.go
@@ -1,0 +1,90 @@
+package api_test
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/k8sd/api"
+	"github.com/canonical/k8s/pkg/k8sd/database"
+	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	"github.com/canonical/microcluster/v2/state"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateCAPIAuthTokenAccessHandler(t *testing.T) {
+	g := NewWithT(t)
+
+	for _, tc := range []struct {
+		name               string
+		tokenHeaderContent string
+		tokenDBContent     string
+		expectErr          bool
+	}{
+		{
+			name:               "valid token",
+			tokenHeaderContent: "test-token",
+			tokenDBContent:     "test-token",
+			expectErr:          false,
+		},
+		{
+			name:               "wrong token in header",
+			tokenHeaderContent: "invalid-token",
+			tokenDBContent:     "expected-token",
+			expectErr:          true,
+		},
+		{
+			name:               "wrong token in db",
+			tokenHeaderContent: "expected-token",
+			tokenDBContent:     "invalid-token",
+			expectErr:          true,
+		},
+		{
+			name:               "empty token in header",
+			tokenHeaderContent: "",
+			tokenDBContent:     "test-token",
+			expectErr:          true,
+		},
+		{
+			name:               "empty token in db",
+			tokenHeaderContent: "test-token",
+			tokenDBContent:     "",
+			expectErr:          true,
+		},
+		{
+			name:               "empty token in header and db",
+			tokenHeaderContent: "",
+			tokenDBContent:     "",
+			expectErr:          true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+				var err error
+				if tc.tokenDBContent != "" {
+					err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+						return database.SetClusterAPIToken(ctx, tx, tc.tokenDBContent)
+					})
+					g.Expect(err).To(Not(HaveOccurred()))
+				}
+
+				req := &http.Request{
+					Header: make(http.Header),
+				}
+				req.Header.Set("Authorization", tc.tokenHeaderContent)
+
+				handler := api.ValidateCAPIAuthTokenAccessHandler("Authorization")
+				valid, resp := handler(s, req)
+
+				if tc.expectErr {
+					g.Expect(valid).To(BeFalse())
+					g.Expect(resp).To(Not(BeNil()))
+				} else {
+					g.Expect(valid).To(BeTrue())
+					g.Expect(resp).To(BeNil())
+				}
+			})
+		})
+	}
+}

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -8,11 +8,6 @@ import (
 	"github.com/canonical/microcluster/v2/rest"
 )
 
-const (
-	TokenHeaderName     = "node-token"
-	CAPITokenHeaderName = "capi-auth-token"
-)
-
 type Endpoints struct {
 	context  context.Context
 	provider Provider
@@ -133,7 +128,7 @@ func (e *Endpoints) Endpoints() []rest.Endpoint {
 		{
 			Name: "ClusterAPI/GetJoinToken",
 			Path: apiv1.ClusterAPIGetJoinTokenRPC,
-			Post: rest.EndpointAction{Handler: e.postClusterJoinTokens, AccessHandler: ValidateCAPIAuthTokenAccessHandler(CAPITokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postClusterJoinTokens, AccessHandler: ValidateCAPIAuthTokenAccessHandler("capi-auth-token"), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/SetAuthToken",
@@ -143,38 +138,38 @@ func (e *Endpoints) Endpoints() []rest.Endpoint {
 		{
 			Name: "ClusterAPI/RemoveNode",
 			Path: apiv1.ClusterAPIRemoveNodeRPC,
-			Post: rest.EndpointAction{Handler: e.postClusterRemove, AccessHandler: ValidateCAPIAuthTokenAccessHandler(CAPITokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postClusterRemove, AccessHandler: ValidateCAPIAuthTokenAccessHandler("capi-auth-token"), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/CertificatesExpiry",
 			Path: apiv1.ClusterAPICertificatesExpiryRPC,
-			Post: rest.EndpointAction{Handler: e.postCertificatesExpiry, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postCertificatesExpiry, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/RefreshCerts/Plan",
 			Path: apiv1.ClusterAPICertificatesPlanRPC,
-			Post: rest.EndpointAction{Handler: e.postRefreshCertsPlan, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postRefreshCertsPlan, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/RefreshCerts/Run",
 			Path: apiv1.ClusterAPICertificatesRunRPC,
-			Post: rest.EndpointAction{Handler: e.postRefreshCertsRun, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postRefreshCertsRun, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/RefreshCerts/Approve",
 			Path: apiv1.ClusterAPIApproveWorkerCSRRPC,
-			Post: rest.EndpointAction{Handler: e.postApproveWorkerCSR, AccessHandler: ValidateCAPIAuthTokenAccessHandler(CAPITokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postApproveWorkerCSR, AccessHandler: ValidateCAPIAuthTokenAccessHandler("capi-auth-token"), AllowUntrusted: true},
 		},
 		// Snap refreshes
 		{
 			Name: "Snap/Refresh",
 			Path: apiv1.SnapRefreshRPC,
-			Post: rest.EndpointAction{Handler: e.postSnapRefresh, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postSnapRefresh, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
 		},
 		{
 			Name: "Snap/RefreshStatus",
 			Path: apiv1.SnapRefreshStatusRPC,
-			Post: rest.EndpointAction{Handler: e.postSnapRefreshStatus, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postSnapRefreshStatus, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
 		},
 	}
 }

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -8,6 +8,11 @@ import (
 	"github.com/canonical/microcluster/v2/rest"
 )
 
+const (
+	TokenHeaderName     = "node-token"
+	CAPITokenHeaderName = "capi-auth-token"
+)
+
 type Endpoints struct {
 	context  context.Context
 	provider Provider
@@ -128,7 +133,7 @@ func (e *Endpoints) Endpoints() []rest.Endpoint {
 		{
 			Name: "ClusterAPI/GetJoinToken",
 			Path: apiv1.ClusterAPIGetJoinTokenRPC,
-			Post: rest.EndpointAction{Handler: e.postClusterJoinTokens, AccessHandler: ValidateCAPIAuthTokenAccessHandler("capi-auth-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postClusterJoinTokens, AccessHandler: ValidateCAPIAuthTokenAccessHandler(CAPITokenHeaderName), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/SetAuthToken",
@@ -138,38 +143,38 @@ func (e *Endpoints) Endpoints() []rest.Endpoint {
 		{
 			Name: "ClusterAPI/RemoveNode",
 			Path: apiv1.ClusterAPIRemoveNodeRPC,
-			Post: rest.EndpointAction{Handler: e.postClusterRemove, AccessHandler: ValidateCAPIAuthTokenAccessHandler("capi-auth-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postClusterRemove, AccessHandler: ValidateCAPIAuthTokenAccessHandler(CAPITokenHeaderName), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/CertificatesExpiry",
 			Path: apiv1.ClusterAPICertificatesExpiryRPC,
-			Post: rest.EndpointAction{Handler: e.postCertificatesExpiry, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postCertificatesExpiry, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/RefreshCerts/Plan",
 			Path: apiv1.ClusterAPICertificatesPlanRPC,
-			Post: rest.EndpointAction{Handler: e.postRefreshCertsPlan, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postRefreshCertsPlan, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/RefreshCerts/Run",
 			Path: apiv1.ClusterAPICertificatesRunRPC,
-			Post: rest.EndpointAction{Handler: e.postRefreshCertsRun, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postRefreshCertsRun, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
 		},
 		{
 			Name: "ClusterAPI/RefreshCerts/Approve",
 			Path: apiv1.ClusterAPIApproveWorkerCSRRPC,
-			Post: rest.EndpointAction{Handler: e.postApproveWorkerCSR, AccessHandler: ValidateCAPIAuthTokenAccessHandler("capi-auth-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postApproveWorkerCSR, AccessHandler: ValidateCAPIAuthTokenAccessHandler(CAPITokenHeaderName), AllowUntrusted: true},
 		},
 		// Snap refreshes
 		{
 			Name: "Snap/Refresh",
 			Path: apiv1.SnapRefreshRPC,
-			Post: rest.EndpointAction{Handler: e.postSnapRefresh, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postSnapRefresh, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
 		},
 		{
 			Name: "Snap/RefreshStatus",
 			Path: apiv1.SnapRefreshStatusRPC,
-			Post: rest.EndpointAction{Handler: e.postSnapRefreshStatus, AccessHandler: e.ValidateNodeTokenAccessHandler("node-token"), AllowUntrusted: true},
+			Post: rest.EndpointAction{Handler: e.postSnapRefreshStatus, AccessHandler: e.ValidateNodeTokenAccessHandler(TokenHeaderName), AllowUntrusted: true},
 		},
 	}
 }

--- a/src/k8s/pkg/k8sd/api/node_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/node_access_handler_test.go
@@ -83,9 +83,9 @@ func TestValidateNodeTokenAccessHandler(t *testing.T) {
 			req := &http.Request{
 				Header: make(http.Header),
 			}
-			req.Header.Set(TokenHeaderName, tc.tokenHeaderContent)
+			req.Header.Set("node-token", tc.tokenHeaderContent)
 
-			handler := e.ValidateNodeTokenAccessHandler(TokenHeaderName)
+			handler := e.ValidateNodeTokenAccessHandler("node-token")
 			valid, resp := handler(nil, req)
 
 			if tc.expectErr {

--- a/src/k8s/pkg/k8sd/api/node_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/node_access_handler_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateNodeTokenAccessHandler(t *testing.T) {
+	g := NewWithT(t)
+
+	const tokenFileName = "tmp-token-file"
+	const tokenHeaderName = "X-Node-Token"
+
+	tempDir := os.TempDir()
+	defer os.RemoveAll(tempDir)
+
+	for _, tc := range []struct {
+		tokenHeaderContent string
+		tokenFileContent   string
+		expectErr          bool
+		createFile         bool
+	}{
+		{
+			tokenHeaderContent: "node-token",
+			tokenFileContent:   "node-token",
+			createFile:         true,
+		},
+		{
+			tokenHeaderContent: "node-token",
+			tokenFileContent:   "different-node-token",
+			expectErr:          true,
+			createFile:         true,
+		},
+		{
+			tokenHeaderContent: "",
+			tokenFileContent:   "node-token",
+			expectErr:          true,
+			createFile:         true,
+		},
+		{
+			tokenHeaderContent: "node-token",
+			tokenFileContent:   "node-token",
+			expectErr:          true,
+		},
+	} {
+		var err error
+		if tc.createFile {
+			err = os.WriteFile(path.Join(tempDir, tokenFileName), []byte(tc.tokenFileContent), 0o644)
+			g.Expect(err).To(BeNil())
+		}
+
+		e := &Endpoints{
+			context: context.Background(),
+			provider: &mock.Provider{
+				SnapFn: func() snap.Snap {
+					return &mock.Snap{
+						Mock: mock.Mock{
+							NodeTokenFile: path.Join(tempDir, tokenFileName),
+						},
+					}
+				},
+			},
+		}
+
+		req := &http.Request{
+			Header: make(http.Header),
+		}
+		req.Header.Set(tokenHeaderName, tc.tokenHeaderContent)
+
+		handler := e.ValidateNodeTokenAccessHandler(tokenHeaderName)
+		valid, resp := handler(nil, req)
+
+		os.Remove(path.Join(tempDir, tokenFileName))
+
+		if tc.expectErr {
+			g.Expect(valid).To(BeFalse())
+			g.Expect(resp).NotTo(BeNil())
+		} else {
+			g.Expect(valid).To(BeTrue())
+			g.Expect(resp).To(BeNil())
+		}
+	}
+}

--- a/src/k8s/pkg/k8sd/api/node_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/node_access_handler_test.go
@@ -83,9 +83,9 @@ func TestValidateNodeTokenAccessHandler(t *testing.T) {
 			req := &http.Request{
 				Header: make(http.Header),
 			}
-			req.Header.Set("node-token", tc.tokenHeaderContent)
+			req.Header.Set("Node-Token", tc.tokenHeaderContent)
 
-			handler := e.ValidateNodeTokenAccessHandler("node-token")
+			handler := e.ValidateNodeTokenAccessHandler("Node-Token")
 			valid, resp := handler(nil, req)
 
 			if tc.expectErr {

--- a/src/k8s/pkg/k8sd/api/node_access_handler_test.go
+++ b/src/k8s/pkg/k8sd/api/node_access_handler_test.go
@@ -27,33 +27,33 @@ func TestValidateNodeTokenAccessHandler(t *testing.T) {
 		createFile         bool
 	}{
 		{
-			name:               "Header and file token match",
+			name:               "header and file token match",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "node-token",
 			createFile:         true,
 		},
 		{
-			name:               "Header and file token differ",
+			name:               "header and file token differ",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "different-node-token",
 			expectErr:          true,
 			createFile:         true,
 		},
 		{
-			name:               "Missing header token",
+			name:               "missing header token",
 			tokenHeaderContent: "",
 			tokenFileContent:   "node-token",
 			expectErr:          true,
 			createFile:         true,
 		},
 		{
-			name:               "Missing token file",
+			name:               "missing token file",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "node-token",
 			expectErr:          true,
 		},
 		{
-			name:               "Missing token in token file",
+			name:               "missing token in token file",
 			tokenHeaderContent: "node-token",
 			tokenFileContent:   "",
 			expectErr:          true,

--- a/src/k8s/pkg/k8sd/database/capi_auth_test.go
+++ b/src/k8s/pkg/k8sd/database/capi_auth_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
-	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	testenv "github.com/canonical/k8s/pkg/utils/microcluster"
 	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestClusterAPIAuthTokens(t *testing.T) {
-	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+	testenv.WithState(t, func(ctx context.Context, s state.State) {
 		var token string = "test-token"
 
 		t.Run("SetAuthToken", func(t *testing.T) {

--- a/src/k8s/pkg/k8sd/database/capi_auth_test.go
+++ b/src/k8s/pkg/k8sd/database/capi_auth_test.go
@@ -6,16 +6,18 @@ import (
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
+	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestClusterAPIAuthTokens(t *testing.T) {
-	WithDB(t, func(ctx context.Context, db DB) {
+	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
 		var token string = "test-token"
 
 		t.Run("SetAuthToken", func(t *testing.T) {
 			g := NewWithT(t)
-			err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				err := database.SetClusterAPIToken(ctx, tx, token)
 				g.Expect(err).To(Not(HaveOccurred()))
 				return nil
@@ -26,7 +28,7 @@ func TestClusterAPIAuthTokens(t *testing.T) {
 		t.Run("CheckAuthToken", func(t *testing.T) {
 			t.Run("ValidToken", func(t *testing.T) {
 				g := NewWithT(t)
-				err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+				err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 					valid, err := database.ValidateClusterAPIToken(ctx, tx, token)
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(valid).To(BeTrue())
@@ -37,7 +39,7 @@ func TestClusterAPIAuthTokens(t *testing.T) {
 
 			t.Run("InvalidToken", func(t *testing.T) {
 				g := NewWithT(t)
-				err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+				err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 					valid, err := database.ValidateClusterAPIToken(ctx, tx, "invalid-token")
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(valid).To(BeFalse())

--- a/src/k8s/pkg/k8sd/database/cluster_config_test.go
+++ b/src/k8s/pkg/k8sd/database/cluster_config_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
-	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	testenv "github.com/canonical/k8s/pkg/utils/microcluster"
 	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestClusterConfig(t *testing.T) {
-	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+	testenv.WithState(t, func(ctx context.Context, s state.State) {
 		t.Run("Set", func(t *testing.T) {
 			g := NewWithT(t)
 			expectedClusterConfig := types.ClusterConfig{

--- a/src/k8s/pkg/k8sd/database/cluster_config_test.go
+++ b/src/k8s/pkg/k8sd/database/cluster_config_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/utils"
+	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestClusterConfig(t *testing.T) {
-	WithDB(t, func(ctx context.Context, d DB) {
+	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
 		t.Run("Set", func(t *testing.T) {
 			g := NewWithT(t)
 			expectedClusterConfig := types.ClusterConfig{
@@ -24,7 +26,7 @@ func TestClusterConfig(t *testing.T) {
 			expectedClusterConfig.SetDefaults()
 
 			// Write some config to the database
-			err := d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				_, err := database.SetClusterConfig(context.Background(), tx, expectedClusterConfig)
 				g.Expect(err).To(Not(HaveOccurred()))
 				return nil
@@ -32,7 +34,7 @@ func TestClusterConfig(t *testing.T) {
 			g.Expect(err).To(Not(HaveOccurred()))
 
 			// Retrieve it and map it to the struct
-			err = d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				clusterConfig, err := database.GetClusterConfig(ctx, tx)
 				g.Expect(err).To(Not(HaveOccurred()))
 				g.Expect(clusterConfig).To(Equal(expectedClusterConfig))
@@ -52,7 +54,7 @@ func TestClusterConfig(t *testing.T) {
 			}
 			expectedClusterConfig.SetDefaults()
 
-			err := d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				_, err := database.SetClusterConfig(context.Background(), tx, types.ClusterConfig{
 					Certificates: types.Certificates{
 						CACert: utils.Pointer("CA CERT NEW DATA"),
@@ -63,7 +65,7 @@ func TestClusterConfig(t *testing.T) {
 			})
 			g.Expect(err).To(HaveOccurred())
 
-			err = d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				clusterConfig, err := database.GetClusterConfig(ctx, tx)
 				g.Expect(err).To(Not(HaveOccurred()))
 				g.Expect(clusterConfig).To(Equal(expectedClusterConfig))
@@ -90,7 +92,7 @@ func TestClusterConfig(t *testing.T) {
 			}
 			expectedClusterConfig.SetDefaults()
 
-			err := d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				returnedConfig, err := database.SetClusterConfig(context.Background(), tx, types.ClusterConfig{
 					Kubelet: types.Kubelet{
 						ClusterDNS: utils.Pointer("10.152.183.10"),
@@ -109,7 +111,7 @@ func TestClusterConfig(t *testing.T) {
 			})
 			g.Expect(err).To(Not(HaveOccurred()))
 
-			err = d.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				clusterConfig, err := database.GetClusterConfig(ctx, tx)
 				g.Expect(err).To(Not(HaveOccurred()))
 				g.Expect(clusterConfig).To(Equal(expectedClusterConfig))

--- a/src/k8s/pkg/k8sd/database/feature_status_test.go
+++ b/src/k8s/pkg/k8sd/database/feature_status_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/k8sd/features"
 	"github.com/canonical/k8s/pkg/k8sd/types"
-	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	testenv "github.com/canonical/k8s/pkg/utils/microcluster"
 	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestFeatureStatus(t *testing.T) {
-	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+	testenv.WithState(t, func(ctx context.Context, s state.State) {
 		_ = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 			t0, _ := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
 			networkStatus := types.FeatureStatus{

--- a/src/k8s/pkg/k8sd/database/feature_status_test.go
+++ b/src/k8s/pkg/k8sd/database/feature_status_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/k8sd/features"
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestFeatureStatus(t *testing.T) {
-	WithDB(t, func(ctx context.Context, db DB) {
-		_ = db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+		_ = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 			t0, _ := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
 			networkStatus := types.FeatureStatus{
 				Enabled:   true,

--- a/src/k8s/pkg/k8sd/database/kubernetes_auth_tokens_test.go
+++ b/src/k8s/pkg/k8sd/database/kubernetes_auth_tokens_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
-	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	testenv "github.com/canonical/k8s/pkg/utils/microcluster"
 	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestKubernetesAuthTokens(t *testing.T) {
-	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+	testenv.WithState(t, func(ctx context.Context, s state.State) {
 		var token1, token2 string
 
 		t.Run("GetOrCreateToken", func(t *testing.T) {

--- a/src/k8s/pkg/k8sd/database/kubernetes_auth_tokens_test.go
+++ b/src/k8s/pkg/k8sd/database/kubernetes_auth_tokens_test.go
@@ -6,16 +6,18 @@ import (
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
+	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestKubernetesAuthTokens(t *testing.T) {
-	WithDB(t, func(ctx context.Context, db DB) {
+	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
 		var token1, token2 string
 
 		t.Run("GetOrCreateToken", func(t *testing.T) {
 			g := NewWithT(t)
-			err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				var err error
 
 				token1, err = database.GetOrCreateToken(ctx, tx, "user1", []string{"group1", "group2"})
@@ -33,7 +35,7 @@ func TestKubernetesAuthTokens(t *testing.T) {
 
 			t.Run("Existing", func(t *testing.T) {
 				g := NewWithT(t)
-				err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+				err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 					token, err := database.GetOrCreateToken(ctx, tx, "user1", []string{"group1", "group2"})
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(token).To(Equal(token1))
@@ -46,7 +48,7 @@ func TestKubernetesAuthTokens(t *testing.T) {
 		t.Run("CheckToken", func(t *testing.T) {
 			t.Run("user1", func(t *testing.T) {
 				g := NewWithT(t)
-				err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+				err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 					username, groups, err := database.CheckToken(ctx, tx, token1)
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(username).To(Equal("user1"))
@@ -57,7 +59,7 @@ func TestKubernetesAuthTokens(t *testing.T) {
 			})
 			t.Run("user2", func(t *testing.T) {
 				g := NewWithT(t)
-				err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+				err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 					username, groups, err := database.CheckToken(ctx, tx, token2)
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(username).To(Equal("user2"))
@@ -70,7 +72,7 @@ func TestKubernetesAuthTokens(t *testing.T) {
 
 		t.Run("DeleteToken", func(t *testing.T) {
 			g := NewWithT(t)
-			err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 				err := database.DeleteToken(ctx, tx, token2)
 				g.Expect(err).To(Not(HaveOccurred()))
 

--- a/src/k8s/pkg/k8sd/database/worker_test.go
+++ b/src/k8s/pkg/k8sd/database/worker_test.go
@@ -7,13 +7,13 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
-	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	testenv "github.com/canonical/k8s/pkg/utils/microcluster"
 	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestWorkerNodeToken(t *testing.T) {
-	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+	testenv.WithState(t, func(ctx context.Context, s state.State) {
 		_ = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 			tokenExpiry := time.Now().Add(time.Hour)
 			t.Run("Default", func(t *testing.T) {

--- a/src/k8s/pkg/k8sd/database/worker_test.go
+++ b/src/k8s/pkg/k8sd/database/worker_test.go
@@ -7,12 +7,14 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
+	microcluster_testenv "github.com/canonical/k8s/pkg/utils/microcluster"
+	"github.com/canonical/microcluster/v2/state"
 	. "github.com/onsi/gomega"
 )
 
 func TestWorkerNodeToken(t *testing.T) {
-	WithDB(t, func(ctx context.Context, db DB) {
-		_ = db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	microcluster_testenv.WithState(t, func(ctx context.Context, s state.State) {
+		_ = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 			tokenExpiry := time.Now().Add(time.Hour)
 			t.Run("Default", func(t *testing.T) {
 				g := NewWithT(t)

--- a/src/k8s/pkg/snap/mock/provider.go
+++ b/src/k8s/pkg/snap/mock/provider.go
@@ -1,0 +1,39 @@
+package mock
+
+import (
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/microcluster/v2/microcluster"
+)
+
+type Provider struct {
+	MicroClusterFn                     func() *microcluster.MicroCluster
+	SnapFn                             func() snap.Snap
+	NotifyUpdateNodeConfigControllerFn func()
+	NotifyFeatureControllerFn          func(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool)
+}
+
+func (p *Provider) MicroCluster() *microcluster.MicroCluster {
+	if p.MicroClusterFn != nil {
+		return p.MicroClusterFn()
+	}
+	return nil
+}
+
+func (p *Provider) Snap() snap.Snap {
+	if p.SnapFn != nil {
+		return p.SnapFn()
+	}
+	return nil
+}
+
+func (p *Provider) NotifyUpdateNodeConfigController() {
+	if p.NotifyUpdateNodeConfigControllerFn != nil {
+		p.NotifyUpdateNodeConfigControllerFn()
+	}
+}
+
+func (p *Provider) NotifyFeatureController(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool) {
+	if p.NotifyFeatureControllerFn != nil {
+		p.NotifyFeatureControllerFn(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns)
+	}
+}

--- a/src/k8s/pkg/utils/microcluster/state.go
+++ b/src/k8s/pkg/utils/microcluster/state.go
@@ -1,4 +1,4 @@
-package microcluster_testenv
+package testenv
 
 import (
 	"context"

--- a/src/k8s/pkg/utils/microcluster/state.go
+++ b/src/k8s/pkg/utils/microcluster/state.go
@@ -1,8 +1,7 @@
-package database_test
+package microcluster_testenv
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -21,21 +20,17 @@ const (
 // nextIdx is used to pick different listen ports for each microcluster instance.
 var nextIdx int
 
-// DB is an interface for the internal microcluster DB type.
-type DB interface {
-	Transaction(ctx context.Context, f func(context.Context, *sql.Tx) error) error
-}
-
-// WithDB can be used to run isolated tests against the microcluster database.
+// WithState can be used to run isolated tests against the microcluster database.
+// The Database() can be accessed by calling s.Database().
 //
 // Example usage:
 //
 //	func TestKubernetesAuthTokens(t *testing.T) {
 //		t.Run("ValidToken", func(t *testing.T) {
 //			g := NewWithT(t)
-//			WithDB(t, func(ctx context.Context, db DB) {
+//			WithState(t, func(ctx context.Context, s state.State) {
 //				err := db.Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-//					token, err := database.GetOrCreateToken(ctx, tx, "user1", []string{"group1", "group2"})
+//					token, err := s.Database().GetOrCreateToken(ctx, tx, "user1", []string{"group1", "group2"})
 //					if !g.Expect(err).To(Not(HaveOccurred())) {
 //						return err
 //					}
@@ -46,7 +41,7 @@ type DB interface {
 //			})
 //		})
 //	}
-func WithDB(t *testing.T, f func(context.Context, DB)) {
+func WithState(t *testing.T, f func(context.Context, state.State)) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -57,16 +52,16 @@ func WithDB(t *testing.T, f func(context.Context, DB)) {
 		t.Fatalf("failed to create microcluster app: %v", err)
 	}
 
-	databaseCh := make(chan DB, 1)
+	stateChan := make(chan state.State, 1)
 	doneCh := make(chan error, 1)
-	defer close(databaseCh)
+	defer close(stateChan)
 	defer close(doneCh)
 
-	// app.Run() is blocking, so we get the database handle through a channel
+	// app.Run() is blocking, so we get the state handle through a channel
 	go func() {
 		doneCh <- app.Run(ctx, &state.Hooks{
 			PostBootstrap: func(ctx context.Context, s state.State, initConfig map[string]string) error {
-				databaseCh <- s.Database()
+				stateChan <- s
 				return nil
 			},
 			OnStart: func(ctx context.Context, s state.State) error {
@@ -95,8 +90,8 @@ func WithDB(t *testing.T, f func(context.Context, DB)) {
 	select {
 	case <-time.After(microclusterDatabaseInitTimeout):
 		t.Fatalf("timed out waiting for microcluster to start")
-	case db := <-databaseCh:
-		f(ctx, db)
+	case state := <-stateChan:
+		f(ctx, state)
 	}
 
 	// cancel context to stop the microcluster instance, and wait for it to shutdown


### PR DESCRIPTION
* TestValidateCAPIAuthTokenAccessHandler
* rename WithDB to WithState and move to a new location with package name microcluster_testenv
* WithState gives access to the whole state.State type instead of state.State.Database() only

Depends on https://github.com/canonical/k8s-snap/pull/880