### PR TITLE
Enable cluster-config.load-balancer.l2-mode by default

### DIFF
--- a/docs/src/_parts/bootstrap_config.md
+++ b/docs/src/_parts/bootstrap_config.md
@@ -93,7 +93,7 @@ Sets the CIDRs used for assigning IP addresses to Kubernetes services with type
 **Type:** `bool`<br>
 
 Determines if L2 mode should be enabled.
-If omitted defaults to `false`.
+If omitted defaults to `true`.
 
 ### cluster-config.load-balancer.l2-interfaces
 **Type:** `[]string`<br>

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.15
+	github.com/canonical/k8s-snap-api v1.0.16
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250115174915-f2320c71e720
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.15 h1:uhEJiEhrK93tJAly+quuAayanMhT/5vpePlG+xxVCPA=
-github.com/canonical/k8s-snap-api v1.0.15/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
+github.com/canonical/k8s-snap-api v1.0.16 h1:j1VPvWimgRt3P5uRtD2ZCPGalSFvU5AJ/Jbz60QMoBs=
+github.com/canonical/k8s-snap-api v1.0.16/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250115174915-f2320c71e720 h1:LLegPoZ5bY/PGx3x1xtzggy2xvQvZ5sCw6jlQJ3BRFg=

--- a/src/k8s/pkg/k8sd/types/cluster_config_defaults.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_defaults.go
@@ -61,7 +61,7 @@ func (c *ClusterConfig) SetDefaults() {
 		c.LoadBalancer.CIDRs = utils.Pointer([]string{})
 	}
 	if c.LoadBalancer.L2Mode == nil {
-		c.LoadBalancer.L2Mode = utils.Pointer(false)
+		c.LoadBalancer.L2Mode = utils.Pointer(true)
 	}
 	if c.LoadBalancer.L2Interfaces == nil {
 		c.LoadBalancer.L2Interfaces = utils.Pointer([]string{})

--- a/src/k8s/pkg/k8sd/types/cluster_config_defaults_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_defaults_test.go
@@ -43,7 +43,7 @@ func TestSetDefaults(t *testing.T) {
 		LoadBalancer: types.LoadBalancer{
 			Enabled:        utils.Pointer(false),
 			CIDRs:          utils.Pointer([]string{}),
-			L2Mode:         utils.Pointer(false),
+			L2Mode:         utils.Pointer(true),
 			L2Interfaces:   utils.Pointer([]string{}),
 			BGPMode:        utils.Pointer(false),
 			BGPLocalASN:    utils.Pointer(0),

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -20,7 +20,7 @@ STATUS_PATTERNS = [
     r"network:\s*enabled",
     r"dns:\s*enabled at (\d{1,3}(?:\.\d{1,3}){3})",
     r"ingress:\s*enabled",
-    r"load-balancer:\s*enabled, Unknown mode",
+    r"load-balancer:\s*enabled, L2 mode",
     r"local-storage:\s*enabled at /var/snap/k8s/common/rawfile-storage",
     r"gateway\s*enabled",
 ]
@@ -145,6 +145,6 @@ def test_smoke(instances: List[harness.Instance]):
         return True
 
     LOG.info("Verifying the output of `k8s status`")
-    util.stubbornly(retries=10, delay_s=10).on(instance).until(
+    util.stubbornly(retries=15, delay_s=10).on(instance).until(
         condition=status_output_matches,
     ).exec(["k8s", "status", "--wait-ready"])


### PR DESCRIPTION
We'll change the defalt value of cluster-config.load-balancer.l2-mode, enabling it by default.

Docstring update: https://github.com/canonical/k8s-snap-api/pull/22