### PR TITLE
docs: config file reference

### DIFF
--- a/docs/src/snap/reference/config-files/bootstrap-config.md
+++ b/docs/src/snap/reference/config-files/bootstrap-config.md
@@ -1,4 +1,4 @@
-# Bootstrap configuration file reference
+# Bootstrap configuration file
 
 A YAML file can be supplied to the `k8s join-cluster` command to configure and
 customise the cluster. This reference section provides the format of this file

--- a/docs/src/snap/reference/config-files/control-plane-join-config.md
+++ b/docs/src/snap/reference/config-files/control-plane-join-config.md
@@ -7,6 +7,5 @@ This reference section provides all available options for control plane nodes.
 
 ## Configuration options
 
-```{literalinclude} /src/_parts/control_plane_join_config.md
-:language: yaml
+```{include} /src/_parts/control_plane_join_config.md
 ```

--- a/docs/src/snap/reference/config-files/control-plane-join-config.md
+++ b/docs/src/snap/reference/config-files/control-plane-join-config.md
@@ -1,4 +1,4 @@
-# Control plane node join configuration file reference
+# Control plane node join configuration file
 
 A YAML file can be supplied to the `k8s join-cluster ` command to configure and
 customise new nodes.

--- a/docs/src/snap/reference/config-files/control-plane-join-config.md
+++ b/docs/src/snap/reference/config-files/control-plane-join-config.md
@@ -7,6 +7,6 @@ This reference section provides all available options for control plane nodes.
 
 ## Configuration options
 
-```{literalinclude} /src/_parts/control_plane_join_config.yaml
+```{literalinclude} /src/_parts/control_plane_join_config.md
 :language: yaml
 ```

--- a/docs/src/snap/reference/config-files/control-plane-join-config.md
+++ b/docs/src/snap/reference/config-files/control-plane-join-config.md
@@ -7,5 +7,6 @@ This reference section provides all available options for control plane nodes.
 
 ## Configuration options
 
-```{include} ../../_parts/control_plane_join_config.md
+```{literalinclude} /src/_parts/control_plane_join_config.yaml
+:language: yaml
 ```

--- a/docs/src/snap/reference/config-files/index.md
+++ b/docs/src/snap/reference/config-files/index.md
@@ -1,0 +1,20 @@
+# Configuration files
+
+```{toctree}
+:hidden:
+Configuration Files <self>
+```
+
+{{product}} uses several configuration files to control its behavior and
+settings. Links below provides detailed information about each configuration
+file.
+
+```{toctree}
+:glob:
+:titlesonly:
+
+Install from a snap <snap.md>
+bootstrap-config
+control-plane-join-config
+worker-join-config
+```

--- a/docs/src/snap/reference/config-files/worker-join-config.md
+++ b/docs/src/snap/reference/config-files/worker-join-config.md
@@ -7,6 +7,5 @@ This reference section provides all available options for worker nodes.
 
 ## Configuration options
 
-```{literalinclude} /src/_parts/worker_join_config.yaml
-:language: yaml
+```{include} /src/_parts/worker_join_config.md
 ```

--- a/docs/src/snap/reference/config-files/worker-join-config.md
+++ b/docs/src/snap/reference/config-files/worker-join-config.md
@@ -1,4 +1,4 @@
-# Worker node join configuration file reference
+# Worker node join configuration file
 
 A YAML file can be supplied to the `k8s join-cluster ` command to configure and
 customise new worker nodes.

--- a/docs/src/snap/reference/config-files/worker-join-config.md
+++ b/docs/src/snap/reference/config-files/worker-join-config.md
@@ -7,5 +7,6 @@ This reference section provides all available options for worker nodes.
 
 ## Configuration options
 
-```{include} ../../_parts/worker_join_config.md
+```{literalinclude} /src/_parts/worker_join_config.yaml
+:language: yaml
 ```

--- a/docs/src/snap/reference/index.md
+++ b/docs/src/snap/reference/index.md
@@ -12,13 +12,11 @@ Overview <self>
 :titlesonly:
 
 releases
+config-files/index
 commands
 ports-and-services
 annotations
 certificates
-bootstrap-config-reference
-control-plane-join-config-reference
-worker-join-config-reference
 proxy
 troubleshooting
 architecture


### PR DESCRIPTION
* Remove redundant "reference" word from titles in files and therefore navbar
* Move config file references to their own folder, config-files.
* Reference config-files folder in the navbar.
* Use absolute path references to config files