### PR TITLE
docs: correct EPA doc typo of default CNI 

### DIFF
--- a/docs/canonicalk8s/snap/howto/epa.md
+++ b/docs/canonicalk8s/snap/howto/epa.md
@@ -331,7 +331,7 @@ EPA capabilities.
 
 2. Create a file called *configuration.yaml* or download it
 {download}`here </assets/configuration.yaml>`. In this configuration file
-we let the snap start with its default CNI (calico), with CoreDNS deployed and
+we let the snap start with its default CNI (cilium), with CoreDNS deployed and
 we also point k8s to the external etcd.
 
 ```{literalinclude} /assets/configuration.yaml


### PR DESCRIPTION
## Description
Correct EPA doc default CNI mention.

Closes https://github.com/canonical/k8s-snap/issues/1051