### PR TITLE
test_ingress: fix service ip poller

### DIFF
--- a/docs/src/_parts/bootstrap_config.md
+++ b/docs/src/_parts/bootstrap_config.md
@@ -11,7 +11,7 @@ Configuration options for the network feature.
 **Type:** `bool`<br>
 
 Determines if the feature should be enabled.
-If omitted defaults to `false`
+If omitted defaults to `true`
 
 ### cluster-config.dns
 **Type:** `object`<br>
@@ -22,7 +22,7 @@ Configuration options for the dns feature.
 **Type:** `bool`<br>
 
 Determines if the feature should be enabled.
-If omitted defaults to `false`
+If omitted defaults to `true`
 
 ### cluster-config.dns.cluster-domain
 **Type:** `string`<br>
@@ -170,7 +170,7 @@ Configuration options for the gateway feature.
 **Type:** `bool`<br>
 
 Determines if the feature should be enabled.
-If omitted defaults to `false`.
+If omitted defaults to `true`.
 
 ### cluster-config.metrics-server
 **Type:** `object`<br>

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -41,7 +41,7 @@ def get_ingress_service_node_port(p):
 def get_external_service_ip(instance: harness.Instance, service_namespace) -> str:
     try_count = 0
     ingress_ip = None
-    while ingress_ip is None and try_count < 20:
+    while not ingress_ip and try_count < 60:
         try_count += 1
         for svcns in service_namespace:
             svc = svcns["service"]
@@ -64,7 +64,7 @@ def get_external_service_ip(instance: harness.Instance, service_namespace) -> st
                     .stdout.decode()
                     .replace("'", "")
                 )
-                if ingress_ip is not None:
+                if ingress_ip:
                     return ingress_ip
             except subprocess.CalledProcessError:
                 ingress_ip = None


### PR DESCRIPTION
get_external_service_ip repeatedly attempts to retrieve the
specified service ip.

The problem is that it uses "is None" checks to determine if
an ip was retrieved. This returns "False" for empty strings,
so the loop exits prematurely.

Note that "is None" checks are strongly discouraged in Python.

While at it, we're bumpting the timeout as well.