### PR TITLE
inspect.sh: avoid logging an error if there are no core dumps

### DIFF
--- a/k8s/scripts/inspect.sh
+++ b/k8s/scripts/inspect.sh
@@ -189,12 +189,12 @@ function collect_registry_mirror_logs {
 
 function collect_core_dumps {
   mkdir -p "$INSPECT_DUMP/core_dumps"
-  if [[ -d $CORE_DUMP_DIR ]]; then
+  if [[ -d $CORE_DUMP_DIR && ! -z `ls -A $CORE_DUMP_DIR` ]]; then
     local dump_dir_size=`du -sh $CORE_DUMP_DIR`
     log_info "Collecting core dumps from $CORE_DUMP_DIR. Size: $dump_dir_size"
     cp $CORE_DUMP_DIR/* "$INSPECT_DUMP/core_dumps/"
   else
-    log_info "Core dump directory missing, skipping..."
+    log_info "Core dump directory empty or missing, skipping..."
   fi
 }
 

--- a/k8s/scripts/inspect.sh
+++ b/k8s/scripts/inspect.sh
@@ -189,8 +189,8 @@ function collect_registry_mirror_logs {
 
 function collect_core_dumps {
   mkdir -p "$INSPECT_DUMP/core_dumps"
-  if [[ -d $CORE_DUMP_DIR && ! -z `ls -A $CORE_DUMP_DIR` ]]; then
-    local dump_dir_size=`du -sh $CORE_DUMP_DIR`
+  if [[ -d $CORE_DUMP_DIR && ! -z $(ls -A $CORE_DUMP_DIR) ]]; then
+    local dump_dir_size=$(du -sh $CORE_DUMP_DIR)
     log_info "Collecting core dumps from $CORE_DUMP_DIR. Size: $dump_dir_size"
     cp $CORE_DUMP_DIR/* "$INSPECT_DUMP/core_dumps/"
   else


### PR DESCRIPTION
The inspect.sh script will log an error if the core dump dir is empty. We'll add a check to improve the user experience.

   INFO:  Copy dmesg entries
   INFO:  Collecting core dumps from /var/crash. Size: 4.0K    /var/crash
   cp: cannot stat '/var/crash/*': No such file or directory
   Collecting snap and related information