### PR TITLE
Ensure lxd is installed before attempting snap refresh

### DIFF
--- a/.github/actions/install-lxd/action.yaml
+++ b/.github/actions/install-lxd/action.yaml
@@ -23,10 +23,14 @@ runs:
       shell: bash
       run: |
         sudo lxd init --auto
+    - name: Add user to lxd group
+      shell: bash
+      run: |
         sudo usermod --append --groups lxd $USER
-        newgrp lxd <<EOF
-        lxc version
-        EOF
+    - name: Check lxd version
+      shell: bash
+      run: |
+        sg lxd -c 'lxc version'
     # Docker sets iptables rules that interfere with LXD.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/actions/install-lxd/action.yaml
+++ b/.github/actions/install-lxd/action.yaml
@@ -23,14 +23,10 @@ runs:
       shell: bash
       run: |
         sudo lxd init --auto
-    - name: Add user to lxd group
-      shell: bash
-      run: |
         sudo usermod --append --groups lxd $USER
-    - name: Check lxd version
-      shell: bash
-      run: |
-        sg lxd -c 'lxc version'
+        # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+        # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
+        sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc version'
     # Docker sets iptables rules that interfere with LXD.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/actions/install-lxd/action.yaml
+++ b/.github/actions/install-lxd/action.yaml
@@ -26,7 +26,7 @@ runs:
         sudo usermod --append --groups lxd $USER
         # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
         # See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305
-        sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc version'
+        sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxc version
     # Docker sets iptables rules that interfere with LXD.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/actions/install-lxd/action.yaml
+++ b/.github/actions/install-lxd/action.yaml
@@ -12,7 +12,13 @@ runs:
     - name: Install lxd snap
       shell: bash
       run: |
-        sudo snap refresh lxd --channel ${{ inputs.channel }}
+        if ! snap list lxd &> /dev/null; then
+          echo "Installing lxd snap"
+          sudo snap install lxd --channel ${{ inputs.channel }}
+        else
+          echo "lxd snap found, refreshing to specified channel"
+          sudo snap refresh lxd --channel ${{ inputs.channel }}
+        fi
     - name: Initialize lxd
       shell: bash
       run: |

--- a/.github/actions/install-lxd/action.yaml
+++ b/.github/actions/install-lxd/action.yaml
@@ -24,7 +24,9 @@ runs:
       run: |
         sudo lxd init --auto
         sudo usermod --append --groups lxd $USER
-        sg lxd -c 'lxc version'
+        newgrp lxd <<EOF
+        lxc version
+        EOF
     # Docker sets iptables rules that interfere with LXD.
     # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
     - name: Apply Docker iptables workaround

--- a/.github/workflows/build-snap.yaml
+++ b/.github/workflows/build-snap.yaml
@@ -43,7 +43,7 @@ jobs:
             out_snap=k8s.snap
           fi
 
-          sg lxd -c 'snapcraft --use-lxd'
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft --use-lxd
           mv k8s_*.snap $out_snap
 
           echo "snap-artifact=$out_snap" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sg lxd -c "tox -e integration -- --tags ${{ inputs.test-tags }}"
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }}
       - name: Prepare inspection reports
         if: failure()
         run: |


### PR DESCRIPTION
- Add a check to determine if the `lxd` snap is already installed before attempting to refresh or install it. This is required because the LXD snap is not shipped by default in 24.04 anymore.

- Replace the use of `sg lxd -c` with `sudo --user "$USER"`. This eliminates the need for password entry during the `lxc` command execution.
See https://github.com/actions/runner-images/issues/9932#issuecomment-2573170305