### PR TITLE
Add k8s inspect command

### DIFF
--- a/docs/src/_parts/commands/k8s.md
+++ b/docs/src/_parts/commands/k8s.md
@@ -16,6 +16,7 @@ Canonical Kubernetes CLI
 * [k8s enable](k8s_enable.md)	 - Enable core cluster features
 * [k8s get](k8s_get.md)	 - Get cluster configuration
 * [k8s get-join-token](k8s_get-join-token.md)	 - Create a token for a node to join the cluster
+* [k8s inspect](k8s_inspect.md)	 - Generate inspection report
 * [k8s join-cluster](k8s_join-cluster.md)	 - Join a cluster using the provided token
 * [k8s kubectl](k8s_kubectl.md)	 - Integrated Kubernetes kubectl client
 * [k8s refresh-certs](k8s_refresh-certs.md)	 - Refresh the certificates of the running node

--- a/docs/src/_parts/commands/k8s_inspect.md
+++ b/docs/src/_parts/commands/k8s_inspect.md
@@ -21,6 +21,7 @@ Arguments:
                           from snap services. Default: 100000.
   --timeout               (Optional) The maximum time in seconds to wait for a command.
                           Default: 180s.
+  --core-dump-dir         (Optional) Core dump location. Default: /var/crash.
 
 
 ```

--- a/docs/src/_parts/commands/k8s_inspect.md
+++ b/docs/src/_parts/commands/k8s_inspect.md
@@ -1,20 +1,10 @@
-package k8s
+## k8s inspect
 
-import (
-	"syscall"
+Generate inspection report
 
-	cmdutil "github.com/canonical/k8s/cmd/util"
-	"github.com/spf13/cobra"
-)
+### Synopsis
 
-func newInspectCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
-	// We're copying the help string from the "inspect.sh" script with
-	// only minor adjustments. At the same time, we'll avoid parsing the
-	// same arguments twice.
-	return &cobra.Command{
-		Use:   "inspect <output-file>",
-		Short: "Generate inspection report",
-		Long: `
+
 This command collects diagnostics and other relevant information from a Kubernetes
 node (either control-plane or worker node) and compiles them into a tarball report.
 The collected data includes service arguments, Kubernetes cluster info, SBOM, system
@@ -31,21 +21,19 @@ Arguments:
                           from snap services. Default: 100000.
   --timeout               (Optional) The maximum time in seconds to wait for a command.
                           Default: 180s.
-`,
-		DisableFlagParsing: true,
-		PreRun:             chainPreRunHooks(hookRequireRoot(env)),
-		Run: func(cmd *cobra.Command, args []string) {
-			inspectScriptPath := env.Snap.K8sInspectScriptPath()
 
-			command := append([]string{inspectScriptPath}, args...)
-			environ := cmdutil.EnvironWithDefaults(
-				env.Environ,
-			)
-			if err := syscall.Exec(inspectScriptPath, command, environ); err != nil {
-				cmd.PrintErrf("Failed to run %s.\n\nError: %v\n", command, err)
-				env.Exit(1)
-				return
-			}
-		},
-	}
-}
+
+```
+k8s inspect <output-file> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for inspect
+```
+
+### SEE ALSO
+
+* [k8s](k8s.md)	 - Canonical Kubernetes CLI
+

--- a/docs/src/_parts/commands/k8s_inspect.md
+++ b/docs/src/_parts/commands/k8s_inspect.md
@@ -12,7 +12,7 @@ diagnostics, network diagnostics, and more. The command needs to be run with
 elevated permissions (sudo).
 
 Arguments:
-  output_file             (Optional) The full path and filename for the generated tarball.
+  output-file             (Optional) The full path and filename for the generated tarball.
                           If not provided, a default filename based on the current date
                           and time will be used.
   --all-namespaces        (Optional) Acquire detailed debugging information, including logs

--- a/docs/src/charm/howto/troubleshooting.md
+++ b/docs/src/charm/howto/troubleshooting.md
@@ -201,17 +201,17 @@ kubectl --kubeconfig cluster-kubeconfig.yaml logs <pod-name> -n <namespace>
 You can check out the upstream [debug pods documentation][] for more
 information.
 
-## Use the built-in inspection script
+## Use the built-in inspection command
 
-{{product}} ships with a script to compile a complete report on {{product}} and
+{{product}} ships with a command to compile a complete report on {{product}} and
 its underlying system. This is an essential tool for bug reports and for
 investigating whether a system is (or isn’t) working.
 
-Inspection script can be executed on a specific unit by running the following
+The inspection command can be executed on a specific unit by running the following
 commands:
 
 ```
-juju exec --unit <k8s/unit#> -- sudo /snap/k8s/current/k8s/scripts/inspect.sh /home/ubuntu/inspection-report.tar.gz
+juju exec --unit <k8s/unit#> -- sudo k8s inspect /home/ubuntu/inspection-report.tar.gz
 juju scp <k8s/unit#>:/home/ubuntu/inspection-report.tar.gz ./
 ```
 

--- a/docs/src/snap/howto/troubleshooting.md
+++ b/docs/src/snap/howto/troubleshooting.md
@@ -175,17 +175,17 @@ sudo k8s kubectl logs <pod-name> -n <namespace>
 You can check out the upstream [debug pods documentation][] for more
 information.
 
-## Using the built-in inspection script
+## Using the built-in inspection command
 
-{{product}} ships with a script to compile a complete report on {{product}} and
+{{product}} ships with a command to compile a complete report on {{product}} and
 its underlying system. This is an essential tool for bug reports and for
 investigating whether a system is (or isn’t) working.
 
-Run the inspection script, by entering the command (admin privileges are
+Run the inspection command, by entering the command (admin privileges are
 required to collect all the data):
 
 ```
-sudo /snap/k8s/current/k8s/scripts/inspect.sh
+sudo k8s inspect
 ```
 
 The command output is similar to the following:

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -88,6 +88,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		newRefreshCertsCmd(env),
 		newSetCmd(env),
 		newGetCmd(env),
+		newInspectCmd(env),
 	)
 
 	// hidden commands

--- a/src/k8s/cmd/k8s/k8s_inspect.go
+++ b/src/k8s/cmd/k8s/k8s_inspect.go
@@ -31,6 +31,7 @@ Arguments:
                           from snap services. Default: 100000.
   --timeout               (Optional) The maximum time in seconds to wait for a command.
                           Default: 180s.
+  --core-dump-dir         (Optional) Core dump location. Default: /var/crash.
 `,
 		DisableFlagParsing: true,
 		PreRun:             chainPreRunHooks(hookRequireRoot(env)),

--- a/src/k8s/cmd/k8s/k8s_inspect.go
+++ b/src/k8s/cmd/k8s/k8s_inspect.go
@@ -1,0 +1,51 @@
+package k8s
+
+import (
+    "syscall"
+
+    cmdutil "github.com/canonical/k8s/cmd/util"
+    "github.com/spf13/cobra"
+)
+
+func newInspectCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+    // We're copying the help string from the "inspect.sh" script with
+    // only minor adjustments. At the same time, we'll avoid parsing the
+    // same arguments twice.
+    return &cobra.Command{
+        Use:                "inspect <output-file>",
+        Short:              "generate inspection report",
+        Long: `
+This command collects diagnostics and other relevant information from a Kubernetes
+node (either control-plane or worker node) and compiles them into a tarball report.
+The collected data includes service arguments, Kubernetes cluster info, SBOM, system
+diagnostics, network diagnostics, and more. The command needs to be run with
+elevated permissions (sudo).
+
+Arguments:
+  output_file             (Optional) The full path and filename for the generated tarball.
+                          If not provided, a default filename based on the current date
+                          and time will be used.
+  --all-namespaces        (Optional) Acquire detailed debugging information, including logs
+                          from all Kubernetes namespaces.
+  --num-snap-log-entries  (Optional) The maximum number of log entries to collect
+                          from snap services. Default: 100000.
+  --timeout               (Optional) The maximum time in seconds to wait for a command.
+                          Default: 180s.
+`,
+        DisableFlagParsing: true,
+        PreRun:             chainPreRunHooks(hookRequireRoot(env)),
+        Run: func(cmd *cobra.Command, args []string) {
+            inspectScriptPath := env.Snap.K8sInspectScriptPath()
+
+            command := append([]string{inspectScriptPath}, args...)
+            environ := cmdutil.EnvironWithDefaults(
+                env.Environ,
+            )
+            if err := syscall.Exec(inspectScriptPath, command, environ); err != nil {
+                cmd.PrintErrf("Failed to run %s.\n\nError: %v\n", command, err)
+                env.Exit(1)
+                return
+            }
+        },
+    }
+}

--- a/src/k8s/cmd/k8s/k8s_inspect.go
+++ b/src/k8s/cmd/k8s/k8s_inspect.go
@@ -22,7 +22,7 @@ diagnostics, network diagnostics, and more. The command needs to be run with
 elevated permissions (sudo).
 
 Arguments:
-  output_file             (Optional) The full path and filename for the generated tarball.
+  output-file             (Optional) The full path and filename for the generated tarball.
                           If not provided, a default filename based on the current date
                           and time will be used.
   --all-namespaces        (Optional) Acquire detailed debugging information, including logs

--- a/src/k8s/cmd/k8s/k8s_inspect.go
+++ b/src/k8s/cmd/k8s/k8s_inspect.go
@@ -1,20 +1,20 @@
 package k8s
 
 import (
-    "syscall"
+	"syscall"
 
-    cmdutil "github.com/canonical/k8s/cmd/util"
-    "github.com/spf13/cobra"
+	cmdutil "github.com/canonical/k8s/cmd/util"
+	"github.com/spf13/cobra"
 )
 
 func newInspectCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
-    // We're copying the help string from the "inspect.sh" script with
-    // only minor adjustments. At the same time, we'll avoid parsing the
-    // same arguments twice.
-    return &cobra.Command{
-        Use:                "inspect <output-file>",
-        Short:              "generate inspection report",
-        Long: `
+	// We're copying the help string from the "inspect.sh" script with
+	// only minor adjustments. At the same time, we'll avoid parsing the
+	// same arguments twice.
+	return &cobra.Command{
+		Use:   "inspect <output-file>",
+		Short: "generate inspection report",
+		Long: `
 This command collects diagnostics and other relevant information from a Kubernetes
 node (either control-plane or worker node) and compiles them into a tarball report.
 The collected data includes service arguments, Kubernetes cluster info, SBOM, system
@@ -32,20 +32,20 @@ Arguments:
   --timeout               (Optional) The maximum time in seconds to wait for a command.
                           Default: 180s.
 `,
-        DisableFlagParsing: true,
-        PreRun:             chainPreRunHooks(hookRequireRoot(env)),
-        Run: func(cmd *cobra.Command, args []string) {
-            inspectScriptPath := env.Snap.K8sInspectScriptPath()
+		DisableFlagParsing: true,
+		PreRun:             chainPreRunHooks(hookRequireRoot(env)),
+		Run: func(cmd *cobra.Command, args []string) {
+			inspectScriptPath := env.Snap.K8sInspectScriptPath()
 
-            command := append([]string{inspectScriptPath}, args...)
-            environ := cmdutil.EnvironWithDefaults(
-                env.Environ,
-            )
-            if err := syscall.Exec(inspectScriptPath, command, environ); err != nil {
-                cmd.PrintErrf("Failed to run %s.\n\nError: %v\n", command, err)
-                env.Exit(1)
-                return
-            }
-        },
-    }
+			command := append([]string{inspectScriptPath}, args...)
+			environ := cmdutil.EnvironWithDefaults(
+				env.Environ,
+			)
+			if err := syscall.Exec(inspectScriptPath, command, environ); err != nil {
+				cmd.PrintErrf("Failed to run %s.\n\nError: %v\n", command, err)
+				env.Exit(1)
+				return
+			}
+		},
+	}
 }

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -49,7 +49,7 @@ type Snap interface {
 	ContainerdSocketPath() string        // classic confinement: /run/containerd/containerd.sock, strict confinement: /var/snap/k8s/common/run/containerd/containerd.sock
 	ContainerdStateDir() string          // classic confinement: /run/containerd, strict confinement: /var/snap/k8s/common/run/containerd
 
-	K8sScriptsDir() string 		  //  /snap/k8s/current/k8s/scripts
+	K8sScriptsDir() string        //  /snap/k8s/current/k8s/scripts
 	K8sInspectScriptPath() string //  /snap/k8s/current/k8s/scripts/inspect.sh
 
 	K8sdStateDir() string      // /var/snap/k8s/common/var/lib/k8sd/state

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -49,6 +49,9 @@ type Snap interface {
 	ContainerdSocketPath() string        // classic confinement: /run/containerd/containerd.sock, strict confinement: /var/snap/k8s/common/run/containerd/containerd.sock
 	ContainerdStateDir() string          // classic confinement: /run/containerd, strict confinement: /var/snap/k8s/common/run/containerd
 
+	K8sScriptsDir() string 		  //  /snap/k8s/current/k8s/scripts
+	K8sInspectScriptPath() string //  /snap/k8s/current/k8s/scripts/inspect.sh
+
 	K8sdStateDir() string      // /var/snap/k8s/common/var/lib/k8sd/state
 	K8sDqliteStateDir() string // /var/snap/k8s/common/var/lib/k8s-dqlite
 

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -35,7 +35,7 @@ type Mock struct {
 	ContainerdSocketDir         string
 	ContainerdSocketPath        string
 	ContainerdStateDir          string
-	K8sScriptsDir			    string
+	K8sScriptsDir               string
 	K8sInspectScriptPath        string
 	K8sdStateDir                string
 	K8sDqliteStateDir           string
@@ -177,7 +177,6 @@ func (s *snap) K8sScriptsDir() string {
 func (s *snap) K8sInspectScriptPath() string {
 	return s.Mock.K8sInspectScriptPath
 }
-
 
 func (s *Snap) KubernetesConfigDir() string {
 	return s.Mock.KubernetesConfigDir

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -170,11 +170,11 @@ func (s *Snap) ContainerdRegistryConfigDir() string {
 	return s.Mock.ContainerdRegistryConfigDir
 }
 
-func (s *snap) K8sScriptsDir() string {
+func (s *Snap) K8sScriptsDir() string {
 	return s.Mock.K8sScriptsDir
 }
 
-func (s *snap) K8sInspectScriptPath() string {
+func (s *Snap) K8sInspectScriptPath() string {
 	return s.Mock.K8sInspectScriptPath
 }
 

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -35,6 +35,8 @@ type Mock struct {
 	ContainerdSocketDir         string
 	ContainerdSocketPath        string
 	ContainerdStateDir          string
+	K8sScriptsDir			    string
+	K8sInspectScriptPath        string
 	K8sdStateDir                string
 	K8sDqliteStateDir           string
 	ServiceArgumentsDir         string
@@ -167,6 +169,15 @@ func (s *Snap) ContainerdExtraConfigDir() string {
 func (s *Snap) ContainerdRegistryConfigDir() string {
 	return s.Mock.ContainerdRegistryConfigDir
 }
+
+func (s *snap) K8sScriptsDir() string {
+	return s.Mock.K8sScriptsDir
+}
+
+func (s *snap) K8sInspectScriptPath() string {
+	return s.Mock.K8sInspectScriptPath
+}
+
 
 func (s *Snap) KubernetesConfigDir() string {
 	return s.Mock.KubernetesConfigDir

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -286,6 +286,14 @@ func (s *snap) ContainerdRegistryConfigDir() string {
 	return filepath.Join(s.containerdBaseDir, "etc", "containerd", "hosts.d")
 }
 
+func (s *snap) K8sScriptsDir() string {
+	return filepath.Join(s.snapDir, "k8s", "scripts")
+}
+
+func (s *snap) K8sInspectScriptPath() string {
+	return filepath.Join(s.K8sScriptsDir(), "inspect.sh")
+}
+
 func (s *snap) restClientGetter(path string, namespace string) genericclioptions.RESTClientGetter {
 	flags := &genericclioptions.ConfigFlags{
 		KubeConfig: utils.Pointer(path),


### PR DESCRIPTION
We're adding a "k8s inspect" command that will invoke the "inspect.sh" script, aiming to improve the user experience.

Note that we'll avoid parsing the arguments twice since that's unnecessary and would complicate the process of adding new parameters.