### PR TITLE
Use controller-runtime for update-node-configuration-controller

### DIFF
--- a/src/k8s/pkg/k8sd/api/capi_access_handler.go
+++ b/src/k8s/pkg/k8sd/api/capi_access_handler.go
@@ -23,7 +23,7 @@ func ValidateCAPIAuthTokenAccessHandler(tokenHeaderName string) func(s state.Sta
 			var err error
 			tokenIsValid, err = database.ValidateClusterAPIToken(ctx, tx, token)
 			if err != nil {
-				return fmt.Errorf("failed to check CAPI auth token: %w", err)
+				return fmt.Errorf("ffailed to check CAPI auth token: %w", err)
 			}
 			return nil
 		}); err != nil {

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -39,7 +39,6 @@ func (e *Endpoints) putClusterConfig(s state.State, r *http.Request) response.Re
 		return response.InternalError(fmt.Errorf("database transaction to update cluster configuration failed: %w", err))
 	}
 
-	e.provider.NotifyUpdateNodeConfigController()
 	e.provider.NotifyFeatureController(
 		!requestedConfig.Network.Empty(),
 		!requestedConfig.Gateway.Empty(),

--- a/src/k8s/pkg/k8sd/api/provider.go
+++ b/src/k8s/pkg/k8sd/api/provider.go
@@ -9,6 +9,5 @@ import (
 type Provider interface {
 	MicroCluster() *microcluster.MicroCluster
 	Snap() snap.Snap
-	NotifyUpdateNodeConfigController()
 	NotifyFeatureController(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool)
 }

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -132,7 +132,7 @@ func New(cfg Config) (*App, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to setup manager: %w", err)
 		}
-		ctrller, err := setupControllers(mgr, cfg)
+		ctrller, err := setupControllers(app, mgr, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to setup controllers: %w", err)
 		}
@@ -294,7 +294,7 @@ func setupManager(cfg Config) (manager.Manager, error) {
 	return mgr, nil
 }
 
-func setupControllers(mgr manager.Manager, cfg Config) (*controllers.NodeConfigurationReconciler, error) {
+func setupControllers(app *App, mgr manager.Manager, cfg Config) (*controllers.NodeConfigurationReconciler, error) {
 	scheme := mgr.GetScheme()
 
 	if !cfg.DisableUpdateNodeConfigController {
@@ -302,7 +302,7 @@ func setupControllers(mgr manager.Manager, cfg Config) (*controllers.NodeConfigu
 			mgr.GetClient(),
 			scheme,
 			cfg.Snap,
-			func() {},
+			app.readyWg.Wait,
 		)
 
 		if err := controller.SetupWithManager(mgr); err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -519,6 +519,5 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 		cfg.MetricsServer.GetEnabled(),
 		cfg.DNS.GetEnabled(),
 	)
-	a.NotifyUpdateNodeConfigController()
 	return nil
 }

--- a/src/k8s/pkg/k8sd/app/provider.go
+++ b/src/k8s/pkg/k8sd/app/provider.go
@@ -15,10 +15,6 @@ func (a *App) Snap() snap.Snap {
 	return a.snap
 }
 
-func (a *App) NotifyUpdateNodeConfigController() {
-	utils.MaybeNotify(a.triggerUpdateNodeConfigControllerCh)
-}
-
 func (a *App) NotifyFeatureController(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool) {
 	if network {
 		utils.MaybeNotify(a.triggerFeatureControllerNetworkCh)

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler.go
@@ -1,0 +1,136 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type NodeConfigurationReconciler struct {
+	client.Client
+	scheme *runtime.Scheme
+	snap   snap.Snap
+
+	waitReady func()
+
+	getClusterConfig func(ctx context.Context) (types.ClusterConfig, error)
+
+	reconciledCh chan struct{}
+}
+
+func NewNodeConfigurationReconciler(
+	client client.Client,
+	scheme *runtime.Scheme,
+	snap snap.Snap,
+	waitReady func(),
+) *NodeConfigurationReconciler {
+	return &NodeConfigurationReconciler{
+		Client:       client,
+		scheme:       scheme,
+		snap:         snap,
+		waitReady:    waitReady,
+		reconciledCh: make(chan struct{}, 1),
+	}
+}
+
+func (c *NodeConfigurationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).WithEventFilter(predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isTargetConfigMap(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isTargetConfigMap(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isTargetConfigMap(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return isTargetConfigMap(e.Object)
+		},
+	}).Complete(c)
+}
+
+func isTargetConfigMap(obj client.Object) bool {
+	return obj.GetName() == "k8sd-config" && obj.GetNamespace() == "kube-system"
+}
+
+func (c *NodeConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"controller", "update-node-configuration",
+		"configmap", req.NamespacedName,
+	)
+
+	// Check if we're running on a worker node
+	if isWorker, err := snaputil.IsWorker(c.snap); err != nil {
+		logger.Error(err, "Failed to check if running on a worker node")
+		return reconcile.Result{RequeueAfter: time.Second * 30}, err
+	} else if isWorker {
+		logger.Info("Running on worker node, skipping reconciliation")
+		return reconcile.Result{}, nil
+	}
+
+	// Get cluster configuration
+	config, err := c.getClusterConfig(ctx)
+	if err != nil {
+		logger.Error(err, "Failed to retrieve cluster configuration")
+		return reconcile.Result{RequeueAfter: time.Second * 30}, err
+	}
+
+	// Load and process certificates
+	keyPEM := config.Certificates.GetK8sdPrivateKey()
+	key, err := pkiutil.LoadRSAPrivateKey(keyPEM)
+	if err != nil && keyPEM != "" {
+		return reconcile.Result{}, fmt.Errorf("failed to load cluster RSA key: %w", err)
+	}
+
+	// Generate ConfigMap data
+	cmData, err := config.Kubelet.ToConfigMap(key)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to format kubelet configmap data: %w", err)
+	}
+
+	// Get existing ConfigMap
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, req.NamespacedName, cm); err != nil {
+		logger.Error(err, "Failed to get ConfigMap")
+		return reconcile.Result{}, err
+	}
+
+	// Update ConfigMap
+	cm.Data = cmData
+	if err := c.Update(ctx, cm); err != nil {
+		logger.Error(err, "Failed to update ConfigMap")
+		return reconcile.Result{}, err
+	}
+
+	// Notify that reconciliation is complete
+	select {
+	case c.reconciledCh <- struct{}{}:
+	default:
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// ReconciledCh returns the channel that receives notifications when reconciliation completes
+func (c *NodeConfigurationReconciler) ReconciledCh() <-chan struct{} {
+	return c.reconciledCh
+}
+
+func (r *NodeConfigurationReconciler) SetConfigGetter(getter func(context.Context) (types.ClusterConfig, error)) {
+	r.getClusterConfig = getter
+}

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler_test.go
@@ -1,0 +1,117 @@
+package controllers_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/k8sd/controllers"
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/k8s/pkg/utils"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestNodeConfigurationReconciler(t *testing.T) {
+	testCases := []struct {
+		name            string
+		initialConfig   types.ClusterConfig
+		expectedConfig  types.ClusterConfig
+		expectedFailure bool
+	}{
+		{
+			name:          "ControlPlane_DefaultConfig",
+			initialConfig: types.ClusterConfig{},
+			expectedConfig: types.ClusterConfig{
+				Kubelet: types.Kubelet{
+					ClusterDomain: utils.Pointer("cluster.local"),
+				},
+			},
+			expectedFailure: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			// Setup scheme
+			scheme := runtime.NewScheme()
+			g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			// Create initial ConfigMap
+			kubeletConfigMap, err := tc.initialConfig.Kubelet.ToConfigMap(nil)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "k8sd-config",
+					Namespace: "kube-systems",
+				},
+				Data: kubeletConfigMap,
+			}
+
+			// Create fake client
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(configMap).
+				Build()
+
+			// Setup mock snap
+			s := &mock.Snap{
+				Mock: mock.Mock{
+					EtcdPKIDir:          filepath.Join(t.TempDir(), "etcd-pki"),
+					ServiceArgumentsDir: filepath.Join(t.TempDir(), "args"),
+				},
+			}
+
+			// Create controller
+			reconciler := controllers.NewNodeConfigurationReconciler(
+				k8sClient,
+				scheme,
+				s,
+				func() {}, // Mock ready function
+			)
+
+			// Set the config getter
+			reconciler.SetConfigGetter(func(context.Context) (types.ClusterConfig, error) {
+				return tc.expectedConfig, nil
+			})
+
+			// Trigger reconciliation
+			req := reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      "k8sd-config",
+					Namespace: "kube-systems",
+				},
+			}
+
+			result, err := reconciler.Reconcile(ctx, req)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(reconcile.Result{}))
+
+			// Verify results
+			var getResult corev1.ConfigMap
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+				Name:      "k8sd-config",
+				Namespace: "kube-system",
+			}, &getResult)).To(Succeed())
+
+			expectedConfigMap, err := tc.expectedConfig.Kubelet.ToConfigMap(nil)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tc.expectedFailure {
+				g.Expect(getResult.Data).ToNot(Equal(expectedConfigMap))
+			} else {
+				g.Expect(getResult.Data).To(Equal(expectedConfigMap))
+			}
+		})
+	}
+}

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/k8s/pkg/utils"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,20 +21,27 @@ import (
 
 func TestNodeConfigurationReconciler(t *testing.T) {
 	testCases := []struct {
-		name            string
-		initialConfig   types.ClusterConfig
-		expectedConfig  types.ClusterConfig
-		expectedFailure bool
+		name           string
+		existingMap    bool
+		expectedConfig types.ClusterConfig
 	}{
 		{
-			name:          "ControlPlane_DefaultConfig",
-			initialConfig: types.ClusterConfig{},
+			name:        "ControlPlane_NotExist",
+			existingMap: false,
 			expectedConfig: types.ClusterConfig{
 				Kubelet: types.Kubelet{
 					ClusterDomain: utils.Pointer("cluster.local"),
 				},
 			},
-			expectedFailure: false,
+		},
+		{
+			name:        "ControlPlane_ExistingConfig",
+			existingMap: true,
+			expectedConfig: types.ClusterConfig{
+				Kubelet: types.Kubelet{
+					ClusterDomain: utils.Pointer("cluster.local"),
+				},
+			},
 		},
 	}
 
@@ -46,22 +54,24 @@ func TestNodeConfigurationReconciler(t *testing.T) {
 			scheme := runtime.NewScheme()
 			g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
-			// Create initial ConfigMap
-			kubeletConfigMap, err := tc.initialConfig.Kubelet.ToConfigMap(nil)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			configMap := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "k8sd-config",
-					Namespace: "kube-systems",
-				},
-				Data: kubeletConfigMap,
+			// Setup objects for fake client
+			objects := []client.Object{}
+			if tc.existingMap {
+				// Only create initial ConfigMap if test case requires it
+				initialMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "k8sd-config",
+						Namespace: "kube-system",
+					},
+					Data: map[string]string{"initial": "data"},
+				}
+				objects = append(objects, initialMap)
 			}
 
 			// Create fake client
 			k8sClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(configMap).
+				WithObjects(objects...).
 				Build()
 
 			// Setup mock snap
@@ -85,11 +95,22 @@ func TestNodeConfigurationReconciler(t *testing.T) {
 				return tc.expectedConfig, nil
 			})
 
+			// Verify ConfigMap doesn't exist if it shouldn't
+			if !tc.existingMap {
+				var cm corev1.ConfigMap
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      "k8sd-config",
+					Namespace: "kube-system",
+				}, &cm)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Expected ConfigMap not to exist")
+			}
+
 			// Trigger reconciliation
 			req := reconcile.Request{
 				NamespacedName: client.ObjectKey{
 					Name:      "k8sd-config",
-					Namespace: "kube-systems",
+					Namespace: "kube-system",
 				},
 			}
 
@@ -106,12 +127,7 @@ func TestNodeConfigurationReconciler(t *testing.T) {
 
 			expectedConfigMap, err := tc.expectedConfig.Kubelet.ToConfigMap(nil)
 			g.Expect(err).ToNot(HaveOccurred())
-
-			if tc.expectedFailure {
-				g.Expect(getResult.Data).ToNot(Equal(expectedConfigMap))
-			} else {
-				g.Expect(getResult.Data).To(Equal(expectedConfigMap))
-			}
+			g.Expect(getResult.Data).To(Equal(expectedConfigMap))
 		})
 	}
 }

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_reconciler_test.go
@@ -84,11 +84,12 @@ func TestNodeConfigurationReconciler(t *testing.T) {
 
 			// Create controller
 			reconciler := controllers.NewNodeConfigurationReconciler(
-				k8sClient,
-				scheme,
 				s,
 				func() {}, // Mock ready function
 			)
+
+			reconciler.SetClient(k8sClient)
+			reconciler.SetScheme(scheme)
 
 			// Set the config getter
 			reconciler.SetConfigGetter(func(context.Context) (types.ClusterConfig, error) {


### PR DESCRIPTION
Rename UpdateNodeConfigurationController to NodeConfigurationReconciler
Only use controller-runtime with NodeConfigurationReconciler for now
Removes use of channels and MaybeNotify when the cluster config is changed, replaced by controller-runtime's Manager which watches for changes exclusively on the k8sd-config ConfigMap