### PR TITLE
[Docs] Update outdated links

### DIFF
--- a/docs/src/charm/howto/index.md
+++ b/docs/src/charm/howto/index.md
@@ -15,7 +15,6 @@ Overview <self>
 :titlesonly:
 
 install/index
-Add worker nodes with custom configurations <custom-workers>
 Configure the cluster <configure-cluster>
 Integrate with OpenStack <openstack>
 Integrate with etcd <etcd>

--- a/docs/src/charm/howto/install/charm.md
+++ b/docs/src/charm/howto/install/charm.md
@@ -37,7 +37,7 @@ page][channels] for an explanation of the different types of channel.
 
 The charm can be installed with the `juju` command:
 
-```{literalinclude} ../../_parts/install.md
+```{literalinclude} /src/_parts/install.md
 :start-after: <!-- juju control start -->
 :end-before: <!-- juju control end -->
 ```
@@ -78,7 +78,7 @@ After deployment, integrate these new nodes with control-plane units so they joi
 the cluster.
 
 
-```{literalinclude} ../../_parts/install.md
+```{literalinclude} /src/_parts/install.md
 :start-after: <!-- juju worker start -->
 :end-before: <!-- juju worker end -->
 :append: juju integrate k8s k8s-worker:cluster

--- a/docs/src/charm/howto/install/install-custom.md
+++ b/docs/src/charm/howto/install/install-custom.md
@@ -66,7 +66,7 @@ align with your requirements.
 
 Deploy the `k8s` charm with your custom configuration:
 
-```{literalinclude} ../../_parts/install.md
+```{literalinclude} /src/_parts/install.md
 :start-after: <!-- juju controlplane custom config start -->
 :end-before: <!-- juju controlplane custom config end -->
 ```

--- a/docs/src/snap/reference/config-files/bootstrap-config.md
+++ b/docs/src/snap/reference/config-files/bootstrap-config.md
@@ -6,7 +6,7 @@ by listing all available options and their details. See below for an example.
 
 ## Configuration options
 
-```{include} ../../_parts/bootstrap_config.md
+```{include} /src/_parts/bootstrap_config.md
 ```
 
 

--- a/docs/src/snap/reference/config-files/index.md
+++ b/docs/src/snap/reference/config-files/index.md
@@ -13,7 +13,6 @@ file.
 :glob:
 :titlesonly:
 
-Install from a snap <snap.md>
 bootstrap-config
 control-plane-join-config
 worker-join-config


### PR DESCRIPTION
During a previous PR where these files were moved in the the config files folder, the reference to the _parts directory was not updated correctly. This was highlighted in issue #986 . I will create another PR to address the other comments about docs in this issue.