### PR TITLE
donotmerge: debug cilium (use etcd)

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} -k test_no_remove
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} -k test_etcd
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} -k test_no_remove
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -10,9 +10,9 @@ on:
       - autoupdate/moonray
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+  # pull_request:
+  #   paths-ignore:
+  #     - 'docs/**'
 
 permissions:
   contents: read

--- a/k8s/scripts/inspect.sh
+++ b/k8s/scripts/inspect.sh
@@ -31,7 +31,7 @@ TIMEOUT_LOG="$INSPECT_DUMP"/timeout_warnings.log
 # We won't fetch all namespaces by default to avoid logging potentially sensitive
 # user data.
 ALL_NAMESPACES=0
-NUM_SNAP_LOG_ENTRIES=100000
+NUM_SNAP_LOG_ENTRIES=1000000
 TIMEOUT=180s
 CORE_DUMP_DIR="/var/crash"
 

--- a/tests/integration/templates/bootstrap-no-k8s-node-remove.yaml
+++ b/tests/integration/templates/bootstrap-no-k8s-node-remove.yaml
@@ -7,3 +7,13 @@ cluster-config:
     enabled: true
   annotations:
     k8sd/v1alpha/lifecycle/skip-cleanup-kubernetes-node-on-remove: true
+extra-node-containerd-args:
+  --log-level: debug
+extra-node-kubelet-args:
+  --v: "6"
+extra-node-kube-apiserver-args:
+  --v: "6"
+extra-node-kube-controller-manager-args:
+  --v: "6"
+extra-node-kube-scheduler-args:
+  --v: "6"

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -24,11 +24,12 @@ def test_no_remove(instances: List[harness.Instance]):
     join_token = util.get_join_token(cluster_node, joining_cp)
     join_token_2 = util.get_join_token(cluster_node, joining_cp_2)
     join_token_worker = util.get_join_token(cluster_node, joining_worker, "--worker")
+
     util.join_cluster(joining_cp, join_token)
     util.wait_until_k8s_ready(cluster_node, [joining_cp])
     util.join_cluster(joining_cp_2, join_token_2)
     util.wait_until_k8s_ready(cluster_node, [joining_cp, joining_cp_2])
-    util.join_cluster(joining_worker, join_token_worker)
+    util.join_cluster(joining_worker, join_token_worker, worker=True)
     util.wait_until_k8s_ready(cluster_node, instances)
 
     nodes = util.ready_nodes(cluster_node)

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -25,10 +25,12 @@ def test_no_remove(instances: List[harness.Instance]):
     join_token_2 = util.get_join_token(cluster_node, joining_cp_2)
     join_token_worker = util.get_join_token(cluster_node, joining_worker, "--worker")
     util.join_cluster(joining_cp, join_token)
+    util.wait_until_k8s_ready(cluster_node, [joining_cp])
     util.join_cluster(joining_cp_2, join_token_2)
+    util.wait_until_k8s_ready(cluster_node, [joining_cp, joining_cp_2])
     util.join_cluster(joining_worker, join_token_worker)
-
     util.wait_until_k8s_ready(cluster_node, instances)
+
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 4, "nodes should have joined cluster"
 
@@ -71,8 +73,12 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
     join_token = util.get_join_token(cluster_node, joining_cp)
     util.join_cluster(joining_cp, join_token)
 
+    util.wait_until_k8s_ready(cluster_node, [joining_cp])
+
     join_token_2 = util.get_join_token(cluster_node, joining_cp_2)
     util.join_cluster(joining_cp_2, join_token_2)
+
+    util.wait_until_k8s_ready(cluster_node, [joining_cp, joining_cp_2])
 
     join_token_worker = util.get_join_token(cluster_node, worker, "--worker")
     util.join_cluster(worker, join_token_worker)

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -124,6 +124,7 @@ extra-sans:
         text=True,
     )
 
+    util.wait_until_k8s_ready(cluster_node, [cluster_node, joining_cp])
     out = cluster_node.exec(
         ["k8s", "get-join-token", "my-token-2"],
         capture_output=True,

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -374,15 +374,29 @@ def get_join_token(
 
 
 # Join an existing cluster.
-def join_cluster(instance: harness.Instance, join_token: str):
+def join_cluster(instance: harness.Instance, join_token: str, worker=False):
     join_cfg = {
-        "extra-node-kubelet-args": {
-            "--v": "6",
-        },
         "extra-node-containerd-args": {
             "--log-level": "debug",
         },
+        "extra-node-kubelet-args": {
+            "--v": "6",
+        },
     }
+    if not worker:
+        join_cfg.update(
+            {
+                "extra-node-kube-apiserver-args": {
+                    "--v": "6",
+                },
+                "extra-node-kube-controller-manager-args": {
+                    "--v": "6",
+                },
+                "extra-node-kube-scheduler-args": {
+                    "--v": "6",
+                },
+            }
+        )
     instance.exec(
         ["k8s", "join-cluster", join_token, "--file", "-"],
         input=str.encode(yaml.safe_dump(join_cfg)),

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable, List, Mapping, Optional, Union
+import yaml
 
 import pytest
 from tenacity import (
@@ -374,7 +375,17 @@ def get_join_token(
 
 # Join an existing cluster.
 def join_cluster(instance: harness.Instance, join_token: str):
-    instance.exec(["k8s", "join-cluster", join_token])
+    join_cfg = {
+        'extra-node-kubelet-args': {
+            '--v': '6',
+        },
+        'extra-node-containerd-args': {
+            '--log-level': 'debug',
+        }
+    }
+    instance.exec(
+        ["k8s", "join-cluster", join_token, '--file', '-'],
+        input=str.encode(yaml.safe_dump(join_cfg)))
 
 
 def is_ipv6(ip: str) -> bool:

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -14,9 +14,9 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import Any, Callable, List, Mapping, Optional, Union
-import yaml
 
 import pytest
+import yaml
 from tenacity import (
     RetryCallState,
     retry,
@@ -376,16 +376,17 @@ def get_join_token(
 # Join an existing cluster.
 def join_cluster(instance: harness.Instance, join_token: str):
     join_cfg = {
-        'extra-node-kubelet-args': {
-            '--v': '6',
+        "extra-node-kubelet-args": {
+            "--v": "6",
         },
-        'extra-node-containerd-args': {
-            '--log-level': 'debug',
-        }
+        "extra-node-containerd-args": {
+            "--log-level": "debug",
+        },
     }
     instance.exec(
-        ["k8s", "join-cluster", join_token, '--file', '-'],
-        input=str.encode(yaml.safe_dump(join_cfg)))
+        ["k8s", "join-cluster", join_token, "--file", "-"],
+        input=str.encode(yaml.safe_dump(join_cfg)),
+    )
 
 
 def is_ipv6(ip: str) -> bool:

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -261,7 +261,7 @@ def wait_until_k8s_ready(
     instances: List[harness.Instance],
     retries: int = config.DEFAULT_WAIT_RETRIES,
     delay_s: int = config.DEFAULT_WAIT_DELAY_S,
-    node_names: Mapping[str, str] = {},
+    node_names: Optional[dict[str, str]] = None,
 ):
     """
     Validates that the K8s node is in Ready state.
@@ -270,21 +270,32 @@ def wait_until_k8s_ready(
     If the instance name is different from the hostname, the instance name should be passed to the
     node_names dictionary, e.g. {"instance_id": "node_name"}.
     """
+    if node_names is None:
+        node_names = {}
+
     instance_id_node_name_map = {}
     for instance in instances:
-        node_name = node_names.get(instance.id)
-        if node_name is None:
-            node_name = hostname(instance)
+        node_name = node_names.get(instance.id, hostname(instance))
+        LOG.info(f"Checking if Kubelet is ready on '{instance.id}' (node: {node_name})")
 
-        result = (
-            stubbornly(retries=retries, delay_s=delay_s)
-            .on(control_node)
-            .until(lambda p: " Ready" in p.stdout.decode())
-            .exec(["k8s", "kubectl", "get", "node", node_name, "--no-headers"])
-        )
-        LOG.info(f"Kubelet registered successfully on instance '{instance.id}'")
-        LOG.info("%s", result.stdout.decode())
-        instance_id_node_name_map[instance.id] = node_name
+        try:
+            result = (
+                stubbornly(retries=retries, delay_s=delay_s)
+                .on(control_node)
+                .until(lambda p: " Ready" in p.stdout.decode())
+                .exec(["k8s", "kubectl", "get", "node", node_name, "--no-headers"])
+            )
+            instance_id_node_name_map[instance.id] = node_name
+            LOG.info(
+                f"Kubelet registered successfully on instance '{instance.id}' (node: {node_name})"
+            )
+            LOG.info("Command output: %s", result.stdout.decode())
+
+        except Exception as e:
+            LOG.error(
+                f"Failed to verify readiness of instance '{instance.id}' (node: {node_name}): {e}"
+            )
+            raise
     LOG.info(
         "Successfully checked Kubelet registered on all harness instances: "
         f"{instance_id_node_name_map}"


### PR DESCRIPTION
We're seeing cp node join failures as the cilium pod hangs in PodScheduled state.

This PR aims to provide additional information:

* kubelet and containerd debug logs (--v=6)
* additional snap log entries
* we'll only run test_no_remove, which seems to fail consistently with https://github.com/canonical/k8s-snap/pull/1017
* use etcd instead of dqlite by adapting the etcd test
  * kublet is missing Pod events, this might help