### PR TITLE
docs: add missing commands to ref

### DIFF
--- a/docs/src/snap/reference/commands.md
+++ b/docs/src/snap/reference/commands.md
@@ -49,3 +49,11 @@ These are the commands provided by the k8s snap:
 ```{include} ../../_parts/commands/k8s_status.md
    :end-before: '### SEE ALSO'
 ```
+
+```{include} ../../_parts/commands/k8s_refresh-certs.md
+   :end-before: '### SEE ALSO'
+```
+
+```{include} ../../_parts/commands/k8s_completion.md
+   :end-before: '### SEE ALSO'
+```

--- a/docs/src/snap/reference/commands.md
+++ b/docs/src/snap/reference/commands.md
@@ -1,4 +1,4 @@
-# Command reference
+# Commands
 
 These are the commands provided by the k8s snap:
 


### PR DESCRIPTION
* Adds missing `k8s` commands to the command reference page:
    - k8s refresh-certs
    - k8s completion
* Remove redundant "reference" word from page title/nav