### PR TITLE
Generate and collect core dumps

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -190,6 +190,8 @@ k8s::common::execute_service() {
   declare -a args="($(cat "${SNAP_COMMON}/args/${service_name}"))"
 
   set -xe
+  ulimit -c unlimited
+  export GOTRACEBACK="crash"
   if [[ -f "${SNAP_COMMON}/args/${service_name}-env" ]]; then
     mapfile -t env_vars < "${SNAP_COMMON}/args/${service_name}-env"
     exec env -S "${env_vars[@]}" "${SNAP}/bin/${service_name}" "${args[@]}"

--- a/src/k8s/hack/dynamic-dqlite.sh
+++ b/src/k8s/hack/dynamic-dqlite.sh
@@ -92,7 +92,7 @@ if [ ! -f "${BUILD_DIR}/dqlite/libdqlite.la" ]; then
     cd dqlite
     autoreconf -i > /dev/null
     ./configure --enable-build-raft \
-      CFLAGS="-I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -Werror=implicit-function-declaration" \
+      CFLAGS=" -g -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -Werror=implicit-function-declaration" \
       LDFLAGS=" -L${BUILD_DIR}/libuv/.libs -L${BUILD_DIR}/lz4/lib -L${BUILD_DIR}/libnsl/src" \
       UV_CFLAGS="-I${BUILD_DIR}/libuv/include" \
       UV_LIBS="-L${BUILD_DIR}/libuv/.libs" \

--- a/src/k8s/hack/dynamic-go-build.sh
+++ b/src/k8s/hack/dynamic-go-build.sh
@@ -13,6 +13,5 @@ if [[ "$DEBUG_BUILD" == "y" ]]; then
 else
   go build \
   -tags dqlite,libsqlite3 \
-  -ldflags '-s -w' \
   "${@}"
 fi

--- a/src/k8s/hack/static-dqlite.sh
+++ b/src/k8s/hack/static-dqlite.sh
@@ -123,7 +123,7 @@ if [ ! -f "${BUILD_DIR}/dqlite/libdqlite.la" ]; then
     cd dqlite
     autoreconf -i > /dev/null
     ./configure --disable-shared --enable-build-raft \
-      CFLAGS="${CFLAGS} -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -I${INSTALL_DIR}/musl/include -Werror=implicit-function-declaration" \
+      CFLAGS="${CFLAGS} -g -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -I${INSTALL_DIR}/musl/include -Wno-suggest-attribute=noreturn -Werror=implicit-function-declaration" \
       LDFLAGS="${LDFLAGS} -L${BUILD_DIR}/libuv/.libs -L${BUILD_DIR}/lz4/lib -L${BUILD_DIR}/libnsl/src" \
       UV_CFLAGS="-I${BUILD_DIR}/libuv/include" \
       UV_LIBS="-L${BUILD_DIR}/libuv/.libs" \

--- a/src/k8s/hack/static-dqlite.sh
+++ b/src/k8s/hack/static-dqlite.sh
@@ -123,7 +123,7 @@ if [ ! -f "${BUILD_DIR}/dqlite/libdqlite.la" ]; then
     cd dqlite
     autoreconf -i > /dev/null
     ./configure --disable-shared --enable-build-raft \
-      CFLAGS="${CFLAGS} -g -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -I${INSTALL_DIR}/musl/include -Wno-suggest-attribute=noreturn -Werror=implicit-function-declaration" \
+      CFLAGS="${CFLAGS} -g -I${BUILD_DIR}/sqlite -I${BUILD_DIR}/libuv/include -I${BUILD_DIR}/lz4/lib -I${INSTALL_DIR}/musl/include -Werror=implicit-function-declaration" \
       LDFLAGS="${LDFLAGS} -L${BUILD_DIR}/libuv/.libs -L${BUILD_DIR}/lz4/lib -L${BUILD_DIR}/libnsl/src" \
       UV_CFLAGS="-I${BUILD_DIR}/libuv/include" \
       UV_LIBS="-L${BUILD_DIR}/libuv/.libs" \

--- a/src/k8s/hack/static-go-build.sh
+++ b/src/k8s/hack/static-go-build.sh
@@ -14,6 +14,6 @@ if [[ "$DEBUG_BUILD" == "y" ]]; then
 else
   go build \
     -tags dqlite,libsqlite3 \
-    -ldflags '-s -w --linkmode "external" -extldflags "-static"' \
+    -ldflags '--linkmode "external" -extldflags "-static"' \
     "${@}"
 fi

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -57,6 +57,8 @@ def _generate_inspection_report(h: harness.Harness, instance_id: str):
         [
             "/snap/k8s/current/k8s/scripts/inspect.sh",
             "--all-namespaces",
+            "--core-dump-dir",
+            config.CORE_DUMP_DIR,
             "/inspection-report.tar.gz",
         ],
         capture_output=True,
@@ -251,6 +253,7 @@ def instances(
                 instance.exec(["snap", "install", remote_path])
 
         if not no_setup:
+            util.setup_core_dumps(instance)
             util.setup_k8s_snap(instance, tmp_path, snap)
 
             if config.USE_LOCAL_MIRROR:

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -51,6 +51,10 @@ SUBSTRATE = os.getenv("TEST_SUBSTRATE") or "lxd"
 # after the tests complete.
 SKIP_CLEANUP = (os.getenv("TEST_SKIP_CLEANUP") or "") == "1"
 
+# Note that when using containers, this will override the host configuration.
+CORE_DUMP_PATTERN = (os.getenv("TEST_CORE_DUMP_PATTERN")) or r"core-%e.%p.%h"
+CORE_DUMP_DIR = (os.getenv("TEST_CORE_DUMP_DIR")) or "/var/crash"
+
 # INSPECTION_REPORTS_DIR is the directory where inspection reports are stored.
 # If empty, no reports are generated.
 INSPECTION_REPORTS_DIR = os.getenv("TEST_INSPECTION_REPORTS_DIR")

--- a/tests/integration/tests/test_util/harness/juju.py
+++ b/tests/integration/tests/test_util/harness/juju.py
@@ -136,6 +136,12 @@ class JujuHarness(Harness):
         check = kwargs.pop("check", True)
         stdout = kwargs.pop("stdout", None)
         stderr = kwargs.pop("stderr", None)
+
+        if ">" in " ".join(command):
+            command_str = " ".join(command)
+        else:
+            command_str = shlex.join(command)
+
         input = f" <<EOF\n{b.decode()}\nEOF" if (b := kwargs.pop("input", None)) else ""
         s_result = run(
             [
@@ -154,7 +160,7 @@ class JujuHarness(Harness):
                 "-E",
                 "bash",
                 "-c",
-                shlex.join(command) + input,
+                command_str + input,
             ],
             capture_output=True,
             check=False,

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -224,8 +224,14 @@ class LXDHarness(Harness):
             raise HarnessError(f"unknown instance {instance_id}")
 
         LOG.debug("Execute command %s in instance %s", command, instance_id)
+
+        if ">" in " ".join(command):
+            command_str = " ".join(command)
+        else:
+            command_str = shlex.join(command)
+
         return run(
-            ["lxc", "shell", instance_id, "--", "bash", "-c", shlex.join(command)],
+            ["lxc", "shell", instance_id, "--", "bash", "-c", command_str],
             **kwargs,
         )
 

--- a/tests/integration/tests/test_util/harness/multipass.py
+++ b/tests/integration/tests/test_util/harness/multipass.py
@@ -106,6 +106,12 @@ class MultipassHarness(Harness):
             raise HarnessError(f"unknown instance {instance_id}")
 
         LOG.debug("Execute command %s in instance %s", command, instance_id)
+
+        if ">" in " ".join(command):
+            command_str = " ".join(command)
+        else:
+            command_str = shlex.join(command)
+
         return run(
             [
                 "multipass",
@@ -115,7 +121,7 @@ class MultipassHarness(Harness):
                 "sudo",
                 "bash",
                 "-c",
-                shlex.join(command),
+                command_str,
             ],
             **kwargs,
         )

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -4,6 +4,7 @@
 import ipaddress
 import json
 import logging
+import os
 import re
 import shlex
 import subprocess
@@ -159,6 +160,14 @@ def _as_int(value: Optional[str]) -> Optional[int]:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def setup_core_dumps(instance: harness.Instance):
+    core_pattern = os.path.join(config.CORE_DUMP_DIR, config.CORE_DUMP_PATTERN)
+    LOG.info("Configuring core dumps. Pattern: %s", core_pattern)
+    instance.exec(["echo", core_pattern, ">", "/proc/sys/kernel/core_pattern"])
+    instance.exec(["echo", "1", ">", "/proc/sys/fs/suid_dumpable"])
+    instance.exec(["snap", "set", "system", "system.coredump.enable=true"])
 
 
 def setup_k8s_snap(


### PR DESCRIPTION
We need core dumps in order to effectively debug crashes, especially the ones caused by external C libraries such as dqlite.

The service start wrapper will now set ``GOTRACEBACK=crash`` and adjust the core dump limit.

We'll also need debug symbols in order to make use of the collected core dumps, which is why we'll include debug symbols even for release builds. This increases the snap size from 107MB to 135MB, which seems reasonable.

``inspect.sh`` as well as the e2e tests are updated to collect the core dumps. The core dump location defaults to /var/crash.
