### PR TITLE
ci: Fix token permissions alert

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -2,7 +2,6 @@ name: Security scan
 
 permissions:
   contents: read  # for actions/checkout to fetch code
-  security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
 
 on:
   workflow_call:
@@ -20,6 +19,8 @@ on:
 
 jobs:
   security-scan:
+    permissions:
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: Security scan
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes https://github.com/canonical/k8s-snap/security/code-scanning/469

### Overview
This PR removes the top level write permission and grants job level write permissions when necessary.

### Note
Does not need a backport since the job manifest is not available in `release-1.32`.