### PR TITLE
feat(k8sd): introduce support for helm repository endpoints backed by microcluster

### DIFF
--- a/src/k8s/pkg/client/helm/repo.go
+++ b/src/k8s/pkg/client/helm/repo.go
@@ -1,0 +1,95 @@
+package helm
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/pkg/errors"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/provenance"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+// InMemoryLoader loads a chart from a byte slice
+type InMemoryLoader []byte
+
+// Load loads a chart
+func (l InMemoryLoader) Load() (*chart.Chart, error) {
+	return LoadBytes(bytes.NewReader(l))
+}
+
+// LoadBytes loads from a byte slice.
+func LoadBytes(raw *bytes.Reader) (*chart.Chart, error) {
+	if err := ensureArchive(raw); err != nil {
+		return nil, err
+	}
+
+	c, err := loader.LoadArchive(raw)
+	if err != nil {
+		if err == gzip.ErrHeader {
+			return nil, fmt.Errorf("file does not appear to be a valid chart file (details: %s)", err)
+		}
+	}
+	return c, err
+}
+
+// isGZipApplication checks whether the achieve is of the application/x-gzip type.
+func isGZipApplication(data []byte) bool {
+	sig := []byte("\x1F\x8B\x08")
+	return bytes.HasPrefix(data, sig)
+}
+
+// ensureArchive's job is to return an informative error if the file does not appear to be a gzipped archive.
+//
+// Sometimes users will provide a values.yaml for an argument where a chart is expected. One common occurrence
+// of this is invoking `helm template values.yaml mychart` which would otherwise produce a confusing error
+// if we didn't check for this.
+func ensureArchive(raw *bytes.Reader) error {
+	defer raw.Seek(0, 0) // reset read offset to allow archive loading to proceed.
+
+	// Check the file format to give us a chance to provide the user with more actionable feedback.
+	buffer := make([]byte, 512)
+	_, err := raw.Read(buffer)
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("file cannot be read: %s", err)
+	}
+
+	// Helm may identify achieve of the application/x-gzip as application/vnd.ms-fontobject.
+	// Fix for: https://github.com/helm/helm/issues/12261
+	if contentType := http.DetectContentType(buffer); contentType != "application/x-gzip" && !isGZipApplication(buffer) {
+		// TODO: Is there a way to reliably test if a file content is YAML? ghodss/yaml accepts a wide
+		//       variety of content (Makefile, .zshrc) as valid YAML without errors.
+		return fmt.Errorf("file does not appear to be a gzipped archive; got '%s'", contentType)
+	}
+	return nil
+}
+
+func GenerateIndex(charts []types.HelmChart) (*repo.IndexFile, error) {
+	indexFile := repo.NewIndexFile()
+
+	for _, chart := range charts {
+		ch, err := InMemoryLoader(chart.Contents).Load()
+		if err != nil {
+			return nil, err
+		}
+
+		digest, err := provenance.Digest(bytes.NewReader(chart.Contents))
+		if err != nil {
+			return nil, err
+		}
+
+		if !indexFile.Has(ch.Name(), ch.Metadata.Version) {
+			// TODO(berkayoz): Look into baseurl later
+			if err := indexFile.MustAdd(ch.Metadata, chart.Name, "", digest); err != nil {
+				return nil, errors.Wrapf(err, "failed adding to %s - %s to index", chart.Name, chart.Version)
+			}
+		}
+	}
+	indexFile.SortEntries()
+	return indexFile, nil
+}

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -50,6 +50,16 @@ func (e *Endpoints) Endpoints() []rest.Endpoint {
 			Post:              rest.EndpointAction{Handler: e.postClusterBootstrap},
 			AllowedBeforeInit: true,
 		},
+		{
+			Name: "ChartIndex",
+			Path: "k8sd/charts/index.yaml",
+			Get:  rest.EndpointAction{Handler: e.getHelmChartsIndex, AccessHandler: e.restrictWorkers, AllowUntrusted: true},
+		},
+		{
+			Name: "InsertChart",
+			Path: "k8sd/charts",
+			Post: rest.EndpointAction{Handler: e.postHelmChart, AccessHandler: e.restrictWorkers, AllowUntrusted: true},
+		},
 		// Node
 		// Returns the status (e.g. current role) of the local node (control-plane, worker or unknown).
 		{

--- a/src/k8s/pkg/k8sd/api/helm_chart.go
+++ b/src/k8s/pkg/k8sd/api/helm_chart.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/canonical/k8s/pkg/client/helm"
+	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/v2/state"
+	"gopkg.in/yaml.v2"
+)
+
+type InsertHelmChartRequest struct {
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Contents string `json:"contents"`
+}
+
+type InsertHelmChartResponse struct {
+}
+
+func (e *Endpoints) postHelmChart(s state.State, r *http.Request) response.Response {
+	req := InsertHelmChartRequest{}
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
+	}
+
+	contents, err := base64.StdEncoding.DecodeString(req.Contents)
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("failed to decode contents: %w", err))
+	}
+
+	if err := s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		var err error
+		err = database.InsertHelmChart(ctx, tx, req.Name, req.Version, contents)
+		if err != nil {
+			return fmt.Errorf("failed to create worker node token: %w", err)
+		}
+		return err
+	}); err != nil {
+		return response.InternalError(fmt.Errorf("database transaction failed: %w", err))
+	}
+
+	return response.SyncResponse(true, &InsertHelmChartResponse{})
+}
+
+type GetHelmChartsIndexResponse struct {
+	Index string `json:"index"`
+}
+
+func (e *Endpoints) getHelmChartsIndex(s state.State, r *http.Request) response.Response {
+	var charts []types.HelmChart
+	var err error
+
+	if err := s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		charts, err = database.GetHelmCharts(ctx, tx)
+		if err != nil {
+			return fmt.Errorf("failed to create worker node token: %w", err)
+		}
+		return err
+	}); err != nil {
+		return response.InternalError(fmt.Errorf("database transaction failed: %w", err))
+	}
+
+	indexFile, err := helm.GenerateIndex(charts)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to generate index: %w", err))
+	}
+
+	index, err := yaml.Marshal(indexFile)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to marshal index: %w", err))
+	}
+
+	return response.ManualResponse(func(w http.ResponseWriter) error {
+		w.Header().Set("Content-Type", "application/x-yaml")
+
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(index); err != nil {
+			return fmt.Errorf("failed to write response: %w", err)
+		}
+
+		f, ok := w.(http.Flusher)
+		if !ok {
+			return fmt.Errorf("ResponseWriter is not type http.Flusher")
+		}
+
+		f.Flush()
+		return nil
+	})
+}

--- a/src/k8s/pkg/k8sd/database/helm_chart.go
+++ b/src/k8s/pkg/k8sd/database/helm_chart.go
@@ -1,0 +1,65 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/microcluster/v2/cluster"
+)
+
+var chartStmts = map[string]int{
+	"insert-chart": MustPrepareStatement("helm-charts", "insert.sql"),
+	"select-all":   MustPrepareStatement("helm-charts", "select.sql"),
+	"select-chart": MustPrepareStatement("helm-charts", "select-chart.sql"),
+}
+
+// GetFeatureStatuses returns a map of feature names to their status.
+func GetHelmCharts(ctx context.Context, tx *sql.Tx) ([]types.HelmChart, error) {
+	selectTxStmt, err := cluster.Stmt(tx, chartStmts["select-all"])
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare select statement: %w", err)
+	}
+
+	rows, err := selectTxStmt.QueryContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute select statement: %w", err)
+	}
+
+	var result []types.HelmChart
+
+	for rows.Next() {
+		chart := types.HelmChart{}
+
+		if err := rows.Scan(&chart.Name, &chart.Version, &chart.Contents); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		result = append(result, chart)
+	}
+
+	if rows.Err() != nil {
+		return nil, fmt.Errorf("failed to read rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// InsertHelmChart inserts a helm chart into the database.
+func InsertHelmChart(ctx context.Context, tx *sql.Tx, name string, version string, contents []byte) error {
+	insertTxStmt, err := cluster.Stmt(tx, chartStmts["insert-chart"])
+	if err != nil {
+		return fmt.Errorf("failed to prepare upsert statement: %w", err)
+	}
+
+	if _, err := insertTxStmt.ExecContext(ctx,
+		name,
+		version,
+		contents,
+	); err != nil {
+		return fmt.Errorf("failed to execute upsert statement: %w", err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -23,6 +23,7 @@ var (
 		schemaApplyMigration("feature-status", "000-feature-status.sql"),
 		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
 		schemaApplyMigration("worker-nodes", "001-delete.sql"),
+		schemaApplyMigration("helm-charts", "002-create.sql"),
 	}
 
 	//go:embed sql/migrations

--- a/src/k8s/pkg/k8sd/database/sql/migrations/helm-charts/002-create.sql
+++ b/src/k8s/pkg/k8sd/database/sql/migrations/helm-charts/002-create.sql
@@ -1,0 +1,6 @@
+CREATE TABLE helm_charts (
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    contents BLOB NOT NULL,
+    PRIMARY KEY (name, version)
+)

--- a/src/k8s/pkg/k8sd/database/sql/queries/helm-charts/insert.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/helm-charts/insert.sql
@@ -1,0 +1,4 @@
+INSERT INTO
+    helm_charts(name, version, contents)
+VALUES
+    ( ?, ?, ? )

--- a/src/k8s/pkg/k8sd/database/sql/queries/helm-charts/select-chart.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/helm-charts/select-chart.sql
@@ -1,0 +1,7 @@
+SELECT
+    c.name, c.version, c.contents
+FROM
+    helm_charts AS c
+WHERE
+    ( c.name = ? ) AND ( c.version = ? )
+LIMIT 1

--- a/src/k8s/pkg/k8sd/database/sql/queries/helm-charts/select.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/helm-charts/select.sql
@@ -1,0 +1,4 @@
+SELECT
+    c.name, c.version, c.contents
+FROM
+    helm_charts AS c

--- a/src/k8s/pkg/k8sd/types/helm_chart.go
+++ b/src/k8s/pkg/k8sd/types/helm_chart.go
@@ -1,0 +1,10 @@
+package types
+
+type HelmChart struct {
+	// Name is the name of the chart.
+	Name string `json:"name"`
+	// Version is the version of the chart.
+	Version string `json:"version"`
+	// Contents is the contents of the chart.
+	Contents []byte `json:"contents"`
+}


### PR DESCRIPTION
# 🚧 DO NOT MERGE 🚧
Added a table to the microcluster database for storing helm charts.
Added queries for inserting, listing and selecting helm chart(s).
Introduced helpers to build the helm repository `index.yaml` dynamically from a list of helm charts.
Added an endpoint to serve the repository index file `index.yaml`.
Added an endpoint to insert/upload helm charts to the k8sd cluster.