### PR TITLE
Remove obsolete loadbalancer feature check

### DIFF
--- a/src/k8s/pkg/k8sd/types/cluster_config_merge_test.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_merge_test.go
@@ -290,17 +290,6 @@ func TestMergeClusterConfig_Scenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "LoadBalancer/NeedNetwork",
-			old: types.ClusterConfig{
-				Network:      types.Network{Enabled: utils.Pointer(true)},
-				LoadBalancer: types.LoadBalancer{Enabled: utils.Pointer(true)},
-			},
-			new: types.ClusterConfig{
-				Network: types.Network{Enabled: utils.Pointer(false)},
-			},
-			expectErr: true,
-		},
-		{
 			name: "LoadBalancer/DisableWithNetwork",
 			old: types.ClusterConfig{
 				Network:      types.Network{Enabled: utils.Pointer(true)},

--- a/src/k8s/pkg/k8sd/types/cluster_config_validate.go
+++ b/src/k8s/pkg/k8sd/types/cluster_config_validate.go
@@ -105,9 +105,6 @@ func (c *ClusterConfig) Validate() error {
 		if c.Gateway.GetEnabled() {
 			return fmt.Errorf("gateway requires network to be enabled")
 		}
-		if c.LoadBalancer.GetEnabled() {
-			return fmt.Errorf("load-balancer requires network to be enabled")
-		}
 		if c.Ingress.GetEnabled() {
 			return fmt.Errorf("ingress requires network to be enabled")
 		}


### PR DESCRIPTION
Historically, we used the Cilium loadbalancer for the loadbalancer feature. With the move to Metallb, the dependency to the network feature is no longer required.