### PR TITLE
test: implement version_downgrade_with_rollback test

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -65,6 +65,7 @@ jobs:
           # Test the latest (up to) 6 releases for the flavour
           # TODO(ben): upgrade nightly to run all flavours
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
+          TEST_VERSION_DOWNGRADE_CHANNELS: "recent 6 classic"
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -65,6 +65,7 @@ jobs:
           # Test the latest (up to) 6 releases for the flavour
           # TODO(ben): upgrade nightly to run all flavours
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
+          # TODO(etienne): change to "recent" when 1.33 is stable
           TEST_VERSION_DOWNGRADE_CHANNELS: "1.32-classic/stable 1.32-classic/beta 1.31-classic/stable 1.31-classic/beta"
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Apply patches
         if: inputs.flavor != ''
         run: |
@@ -65,7 +65,7 @@ jobs:
           # Test the latest (up to) 6 releases for the flavour
           # TODO(ben): upgrade nightly to run all flavours
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
-          TEST_VERSION_DOWNGRADE_CHANNELS: "recent 6 classic"
+          TEST_VERSION_DOWNGRADE_CHANNELS: "1.32-classic/stable 1.32-classic/beta 1.31-classic/stable 1.31-classic/beta"
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -141,6 +141,11 @@ VERSION_UPGRADE_CHANNELS = (
 # Only relevant when using 'recent' in VERSION_UPGRADE_CHANNELS.
 VERSION_UPGRADE_MIN_RELEASE = os.environ.get("TEST_VERSION_UPGRADE_MIN_RELEASE")
 
+# Same usage as VERSION_UPGRADE_MIN_RELEASE but for downgrades.
+VERSION_DOWNGRADE_CHANNELS = (
+    os.environ.get("TEST_VERSION_DOWNGRADE_CHANNELS", "").strip().split()
+)
+
 # A list of space-separated channels for which the strict interface tests should be run in sequential order.
 # Alternatively, use 'recent <num> strict' to get the latest <num> channels for strict.
 STRICT_INTERFACE_CHANNELS = (

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -68,6 +68,7 @@ def get_most_stable_channels(
     include_latest: bool = True,
     min_release: Optional[str] = None,
     max_release: Optional[str] = None,
+    reverse: bool = False,
 ) -> List[str]:
     """Get an ascending list of latest channels based on the number of channels
     flavour and architecture."""
@@ -99,7 +100,9 @@ def get_most_stable_channels(
             channel_map[version_key] = (channel, risk)
 
     # Sort channels by major and minor version (ascending order)
-    sorted_versions = sorted(channel_map.keys(), key=lambda v: (v[0], v[1]))
+    sorted_versions = sorted(
+        channel_map.keys(), key=lambda v: (v[0], v[1]), reverse=reverse
+    )
 
     # Extract only the channel names
     final_channels = [channel_map[v][0] for v in sorted_versions[:num_of_channels]]

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -262,7 +262,6 @@ def wait_until_k8s_ready(
     retries: int = config.DEFAULT_WAIT_RETRIES,
     delay_s: int = config.DEFAULT_WAIT_DELAY_S,
     node_names: Mapping[str, str] = {},
-    output: bool = True,
 ):
     """
     Validates that the K8s node is in Ready state.
@@ -283,11 +282,9 @@ def wait_until_k8s_ready(
             .until(lambda p: " Ready" in p.stdout.decode())
             .exec(["k8s", "kubectl", "get", "node", node_name, "--no-headers"])
         )
-        if output:
-            LOG.info(f"Kubelet registered successfully on instance '{instance.id}'")
-            LOG.info("%s", result.stdout.decode().strip())
+        LOG.info(f"Kubelet registered successfully on instance '{instance.id}'")
+        LOG.info("%s", result.stdout.decode().strip())
         instance_id_node_name_map[instance.id] = node_name
-    if output:
         LOG.info(
             "Successfully checked Kubelet registered on all harness instances: "
             f"{instance_id_node_name_map}"

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -262,6 +262,7 @@ def wait_until_k8s_ready(
     retries: int = config.DEFAULT_WAIT_RETRIES,
     delay_s: int = config.DEFAULT_WAIT_DELAY_S,
     node_names: Mapping[str, str] = {},
+    output: bool = True,
 ):
     """
     Validates that the K8s node is in Ready state.
@@ -282,13 +283,15 @@ def wait_until_k8s_ready(
             .until(lambda p: " Ready" in p.stdout.decode())
             .exec(["k8s", "kubectl", "get", "node", node_name, "--no-headers"])
         )
-        LOG.info(f"Kubelet registered successfully on instance '{instance.id}'")
-        LOG.info("%s", result.stdout.decode())
+        if output:
+            LOG.info(f"Kubelet registered successfully on instance '{instance.id}'")
+            LOG.info("%s", result.stdout.decode().strip())
         instance_id_node_name_map[instance.id] = node_name
-    LOG.info(
-        "Successfully checked Kubelet registered on all harness instances: "
-        f"{instance_id_node_name_map}"
-    )
+    if output:
+        LOG.info(
+            "Successfully checked Kubelet registered on all harness instances: "
+            f"{instance_id_node_name_map}"
+        )
 
 
 def wait_for_dns(instance: harness.Instance):

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -78,6 +78,18 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
 )
 @pytest.mark.tags(tags.NIGHTLY)
 def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp_path):
+    """
+    This test will downgrade the snap through the channels, and at each downgrade, attempt a rollback.
+
+    Example of downgrading while rolling back through channels:
+    Channels from config:  1.32-classic/stable, 1.31-classic/stable
+    Segment 1: 1.32-classic/stable -> 1.31-classic/stable -> 1.32-classic/stable -> 1.31-classic/stable
+
+    Example 2 of downgrading while rolling back through channels:
+    Channels from config: 1.32-classic/stable 1.32-classic/beta 1.31-classic/stable
+    Segment 1: 1.32-classic/stable -> 1.32-classic/beta -> 1.32-classic/stable -> 1.32-classic/beta
+    Segment 2: 1.32-classic/beta -> 1.31-classic/stable -> 1.32-classic/beta -> 1.31-classic/stable
+    """
     channels = config.VERSION_DOWNGRADE_CHANNELS
     cp = instances[0]
     current_channel = channels[0]
@@ -112,12 +124,6 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
 
     util.wait_until_k8s_ready(cp, instances)
     LOG.info(f"Installed {cp.id} on channel {current_channel}")
-
-    # This test will downgrade the snap through the channels, and at each downgrade, attempt a rollback.
-    # Example of downgrading while rolling back through channels:
-    # Channels:  1.32-classic/stable, 1.31-classic/stable
-    # Segment 1: 1.32-classic/stable -> 1.31-classic/stable -> 1.32-classic/stable
-    # Segment 2: 1.31-classic/stable -> 1.30-classic/stable -> 1.31-classic/stable
 
     for channel in channels[1:]:
         LOG.info(

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -59,7 +59,8 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
 
         # Log the current snap version on the node.
         out = cp.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
-        LOG.info(f"Current snap version: {out.stdout.decode().strip()}")
+        latest_version = out.stdout.decode().strip().split("\n")[-1]
+        LOG.info(f"Current snap version: {latest_version}")
 
         # note: the `--classic` flag will be ignored by snapd for strict snaps.
         cp.exec(
@@ -123,7 +124,8 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
             f">>> Initiating downgrade + rollback segment from {current_channel} → {channel}"
         )
         out = cp.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
-        LOG.info(f"Current snap version: {out.stdout.decode().strip().split('\n')[-1]}")
+        latest_version = out.stdout.decode().strip().split("\n")[-1]
+        LOG.info(f"Current snap version: {latest_version}")
 
         LOG.info(f"Step 1. Downgrade {cp.id} from {current_channel} → {channel}")
         # note: the `--classic` flag will be ignored by snapd for strict snaps.

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -97,8 +97,7 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
         )
         if len(channels) < 2:
             pytest.fail(
-                f"Need at least 2 channels to downgrade, got {
-                    len(channels)} for flavour {flavour}"
+                f"Need at least 2 channels to downgrade, got {len(channels)} for flavour {flavour}"
             )
         current_channel = channels[0]
 

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -102,8 +102,7 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
         current_channel = channels[0]
 
     LOG.info(
-        f"Bootstrap node on {
-            current_channel} and downgrade through channels: {channels[1:]}"
+        f"Bootstrap node on {current_channel} and downgrade through channels: {channels[1:]}"
     )
 
     # Setup the k8s snap from the bootstrap channel and setup basic configuration.

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -123,7 +123,7 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
             f">>> Initiating downgrade + rollback segment from {current_channel} → {channel}"
         )
         out = cp.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
-        LOG.info(f"Current snap version: {out.stdout.decode().strip().split("\n")[-1]}")
+        LOG.info(f"Current snap version: {out.stdout.decode().strip().split('\n')[-1]}")
 
         LOG.info(f"Step 1. Downgrade {cp.id} from {current_channel} → {channel}")
         # note: the `--classic` flag will be ignored by snapd for strict snaps.

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -127,13 +127,13 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
 
     for channel in channels[1:]:
         LOG.info(
-            f">>> Initiating downgrade + rollback segment from {current_channel} → {channel}"
+            f"Initiating downgrade + rollback segment from {current_channel} → {channel}"
         )
         out = cp.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
         latest_version = out.stdout.decode().strip().split("\n")[-1]
         LOG.info(f"Current snap version: {latest_version}")
 
-        LOG.info(f"Step 1. Downgrade {cp.id} from {current_channel} → {channel}")
+        LOG.debug(f"Step 1. Downgrade {cp.id} from {current_channel} → {channel}")
         # note: the `--classic` flag will be ignored by snapd for strict snaps.
         cp.exec(
             ["snap", "refresh", config.SNAP_NAME, "--channel", channel, "--classic"]
@@ -143,7 +143,7 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
         last_channel = current_channel
         current_channel = channel
 
-        LOG.info(f"Step 2. Roll back from {current_channel} → {last_channel}")
+        LOG.debug(f"Step 2. Roll back from {current_channel} → {last_channel}")
         # note: the `--classic` flag will be ignored by snapd for strict snaps.
         cp.exec(
             [
@@ -157,7 +157,7 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
         )
         util.wait_until_k8s_ready(cp, instances)
 
-        LOG.info(
+        LOG.debug(
             f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
         )
         cp.exec(
@@ -172,6 +172,6 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
         )
         util.wait_until_k8s_ready(cp, instances)
 
-        LOG.info(">>> Rollback segment complete. Proceeding to next downgrade segment.")
+        LOG.info("Rollback segment complete. Proceeding to next downgrade segment.")
 
-    LOG.info(">>> Rollback test complete. All downgrade segments verified.")
+    LOG.info("Rollback test complete. All downgrade segments verified.")

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -172,8 +172,6 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
         )
         util.wait_until_k8s_ready(cp, instances)
 
-        LOG.info(
-            ">>> Rollback segment complete. Proceeding to next downgrade segment."
-        )
+        LOG.info(">>> Rollback segment complete. Proceeding to next downgrade segment.")
 
     LOG.info(">>> Rollback test complete. All downgrade segments verified.")

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -138,7 +138,7 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
         cp.exec(
             ["snap", "refresh", config.SNAP_NAME, "--channel", channel, "--classic"]
         )
-        util.wait_until_k8s_ready(cp, instances, output=False)
+        util.wait_until_k8s_ready(cp, instances)
 
         last_channel = current_channel
         current_channel = channel
@@ -155,7 +155,7 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
                 "--classic",
             ]
         )
-        util.wait_until_k8s_ready(cp, instances, output=False)
+        util.wait_until_k8s_ready(cp, instances)
 
         LOG.info(
             f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
@@ -170,11 +170,10 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
                 "--classic",
             ]
         )
-        util.wait_until_k8s_ready(cp, instances, output=False)
+        util.wait_until_k8s_ready(cp, instances)
 
-        if channel == channels[-1]:
-            LOG.info(">>> Rollback test complete. All downgrade segments verified.")
-        else:
-            LOG.info(
-                ">>> Rollback segment complete. Proceeding to next downgrade segment."
-            )
+        LOG.info(
+            ">>> Rollback segment complete. Proceeding to next downgrade segment."
+        )
+
+    LOG.info(">>> Rollback test complete. All downgrade segments verified.")

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -68,3 +68,107 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
         util.wait_until_k8s_ready(cp, instances)
         current_channel = channel
         LOG.info(f"Upgraded {cp.id} on channel {channel}")
+
+
+@pytest.mark.node_count(1)
+@pytest.mark.no_setup()
+@pytest.mark.skipif(
+    not config.VERSION_DOWNGRADE_CHANNELS, reason="No downgrade channels configured"
+)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp_path):
+    channels = config.VERSION_DOWNGRADE_CHANNELS
+    cp = instances[0]
+    current_channel = channels[0]
+
+    if current_channel.lower() == "recent":
+        if len(channels) != 3:
+            pytest.fail(
+                "'recent' requires the number of releases as second argument and the flavour as third argument"
+            )
+        _, num_channels, flavour = channels
+        channels = snap.get_most_stable_channels(
+            int(num_channels),
+            flavour,
+            cp.arch,
+            min_release=config.VERSION_UPGRADE_MIN_RELEASE,
+            reverse=True,
+            include_latest=False,
+        )
+        if len(channels) < 2:
+            pytest.fail(
+                f"Need at least 2 channels to downgrade, got {
+                    len(channels)} for flavour {flavour}"
+            )
+        current_channel = channels[0]
+
+    LOG.info(
+        f"Bootstrap node on {
+            current_channel} and downgrade through channels: {channels[1:]}"
+    )
+
+    # Setup the k8s snap from the bootstrap channel and setup basic configuration.
+    util.setup_k8s_snap(cp, tmp_path, current_channel)
+    cp.exec(["k8s", "bootstrap"])
+
+    util.wait_until_k8s_ready(cp, instances)
+    LOG.info(f"Installed {cp.id} on channel {current_channel}")
+
+    # This test will downgrade the snap through the channels, and at each downgrade, attempt a rollback.
+    # Example of downgrading while rolling back through channels:
+    # Channels:  1.32-classic/stable, 1.31-classic/stable
+    # Segment 1: 1.32-classic/stable -> 1.31-classic/stable -> 1.32-classic/stable
+    # Segment 2: 1.31-classic/stable -> 1.30-classic/stable -> 1.31-classic/stable
+
+    for channel in channels[1:]:
+        LOG.info(
+            f">>> Initiating downgrade + rollback segment from {current_channel} → {channel}"
+        )
+        out = cp.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
+        LOG.info(f"Current snap version: {out.stdout.decode().strip().split("\n")[-1]}")
+
+        LOG.info(f"Step 1. Downgrade {cp.id} from {current_channel} → {channel}")
+        # note: the `--classic` flag will be ignored by snapd for strict snaps.
+        cp.exec(
+            ["snap", "refresh", config.SNAP_NAME, "--channel", channel, "--classic"]
+        )
+        util.wait_until_k8s_ready(cp, instances, output=False)
+
+        last_channel = current_channel
+        current_channel = channel
+
+        LOG.info(f"Step 2. Roll back from {current_channel} → {last_channel}")
+        # note: the `--classic` flag will be ignored by snapd for strict snaps.
+        cp.exec(
+            [
+                "snap",
+                "refresh",
+                config.SNAP_NAME,
+                "--channel",
+                last_channel,
+                "--classic",
+            ]
+        )
+        util.wait_until_k8s_ready(cp, instances, output=False)
+
+        LOG.info(
+            f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
+        )
+        cp.exec(
+            [
+                "snap",
+                "refresh",
+                config.SNAP_NAME,
+                "--channel",
+                current_channel,
+                "--classic",
+            ]
+        )
+        util.wait_until_k8s_ready(cp, instances, output=False)
+
+        if channel == channels[-1]:
+            LOG.info(">>> Rollback test complete. All downgrade segments verified.")
+        else:
+            LOG.info(
+                ">>> Rollback segment complete. Proceeding to next downgrade segment."
+            )


### PR DESCRIPTION
It is possible that during a refresh something goes wrong and snapd decides it should rollback.  To simulate this we should have a test as part of the upgrade suite that would do a refresh to the new revision.

This test will downgrade the snap through the channels, and at each downgrade, attempt a rollback.
Example of downgrading while rolling back through channels:
Channels:  1.32-classic/stable, 1.31-classic/stable
Segment 1: 1.32-classic/stable -> 1.31-classic/stable -> 1.32-classic/stable
Segment 2: 1.31-classic/stable -> 1.30-classic/stable -> 1.31-classic/stable