### PR TITLE
doc: add link to dev env guide

### DIFF
--- a/docs/src/snap/howto/install/index.md
+++ b/docs/src/snap/howto/install/index.md
@@ -17,5 +17,6 @@ the current How-to guides below.
 ... with Multipass <multipass>
 ... in LXD <lxd.md>
 ... in air-gapped environments <offline.md>
+... in a development environment <dev-env.md>
 Uninstall the snap <uninstall.md>
 ```


### PR DESCRIPTION
We have a document describing how to install k8s-snap in dev environments that are likely to contain conflicting software such as Docker or containerd.

We need to add a link to the corresponding index page.