### PR TITLE
Document k8s-snap installation on dev environments

### DIFF
--- a/docs/src/snap/howto/contribute.md
+++ b/docs/src/snap/howto/contribute.md
@@ -47,6 +47,15 @@ sudo snap install k8s_v1.32.1_multi.snap --dangerous --classic
    k8s snap installed on your system.
 ```
 
+```{note}
+The snap may conflict with other software such as Docker or containerd,
+which is why we recommend using a clean, isolated environment such as a
+VM or LXD container.
+
+See the [development env guide] if you'd rather install the snap directly
+on your development machine.
+```
+
 Once you have verified the current snap build works, it can be removed with:
 
 ```
@@ -200,3 +209,4 @@ press `F5` in your browser to reload the page without caching)!
 [How to template]: https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/src/_parts/template-howto
 [Explanation template]: https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/src/_parts/template-explanation
 [Reference template]: https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/src/_parts/template-reference
+[development env guide]: ./install/dev-env.md

--- a/docs/src/snap/howto/install/dev-env.md
+++ b/docs/src/snap/howto/install/dev-env.md
@@ -8,11 +8,10 @@ please take note of the following considerations.
 
 ## Containerd conflicts
 
-In classic confinement mode, {{product}} uses the default containerd paths.
-This means that a {{product}} installation will conflict with any existing
-system configuration where containerd is already installed. For example,
-if you have Docker installed, or another Kubernetes distribution that uses
-containerd.
+{{product}} uses the default containerd paths, which means that a {{product}}
+installation will conflict with any existing system configuration where
+containerd is already installed. For example, if you have Docker installed,
+or another Kubernetes distribution that uses containerd.
 
 You may specify a custom containerd path like so:
 

--- a/docs/src/snap/howto/install/dev-env.md
+++ b/docs/src/snap/howto/install/dev-env.md
@@ -1,0 +1,45 @@
+# Install {{product}} in development environments
+
+We recommend testing {{product}} in an isolated environment such as a clean
+virtual machine or LXD container.
+
+If you choose to install {{product}} directly on your development machine,
+please take note of the following considerations.
+
+## Containerd conflicts
+
+In classic confinement mode, {{product}} uses the default containerd paths.
+This means that a {{product}} installation will conflict with any existing
+system configuration where containerd is already installed. For example,
+if you have Docker installed, or another Kubernetes distribution that uses
+containerd.
+
+You may specify a custom containerd path like so:
+
+```bash
+cat <<EOF | sudo k8s bootstrap --file -
+containerd-base-dir: $containerdBaseDir
+EOF
+```
+
+## Changing IP addresses
+
+The local IP addresses of your development machine are likely to change,
+for example after joining a different wi-fi network.
+
+In this case, you may configure {{product}} to use the ``localhost`` address:
+
+```bash
+sudo k8s boostrap --address=127.0.0.1
+```
+
+## Conflicting Docker iptables rules
+
+Docker can interfere with LXD and Multipass installations, setting the global
+``FORWARD`` policy to drop.
+
+See the [lxd network troubleshooting guide] for more details and possible
+workarounds.
+
+<!--LINKS -->
+[lxd network troubleshooting guide]: https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker

--- a/docs/src/snap/howto/install/snap.md
+++ b/docs/src/snap/howto/install/snap.md
@@ -20,6 +20,15 @@ If you cannot meet these requirements, please see the [Installing][] page for
 alternative options.
 ```
 
+```{note}
+The snap may conflict with other software such as Docker or containerd,
+which is why we recommend using a clean, isolated environment such as a
+VM or LXD container when trying out {{product}}.
+
+See the [development env guide] if you'd rather install the snap directly
+on your development machine.
+```
+
 ## Check available channels (optional)
 
 It is a good idea to check the available channels before installing the snap.
@@ -77,3 +86,4 @@ ready state.
 [snap]: https://snapcraft.io/docs
 [snapd support]: https://snapcraft.io/docs/installing-snapd
 [bootstrap]: ../../reference/bootstrap-config-reference
+[development env guide]: ./dev-env.md

--- a/docs/src/snap/howto/restore-quorum.md
+++ b/docs/src/snap/howto/restore-quorum.md
@@ -14,44 +14,7 @@ This guide can be used to recover the default {{product}} datastore,
 Dqlite. Persistent volumes on the lost nodes are *not* recovered.
 ```
 
-## Dqlite configuration
-
-Be aware that {{product}} uses not one, but two Dqlite databases:
-
-* k8s-dqlite - used by Kubernetes itself (as an ETCD replacement)
-* k8sd - Kubernetes cluster management data
-
-Each database has its own state directory:
-
-* ``/var/snap/k8s/common/var/lib/k8s-dqlite``
-* ``/var/snap/k8s/common/var/lib/k8sd/state``
-
-The state directory normally contains:
-
-* ``info.yaml`` - the id, address and cluster role of this node
-* ``cluster.yaml`` - the state of the cluster, as seen by this Dqlite node.
-  It includes the same information as info.yaml, but for all cluster nodes
-* ``00000abcxx-00000abcxx``, ``open-abc`` - database segments
-* ``cluster.crt``, ``cluster.key`` - node certificates
-* ``snapshot-abc-abc-abc.meta``
-* ``metadata{1,2}``
-* ``*.sock`` - control unix sockets
-
-K8sd contains additional files to manage cluster memberships and member's
-secure communication:
-
-* ``server.crt``, ``server.key`` certificates
-* ``truststore`` folder, containing trusted certificates
-* ``daemon.yaml`` - k8sd daemon configuration
-* separate ``database`` folder
-
-Dqlite cluster members have one of the following roles:
-
-| Role enum | Role name | Replicates database | Voting in leader elections |
-|-----------|-----------|---------------------|----------------------------|
-| 0         | voter     | yes                 | yes                        |
-| 1         | stand-by  | yes                 | no                         |
-| 2         | spare     | no                  | no                         |
+Please consult the [Dqlite configuration reference] before moving forward.
 
 ## Stop {{product}} services on all nodes
 
@@ -184,4 +147,5 @@ gateway                   enabled
 
 <!-- LINKS -->
 [Dqlite]: https://dqlite.io/
+[Dqlite configuration reference]: ../reference/dqlite.md
 [Raft]: https://raft.github.io/

--- a/docs/src/snap/reference/dqlite.md
+++ b/docs/src/snap/reference/dqlite.md
@@ -53,8 +53,8 @@ sudo /snap/k8s/current/bin/dqlite \
 
 The ``.leader`` command displays the current cluster leader.
 
-The kine key-value pairs are stored in the ``kine`` database and can be retrieved
-like so:
+The kine key-value pairs are stored in the ``kine`` database and can be
+retrieved like so:
 
 ```
 select id, name, value from kine limit 100;

--- a/docs/src/snap/reference/dqlite.md
+++ b/docs/src/snap/reference/dqlite.md
@@ -59,3 +59,13 @@ like so:
 ```
 select id, name, value from kine limit 100;
 ```
+
+Use ``/snap/k8s/current/bin/k8sd sql`` to issue k8sd sql commands.
+Note that a very limited subset of SQL syntax is available, however the
+following can be used to enumerate the tables:
+
+```
+/snap/k8s/current/bin/k8sd sql \
+  --state-dir /var/snap/k8s/common/var/lib/k8sd/state
+  "SELECT * FROM sqlite_master WHERE type='table'"
+```

--- a/docs/src/snap/reference/dqlite.md
+++ b/docs/src/snap/reference/dqlite.md
@@ -1,0 +1,61 @@
+# Dqlite database
+
+{{product}} uses not one, but two Dqlite databases:
+
+* k8s-dqlite - used by Kubernetes itself (as an ETCD replacement)
+* k8sd - Kubernetes cluster management data
+
+## Database files
+
+Each database has its own state directory:
+
+* ``/var/snap/k8s/common/var/lib/k8s-dqlite``
+* ``/var/snap/k8s/common/var/lib/k8sd/state``
+
+The state directory normally contains:
+
+* ``info.yaml`` - the id, address and cluster role of this node
+* ``cluster.yaml`` - the state of the cluster, as seen by this Dqlite node.
+  It includes the same information as info.yaml, but for all cluster nodes
+* ``00000abcxx-00000abcxx``, ``open-abc`` - database segments
+* ``cluster.crt``, ``cluster.key`` - node certificates
+* ``snapshot-abc-abc-abc.meta``
+* ``metadata{1,2}``
+* ``*.sock`` - control unix sockets
+
+K8sd contains additional files to manage cluster memberships and member's
+secure communication:
+
+* ``server.crt``, ``server.key`` certificates
+* ``truststore`` folder, containing trusted certificates
+* ``daemon.yaml`` - k8sd daemon configuration
+* separate ``database`` folder
+
+Dqlite cluster members have one of the following roles:
+
+| Role enum | Role name | Replicates database | Voting in leader elections |
+|-----------|-----------|---------------------|----------------------------|
+| 0         | voter     | yes                 | yes                        |
+| 1         | stand-by  | yes                 | no                         |
+| 2         | spare     | no                  | no                         |
+
+## Inspecting the databases
+
+Use the following command to connect to the k8s-dqlite database:
+
+```
+sudo /snap/k8s/current/bin/dqlite \
+  -s file:///var/snap/k8s/common/var/lib/k8s-dqlite/cluster.yaml \
+  -c /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt \
+  -k /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key \
+  k8s
+```
+
+The ``.leader`` command displays the current cluster leader.
+
+The kine key-value pairs are stored in the ``kine`` database and can be retrieved
+like so:
+
+```
+select id, name, value from kine limit 100;
+```

--- a/docs/src/snap/reference/dqlite.md
+++ b/docs/src/snap/reference/dqlite.md
@@ -60,9 +60,9 @@ like so:
 select id, name, value from kine limit 100;
 ```
 
-Use ``/snap/k8s/current/bin/k8sd sql`` to issue k8sd sql commands.
-Note that a very limited subset of SQL syntax is available, however the
-following can be used to enumerate the tables:
+Use ``/snap/k8s/current/bin/k8sd sql`` to issue SQL queries to the k8sd
+Dqlite database. Note that a very limited subset of SQL syntax is available,
+however the following can be used to enumerate the tables:
 
 ```
 /snap/k8s/current/bin/k8sd sql \

--- a/docs/src/snap/reference/index.md
+++ b/docs/src/snap/reference/index.md
@@ -20,6 +20,7 @@ certificates
 proxy
 troubleshooting
 architecture
+dqlite
 Community <community>
 ```
 

--- a/docs/src/snap/reference/troubleshooting.md
+++ b/docs/src/snap/reference/troubleshooting.md
@@ -104,6 +104,14 @@ We recommend running {{product}} in an isolated environment, for this purpose,
 you can create a LXD container for your installation. See
 [Install {{product}} in LXD][lxd-install] for instructions.
 
+As an alternative, you may specify a custom containerd path like so:
+
+```bash
+cat <<EOF | sudo k8s bootstrap --file -
+containerd-base-dir: $containerdBaseDir
+EOF
+```
+
 <!-- LINKS -->
 
 [lxd-install]: ../howto/install/lxd.md

--- a/docs/src/snap/reference/versions/1.32.md
+++ b/docs/src/snap/reference/versions/1.32.md
@@ -23,7 +23,7 @@ provided certificates allowing greater control over the cluster.
 
 - **Configurable containerd installation** - This new feature allows the user to
 specify the installation path of containerd at bootstrap and node join with
-`--containerd-base-dir`. This means configurations files will not conflict with
+`containerd-base-dir`. This means configurations files will not conflict with
  other containerd installations already on the host (for example from docker).
 
 ## Also in this release


### PR DESCRIPTION
We'll recommend the users to use a clean virtual machine or LXD container when trying out k8s-snap.

At the same time, we'll document common problems that can arise when installing k8s-snap directly on the development machine along with possible workarounds:

* docker and containerd conflicts
  * fixing the "FORWARD" rules
  * custom containerd base dir
* changing ip addresses
  * listening on "localhost"

Other changes:
* move dqlite docs to a separate reference page and add an example on how to connect to k8s-dqlite
* fix the release note on "containerd-base-dir", it's a bootstrap config yaml entry, not a cli parameter