### PR TITLE
Add a systemd override to add containerd defaults

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -219,3 +219,16 @@ k8s::util::load_kernel_modules() {
 
   modprobe $@
 }
+
+k8s::containerd::ensure_systemd_defaults() {
+  k8s::common::setup_env
+
+  local override_dir="/etc/systemd/system/snap.k8s.containerd.service.d"
+  local override_file="$SNAP/k8s/systemd/containerd-defaults.conf"
+
+  if ! [ -f "$override_dir/containerd-defaults.conf" ]; then
+    mkdir -p "$override_dir"
+    cp "$override_file" "$override_dir/"
+  fi
+
+}

--- a/k8s/systemd/containerd-defaults.conf
+++ b/k8s/systemd/containerd-defaults.conf
@@ -1,0 +1,11 @@
+[Service]
+Delegate=yes
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -5,3 +5,5 @@
 k8s::common::setup_env
 
 k8s::cmd::k8s x-snapd-config reconcile
+
+k8s::containerd::ensure_systemd_defaults


### PR DESCRIPTION
Closes #718

Adds a systemd `.conf`  override file to match upstream recommendations, see https://github.com/containerd/containerd/blob/release/1.6/containerd.service for example

File is only copied over if it does not exist to make sure changes are not over-written

This approach might not work in strict as we are editing `/etc/systemd/...` 