### PR TITLE
[Backport 1.32] docs: Bump GitPython to 3.1.41 to fix CVEs

### DIFF
--- a/docs/canonicalk8s/.sphinx/build_requirements.py
+++ b/docs/canonicalk8s/.sphinx/build_requirements.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         "sphinx-design",
         "sphinxcontrib-jquery",
         "watchfiles",
-        "GitPython"
+        "GitPython>=3.1.41"
 
     ]
 

--- a/docs/canonicalk8s/.sphinx/requirements.txt
+++ b/docs/canonicalk8s/.sphinx/requirements.txt
@@ -4,7 +4,7 @@
 # Add custom requirements to the custom_required_modules
 # array in the custom_conf.py file and run:
 # make clean && make install
-GitPython
+GitPython>=3.1.41
 canonical-sphinx-extensions
 furo
 linkify-it-py

--- a/docs/tools/.sphinx/build_requirements.py
+++ b/docs/tools/.sphinx/build_requirements.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         "sphinx-design",
         "sphinxcontrib-jquery",
         "watchfiles",
-        "GitPython"
+        "GitPython>=3.1.41"
 
     ]
 

--- a/docs/tools/.sphinx/requirements.txt
+++ b/docs/tools/.sphinx/requirements.txt
@@ -1,10 +1,10 @@
-# DO NOT MODIFY THIS FILE DIRECTLY! Unless you want to
+# DO NOT MODIFY THIS FILE DIRECTLY!
 #
 # This file is generated automatically.
 # Add custom requirements to the custom_required_modules
 # array in the custom_conf.py file and run:
 # make clean && make install
-GitPython
+GitPython>=3.1.41
 canonical-sphinx-extensions
 furo
 linkify-it-py


### PR DESCRIPTION
Backports https://github.com/canonical/k8s-snap/pull/996 to `release-1.32`

## Original card description:
### Overview
Fixes: https://github.com/canonical/k8s-snap/security/code-scanning/128
This PR puts a >=3.1.41 constraint on the `GitPython` requirement which is suggested by the scanner.
The mentioned scan contains multiple CVEs, all pointing to the `GitPython` dependency and each one points to a different issue that is fixed in a different version of `GitPython`. The highest version (that should contain all the fixes) is `3.1.41`.