### PR TITLE
Allow specifying service env variables

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -191,7 +191,7 @@ k8s::common::execute_service() {
 
   set -xe
   if [[ -f "${SNAP_COMMON}/args/${service_name}-env" ]]; then
-    declare -a env_vars="$(cat "${SNAP_COMMON}/args/${service_name}-env")"
+    mapfile -t env_vars < "${SNAP_COMMON}/args/${service_name}-env"
     exec env -S "${env_vars[@]}" "${SNAP}/bin/${service_name}" "${args[@]}"
   else
     exec "${SNAP}/bin/${service_name}" "${args[@]}"

--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -190,7 +190,12 @@ k8s::common::execute_service() {
   declare -a args="($(cat "${SNAP_COMMON}/args/${service_name}"))"
 
   set -xe
-  exec "${SNAP}/bin/${service_name}" "${args[@]}"
+  if [[ -f "${SNAP_COMMON}/args/${service_name}-env" ]]; then
+    declare -a env_vars="$(cat "${SNAP_COMMON}/args/${service_name}-env")"
+    exec env -S "${env_vars[@]}" "${SNAP}/bin/${service_name}" "${args[@]}"
+  else
+    exec "${SNAP}/bin/${service_name}" "${args[@]}"
+  fi
 }
 
 # Initialize a single-node k8sd cluster


### PR DESCRIPTION
We're adding a mechanism to specify custom service env variables:
  ``/var/snap/k8s/common/args/${service_name}-env``

Note that this feature is already supported by microk8s[1] and documented by k8s-dqlite[2].

[1] https://github.com/canonical/microk8s/blob/master/microk8s-resources/wrappers/run-k8s-dqlite-with-args#L38-L43
[2] https://github.com/canonical/k8s-snap/blob/4615c0377b85e6708ffa144b4667b2dd0fb252cf/k8s/lib.sh#L184-L194