### PR TITLE
docs: Add fan-config instructions to Openstack how-to guide

### DIFF
--- a/docs/canonicalk8s/charm/howto/openstack.md
+++ b/docs/canonicalk8s/charm/howto/openstack.md
@@ -14,6 +14,21 @@ To follow this guide, you will need:
 - Octavia available both to support Kubernetes LoadBalancer services and to
   support the creation of a load balancer for the Kubernetes API.
 - A valid [proxy configuration][proxy] in constrained environments.
+- Before deploying the {{product}} bundle, make sure to apply the following
+configuration on the Juju model:
+
+```
+juju model-config container-networking-method=local fan-config=
+```
+
+Otherwise you might notice the Cilium pods failing with the following message:
+
+```
+failed to start: daemon creation failed: error while initializing daemon: failed 
+while reinitializing datapath: failed to setup vxlan tunnel device: setting up 
+vxlan device: creating vxlan device: setting up device cilium_vxlan: address 
+already in use
+```
 
 ## Installing {{product}} on OpenStack
 

--- a/docs/canonicalk8s/charm/howto/openstack.md
+++ b/docs/canonicalk8s/charm/howto/openstack.md
@@ -14,7 +14,8 @@ To follow this guide, you will need:
 - Octavia available both to support Kubernetes LoadBalancer services and to
   support the creation of a load balancer for the Kubernetes API.
 - A valid [proxy configuration][proxy] in constrained environments.
-- Before deploying the {{product}} bundle, make sure to apply the following
+
+Before deploying {{product}}, make sure to apply the following
 configuration on the Juju model:
 
 ```


### PR DESCRIPTION
### Overview 
This PR adds the `fan-config` instructions to Openstack how-to guide.

Addresses: https://github.com/canonical/k8s-operator/issues/323