### PR TITLE
docs: Add ports and services reference for CAPI

### DIFF
--- a/docs/src/capi/reference/index.md
+++ b/docs/src/capi/reference/index.md
@@ -12,6 +12,7 @@ Overview <self>
 :titlesonly:
 releases
 annotations
+Ports and Services <ports-and-services>
 Community <community>
 configs
 

--- a/docs/src/capi/reference/ports-and-services.md
+++ b/docs/src/capi/reference/ports-and-services.md
@@ -1,0 +1,2 @@
+```{include} /src/snap/reference/ports-and-services.md
+```


### PR DESCRIPTION
The CAPI clusters exposes the same services and ports as the normal snap, hence the reference directly links to the snap docs.