### PR TITLE
docs: Add ports and services reference for the charm

### DIFF
--- a/docs/src/charm/reference/index.md
+++ b/docs/src/charm/reference/index.md
@@ -15,6 +15,7 @@ releases
 charms
 proxy
 architecture
+Ports and Services <ports-and-services>
 charm-configurations
 Community <community>
 

--- a/docs/src/charm/reference/ports-and-services.md
+++ b/docs/src/charm/reference/ports-and-services.md
@@ -1,0 +1,2 @@
+```{include} /src/snap/reference/ports-and-services.md
+```


### PR DESCRIPTION
The charm exposes the same services and ports on a unit as the snap, hence the reference directly links to the snap docs.