### PR TITLE
Fix dualstack yaml indentation

### DIFF
--- a/docs/src/assets/how-to-dualstack-manifest.yaml
+++ b/docs/src/assets/how-to-dualstack-manifest.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-name: nginxdualstack
+  name: nginxdualstack
 spec:
-selector:
+  selector:
     matchLabels:
-    run: nginxdualstack
-replicas: 1
-template:
+      run: nginxdualstack
+  replicas: 1
+  template:
     metadata:
-    labels:
+      labels:
         run: nginxdualstack
     spec:
-    containers:
-    - name: nginxdualstack
+      containers:
+      - name: nginxdualstack
         image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
@@ -21,17 +21,17 @@ template:
 apiVersion: v1
 kind: Service
 metadata:
-name: nginx-dualstack
-labels:
+  name: nginx-dualstack
+  labels:
     run: nginxdualstack
 spec:
-type: NodePort
-ipFamilies:
-- IPv4
-- IPv6
-ipFamilyPolicy: RequireDualStack
-ports:
-- port: 80
+  type: NodePort
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: RequireDualStack
+  ports:
+  - port: 80
     protocol: TCP
-selector:
+  selector:
     run: nginxdualstack


### PR DESCRIPTION
The YAML file in the tutorial had incorrect indentation, resulting in the following error when applying the manifest:
```
ubuntu@juju-f7d895-1:~$ sudo k8s kubectl apply -f https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/src/assets/how-to-dualstack-manifest.yaml
error: error parsing https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/src/assets/how-to-dualstack-manifest.yaml: error converting YAML to JSON: yaml: line 17: mapping values are not allowed in this context
```