### PR TITLE
actions: Adds backport github action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,0 +1,66 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [closed]
+  issue_comment:
+    types: [created]
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+
+    # Only run when pull request is merged
+    # or when a comment containing `/backport` is created by someone other than the
+    # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
+    # own PAT as `github_token`, that you should replace this id with yours.
+    # cdkbot's user ID is 99445902.
+    if: >
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.id != 99445902 &&
+        contains(github.event.comment.body, '/backport')
+      )
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create backport pull requests
+        id: create_backports
+        uses: korthout/backport-action@v3
+        with:
+          # Set (default) action parameters explicitly.
+          branch_name: backport-${pull_number}-to-${target_branch}
+          cherry_picking: auto
+          copy_assignees: false
+          copy_milestone: false
+          copy_requested_reviewers: false
+          experimental: >
+            {
+              "conflict_resolution": "fail"
+            }
+          github_token: ${{ secrets.BOT_TOKEN }}
+          github_workspace: ${{ github.workspace }}
+          label_pattern: ^backport ([^ ]+)$
+          merge_commits: fail
+          pull_description: |-
+            # Description
+            Backport of #${pull_number} to `${target_branch}`.
+          pull_title: >-
+            [Backport ${target_branch}] ${pull_title}
+
+      - name: Label backports with automerge and approve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for pr_number in ${{ steps.create_backports.outputs.created_pull_numbers }}; do
+            gh pr edit "$pr_number" --add-label "automerge"
+            gh pr review "$pr_number" --approve
+          done


### PR DESCRIPTION
Sets default action parameters explicitly.

In order to backport a PR, the PR should have the an appropriate label: ``"backport branch-name"`` (e.g.: ``"backport release-1.32"``). When the PR merges, the github action will automatically backport it. The label can also be added after the PR merges, after which a user should comment ``/backport`` in order to trigger the action.