### PR TITLE
Exit early if node name is not provided in CLI

### DIFF
--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -23,6 +23,8 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if !opts.worker && len(args) == 0 {
 				cmd.PrintErrln("Error: A node name is required for control-plane nodes.")
+				env.Exit(1)
+				return
 			}
 
 			var name string


### PR DESCRIPTION
There is no need to reach out to k8sd if the node name is not provided:
```
$ sudo k8s get-join-token 
Error: A node name is required for control-plane nodes.
Error: Could not generate a join token for "".

The error was: failed to POST /k8sd/cluster/tokens: failed to create token: failed to generate a new microcluster join token: Token name "" is not a valid FQDN: Name must be 1-255 characters long
```