### PR TITLE
actions: Address some of the TICS failures

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -81,6 +81,11 @@ jobs:
           # Install python dependencies
           pip install -r tests/integration/requirements-test.txt
           pip install -r tests/integration/requirements-dev.txt
+          # Needed by pylint (TICSQServer), used in build-scripts, k8s/scripts/cis
+          pip install requests jinja2 semver
+
+          # Integration tests are importing a local test_util module. Needed for pylint.
+          export PYTHONPATH="$PYTHONPATH:$(pwd)/tests/integration/tests"
 
           cd src/k8s
 


### PR DESCRIPTION
There are some errors in the TICS job, even though the job passes. Some of these errors relate to some missing dependencies for ``pylint``.

There is one other notable type of error (hundreds of errors), related to Coverity:

```
[ERROR 5336] No analysis data found for file '/home/runner/work/k8s-snap/k8s-snap/src/k8s/pkg/k8sd/controllers/csrsigning/const.go' in 'Coverity'. Please check if the file is analyzed properly, and whether the file is in the analysis scope of the tool.
```

These errors are currently unsolvable. The current version of TICS comes with the Coverity 2024.9.0 version (as seen in ``cov-build-console.log``):

```
Coverity Build Capture (64-bit) version 2024.9.0 on Linux 6.8.0-1020-azure x86_64
Internal version numbers: 950e903b4e p-2024.9-push-30
```

According to the Coverity documentation [1], this version of Coverity only supports golang 1.21 and 1.22, while this project is built on golang 1.23. Coverity 2024.12.0 supports golang 1.23 as well.

[1] https://documentation.blackduck.com/bundle/coverity-on-polaris-UAT/page/topics/r_coverity-compatible-platforms_2024.9.html