### PR TITLE
Cleans up k8s-dqlite state dir and stops it on remove hook

### DIFF
--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -29,24 +29,6 @@ func startControlPlaneServices(ctx context.Context, snap snap.Snap, datastore st
 	return nil
 }
 
-func stopControlPlaneServices(ctx context.Context, snap snap.Snap, datastore string) error {
-	// Stop services
-	switch datastore {
-	case "k8s-dqlite":
-		if err := snaputil.StopK8sDqliteServices(ctx, snap); err != nil {
-			return fmt.Errorf("failed to stop k8s-dqlite service: %w", err)
-		}
-	case "external":
-	default:
-		return fmt.Errorf("unsupported datastore %s, must be one of %v", datastore, setup.SupportedDatastores)
-	}
-
-	if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
-		return fmt.Errorf("failed to stop control plane services: %w", err)
-	}
-	return nil
-}
-
 func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 	// Wait for API server to come up
 	client, err := snap.KubernetesClient("")


### PR DESCRIPTION
``cfg.Datastore.GetType()`` may return an empty string if the bootstrap action failed before ``database.SetClusterConfig`` has been called. Because of this, we're not removing the state dir for k8s-dqlite, which will be wrongfully removed by ``setup.K8sDqlite`` on the next bootstrap attempt.

We're now opportunistically cleaning up the ``k8s-dqlite`` related state directory.

If a bootstrap attempt fails, the ``k8s-dqlite`` service will still be running, which will cause the next bootstrap attempt to fail, as the ``k8s-dqlite`` port will be currently in use.