### PR TITLE
Move files under src so edit button works

### DIFF
--- a/docs/canonicalk8s/about.md
+++ b/docs/canonicalk8s/about.md
@@ -1,2 +1,0 @@
-```{include} src/snap/explanation/about.md
-```

--- a/docs/canonicalk8s/community.md
+++ b/docs/canonicalk8s/community.md
@@ -1,2 +1,0 @@
-```{include} src/snap/reference/community.md
-```

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -20,11 +20,11 @@ Home <self>
 :titlesonly:
 :maxdepth: 6
 
-about.md
+src/about.md
 Deploy from Snap package <src/snap/index.md>
 Deploy with Juju <src/charm/index.md>
 Deploy with Cluster API <src/capi/index.md>
-Community <community.md>
+Community <src/community.md>
 Release notes <src/snap/reference/releases.md>
 
 ```

--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -1,0 +1,2 @@
+```{include} /src/snap/explanation/about.md
+```

--- a/docs/src/community.md
+++ b/docs/src/community.md
@@ -1,0 +1,2 @@
+```{include} /src/snap/reference/community.md
+```


### PR DESCRIPTION
It was reported in issue #537 that the edit this page button did not work. Previous work was done to fix most pages but the about and community page at the top level were still affected. This PR fixes that functionality