### PR TITLE
Fix test_gateway retries

### DIFF
--- a/tests/branch_management/tests/test_branches.py
+++ b/tests/branch_management/tests/test_branches.py
@@ -25,7 +25,7 @@ def _sh(*args, **kwargs):
 
 def _branch_flavours(branch: str = None):
     patch_dir = Path("build-scripts/patches")
-    branch = "HEAD" if branch is None else branch
+    branch = "HEAD" if not branch else branch
     cmd = f"git ls-tree --full-tree -r --name-only origin/{branch} {patch_dir}"
     output = _sh(cmd.split())
     patches = set(

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -100,7 +100,7 @@ def h() -> harness.Harness:
 
     yield h
 
-    if config.INSPECTION_REPORTS_DIR is not None:
+    if config.INSPECTION_REPORTS_DIR:
         for instance_id in h.instances:
             LOG.debug("Generating inspection reports for session instances")
             _generate_inspection_report(h, instance_id)
@@ -262,7 +262,7 @@ def instances(
     if not disable_k8s_bootstrapping and not no_setup:
         first_node, *_ = instances
 
-        if bootstrap_config is not None:
+        if bootstrap_config:
             first_node.exec(
                 ["k8s", "bootstrap", "--file", "-"],
                 input=str.encode(bootstrap_config),

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -93,7 +93,7 @@ def test_ingress(instances: List[harness.Instance]):
     result = (
         util.stubbornly(retries=20, delay_s=3)
         .on(instance)
-        .until(lambda p: get_ingress_service_node_port(p) is not None)
+        .until(lambda p: get_ingress_service_node_port(p))
         .exec(["k8s", "kubectl", "get", "service", "-A", "-o", "json"])
     )
 

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -95,12 +95,8 @@ def test_smoke(instances: List[harness.Instance]):
         response["error_code"] == 0
     ), "Failed to generate join token using CAPI endpoints."
     metadata = response.get("metadata")
-    assert (
-        metadata is not None
-    ), "Metadata not found in the generate-join-token response."
-    assert (
-        metadata.get("token") is not None
-    ), "Token not found in the generate-join-token response."
+    assert metadata, "Metadata not found in the generate-join-token response."
+    assert metadata.get("token"), "Token not found in the generate-join-token response."
 
     resp = instance.exec(
         [
@@ -121,9 +117,7 @@ def test_smoke(instances: List[harness.Instance]):
         response["error_code"] == 0
     ), "Failed to get certificate expiry using CAPI endpoints."
     metadata = response.get("metadata")
-    assert (
-        metadata is not None
-    ), "Metadata not found in the certificate expiry response."
+    assert metadata, "Metadata not found in the certificate expiry response."
     assert util.is_valid_rfc3339(
         metadata.get("expiry-date")
     ), "Token not found in the certificate expiry response."
@@ -138,7 +132,7 @@ def test_smoke(instances: List[harness.Instance]):
 
         for i in range(len(result_lines)):
             line, pattern = result_lines[i], STATUS_PATTERNS[i]
-            if re.search(pattern, line) is None:
+            if not re.search(pattern, line):
                 LOG.info(f"could not match `{line.strip()}` with `{pattern}`")
                 return False
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -91,7 +91,7 @@ class LXDHarness(Harness):
             )
 
         if network_type.lower() == "dualstack":
-            if self.dualstack_profile is None:
+            if not self.dualstack_profile:
                 raise ValueError(
                     "LXD `dualstack_profile` must be set for network_type=dualstack"
                 )

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -82,9 +82,9 @@ def get_most_stable_channels(
     for channel, major, minor, risk in arch_flavor_channels:
         version_key = (int(major), int(minor))
 
-        if min_release is not None:
+        if min_release:
             _min_release = major_minor(min_release)
-            if _min_release is not None and version_key < _min_release:
+            if _min_release and version_key < _min_release:
                 continue
 
         if version_key not in channel_map or RISK_LEVELS.index(

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -49,7 +49,7 @@ class Retriable:
     def __init__(self, retry_kwargs: Optional[Mapping[str, Any]]) -> None:
         self._condition = None
         self._run = partial(run, capture_output=True)
-        if retry_kwargs is None:
+        if not retry_kwargs:
             retry_kwargs = {}
         self._retry_kwargs = retry_kwargs
 
@@ -129,15 +129,15 @@ def stubbornly(
 
     def _before_sleep(retry_state: RetryCallState):
         attempt = retry_state.attempt_number
-        tries = f"/{retries}" if retries is not None else ""
+        tries = f"/{retries}" if retries else ""
         errstr = ""
         if retry_state.outcome:
             errstr = f" Error: {retry_state.outcome.exception()}"
         LOG.info(f"Attempt {attempt}{tries} failed.{errstr}")
         LOG.info(f"Retrying in {delay_s} seconds...")
 
-    waits = wait_fixed(delay_s) if delay_s is not None else wait_fixed(0)
-    stops = stop_after_attempt(retries) if retries is not None else stop_never
+    waits = wait_fixed(delay_s) if delay_s else wait_fixed(0)
+    stops = stop_after_attempt(retries) if retries else stop_never
     exceptions = exceptions or (Exception,)  # default to retry on all exceptions
 
     retry_args = dict(
@@ -273,7 +273,7 @@ def wait_until_k8s_ready(
     instance_id_node_name_map = {}
     for instance in instances:
         node_name = node_names.get(instance.id)
-        if node_name is None:
+        if not node_name:
             node_name = hostname(instance)
 
         result = (
@@ -600,7 +600,7 @@ def get_os_version_id_for_instance(instance: harness.Instance) -> str:
             release = line.lstrip(f"{var}=")
             break
 
-    if release is None:
+    if not release:
         raise ValueError(
             f"Failed to parse OS release var '{var}' from OS release "
             f"info: {proc.stdout}"


### PR DESCRIPTION
test_gateway performs a few retries, waiting for the service IPs to be set.

The problem is that the checks use "is None" syntax, which won't properly handle empty strings. For this reason, the retry loop stops prematurely, causing test flakiness.

```
Execute command ['curl', '', '-H', 'Host: foo.bar.com'] in instance k8s-integration-a6f840-37
```

In general "is None" / "is not None" checks should be avoided. We'll update the k8s-snap tests accordingly.