### PR TITLE
test: Remove --maxfail 1 from integration tests

### DIFF
--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -34,7 +34,6 @@ deps =
     -r {toxinidir}/requirements-test.txt
 commands =
     pytest -vv \
-        --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \
         --log-format "%(asctime)s %(levelname)s %(message)s" \


### PR DESCRIPTION
The CI takes some time to run. We would like to catch all failing tests in one run so that they can be fixed all individually before doing another CI run.