### PR TITLE
docs: Add how-to uninstall the snap section

### DIFF
--- a/docs/src/snap/howto/install/index.md
+++ b/docs/src/snap/howto/install/index.md
@@ -16,4 +16,5 @@ Install from a snap <snap.md>
 multipass
 Install in LXD <lxd.md>
 Install in air-gapped environments <offline.md>
+Uninstall the snap <uninstall.md>
 ```

--- a/docs/src/snap/howto/install/uninstall.md
+++ b/docs/src/snap/howto/install/uninstall.md
@@ -5,9 +5,7 @@ snap from your system.
 
 ---
 
-## Steps to Uninstall
-
-### Remove the snap
+## Removing the k8s snap
 
 To uninstall the `k8s` snap, run the following command:
 

--- a/docs/src/snap/howto/install/uninstall.md
+++ b/docs/src/snap/howto/install/uninstall.md
@@ -1,9 +1,8 @@
-# How to Uninstall the {{ product }} Snap
+# How to uninstall the {{product}} snap
 
 This guide provides step-by-step instructions for removing the {{ product }}
 snap from your system.
 
----
 
 ## Removing the k8s snap
 

--- a/docs/src/snap/howto/install/uninstall.md
+++ b/docs/src/snap/howto/install/uninstall.md
@@ -30,7 +30,7 @@ snaps:
 snap list k8s
 ```
 
-which should produce an output similar to:
+This command should produce an output similar to:
 
 ```
 error: no matching snaps installed

--- a/docs/src/snap/howto/install/uninstall.md
+++ b/docs/src/snap/howto/install/uninstall.md
@@ -1,4 +1,4 @@
-# How to uninstall the {{ product }} snap
+# How to Uninstall the {{ product }} Snap
 
 This guide provides step-by-step instructions for removing the {{ product }}
 snap from your system.

--- a/docs/src/snap/howto/install/uninstall.md
+++ b/docs/src/snap/howto/install/uninstall.md
@@ -13,7 +13,7 @@ To uninstall the `k8s` snap, run the following command:
 sudo snap remove k8s
 ```
 
-This command uninstalls the snap but may leave some configuration and data
+This command uninstalls the snap but may leave some configurations and data
 files on the system.
 For a complete removal, including all cluster data, use the `--purge` option:
 

--- a/docs/src/snap/howto/install/uninstall.md
+++ b/docs/src/snap/howto/install/uninstall.md
@@ -1,0 +1,39 @@
+# How to uninstall the {{ product }} snap
+
+This guide provides step-by-step instructions for removing the {{ product }}
+snap from your system.
+
+---
+
+## Steps to Uninstall
+
+### Remove the snap
+
+To uninstall the `k8s` snap, run the following command:
+
+```
+sudo snap remove k8s
+```
+
+This command uninstalls the snap but may leave some configuration and data
+files on the system.
+For a complete removal, including all cluster data, use the `--purge` option:
+
+```
+sudo snap remove k8s --purge
+```
+
+### Verify removal
+
+To confirm the snap has been successfully removed, check the list of installed
+snaps:
+
+```
+snap list k8s
+```
+
+which should produce an output similar to:
+
+```
+error: no matching snaps installed
+```

--- a/docs/src/snap/howto/install/uninstall.md
+++ b/docs/src/snap/howto/install/uninstall.md
@@ -23,9 +23,9 @@ For a complete removal, including all cluster data, use the `--purge` option:
 sudo snap remove k8s --purge
 ```
 
-### Verify removal
+## Confirm snap removal
 
-To confirm the snap has been successfully removed, check the list of installed
+To confirm the snap is successfully removed, check the list of installed
 snaps:
 
 ```


### PR DESCRIPTION
A brief docs page that explains how to (completely) remove the `k8s` snap.