### PR TITLE
Retry seed loading in case snap is not ready yet

### DIFF
--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -131,7 +131,7 @@ class LXDHarness(Harness):
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e
 
-        stubbornly(retries=3, delay_s=5).on(instance_id).exec(
+        stubbornly(retries=3, delay_s=5).exec(
             ["snap", "wait", "system", "seed.loaded"]
         )
         return Instance(self, instance_id)

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -131,7 +131,7 @@ class LXDHarness(Harness):
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e
 
-        self.exec(instance_id, ["snap", "wait", "system", "seed.loaded"])
+        stubbornly(retries=3, delay_s=5).on(instance_id).exec(["snap", "wait", "system", "seed.loaded"])
         return Instance(self, instance_id)
 
     def _configure_profile(self, profile_name: str, profile_config: str):

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -132,7 +132,9 @@ class LXDHarness(Harness):
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e
 
         instance = Instance(self, instance_id)
-        stubbornly(retries=3, delay_s=5).on(instance).exec(["snap", "wait", "system", "seed.loaded"])
+        stubbornly(retries=3, delay_s=5).on(instance).exec(
+            ["snap", "wait", "system", "seed.loaded"]
+        )
         return instance
 
     def _configure_profile(self, profile_name: str, profile_config: str):

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -131,8 +131,9 @@ class LXDHarness(Harness):
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e
 
-        stubbornly(retries=3, delay_s=5).exec(["snap", "wait", "system", "seed.loaded"])
-        return Instance(self, instance_id)
+        instance = Instance(self, instance_id)
+        stubbornly(retries=3, delay_s=5).on(instance).exec(["snap", "wait", "system", "seed.loaded"])
+        return instance
 
     def _configure_profile(self, profile_name: str, profile_config: str):
         LOG.debug("Checking for LXD profile %s", profile_name)

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -131,9 +131,7 @@ class LXDHarness(Harness):
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e
 
-        stubbornly(retries=3, delay_s=5).exec(
-            ["snap", "wait", "system", "seed.loaded"]
-        )
+        stubbornly(retries=3, delay_s=5).exec(["snap", "wait", "system", "seed.loaded"])
         return Instance(self, instance_id)
 
     def _configure_profile(self, profile_name: str, profile_config: str):

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -131,7 +131,9 @@ class LXDHarness(Harness):
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e
 
-        stubbornly(retries=3, delay_s=5).on(instance_id).exec(["snap", "wait", "system", "seed.loaded"])
+        stubbornly(retries=3, delay_s=5).on(instance_id).exec(
+            ["snap", "wait", "system", "seed.loaded"]
+        )
         return Instance(self, instance_id)
 
     def _configure_profile(self, profile_name: str, profile_config: str):


### PR DESCRIPTION
The snapd systemctl unit might not be up yet when waiting for that seed.
This can cause  
```
error: cannot communicate with server: Get "http://localhost/v2/snaps/system/conf?keys=seed.loaded": dial unix /run/snapd.socket: connect: no such file or directory
```
See, e.g. https://github.com/canonical/k8s-snap/actions/runs/12394510604/job/34598141169?pr=915
