### PR TITLE
charms docs: Add 1.32 charms release notes

### DIFF
--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -25,7 +25,7 @@ Deploy from Snap package <src/snap/index.md>
 Deploy with Juju <src/charm/index.md>
 Deploy with Cluster API <src/capi/index.md>
 Community <src/community.md>
-Release notes <src/snap/reference/releases.md>
+Release notes <src/releases.md>
 
 ```
 

--- a/docs/src/_parts/install.md
+++ b/docs/src/_parts/install.md
@@ -8,19 +8,19 @@ lxc exec k8s -- sudo snap install k8s --classic --channel=1.32-classic/stable
 sudo snap download k8s --channel 1.32-classic/stable --basename k8s
 <!-- offline end -->
 <!-- juju control start -->
-juju deploy k8s --channel=1.32/edge
+juju deploy k8s --channel=1.32/stable
 <!-- juju control end -->
 <!-- juju worker start -->
-juju deploy k8s-worker --channel=1.32/edge -n 2
+juju deploy k8s-worker --channel=1.32/stable -n 2
 <!-- juju worker end -->
 <!-- juju control constraints start -->
-juju deploy k8s --channel=1.32/edge --constraints='cores=2 mem=16G root-disk=40G'
+juju deploy k8s --channel=1.32/stable --constraints='cores=2 mem=16G root-disk=40G'
 <!-- juju control constraints end -->
 <!-- juju worker constraints start -->
-juju deploy k8s-worker --channel=1.32/edge --constraints='cores=2 mem=16G root-disk=40G'
+juju deploy k8s-worker --channel=1.32/stable --constraints='cores=2 mem=16G root-disk=40G'
 <!-- juju worker constraints end -->
 <!-- juju vm start -->
-juju deploy k8s --channel=latest/edge \
+juju deploy k8s --channel=latest/stable \
     --base "ubuntu@22.04" \
     --constraints "cores=2 mem=8G root-disk=16G virt-type=virtual-machine"
 <!-- juju vm end -->

--- a/docs/src/charm/reference/releases.md
+++ b/docs/src/charm/reference/releases.md
@@ -1,8 +1,8 @@
 # Release notes
 
-This is an index page for all the available releases of {{product}} charms. Each entry
-will take you to version specific information including new features, bug fixes
-and backwards-incompatible changes.
+This is an index page for all the available releases of the {{product}} 
+charms. Each entry will take you to version specific information including 
+new features, bug fixes and backwards-incompatible changes.
 
 ## Releases
 
@@ -21,7 +21,8 @@ available on the main Ubuntu website, on the [release cycle page][].
 
 ## {{product}} Releases
 
-{{product}} charms are Juju operators for {{product}} snap. For the latest changes in the snap, see the [snap release page][].
+{{product}} charms are Juju operators for the {{product}} snap. 
+For the latest changes in the snap, see the [snap release page][].
 
 <!-- LINKS -->
 

--- a/docs/src/charm/reference/releases.md
+++ b/docs/src/charm/reference/releases.md
@@ -1,2 +1,29 @@
-```{include} ../../snap/reference/releases.md
+# Release notes
+
+This is an index page for all the available releases of {{product}} charms. Each entry
+will take you to version specific information including new features, bug fixes
+and backwards-incompatible changes.
+
+## Releases
+
+
+```{toctree}
+:titlesonly:
+:maxdepth: 2
+/src/charm/reference/versions/1.32
 ```
+
+
+## Release policy and schedule
+
+Our release cadence and support window for all Kubernetes-related products are 
+available on the main Ubuntu website, on the [release cycle page][].
+
+## {{product}} Releases
+
+{{product}} charms are Juju operators for {{product}} snap. For the latest changes in the snap, see the [snap release page][].
+
+<!-- LINKS -->
+
+[release cycle page]: https://ubuntu.com/about/release-cycle#canonical-kubernetes-release-cycle
+[snap release page]: ../../snap/reference/releases.md

--- a/docs/src/charm/reference/versions/1.32.md
+++ b/docs/src/charm/reference/versions/1.32.md
@@ -27,9 +27,9 @@ plane nodes [#200].
 - **Multiple Worker Integration** - allow the `k8s` charm to integrate with 
 multiple `k8s-worker` units [#221].
 
-## Fixes
+## Bug fixes
 
-- Worker goes into error after control plane departed [#75][issue #75]
+- Worker goes into error after the control plane departed [#75][issue #75]
 - Control plane does not go into blocked when no relation to worker 
 [#90][issue #90]
 - Enable and configure `Loadbalancer` feature [#109][issue #109]
@@ -37,10 +37,7 @@ multiple `k8s-worker` units [#221].
 - Support to configure Custom registries [#111][issue #111]
 - Ability to configure Cilium option `--vlan-bpf-bypass` [#112][issue #112]
 
-
-## Deprecations and API changes
-
-- Upstream
+## Upstream deprecations and API changes
 
 For details of other deprecation notices and API changes for Kubernetes 1.32, 
 please see the

--- a/docs/src/charm/reference/versions/1.32.md
+++ b/docs/src/charm/reference/versions/1.32.md
@@ -1,0 +1,106 @@
+# 1.32
+
+**{{product}} Charms 1.32 - Release notes - 20 December 2024**
+
+Welcome to the 1.32 release of {{product}} charms, the Juju operators 
+for {{product}}! These release notes cover the highlights of this release.
+
+## What’s new
+
+<!-- add in some text on what is new in a bold -->
+- **Kubernetes 1.32** - read more about the upstream release 
+[here][upstream release].
+- **{{product}} Snap 1.32** - read more about the snap release 
+[here][snap release page].
+- **Reschedule Update Hook** - use systemd to reschedule `update-status` 
+hooks [#118].
+- **Override Installed Snap** - support a charm resource to override the 
+installed snap [#149].
+- **Snap Refresh** - allow for a snap refresh if the charm wishes to refresh 
+the same revision/channel or use a resource override [#166].
+- **Feature Configurations** - expose {{product}} snap feature config through 
+charm config [charm config].
+- **Terraform Modules** - add basic Terraform modules for the {{product}} 
+charms [#194].
+- **Upgrade Orchestration** - introduce upgrade orchestration for control 
+plane nodes [#200].
+- **Multiple Worker Integration** - allow the `k8s` charm to integrate with 
+multiple `k8s-worker` units [#221].
+
+## Fixes
+
+- Worker goes into error after control plane departed [#75][issue #75]
+- Control plane does not go into blocked when no relation to worker 
+[#90][issue #90]
+- Enable and configure `Loadbalancer` feature [#109][issue #109]
+- Enable and configure `LocalStorage` feature [#110][issue #110]
+- Support to configure Custom registries [#111][issue #111]
+- Ability to configure Cilium option `--vlan-bpf-bypass` [#112][issue #112]
+
+
+## Deprecations and API changes
+
+- Upstream
+
+For details of other deprecation notices and API changes for Kubernetes 1.32, 
+please see the
+relevant sections of the [upstream release notes][upstream-changelog-1.32].
+
+[upstream-changelog-1.32]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation
+
+## Also in this release
+
+- Replace `AssertionError` with `ReconcileError` [#173]
+- Renames `annotations` to `cluster-annotations` in charm config [#198]
+- Add `kube-apiserver-extra-sans` option [#201]
+- Add worker `bootstrap-node-taints` setting [#215]
+- Enhance status visibility during cluster upgrades [#216]
+
+## Contributors
+
+Many thanks to [@addyess], [@mateoflorido], [@bschimke95], [@louiseschmidtgen],
+[@eaudetcobello], [@berkayoz], [@HomayoonAlimohammadi], [@ktsakalozos],
+[@kwmonroe], [@maci3jka], [@petrutlucian94], [@evilnick], [@nhennigan],
+[@perk], [@asbalderson].
+
+<!-- LINKS -->
+<!--     PR     -->
+[#118]: https://github.com/canonical/k8s-operator/pull/118
+[#149]: https://github.com/canonical/k8s-operator/pull/149
+[#166]: https://github.com/canonical/k8s-operator/pull/166
+[#173]: https://github.com/canonical/k8s-operator/pull/173
+[#194]: https://github.com/canonical/k8s-operator/pull/194
+[#198]: https://github.com/canonical/k8s-operator/pull/198
+[#200]: https://github.com/canonical/k8s-operator/pull/200
+[#201]: https://github.com/canonical/k8s-operator/pull/201
+[#215]: https://github.com/canonical/k8s-operator/pull/215
+[#216]: https://github.com/canonical/k8s-operator/pull/216
+[#221]: https://github.com/canonical/k8s-operator/pull/221
+<!--     ISSUE      -->
+[issue #75]: https://github.com/canonical/k8s-operator/issues/75
+[issue #90]: https://github.com/canonical/k8s-operator/issues/90
+[issue #109]: https://github.com/canonical/k8s-operator/issues/109
+[issue #110]: https://github.com/canonical/k8s-operator/issues/110
+[issue #111]: https://github.com/canonical/k8s-operator/issues/111
+[issue #112]: https://github.com/canonical/k8s-operator/issues/112
+<!--     MISC       -->
+[charm config]: https://charmhub.io/k8s/configurations
+[upstream release]: https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/
+[snap release page]: /src/snap/reference/versions/1.32.md
+
+<!--    CONTRIBUTORS     -->
+[@asbalderson]: https://github.com/asbalderson
+[@perk]: https://github.com/perk
+[@bschimke95]: https://github.com/bschimke95
+[@evilnick]: https://github.com/evilnick
+[@eaudetcobello]: https://github.com/eaudetcobello
+[@louiseschmidtgen]: https://github.com/louiseschmidtgen
+[@mateoflorido]: https://github.com/mateoflorido
+[@berkayoz]: https://github.com/berkayoz
+[@addyess]: https://github.com/addyess
+[@HomayoonAlimohammadi]: https://github.com/HomayoonAlimohammadi
+[@ktsakalozos]: https://github.com/ktsakalozos
+[@kwmonroe]: https://github.com/kwmonroe
+[@maci3jka]: https://github.com/maci3jka
+[@petrutlucian94]: https://github.com/petrutlucian94
+[@nhennigan]: https://github.com/nhennigan

--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -1,0 +1,25 @@
+# Release notes
+
+This is an index page for all the available releases of {{product}}. Each entry
+will take you to version specific information including new features, bug fixes
+and backwards-incompatible changes.
+
+## Releases
+
+
+```{toctree}
+:titlesonly:
+:maxdepth: 2
+Snap release notes </src/snap/reference/releases.md>
+Charm release notes </src/charm/reference/releases.md>
+```
+
+
+## Release policy and schedule
+
+Our release cadence and support window for all Kubernetes-related products are
+available on the main Ubuntu website, on the [release cycle page][].
+
+<!-- LINKS -->
+
+[release cycle page]: https://ubuntu.com/about/release-cycle#canonical-kubernetes-release-cycle


### PR DESCRIPTION
### Overview
This PR adds the 1.32 Canonical Kubernetes charms release notes.