### PR TITLE
[Backport 1.32] charms docs: Add 1.32 charms release notes (#913)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For more information and instructions, please see the official documentation at:
 Install Canonical Kubernetes and initialise the cluster with:
 
 ```bash
-sudo snap install k8s --channel=1.31-classic/candidate --classic
+sudo snap install k8s --channel=1.32-classic/stable --classic
 sudo k8s bootstrap
 ```
 

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -24,8 +24,8 @@ about.md
 Deploy from Snap package <src/snap/index.md>
 Deploy with Juju <src/charm/index.md>
 Deploy with Cluster API <src/capi/index.md>
-Community <community.md>
-Release notes <src/snap/reference/releases.md>
+Community <src/community.md>
+Release notes <src/releases.md>
 
 ```
 

--- a/docs/canonicalk8s/reuse/substitutions.yaml
+++ b/docs/canonicalk8s/reuse/substitutions.yaml
@@ -1,6 +1,6 @@
 product: 'Canonical Kubernetes'
-version: '1.31'
-channel: '1.31/candidate'
+version: '1.32'
+channel: '1.32/stable'
 multi_line_example: |-
   *Multi-line* text
    that uses basic **markup**.

--- a/docs/src/_parts/install.md
+++ b/docs/src/_parts/install.md
@@ -8,19 +8,19 @@ lxc exec k8s -- sudo snap install k8s --classic --channel=1.31-classic/candidate
 sudo snap download k8s --channel 1.31-classic/candidate --basename k8s
 <!-- offline end -->
 <!-- juju control start -->
-juju deploy k8s --channel=1.31/candidate
+juju deploy k8s --channel=1.32/stable
 <!-- juju control end -->
 <!-- juju worker start -->
-juju deploy k8s-worker --channel=1.31/candidate -n 2
+juju deploy k8s-worker --channel=1.32/stable -n 2
 <!-- juju worker end -->
 <!-- juju control constraints start -->
-juju deploy k8s --channel=1.31/candidate --constraints='cores=2 mem=16G root-disk=40G'
+juju deploy k8s --channel=1.32/stable --constraints='cores=2 mem=16G root-disk=40G'
 <!-- juju control constraints end -->
 <!-- juju worker constraints start -->
-juju deploy k8s-worker --channel=1.31/candidate --constraints='cores=2 mem=16G root-disk=40G'
+juju deploy k8s-worker --channel=1.32/stable --constraints='cores=2 mem=16G root-disk=40G'
 <!-- juju worker constraints end -->
 <!-- juju vm start -->
-juju deploy k8s --channel=latest/edge \
+juju deploy k8s --channel=latest/stable \
     --base "ubuntu@22.04" \
     --constraints "cores=2 mem=8G root-disk=16G virt-type=virtual-machine"
 <!-- juju vm end -->

--- a/docs/src/_parts/install.md
+++ b/docs/src/_parts/install.md
@@ -1,11 +1,11 @@
 <!-- snap start -->
-sudo snap install k8s --classic --channel=1.31-classic/candidate
+sudo snap install k8s --classic --channel=1.32-classic/stable
 <!-- snap end -->
 <!-- lxd start -->
-lxc exec k8s -- sudo snap install k8s --classic --channel=1.31-classic/candidate
+lxc exec k8s -- sudo snap install k8s --classic --channel=1.32-classic/stable
 <!-- lxd end -->
 <!-- offline start -->
-sudo snap download k8s --channel 1.31-classic/candidate --basename k8s
+sudo snap download k8s --channel 1.32-classic/stable --basename k8s
 <!-- offline end -->
 <!-- juju control start -->
 juju deploy k8s --channel=1.32/stable

--- a/docs/src/assets/how-to-epa-maas-cloud-init
+++ b/docs/src/assets/how-to-epa-maas-cloud-init
@@ -82,7 +82,7 @@ write_files:
 # install the snap
 snap:
   commands:
-    00: 'snap install k8s --classic --channel=1.31/candidate'
+    00: 'snap install k8s --classic --channel=1.32/stable'
 
 runcmd:
 # fetch dpdk driver binding script

--- a/docs/src/charm/reference/releases.md
+++ b/docs/src/charm/reference/releases.md
@@ -1,2 +1,30 @@
-```{include} ../../snap/reference/releases.md
+# Release notes
+
+This is an index page for all the available releases of the {{product}} 
+charms. Each entry will take you to version specific information including 
+new features, bug fixes and backwards-incompatible changes.
+
+## Releases
+
+
+```{toctree}
+:titlesonly:
+:maxdepth: 2
+/src/charm/reference/versions/1.32
 ```
+
+
+## Release policy and schedule
+
+Our release cadence and support window for all Kubernetes-related products are 
+available on the main Ubuntu website, on the [release cycle page][].
+
+## {{product}} Releases
+
+{{product}} charms are Juju operators for the {{product}} snap. 
+For the latest changes in the snap, see the [snap release page][].
+
+<!-- LINKS -->
+
+[release cycle page]: https://ubuntu.com/about/release-cycle#canonical-kubernetes-release-cycle
+[snap release page]: ../../snap/reference/releases.md

--- a/docs/src/charm/reference/versions/1.32.md
+++ b/docs/src/charm/reference/versions/1.32.md
@@ -1,0 +1,103 @@
+# 1.32
+
+**{{product}} Charms 1.32 - Release notes - 20 December 2024**
+
+Welcome to the 1.32 release of {{product}} charms, the Juju operators 
+for {{product}}! These release notes cover the highlights of this release.
+
+## What’s new
+
+<!-- add in some text on what is new in a bold -->
+- **Kubernetes 1.32** - read more about the upstream release 
+[here][upstream release].
+- **{{product}} Snap 1.32** - read more about the snap release 
+[here][snap release page].
+- **Reschedule Update Hook** - use systemd to reschedule `update-status` 
+hooks [#118].
+- **Override Installed Snap** - support a charm resource to override the 
+installed snap [#149].
+- **Snap Refresh** - allow for a snap refresh if the charm wishes to refresh 
+the same revision/channel or use a resource override [#166].
+- **Feature Configurations** - expose {{product}} snap feature config through 
+charm config [charm config].
+- **Terraform Modules** - add basic Terraform modules for the {{product}} 
+charms [#194].
+- **Upgrade Orchestration** - introduce upgrade orchestration for control 
+plane nodes [#200].
+- **Multiple Worker Integration** - allow the `k8s` charm to integrate with 
+multiple `k8s-worker` units [#221].
+
+## Bug fixes
+
+- Worker goes into error after the control plane departed [#75][issue #75]
+- Control plane does not go into blocked when no relation to worker 
+[#90][issue #90]
+- Enable and configure `Loadbalancer` feature [#109][issue #109]
+- Enable and configure `LocalStorage` feature [#110][issue #110]
+- Support to configure Custom registries [#111][issue #111]
+- Ability to configure Cilium option `--vlan-bpf-bypass` [#112][issue #112]
+
+## Upstream deprecations and API changes
+
+For details of other deprecation notices and API changes for Kubernetes 1.32, 
+please see the
+relevant sections of the [upstream release notes][upstream-changelog-1.32].
+
+[upstream-changelog-1.32]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation
+
+## Also in this release
+
+- Replace `AssertionError` with `ReconcileError` [#173]
+- Renames `annotations` to `cluster-annotations` in charm config [#198]
+- Add `kube-apiserver-extra-sans` option [#201]
+- Add worker `bootstrap-node-taints` setting [#215]
+- Enhance status visibility during cluster upgrades [#216]
+
+## Contributors
+
+Many thanks to [@addyess], [@mateoflorido], [@bschimke95], [@louiseschmidtgen],
+[@eaudetcobello], [@berkayoz], [@HomayoonAlimohammadi], [@ktsakalozos],
+[@kwmonroe], [@maci3jka], [@petrutlucian94], [@evilnick], [@nhennigan],
+[@perk], [@asbalderson].
+
+<!-- LINKS -->
+<!--     PR     -->
+[#118]: https://github.com/canonical/k8s-operator/pull/118
+[#149]: https://github.com/canonical/k8s-operator/pull/149
+[#166]: https://github.com/canonical/k8s-operator/pull/166
+[#173]: https://github.com/canonical/k8s-operator/pull/173
+[#194]: https://github.com/canonical/k8s-operator/pull/194
+[#198]: https://github.com/canonical/k8s-operator/pull/198
+[#200]: https://github.com/canonical/k8s-operator/pull/200
+[#201]: https://github.com/canonical/k8s-operator/pull/201
+[#215]: https://github.com/canonical/k8s-operator/pull/215
+[#216]: https://github.com/canonical/k8s-operator/pull/216
+[#221]: https://github.com/canonical/k8s-operator/pull/221
+<!--     ISSUE      -->
+[issue #75]: https://github.com/canonical/k8s-operator/issues/75
+[issue #90]: https://github.com/canonical/k8s-operator/issues/90
+[issue #109]: https://github.com/canonical/k8s-operator/issues/109
+[issue #110]: https://github.com/canonical/k8s-operator/issues/110
+[issue #111]: https://github.com/canonical/k8s-operator/issues/111
+[issue #112]: https://github.com/canonical/k8s-operator/issues/112
+<!--     MISC       -->
+[charm config]: https://charmhub.io/k8s/configurations
+[upstream release]: https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/
+[snap release page]: /src/snap/reference/versions/1.32.md
+
+<!--    CONTRIBUTORS     -->
+[@asbalderson]: https://github.com/asbalderson
+[@perk]: https://github.com/perk
+[@bschimke95]: https://github.com/bschimke95
+[@evilnick]: https://github.com/evilnick
+[@eaudetcobello]: https://github.com/eaudetcobello
+[@louiseschmidtgen]: https://github.com/louiseschmidtgen
+[@mateoflorido]: https://github.com/mateoflorido
+[@berkayoz]: https://github.com/berkayoz
+[@addyess]: https://github.com/addyess
+[@HomayoonAlimohammadi]: https://github.com/HomayoonAlimohammadi
+[@ktsakalozos]: https://github.com/ktsakalozos
+[@kwmonroe]: https://github.com/kwmonroe
+[@maci3jka]: https://github.com/maci3jka
+[@petrutlucian94]: https://github.com/petrutlucian94
+[@nhennigan]: https://github.com/nhennigan

--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -1,0 +1,25 @@
+# Release notes
+
+This is an index page for all the available releases of {{product}}. Each entry
+will take you to version specific information including new features, bug fixes
+and backwards-incompatible changes.
+
+## Releases
+
+
+```{toctree}
+:titlesonly:
+:maxdepth: 2
+Snap release notes </src/snap/reference/releases.md>
+Charm release notes </src/charm/reference/releases.md>
+```
+
+
+## Release policy and schedule
+
+Our release cadence and support window for all Kubernetes-related products are
+available on the main Ubuntu website, on the [release cycle page][].
+
+<!-- LINKS -->
+
+[release cycle page]: https://ubuntu.com/about/release-cycle#canonical-kubernetes-release-cycle

--- a/docs/src/snap/reference/releases.md
+++ b/docs/src/snap/reference/releases.md
@@ -11,6 +11,7 @@ and backwards-incompatible changes.
 :titlesonly:
 :maxdepth: 2
 /src/snap/reference/versions/1.31
+/src/snap/reference/versions/1.32
 ```
 
 

--- a/docs/src/snap/reference/versions/1.32.md
+++ b/docs/src/snap/reference/versions/1.32.md
@@ -1,0 +1,111 @@
+# 1.32
+
+**{{product}} 1.32 - Release notes - 12 December 2024**
+
+Welcome to the latest release of {{product}}!
+These release notes cover the highlights of this release.
+
+## Requirements and compatibility
+
+{{product}} can be installed on a variety of operating systems using several
+methods. For specific requirements, see the [Installation guides].
+
+## What’s new
+
+- **Kubernetes 1.32** - read more about the upstream release [here].
+
+- **User provided certificate validation** - Now {{product}} can validate user
+provided certificates allowing greater control over the cluster.
+
+- **Additional CNIs** - By adding the annotation `cni.exclusive`, users can now
+ configure their {{product}} cluster to add additional CNIs such as Multus
+ providing greater networking possibilities.
+
+- **Configurable containerd installation** - This new feature allows the user to
+specify the installation path of containerd at bootstrap and node join with
+`--containerd-base-dir`. This means configurations files will not conflict with
+ other containerd installations already on the host (for example from docker).
+
+## Also in this release
+
+- Update to CNI v1.6.0
+- Update go v1.23
+- Update How to use COS Lite tutorial to use k8s-operator charm
+- Update Dqlite to v1.17.1 LTS, go-dqlite to v2 and k8s-dqlite to v1.3.0
+- Update Microcluster to v2.1.0
+- Update lxd to v0.0.0-20241106165613-4aab50ec18c3
+- Implement Vale spellcheck for documentation
+- Use rock for metallb FRR instead of upstream
+- Add review Kubernetes authentication token RPC
+- Make updating documentation easier by implementing literalinclude
+- Checks k8s-related port availability in PreInitChecks
+- Add download links for long files
+- Add patches for Kubernetes 1.32
+- Minor SBOM improvements
+- Add proxy setting from /etc/environment to inspection report
+- Added test level tags
+
+## Deprecations and API changes
+
+- Upstream - For details of other deprecation notices and API changes for
+Kubernetes 1.32, please see the relevant sections of the
+ [upstream release notes][upstream-changelog-1.32].
+
+## Fixed bugs and issues
+
+- Fixed nightly tests ([#876])
+- Fixed containerd pebble path ([#874])
+- Fixed MicroK8s snap check ([#861])
+- Set default k8s snap track for registry in integration tests ([#852])
+- Fixed cilium ingress, refactor string literals ([#848])
+- Removed hardened runner from CI ([#847])
+- Increase integration test timeouts([#798])
+- Changed BusyBox image registry in our integration tests to avoid rate limit
+ errors ([#845])
+
+## Contributors
+
+Many thanks to [@neoaggelos], [@bschimke95], [@evilnick],
+[@eaudetcobello], [@louiseschmidtgen], [@mateoflorido], [@berkayoz],
+[@addyess], [@HomayoonAlimohammadi], [@ktsakalozos], [@kwmonroe], [@maci3jka],
+[@petrutlucian94], [@nhennigan], [@claudiubelu], [@aznashwan], [@YanisaHS],
+[@hemanthnakkina], [@dulmandakh], [@perk].
+
+<!-- LINKS -->
+
+[Installation guides]: ../../howto/install/index
+[tutorial]: ../../tutorial/getting-started
+[here]: https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/
+[upstream-changelog-1.32]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation
+
+<!-- PR -->
+[#876]: https://github.com/canonical/k8s-snap/commit/dd6b5e7075fe5d21df9698cd84eb2a369a446ae8
+[#874]: https://github.com/canonical/k8s-snap/commit/a181d4c0a6be41efc5608c6140bdf3d41c7e4890
+[#861]: https://github.com/canonical/k8s-snap/commit/bb70203feff748282b0ca337a6e9204ed04d2fd7
+[#852]: https://github.com/canonical/k8s-snap/commit/cb4e4b1c78b413aace6656213f81549b9e2cd954
+[#848]: https://github.com/canonical/k8s-snap/commit/b652f3d06c8fb9ffbafccfa6c9bb8ab6c61f5a69
+[#847]: https://github.com/canonical/k8s-snap/commit/457c64021c70483ccb8bc022647269b53fa02b6b
+[#798]: https://github.com/canonical/k8s-snap/commit/1167d62d6a9ef41c4e06b350eb94ab19bcfc82ee
+[#845]: https://github.com/canonical/k8s-snap/commit/334d79e333dc7b49c021c5b66a6da6012b82236b
+
+<!-- CONTRIBUTORS -->
+[@perk]: https://github.com/perk
+[@neoaggelos]: https://github.com/neoaggelos
+[@bschimke95]: https://github.com/bschimke95
+[@evilnick]: https://github.com/evilnick
+[@eaudetcobello]: https://github.com/eaudetcobello
+[@louiseschmidtgen]: https://github.com/louiseschmidtgen
+[@mateoflorido]: https://github.com/mateoflorido
+[@berkayoz]: https://github.com/berkayoz
+[@addyess]: https://github.com/addyess
+[@HomayoonAlimohammadi]: https://github.com/HomayoonAlimohammadi
+[@ktsakalozos]: https://github.com/ktsakalozos
+[@kwmonroe]: https://github.com/kwmonroe
+[@maci3jka]: https://github.com/maci3jka
+[@petrutlucian94]: https://github.com/petrutlucian94
+[@nhennigan]: https://github.com/nhennigan
+[@claudiubelu]: https://github.com/claudiubelu
+[@aznashwan]: https://github.com/aznashwan
+[@YanisaHS]: https://github.com/YanisaHS
+[@hemanthnakkina]: https://github.com/hemanthnakkina
+[@dulmandakh]: https://github.com/dulmandakh


### PR DESCRIPTION
This PR backports #899 and #913 to release 1.32

* Add 1.32 snap release notes
* Add 1.32 charms release notes
* Update navigation and channel
* Update charm channel to 1.32 stable
* Reorganize the navigation side bar to be able to see both snap and charm release notes

---------