### PR TITLE
docs: fix `juju deploy` with etcd config option.

### DIFF
--- a/docs/src/charm/howto/etcd.md
+++ b/docs/src/charm/howto/etcd.md
@@ -75,7 +75,7 @@ juju integrate etcd easyrsa
 Deploy the control plane units of {{product}} with the command:
 
 ```bash
-juju deploy k8s --config datastore=etcd -n 3
+juju deploy k8s --config bootstrap-datastore=etcd -n 3
 ```
 
 This command deploys 3 units of the {{product}} control plane (`k8s`)


### PR DESCRIPTION
The original `datastore=etcd|dqlite` option was renamed to `bootstrap-datastore` in the below k8s-operator patch:

    https://github.com/canonical/k8s-operator/pull/179