### PR TITLE
Switch to cilium native routing mode for ipv6 only setup

### DIFF
--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -3,12 +3,10 @@ package app
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
-	mctypes "github.com/canonical/microcluster/v2/rest/types"
 )
 
 func startControlPlaneServices(ctx context.Context, snap snap.Snap, datastore string) error {
@@ -41,23 +39,4 @@ func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 	}
 
 	return nil
-}
-
-func DetermineLocalhostAddress(clusterMembers []mctypes.ClusterMember) (string, error) {
-	// Check if any of the cluster members have an IPv6 address, if so return "::1"
-	// if one member has an IPv6 address, other members should also have IPv6 interfaces
-	for _, clusterMember := range clusterMembers {
-		memberAddress := clusterMember.Address.Addr().String()
-		nodeIP := net.ParseIP(memberAddress)
-		if nodeIP == nil {
-			return "", fmt.Errorf("failed to parse node IP address %q", memberAddress)
-		}
-
-		if nodeIP.To4() == nil {
-			return "[::1]", nil
-		}
-	}
-
-	// If no IPv6 addresses are found this means the cluster is IPv4 only
-	return "127.0.0.1", nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -61,23 +61,8 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 			func(ctx context.Context) (types.ClusterConfig, error) {
 				return databaseutil.GetClusterConfig(ctx, s)
 			},
-			func() (string, error) {
-				c, err := s.Leader()
-				if err != nil {
-					return "", fmt.Errorf("failed to get leader client: %w", err)
-				}
-
-				clusterMembers, err := c.GetClusterMembers(ctx)
-				if err != nil {
-					return "", fmt.Errorf("failed to get cluster members: %w", err)
-				}
-
-				localhostAddress, err := DetermineLocalhostAddress(clusterMembers)
-				if err != nil {
-					return "", fmt.Errorf("failed to determine localhost address: %w", err)
-				}
-
-				return localhostAddress, nil
+			func() state.State {
+				return s
 			},
 			func(ctx context.Context, dnsIP string) error {
 				if err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {

--- a/src/k8s/pkg/k8sd/features/calico/network.go
+++ b/src/k8s/pkg/k8sd/features/calico/network.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/microcluster/v2/state"
 )
 
 const (
@@ -23,7 +24,7 @@ const (
 // deployment.
 // ApplyNetwork returns an error if anything fails. The error is also wrapped in the .Message field of the
 // returned FeatureStatus.
-func ApplyNetwork(ctx context.Context, snap snap.Snap, _ string, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
+func ApplyNetwork(ctx context.Context, snap snap.Snap, _ state.State, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
 	m := snap.HelmClient()
 
 	if !network.GetEnabled() {

--- a/src/k8s/pkg/k8sd/features/calico/network_test.go
+++ b/src/k8s/pkg/k8sd/features/calico/network_test.go
@@ -46,7 +46,7 @@ func TestDisabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, nil, apiserver, network, nil)
 
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
@@ -75,7 +75,7 @@ func TestDisabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, nil)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, nil, apiserver, network, nil)
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -108,7 +108,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, nil, apiserver, network, defaultAnnotations)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -133,7 +133,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, nil, apiserver, network, defaultAnnotations)
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
@@ -161,7 +161,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, nil, apiserver, network, defaultAnnotations)
 
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
@@ -192,7 +192,7 @@ func TestEnabled(t *testing.T) {
 			SecurePort: ptr.To(6443),
 		}
 
-		status, err := calico.ApplyNetwork(context.Background(), snapM, "127.0.0.1", apiserver, network, defaultAnnotations)
+		status, err := calico.ApplyNetwork(context.Background(), snapM, nil, apiserver, network, defaultAnnotations)
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeTrue())

--- a/src/k8s/pkg/k8sd/features/interface.go
+++ b/src/k8s/pkg/k8sd/features/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/microcluster/v2/state"
 )
 
 // Interface abstracts the management of built-in Canonical Kubernetes features.
@@ -12,7 +13,7 @@ type Interface interface {
 	// ApplyDNS is used to configure the DNS feature on Canonical Kubernetes.
 	ApplyDNS(context.Context, snap.Snap, types.DNS, types.Kubelet, types.Annotations) (types.FeatureStatus, string, error)
 	// ApplyNetwork is used to configure the network feature on Canonical Kubernetes.
-	ApplyNetwork(context.Context, snap.Snap, string, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
+	ApplyNetwork(context.Context, snap.Snap, state.State, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	// ApplyLoadBalancer is used to configure the load-balancer feature on Canonical Kubernetes.
 	ApplyLoadBalancer(context.Context, snap.Snap, types.LoadBalancer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	// ApplyIngress is used to configure the ingress controller feature on Canonical Kubernetes.
@@ -28,7 +29,7 @@ type Interface interface {
 // implementation implements Interface.
 type implementation struct {
 	applyDNS           func(context.Context, snap.Snap, types.DNS, types.Kubelet, types.Annotations) (types.FeatureStatus, string, error)
-	applyNetwork       func(context.Context, snap.Snap, string, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
+	applyNetwork       func(context.Context, snap.Snap, state.State, types.APIServer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	applyLoadBalancer  func(context.Context, snap.Snap, types.LoadBalancer, types.Network, types.Annotations) (types.FeatureStatus, error)
 	applyIngress       func(context.Context, snap.Snap, types.Ingress, types.Network, types.Annotations) (types.FeatureStatus, error)
 	applyGateway       func(context.Context, snap.Snap, types.Gateway, types.Network, types.Annotations) (types.FeatureStatus, error)
@@ -40,8 +41,8 @@ func (i *implementation) ApplyDNS(ctx context.Context, snap snap.Snap, dns types
 	return i.applyDNS(ctx, snap, dns, kubelet, annotations)
 }
 
-func (i *implementation) ApplyNetwork(ctx context.Context, snap snap.Snap, localhostAddress string, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
-	return i.applyNetwork(ctx, snap, localhostAddress, apiserver, network, annotations)
+func (i *implementation) ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver types.APIServer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {
+	return i.applyNetwork(ctx, snap, s, apiserver, network, annotations)
 }
 
 func (i *implementation) ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.LoadBalancer, network types.Network, annotations types.Annotations) (types.FeatureStatus, error) {

--- a/src/k8s/pkg/utils/localhost.go
+++ b/src/k8s/pkg/utils/localhost.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+
+	mctypes "github.com/canonical/microcluster/v2/rest/types"
+)
+
+func DetermineLocalhostAddress(clusterMembers []mctypes.ClusterMember) (string, error) {
+	// Check if any of the cluster members have an IPv6 address, if so return "::1"
+	// if one member has an IPv6 address, other members should also have IPv6 interfaces
+	for _, clusterMember := range clusterMembers {
+		memberAddress := clusterMember.Address.Addr().String()
+		nodeIP := net.ParseIP(memberAddress)
+		if nodeIP == nil {
+			return "", fmt.Errorf("failed to parse node IP address %q", memberAddress)
+		}
+
+		if nodeIP.To4() == nil {
+			return "[::1]", nil
+		}
+	}
+
+	// If no IPv6 addresses are found this means the cluster is IPv4 only
+	return "127.0.0.1", nil
+}

--- a/src/k8s/pkg/utils/localhost_test.go
+++ b/src/k8s/pkg/utils/localhost_test.go
@@ -1,10 +1,9 @@
-package app_test
+package utils
 
 import (
 	"net/netip"
 	"testing"
 
-	"github.com/canonical/k8s/pkg/k8sd/app"
 	mctypes "github.com/canonical/microcluster/v2/rest/types"
 	. "github.com/onsi/gomega"
 )
@@ -40,7 +39,7 @@ func TestDetermineLocalhostAddress(t *testing.T) {
 			},
 		}
 
-		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
+		localhostAddress, err := DetermineLocalhostAddress(mockMembers)
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(localhostAddress).To(Equal("127.0.0.1"))
@@ -76,7 +75,7 @@ func TestDetermineLocalhostAddress(t *testing.T) {
 			},
 		}
 
-		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
+		localhostAddress, err := DetermineLocalhostAddress(mockMembers)
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(localhostAddress).To(Equal("[::1]"))
@@ -112,7 +111,7 @@ func TestDetermineLocalhostAddress(t *testing.T) {
 			},
 		}
 
-		localhostAddress, err := app.DetermineLocalhostAddress(mockMembers)
+		localhostAddress, err := DetermineLocalhostAddress(mockMembers)
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(localhostAddress).To(Equal("[::1]"))


### PR DESCRIPTION
Tunneling/encapsulation is not supported for ipv6 only clusters https://github.com/cilium/cilium/issues/17240 .
This PR configures Cilium to run in native routing mode on ipv6 only setups.