### PR TITLE
feat(k8sd): Update GetNodeStatus and GetClusterConfig RPCs

### DIFF
--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.20
+	github.com/canonical/k8s-snap-api v1.0.23-0.20250328084804-ec487eb35ce6
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.23-0.20250328084804-ec487eb35ce6
+	github.com/canonical/k8s-snap-api v1.0.23
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.20 h1:2dUQFkYoi+VRE09oah+5RfeoP3e8mbm/G1d0F+a0/G0=
-github.com/canonical/k8s-snap-api v1.0.20/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.0.23-0.20250328084804-ec487eb35ce6 h1:lIuphZKmq1hzQHmSnIpk6IE7R4WnpH4dWhB0BdqRKoI=
+github.com/canonical/k8s-snap-api v1.0.23-0.20250328084804-ec487eb35ce6/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18 h1:h5VJaUnE4gAKPolBTJ11HMRTEN5JyA+oR4gHkoK//6o=

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.23-0.20250328084804-ec487eb35ce6 h1:lIuphZKmq1hzQHmSnIpk6IE7R4WnpH4dWhB0BdqRKoI=
-github.com/canonical/k8s-snap-api v1.0.23-0.20250328084804-ec487eb35ce6/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.0.23 h1:P2yYaUnLB1FUjpiOjad3LfuqZRfsdoHMWwmpdmqNmm4=
+github.com/canonical/k8s-snap-api v1.0.23/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18 h1:h5VJaUnE4gAKPolBTJ11HMRTEN5JyA+oR4gHkoK//6o=

--- a/src/k8s/pkg/docgen/godoc.go
+++ b/src/k8s/pkg/docgen/godoc.go
@@ -6,6 +6,7 @@ import (
 	"go/doc"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"reflect"
 	"strings"
 )
@@ -49,7 +50,11 @@ func getStructTypeFromDoc(packageDoc *doc.Package, structName string) (*ast.Stru
 
 func parsePackageDir(packageDir string) (*ast.Package, error) {
 	fset := token.NewFileSet()
-	packages, err := parser.ParseDir(fset, packageDir, nil, parser.ParseComments)
+	// NOTE(Hue): We only want to parse non-test files.
+	nonTestPackagesFilter := func(info fs.FileInfo) bool {
+		return !strings.HasSuffix(info.Name(), "_test.go")
+	}
+	packages, err := parser.ParseDir(fset, packageDir, nonTestPackagesFilter, parser.ParseComments)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse go package: %s", packageDir)
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -60,6 +60,9 @@ func (e *Endpoints) getClusterConfig(s state.State, r *http.Request) response.Re
 	}
 
 	return response.SyncResponse(true, &apiv1.GetClusterConfigResponse{
-		Config: config.ToUserFacing(),
+		Config:      config.ToUserFacing(),
+		Datastore:   config.Datastore.ToUserFacing(),
+		PodCIDR:     config.Network.PodCIDR,
+		ServiceCIDR: config.Network.ServiceCIDR,
 	})
 }

--- a/src/k8s/pkg/k8sd/api/node.go
+++ b/src/k8s/pkg/k8sd/api/node.go
@@ -1,10 +1,16 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/api/impl"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/v2/state"
 )
@@ -17,7 +23,26 @@ func (e *Endpoints) getNodeStatus(s state.State, r *http.Request) response.Respo
 		return response.InternalError(err)
 	}
 
+	taints, err := getNodeTaints(snap)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to get node taints: %w", err))
+	}
+
 	return response.SyncResponse(true, &apiv1.NodeStatusResponse{
 		NodeStatus: status,
+		Taints:     taints,
 	})
+}
+
+// getNodeTaints retrieves the taints of the local node.
+func getNodeTaints(snap snap.Snap) ([]string, error) {
+	taintsStr, err := snaputil.GetServiceArgument(snap, "kubelet", "--register-with-taints")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get kubelet taints: %w", err)
+	}
+
+	return strings.Split(taintsStr, ","), nil
 }

--- a/src/k8s/pkg/k8sd/setup/kubelet_test.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet_test.go
@@ -3,6 +3,7 @@ package setup_test
 import (
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -266,9 +267,12 @@ func TestKubelet(t *testing.T) {
 		// Create a mock snap
 		s := mustSetupSnapAndDirectories(t, setKubeletMock)
 
+		taints := []string{"foo=bar:NoSchedule"}
+		taintsStr := strings.Join(taints, ",")
 		extraArgs := map[string]*string{
-			"--cluster-domain": utils.Pointer("override.local"),
-			"--cloud-provider": nil,
+			"--cluster-domain":       utils.Pointer("override.local"),
+			"--cloud-provider":       nil,
+			"--register-with-taints": utils.Pointer(taintsStr),
 		}
 
 		// Call the kubelet worker setup function
@@ -292,7 +296,7 @@ func TestKubelet(t *testing.T) {
 			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedWorkerLabels},
 			{key: "--read-only-port", expectedVal: "0"},
-			{key: "--register-with-taints", expectedVal: ""},
+			{key: "--register-with-taints", expectedVal: taintsStr},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},

--- a/tests/integration/templates/bootstrap-node-taints.yaml
+++ b/tests/integration/templates/bootstrap-node-taints.yaml
@@ -1,0 +1,35 @@
+# Contains the bootstrap configuration for the node taints test.
+control-plane-taints: 
+  - "taint1=:PreferNoSchedule"
+  - "taint2=value:PreferNoSchedule"
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  ingress:
+    enabled: true
+  load-balancer:
+    enabled: true
+  local-storage:
+    enabled: true
+  gateway:
+    enabled: true
+  metrics-server:
+    enabled: true
+extra-node-config-files:
+  bootstrap-extra-file.yaml: extra-args-test-file-content
+extra-node-kube-apiserver-args:
+  --request-timeout: 2m
+extra-node-kube-controller-manager-args:
+  --leader-elect-retry-period: 3s
+extra-node-kube-scheduler-args:
+  --authorization-webhook-cache-authorized-ttl: 11s
+extra-node-kube-proxy-args:
+  --config-sync-period: 14m
+extra-node-kubelet-args:
+  --authentication-token-webhook-cache-ttl: 3m
+extra-node-containerd-args:
+  --log-level: debug
+extra-node-k8s-dqlite-args:
+  --watch-storage-available-size-interval: 6s

--- a/tests/integration/templates/worker-join-node-taints.yaml
+++ b/tests/integration/templates/worker-join-node-taints.yaml
@@ -1,0 +1,3 @@
+# Contains the join configuration for the worker nodes in the node taints test.
+extra-node-kubelet-args:
+  "--register-with-taints": "workerTaint1=:PreferNoSchedule,workerTaint2=workerValue:PreferNoSchedule"

--- a/tests/integration/tests/test_node_taints.py
+++ b/tests/integration/tests/test_node_taints.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+import json
+import logging
+from typing import Any, List
+
+import pytest
+from test_util import config, harness, tags, util
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-node-taints.yaml").read_text()
+)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_node_taints(instances: List[harness.Instance]):
+    """Test node taints are returned by the GetNodeStatus RPC."""
+    cp_node = instances[0]
+    worker_node = instances[1]
+    join_token = util.get_join_token(cp_node, worker_node, "--worker")
+    util.join_cluster(
+        worker_node,
+        join_token,
+        (config.MANIFESTS_DIR / "worker-join-node-taints.yaml").read_text(),
+    )
+
+    util.wait_until_k8s_ready(cp_node, instances)
+    nodes = util.ready_nodes(cp_node)
+    assert len(nodes) == 2, "worker should have joined cluster"
+
+    cp_taints = get_node_taints(cp_node)
+    worker_taints = get_node_taints(worker_node)
+
+    # NOTE(Hue): these come from the bootstrap and join configs
+    cp_exp_taints = [
+        "taint1=:PreferNoSchedule",
+        "taint2=value:PreferNoSchedule",
+    ]
+    worker_exp_taints = [
+        "workerTaint1=:PreferNoSchedule",
+        "workerTaint2=workerValue:PreferNoSchedule",
+    ]
+
+    assert len(cp_taints) == len(cp_exp_taints), "cp node taints count do not match"
+    assert len(worker_taints) == len(
+        worker_exp_taints
+    ), "worker node taints count do not match"
+    assert set(cp_taints) == set(cp_exp_taints), "cp node taints do not match"
+    assert set(worker_taints) == set(
+        worker_exp_taints
+    ), "worker node taints do not match"
+
+
+def get_node_taints(instance: harness.Instance) -> Any:
+    """Get taints from the node status."""
+    resp = instance.exec(
+        [
+            "curl",
+            "-H",
+            "Content-Type: application/json",
+            "--unix-socket",
+            "/var/snap/k8s/common/var/lib/k8sd/state/control.socket",
+            "http://localhost/1.0/k8sd/node",
+        ],
+        capture_output=True,
+    )
+    assert resp.returncode == 0, "Failed to get node status."
+    response = json.loads(resp.stdout.decode())
+    assert response["error_code"] == 0, "Failed to get node status."
+    assert response["error"] == "", "Failed to get node status."
+
+    metadata = response.get("metadata")
+    assert metadata is not None, "Metadata not found in the node status response."
+    taints = metadata.get("taints")
+    assert taints is not None, "Node taints not found in the node status response."
+
+    return taints

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -410,8 +410,15 @@ def get_join_token(
 
 
 # Join an existing cluster.
-def join_cluster(instance: harness.Instance, join_token: str):
-    instance.exec(["k8s", "join-cluster", join_token])
+def join_cluster(
+    instance: harness.Instance, join_token: str, cfg: Optional[str] = None
+):
+    if cfg:
+        instance.exec(
+            ["k8s", "join-cluster", join_token, "--file", "-"], input=str.encode(cfg)
+        )
+    else:
+        instance.exec(["k8s", "join-cluster", join_token])
 
 
 def is_ipv6(ip: str) -> bool:


### PR DESCRIPTION
### Overview
- Add `taints` to the `GetNodeStatus` RPC.
- Add `datastore`, `pod-cidr`, and `service-cidr` to the `GetClusterConfig` RPC.

### Rationale
`k8s-operator` needs to know certain things about the node and cluster to prevent the user from changing some charm configs that should only be set on bootstrap time and can't be changed later.