### PR TITLE
Adds non-default coredns ServiceAccount

### DIFF
--- a/src/k8s/pkg/k8sd/features/coredns/coredns.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns.go
@@ -53,6 +53,10 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 			"name":      "coredns",
 			"clusterIP": kubelet.GetClusterDNS(),
 		},
+		"serviceAccount": map[string]any{
+			"create": true,
+			"name":   "coredns",
+		},
 		"deployment": map[string]any{
 			"name": "coredns",
 		},

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -60,3 +60,22 @@ def test_dns(instances: List[harness.Instance]):
     )
 
     assert "can't resolve" not in result.stdout.decode()
+
+    # Assert that coredns is not using the default service account name.
+    result = instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "-n",
+            "kube-system",
+            "deployment.apps/coredns",
+            "-o",
+            "jsonpath='{.spec.template.spec.serviceAccount}'",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert (
+        "'coredns'" == result.stdout
+    ), "Expected coredns serviceaccount to be 'coredns', not {result.stdout}"


### PR DESCRIPTION
The CIS 5.1.5 rule specifies: "Ensure that default service accounts are not actively used."

Currently, ``coredns`` is using the ``default`` service account. If this rule is being enforced, ``coredns`` will no longer be able to function properly, as it won't have the expected service account token mounted.

Closes: https://github.com/canonical/cluster-api-k8s/issues/107