### PR TITLE
Enrich node configuration controller tests with signed configmaps

### DIFF
--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -60,62 +60,6 @@ func TestConfigPropagation(t *testing.T) {
 			expectRestart: true,
 		},
 		{
-			name: "InitialWithSignature",
-			configmap: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
-				Data: map[string]string{
-					"cluster-dns":    "10.152.1.1",
-					"cluster-domain": "test-cluster.local",
-					"cloud-provider": "provider",
-				},
-			},
-			expectArgs: map[string]string{
-				"--cluster-dns":    "10.152.1.1",
-				"--cluster-domain": "test-cluster.local",
-				"--cloud-provider": "provider",
-			},
-			privKey:       privKey,
-			pubKey:        &privKey.PublicKey,
-			expectRestart: true,
-		},
-		{
-			name: "InitialExpectedSignature",
-			configmap: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
-				Data: map[string]string{
-					"cluster-dns":    "10.152.1.1",
-					"cluster-domain": "test-cluster.local",
-					"cloud-provider": "provider",
-				},
-			},
-			expectArgs: map[string]string{
-				"--cluster-dns":    "10.152.1.1",
-				"--cluster-domain": "test-cluster.local",
-				"--cloud-provider": "provider",
-			},
-			pubKey:        &privKey.PublicKey,
-			expectRestart: false,
-		},
-		{
-			name: "InitialInvalidSignature",
-			configmap: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
-				Data: map[string]string{
-					"cluster-dns":    "10.152.1.1",
-					"cluster-domain": "test-cluster.local",
-					"cloud-provider": "provider",
-				},
-			},
-			expectArgs: map[string]string{
-				"--cluster-dns":    "10.152.1.1",
-				"--cluster-domain": "test-cluster.local",
-				"--cloud-provider": "provider",
-			},
-			privKey:       wrongPrivKey,
-			pubKey:        &privKey.PublicKey,
-			expectRestart: false,
-		},
-		{
 			name: "IgnoreUnknownFields",
 			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
@@ -175,6 +119,62 @@ func TestConfigPropagation(t *testing.T) {
 				"--cluster-dns":    "10.152.1.3",
 				"--cloud-provider": "provider",
 			},
+		},
+		{
+			name: "WithSignature",
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+				Data: map[string]string{
+					"cluster-dns":    "10.152.1.1",
+					"cluster-domain": "test-cluster.local",
+					"cloud-provider": "provider",
+				},
+			},
+			expectArgs: map[string]string{
+				"--cluster-dns":    "10.152.1.1",
+				"--cluster-domain": "test-cluster.local",
+				"--cloud-provider": "provider",
+			},
+			privKey:       privKey,
+			pubKey:        &privKey.PublicKey,
+			expectRestart: true,
+		},
+		{
+			name: "ExpectedSignature",
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+				Data: map[string]string{
+					"cluster-dns":    "10.152.1.1",
+					"cluster-domain": "test-cluster.local",
+					"cloud-provider": "provider",
+				},
+			},
+			expectArgs: map[string]string{
+				"--cluster-dns":    "10.152.1.1",
+				"--cluster-domain": "test-cluster.local",
+				"--cloud-provider": "provider",
+			},
+			pubKey:        &privKey.PublicKey,
+			expectRestart: false,
+		},
+		{
+			name: "InvalidSignature",
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+				Data: map[string]string{
+					"cluster-dns":    "10.152.1.1",
+					"cluster-domain": "test-cluster.local",
+					"cloud-provider": "provider",
+				},
+			},
+			expectArgs: map[string]string{
+				"--cluster-dns":    "10.152.1.1",
+				"--cluster-domain": "test-cluster.local",
+				"--cloud-provider": "provider",
+			},
+			privKey:       wrongPrivKey,
+			pubKey:        &privKey.PublicKey,
+			expectRestart: false,
 		},
 	}
 

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -140,7 +140,7 @@ func TestConfigPropagation(t *testing.T) {
 			expectRestart: true,
 		},
 		{
-			name: "ExpectedSignature",
+			name: "MissingPrivKey",
 			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
 				Data: map[string]string{

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -145,7 +145,7 @@ func TestConfigPropagation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
 				Data: map[string]string{
 					"cluster-dns":    "10.152.1.1",
-					"cluster-domain": "test-cluster.local",
+					"cluster-domain": "test-cluster2.local",
 					"cloud-provider": "provider",
 				},
 			},
@@ -163,7 +163,7 @@ func TestConfigPropagation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
 				Data: map[string]string{
 					"cluster-dns":    "10.152.1.1",
-					"cluster-domain": "test-cluster.local",
+					"cluster-domain": "test-cluster2.local",
 					"cloud-provider": "provider",
 				},
 			},

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/rsa"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/canonical/k8s/pkg/client/kubernetes"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/snap/mock"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	. "github.com/onsi/gomega"
@@ -26,11 +28,19 @@ func TestConfigPropagation(t *testing.T) {
 
 	g := NewWithT(t)
 
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	wrongPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	g.Expect(err).To(Not(HaveOccurred()))
+
 	tests := []struct {
 		name          string
 		configmap     *corev1.ConfigMap
 		expectArgs    map[string]string
 		expectRestart bool
+		privKey       *rsa.PrivateKey
+		pubKey        *rsa.PublicKey
 	}{
 		{
 			name: "Initial",
@@ -48,6 +58,62 @@ func TestConfigPropagation(t *testing.T) {
 				"--cloud-provider": "provider",
 			},
 			expectRestart: true,
+		},
+		{
+			name: "InitialWithSignature",
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+				Data: map[string]string{
+					"cluster-dns":    "10.152.1.1",
+					"cluster-domain": "test-cluster.local",
+					"cloud-provider": "provider",
+				},
+			},
+			expectArgs: map[string]string{
+				"--cluster-dns":    "10.152.1.1",
+				"--cluster-domain": "test-cluster.local",
+				"--cloud-provider": "provider",
+			},
+			privKey:       privKey,
+			pubKey:        &privKey.PublicKey,
+			expectRestart: true,
+		},
+		{
+			name: "InitialExpectedSignature",
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+				Data: map[string]string{
+					"cluster-dns":    "10.152.1.1",
+					"cluster-domain": "test-cluster.local",
+					"cloud-provider": "provider",
+				},
+			},
+			expectArgs: map[string]string{
+				"--cluster-dns":    "10.152.1.1",
+				"--cluster-domain": "test-cluster.local",
+				"--cloud-provider": "provider",
+			},
+			pubKey:        &privKey.PublicKey,
+			expectRestart: false,
+		},
+		{
+			name: "InitialInvalidSignature",
+			configmap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+				Data: map[string]string{
+					"cluster-dns":    "10.152.1.1",
+					"cluster-domain": "test-cluster.local",
+					"cloud-provider": "provider",
+				},
+			},
+			expectArgs: map[string]string{
+				"--cluster-dns":    "10.152.1.1",
+				"--cluster-domain": "test-cluster.local",
+				"--cloud-provider": "provider",
+			},
+			privKey:       wrongPrivKey,
+			pubKey:        &privKey.PublicKey,
+			expectRestart: false,
 		},
 		{
 			name: "IgnoreUnknownFields",
@@ -129,8 +195,9 @@ func TestConfigPropagation(t *testing.T) {
 
 	ctrl := NewNodeConfigurationController(s, func() {})
 
-	// TODO: add test with signing key
-	go ctrl.Run(ctx, func(ctx context.Context) (*rsa.PublicKey, error) { return nil, nil })
+	keyCh := make(chan *rsa.PublicKey)
+
+	go ctrl.Run(ctx, func(ctx context.Context) (*rsa.PublicKey, error) { return <-keyCh, nil })
 	defer watcher.Stop()
 
 	for _, tc := range tests {
@@ -139,7 +206,17 @@ func TestConfigPropagation(t *testing.T) {
 
 			g := NewWithT(t)
 
+			if tc.privKey != nil {
+				kubelet, err := types.KubeletFromConfigMap(tc.configmap.Data, nil)
+				g.Expect(err).To(Not(HaveOccurred()))
+
+				tc.configmap.Data, err = kubelet.ToConfigMap(tc.privKey)
+				g.Expect(err).To(Not(HaveOccurred()))
+			}
+
 			watcher.Add(tc.configmap)
+
+			keyCh <- tc.pubKey
 
 			// TODO: this is to ensure that the controller has handled the event. This should ideally
 			// be replaced with something like a "<-sentCh" instead


### PR DESCRIPTION
This PR suggests some more tests cases to include scenarios where configmaps are signed 