### PR TITLE
docs(reference): Add `ip rule` priority issue to common issues

### DIFF
--- a/docs/canonicalk8s/snap/reference/troubleshooting.md
+++ b/docs/canonicalk8s/snap/reference/troubleshooting.md
@@ -153,6 +153,28 @@ Restart Dqlite:
 sudo snap restart snap.k8s.k8s-dqlite
 ```
 
+
+## Bootstrap issues on a host with custom routing policy rules
+
+### Problem
+
+{{product}} bootstrap process might fail or face networking issues when
+custom routing policy rules are defined, such as rules in a netplan file.
+
+### Explanation
+
+Cilium, which is the current implementation for the `network` feature,
+introduces and adjusts certain ip rules with
+hard-coded priorities of `0` and `100`.
+
+Adding ip rules with a priority lower than or equal to `100` might introduce
+conflicts and cause networking issues.
+
+### Solution
+
+Adjust the custom defined `ip rule` to have a
+priority value that is greater than `100`.
+
 <!-- LINKS -->
 
 [lxd-install]: ../howto/install/lxd.md


### PR DESCRIPTION
Introduces a section to make sure priority of custom `ip rule`s are greater than `100`.