### PR TITLE
[Docs] Move two-node HA page to /moonray

### DIFF
--- a/docs/moonray/howto/index.md
+++ b/docs/moonray/howto/index.md
@@ -15,6 +15,7 @@ Overview <self>
 :titlesonly:
 install
 networking/index
+two-node-ha
 ```
 
 ---

--- a/docs/moonray/howto/two-node-ha.md
+++ b/docs/moonray/howto/two-node-ha.md
@@ -1,4 +1,4 @@
-# Two-Node High-Availability with Dqlite
+# Two-node High-Availability with Dqlite
 
 High availability (HA) is a mandatory requirement for most production-grade
 Kubernetes deployments, usually implying three or more nodes.
@@ -28,7 +28,7 @@ standby node, allowing access to the latest Dqlite database version.
 
 Additional recovery steps are automated and invoked through Pacemaker.
 
-### Prerequisites:
+### Prerequisites
 
 * Please ensure that both nodes are part of the Kubernetes cluster.
   See the [getting started] and [add/remove nodes] guides.
@@ -420,7 +420,6 @@ sudo drbdadm connect r0
 [Raft]: https://raft.github.io/
 [Distributed Replicated Block Device]: https://ubuntu.com/server/docs/distributed-replicated-block-device-drbd
 [Dqlite recovery guide]: restore-quorum
-[external datastore guide]: external-datastore
 [two-node-ha.sh script]: https://github.com/canonical/k8s-snap/blob/main/k8s/hack/two-node-ha.sh
 [getting started]: ../tutorial/getting-started
 [add/remove nodes]: ../tutorial/add-remove-nodes

--- a/docs/moonray/howto/two-node-ha.md
+++ b/docs/moonray/howto/two-node-ha.md
@@ -31,7 +31,6 @@ Additional recovery steps are automated and invoked through Pacemaker.
 ### Prerequisites
 
 * Please ensure that both nodes are part of the Kubernetes cluster.
-  See the [getting started] and [add/remove nodes] guides.
 * The user associated with the HA service has SSH access to the peer node and
   passwordless sudo configured. For simplicity, the default "ubuntu" user can
   be used.
@@ -421,8 +420,6 @@ sudo drbdadm connect r0
 [Distributed Replicated Block Device]: https://ubuntu.com/server/docs/distributed-replicated-block-device-drbd
 [Dqlite recovery guide]: restore-quorum
 [two-node-ha.sh script]: https://github.com/canonical/k8s-snap/blob/main/k8s/hack/two-node-ha.sh
-[getting started]: ../tutorial/getting-started
-[add/remove nodes]: ../tutorial/add-remove-nodes
 [Pacemaker]: https://clusterlabs.org/pacemaker/
 [Corosync]: https://corosync.github.io/corosync/
 [Pacemaker fencing]: https://clusterlabs.org/pacemaker/doc/2.1/Pacemaker_Explained/html/fencing.html

--- a/docs/src/snap/howto/index.md
+++ b/docs/src/snap/howto/index.md
@@ -23,7 +23,6 @@ Set up cluster observability  <observability>
 Back up and restore <backup-restore>
 Refresh Kubernetes Certificates <refresh-certs>
 Recover a cluster after quorum loss <restore-quorum>
-two-node-ha
 Manage upgrades <upgrades>
 Set up Enhanced Platform Awareness <epa>
 Manage images <image-management.md>


### PR DESCRIPTION
The two node high availability is more of a proof of concept rather than a fully supported feature. This was done at request for moonray so moving there.