### PR TITLE
The command "kubectl config show" does not exist

### DIFF
--- a/docs/src/charm/tutorial/basic-operations.md
+++ b/docs/src/charm/tutorial/basic-operations.md
@@ -96,7 +96,7 @@ juju run k8s/0 get-kubeconfig | yq '.kubeconfig' >> ~/.kube/config
 Confirm that `kubectl` can read the kubeconfig file:
 
 ```
-kubectl config show
+kubectl config view
 ```
 
 The output will be similar to this:


### PR DESCRIPTION
The command "kubectl config show" does not exist and should be "kubectl config view".

```
kubectl config show
error: unknown command "show"
See 'kubectl config -h' for help and examples
```