### PR TITLE
docs: Remove see source button

### DIFF
--- a/docs/canonicalk8s/custom_conf.py
+++ b/docs/canonicalk8s/custom_conf.py
@@ -148,7 +148,8 @@ linkcheck_ignore = [
     'about',
     'https://ceph.io/',
     'https://charmhub.io/k8s/',
-    'https://charmhub.io/k8s-worker/'
+    'https://charmhub.io/k8s-worker/',
+    'http://slack.kubernetes.io/'
     ]
 
 # Pages on which to ignore anchors

--- a/docs/canonicalk8s/custom_conf.py
+++ b/docs/canonicalk8s/custom_conf.py
@@ -118,6 +118,9 @@ html_context = {
     "display_contributors_since": ""
 }
 
+html_copy_source = False
+html_show_sourcelink = False
+
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
 slug = "canonical-kubernetes"


### PR DESCRIPTION
Remove the icon at the top of the docs of an eye to show the source code of the docs. Also removes show source from the footer