### PR TITLE
docs: Add external load balancer relation to openstack how-to

### DIFF
--- a/docs/canonicalk8s/charm/howto/openstack.md
+++ b/docs/canonicalk8s/charm/howto/openstack.md
@@ -47,6 +47,7 @@ relations:
   - [openstack-cloud-controller:external-cloud-provider, k8s:external-cloud-provider]
   - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
   - [cinder-csi:openstack,                               openstack-integrator:clients]
+  - [openstack-integrator:lb-consumers,                  k8s:external-load-balancer]
 ```
 
 ### Deploy the overlay template


### PR DESCRIPTION
### Overview
This PR adds the `k8s:external-load-balancer,   openstack-integrator:lb-consumers` relation to the Openstack how-to docs.