### PR TITLE
Run "tox -e format", bumping copyright headers

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import itertools
 import logging

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from typing import List

--- a/tests/integration/tests/test_bootstrap.py
+++ b/tests/integration/tests/test_bootstrap.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 from typing import List
 

--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 import os

--- a/tests/integration/tests/test_cleanup.py
+++ b/tests/integration/tests/test_cleanup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 import os

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import datetime
 import logging

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 from typing import List
 

--- a/tests/integration/tests/test_config_propagation.py
+++ b/tests/integration/tests/test_config_propagation.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from typing import List

--- a/tests/integration/tests/test_control_plane_taints.py
+++ b/tests/integration/tests/test_control_plane_taints.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 import time

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from typing import List

--- a/tests/integration/tests/test_etcd.py
+++ b/tests/integration/tests/test_etcd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from pathlib import Path

--- a/tests/integration/tests/test_metrics_server.py
+++ b/tests/integration/tests/test_metrics_server.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from typing import List

--- a/tests/integration/tests/test_network.py
+++ b/tests/integration/tests/test_network.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from ipaddress import IPv4Address, IPv6Address, ip_address

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_storage.py
+++ b/tests/integration/tests/test_storage.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from typing import List

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import os

--- a/tests/integration/tests/test_util/etcd.py
+++ b/tests/integration/tests/test_util/etcd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from string import Template

--- a/tests/integration/tests/test_util/harness/__init__.py
+++ b/tests/integration/tests/test_util/harness/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 from test_util.harness.base import Harness, HarnessError, Instance
 from test_util.harness.juju import JujuHarness

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import subprocess
 from functools import cached_property, partial

--- a/tests/integration/tests/test_util/harness/juju.py
+++ b/tests/integration/tests/test_util/harness/juju.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 import os

--- a/tests/integration/tests/test_util/harness/multipass.py
+++ b/tests/integration/tests/test_util/harness/multipass.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 import os

--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 import os

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import json
 import logging

--- a/tests/integration/tests/test_util/tags.py
+++ b/tests/integration/tests/test_util/tags.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 from pytest_tagging import combine_tags
 

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import ipaddress
 import json

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 import logging
 from typing import List


### PR DESCRIPTION
We need to bump the copyright headers as expected by the tox "format" job:

```
   Copyright 2025 Canonical, Ltd.
```