### PR TITLE
[Docs] add dqlite configuration to troubleshooting page

### DIFF
--- a/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
+++ b/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
@@ -376,3 +376,4 @@ DTMs
 cybersecurity
 uid
 runc
+unoptimized

--- a/docs/src/snap/reference/troubleshooting.md
+++ b/docs/src/snap/reference/troubleshooting.md
@@ -145,7 +145,7 @@ snapshot:
 Restart dqlite:
 
 ```
-sudo k8s restart k8s-dqlite
+sudo snap restart snap.k8s.k8s-dqlite
 ```
 
 Work is being done to make these configuration changes dynamic in future

--- a/docs/src/snap/reference/troubleshooting.md
+++ b/docs/src/snap/reference/troubleshooting.md
@@ -130,7 +130,7 @@ node to lag behind the leader before it consumes the updated snapshot of the
 leader. Currently, the default snapshot configuration is 1024 for the
 threshold and 8192 for trailing which is too large for small clusters. Only
 setting the trailing parameter in a configuration yaml automatically sets the
-threshold to 0 leading to a snapshot being taken every transaction and 
+threshold to 0. This leads to a snapshot being taken every transaction and 
 increased CPU usage.
 
 ### Solution

--- a/docs/src/snap/reference/troubleshooting.md
+++ b/docs/src/snap/reference/troubleshooting.md
@@ -117,7 +117,7 @@ EOF
 ### Problem
 
 The datastore used for {{product}} dqlite, reported an [issue #196] of increased
-memory and CPU usage over time. This was particually evident in smaller
+memory and CPU usage over time. This was particularly evident in smaller
 clusters.
 
 ### Explanation
@@ -134,7 +134,7 @@ Apply a tuning.yaml custom configuration to the dqlite datastore in order to
 adjust the trailing and threshold snapshot values. The trailing parameter
 should be twice to four times the threshold value. Create the tuning.yaml
 file and place it in the dqlite directory
-`/var/snap/microk8s/current/var/kubernetes/backend/tuning.yaml`:
+`/var/snap/k8s/common/var/lib/k8s-dqlite/tuning.yaml`:
 
 ```
 snapshot:
@@ -145,7 +145,7 @@ snapshot:
 Restart dqlite:
 
 ```
-sudo snap restart microk8s.daemon-k8s-dqlite
+sudo k8s restart k8s-dqlite
 ```
 
 Work is being done to make these configuration changes dynamic in future

--- a/docs/src/snap/reference/troubleshooting.md
+++ b/docs/src/snap/reference/troubleshooting.md
@@ -112,44 +112,46 @@ containerd-base-dir: $containerdBaseDir
 EOF
 ```
 
-## Increased memory and CPU usage in dqlite
+## Increased memory usage in Dqlite
 
 ### Problem
 
-The datastore used for {{product}} dqlite, reported an [issue #196] of increased
-memory and CPU usage over time. This was particularly evident in smaller
-clusters.
+The datastore used for {{product}} Dqlite, reported an [issue #196] of increased
+memory usage over time. This was particularly evident in smaller clusters.
 
 ### Explanation
 
-This issue was caused due to an unoptimized configuration of dqlite for smaller
-clusters. Currently, the default snapshot configuration is 1024 for the
+This issue was caused due to an inefficient resource configuration of 
+Dqlite for smaller clusters. The threshold and trailing parameters are 
+related to Dqlite transactions and must be adjusted. The threshold is 
+the number of transactions we allow before a snapshot is taken of the 
+leader. The trailing is the number of transactions we allow the follower 
+node to lag behind the leader before it consumes the updated snapshot of the 
+leader. Currently, the default snapshot configuration is 1024 for the
 threshold and 8192 for trailing which is too large for small clusters. Only
 setting the trailing parameter in a configuration yaml automatically sets the
-threshold to 0 leading to increased CPU usage.
+threshold to 0 leading to a snapshot being taken every transaction and increased 
+CPU usage.
 
 ### Solution
 
-Apply a tuning.yaml custom configuration to the dqlite datastore in order to
+Apply a tuning.yaml custom configuration to the Dqlite datastore in order to
 adjust the trailing and threshold snapshot values. The trailing parameter
-should be twice to four times the threshold value. Create the tuning.yaml
-file and place it in the dqlite directory
+should be twice the threshold value. Create the tuning.yaml
+file and place it in the Dqlite directory
 `/var/snap/k8s/common/var/lib/k8s-dqlite/tuning.yaml`:
 
 ```
 snapshot:
-  trailing: 512
-  threshold: 384
+  trailing: 1024
+  threshold: 512
 ```
 
-Restart dqlite:
+Restart Dqlite:
 
 ```
 sudo snap restart snap.k8s.k8s-dqlite
 ```
-
-Work is being done to make these configuration changes dynamic in future
-releases.
 
 <!-- LINKS -->
 

--- a/docs/src/snap/reference/troubleshooting.md
+++ b/docs/src/snap/reference/troubleshooting.md
@@ -130,8 +130,8 @@ node to lag behind the leader before it consumes the updated snapshot of the
 leader. Currently, the default snapshot configuration is 1024 for the
 threshold and 8192 for trailing which is too large for small clusters. Only
 setting the trailing parameter in a configuration yaml automatically sets the
-threshold to 0 leading to a snapshot being taken every transaction and increased 
-CPU usage.
+threshold to 0 leading to a snapshot being taken every transaction and 
+increased CPU usage.
 
 ### Solution
 


### PR DESCRIPTION
There was an issue brought up on the dqlite repo about mis-configuration of small clusters appearing as memory leaks. Adding this to the troubleshooting page. 