### PR TITLE
feat: Support updating node certificates

### DIFF
--- a/docs/canonicalk8s/_parts/commands/k8s.md
+++ b/docs/canonicalk8s/_parts/commands/k8s.md
@@ -23,4 +23,5 @@ Canonical Kubernetes CLI
 * [k8s remove-node](k8s_remove-node.md)	 - Remove a node from the cluster
 * [k8s set](k8s_set.md)	 - Set cluster configuration
 * [k8s status](k8s_status.md)	 - Retrieve the current status of the cluster
+* [k8s update-certs](k8s_update-certs.md)	 - Update the running node's certificates with user provided certificates
 

--- a/docs/canonicalk8s/_parts/commands/k8s_update-certs.md
+++ b/docs/canonicalk8s/_parts/commands/k8s_update-certs.md
@@ -1,0 +1,20 @@
+## k8s update-certs
+
+Update the running node's certificates with user provided certificates
+
+```
+k8s update-certs [flags]
+```
+
+### Options
+
+```
+      --file string        path to the YAML file containing all certificates and key pairs.
+  -h, --help               help for update-certs
+      --timeout duration   the max time to wait for the command to execute (default 1m30s)
+```
+
+### SEE ALSO
+
+* [k8s](k8s.md)	 - Canonical Kubernetes CLI
+

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -86,6 +86,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		newEnableCmd(env),
 		newDisableCmd(env),
 		newRefreshCertsCmd(env),
+		newUpdateCertsCmd(env),
 		newSetCmd(env),
 		newGetCmd(env),
 		newInspectCmd(env),

--- a/src/k8s/cmd/k8s/k8s_update_certs.go
+++ b/src/k8s/cmd/k8s/k8s_update_certs.go
@@ -1,0 +1,92 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	cmdutil "github.com/canonical/k8s/cmd/util"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func newUpdateCertsCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+	var opts struct {
+		file    string
+		timeout time.Duration
+	}
+	cmd := &cobra.Command{
+		Use:    "update-certs",
+		Short:  "Update the running node's certificates with user provided certificates",
+		PreRun: chainPreRunHooks(hookRequireRoot(env)),
+		Run: func(cmd *cobra.Command, args []string) {
+			client, err := env.Snap.K8sdClient("")
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+
+			if _, initialized, err := client.NodeStatus(cmd.Context()); err != nil {
+				cmd.PrintErrf("Error: Failed to check the current node status.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			} else if !initialized {
+				cmd.PrintErrln("Error: The node is not part of a Kubernetes cluster. You can bootstrap a new cluster with:\n\n  sudo k8s bootstrap")
+				env.Exit(1)
+				return
+			}
+
+			config, err := getCertificatesFromYAML(env, opts.file)
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to get the certificates from the YAML file.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			_, err = client.UpdateCertificates(ctx, config)
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to update the certificates.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			cmd.Printf("Certificates updated successfully. The node will be restarted to apply the changes.\n")
+		},
+	}
+	cmd.Flags().StringVar(&opts.file, "file", "", "path to the YAML file containing all certificates and key pairs.")
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
+	cmd.MarkFlagRequired("file")
+
+	return cmd
+}
+
+func getCertificatesFromYAML(env cmdutil.ExecutionEnvironment, filePath string) (apiv1.UpdateCertificatesRequest, error) {
+	var b []byte
+	var err error
+
+	if filePath == "-" {
+		b, err = io.ReadAll(env.Stdin)
+		if err != nil {
+			return apiv1.UpdateCertificatesRequest{}, fmt.Errorf("failed to read config from stdin: %w", err)
+		}
+	} else {
+		b, err = os.ReadFile(filePath)
+		if err != nil {
+			return apiv1.UpdateCertificatesRequest{}, fmt.Errorf("failed to read file: %w", err)
+		}
+	}
+
+	var config apiv1.UpdateCertificatesRequest
+	if err := yaml.UnmarshalStrict(b, &config); err != nil {
+		return apiv1.UpdateCertificatesRequest{}, fmt.Errorf("failed to parse YAML config file: %w", err)
+	}
+
+	return config, nil
+}

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.17
+	github.com/canonical/k8s-snap-api v1.0.18-0.20250217213644-e0993f7255d9
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.17 h1:r+xr+eQflaP+fadIH2RfBcAyF3Q4UFV9FtJ6TnBFm/k=
-github.com/canonical/k8s-snap-api v1.0.17/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
+github.com/canonical/k8s-snap-api v1.0.18-0.20250217213644-e0993f7255d9 h1:2yXRzDKIkOW1uwpkO0AnTFp/PJ6Q/PaBQdBvemdaoxs=
+github.com/canonical/k8s-snap-api v1.0.18-0.20250217213644-e0993f7255d9/go.mod h1:LDPoIYCeYnfgOFrwVPJ/4edGU264w7BB7g0GsVi36AY=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18 h1:h5VJaUnE4gAKPolBTJ11HMRTEN5JyA+oR4gHkoK//6o=

--- a/src/k8s/pkg/client/k8sd/interface.go
+++ b/src/k8s/pkg/client/k8sd/interface.go
@@ -41,6 +41,8 @@ type ClusterMaintenanceClient interface {
 	RefreshCertificatesPlan(context.Context, apiv1.RefreshCertificatesPlanRequest) (apiv1.RefreshCertificatesPlanResponse, error)
 	// RefreshCertificatesRun refreshes the Kubernetes certificates of the node.
 	RefreshCertificatesRun(context.Context, apiv1.RefreshCertificatesRunRequest) (apiv1.RefreshCertificatesRunResponse, error)
+	// UpdateCertificates updates the Kubernetes certificates of the node.
+	UpdateCertificates(context.Context, apiv1.UpdateCertificatesRequest) (apiv1.UpdateCertificatesResponse, error)
 }
 
 // UserClient implements methods to enable accessing the cluster.

--- a/src/k8s/pkg/client/k8sd/manage.go
+++ b/src/k8s/pkg/client/k8sd/manage.go
@@ -13,3 +13,7 @@ func (c *k8sd) RefreshCertificatesPlan(ctx context.Context, request apiv1.Refres
 func (c *k8sd) RefreshCertificatesRun(ctx context.Context, request apiv1.RefreshCertificatesRunRequest) (apiv1.RefreshCertificatesRunResponse, error) {
 	return query(ctx, c, "POST", apiv1.RefreshCertificatesRunRPC, request, &apiv1.RefreshCertificatesRunResponse{})
 }
+
+func (c *k8sd) UpdateCertificates(ctx context.Context, request apiv1.UpdateCertificatesRequest) (apiv1.UpdateCertificatesResponse, error) {
+	return query(ctx, c, "POST", apiv1.UpdateCertificatesRPC, request, &apiv1.UpdateCertificatesResponse{})
+}

--- a/src/k8s/pkg/client/k8sd/mock/mock.go
+++ b/src/k8s/pkg/client/k8sd/mock/mock.go
@@ -41,6 +41,9 @@ type Mock struct {
 	RefreshCertificatesRunCalledWith  apiv1.RefreshCertificatesRunRequest
 	RefreshCertificatesRunResponse    apiv1.RefreshCertificatesRunResponse
 	RefreshCertificatesRunErr         error
+	UpdateCertificatesCalledWith      apiv1.UpdateCertificatesRequest
+	UpdateCertificatesResponse        apiv1.UpdateCertificatesResponse
+	UpdateCertificatesErr             error
 
 	// k8sd.UserClient
 	KubeConfigCalledWith apiv1.KubeConfigRequest
@@ -86,6 +89,10 @@ func (m *Mock) RefreshCertificatesPlan(_ context.Context, request apiv1.RefreshC
 
 func (m *Mock) RefreshCertificatesRun(_ context.Context, request apiv1.RefreshCertificatesRunRequest) (apiv1.RefreshCertificatesRunResponse, error) {
 	return m.RefreshCertificatesRunResponse, m.RefreshCertificatesRunErr
+}
+
+func (m *Mock) UpdateCertificates(_ context.Context, request apiv1.UpdateCertificatesRequest) (apiv1.UpdateCertificatesResponse, error) {
+	return m.UpdateCertificatesResponse, m.UpdateCertificatesErr
 }
 
 func (m *Mock) GetClusterConfig(_ context.Context) (apiv1.GetClusterConfigResponse, error) {

--- a/src/k8s/pkg/k8sd/api/certificates_update.go
+++ b/src/k8s/pkg/k8sd/api/certificates_update.go
@@ -1,0 +1,251 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
+	"github.com/canonical/k8s/pkg/k8sd/pki"
+	"github.com/canonical/k8s/pkg/k8sd/setup"
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/v2/state"
+)
+
+func (e *Endpoints) postUpdateCertificates(s state.State, r *http.Request) response.Response {
+	snap := e.provider.Snap()
+	isWorker, err := snaputil.IsWorker(snap)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to check if node is a worker: %w", err))
+	}
+	if isWorker {
+		return updateCertificatesWorker(s, r, snap)
+	}
+	return updateCertificatesControlPlane(s, r, snap)
+}
+
+// updateCertificatesControlPlane updates the certificates for a control plane node.
+func updateCertificatesControlPlane(s state.State, r *http.Request, snap snap.Snap) response.Response {
+	log := log.FromContext(r.Context())
+
+	req := apiv1.UpdateCertificatesRequest{}
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
+	}
+
+	clusterConfig, err := databaseutil.GetClusterConfig(r.Context(), s)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to recover cluster config: %w", err))
+	}
+
+	nodeIP := net.ParseIP(s.Address().Hostname())
+	if nodeIP == nil {
+		return response.InternalError(fmt.Errorf("failed to parse node IP address %q", s.Address().Hostname()))
+	}
+
+	var localhostAddress string
+	if nodeIP.To4() == nil {
+		localhostAddress = "[::1]"
+	} else {
+		localhostAddress = "127.0.0.1"
+	}
+
+	serviceIPs, err := utils.GetKubernetesServiceIPsFromServiceCIDRs(clusterConfig.Network.GetServiceCIDR())
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to get IP address(es) from ServiceCIDR %q: %w", clusterConfig.Network.GetServiceCIDR(), err))
+	}
+
+	certificates := pki.NewControlPlanePKI(pki.ControlPlanePKIOpts{
+		Hostname:  s.Name(),
+		IPSANs:    append([]net.IP{nodeIP}, serviceIPs...),
+		NotBefore: time.Now(),
+	})
+	certificates.CACert = clusterConfig.Certificates.GetCACert()
+	certificates.CAKey = clusterConfig.Certificates.GetCAKey()
+	certificates.ClientCACert = clusterConfig.Certificates.GetClientCACert()
+	certificates.ClientCAKey = clusterConfig.Certificates.GetClientCAKey()
+	certificates.FrontProxyCACert = clusterConfig.Certificates.GetFrontProxyCACert()
+	certificates.FrontProxyCAKey = clusterConfig.Certificates.GetFrontProxyCAKey()
+	certificates.K8sdPrivateKey = clusterConfig.Certificates.GetK8sdPrivateKey()
+	certificates.K8sdPublicKey = clusterConfig.Certificates.GetK8sdPublicKey()
+	certificates.ServiceAccountKey = clusterConfig.Certificates.GetServiceAccountKey()
+
+	certificates.AdminClientCert = req.GetAdminClientCert()
+	certificates.AdminClientKey = req.GetAdminClientKey()
+	certificates.APIServerKubeletClientCert = req.GetAPIServerKubeletClientCert()
+	certificates.APIServerKubeletClientKey = req.GetAPIServerKubeletClientKey()
+	certificates.KubeControllerManagerClientCert = req.GetKubeControllerManagerClientCert()
+	certificates.KubeControllerManagerClientKey = req.GetKubeControllerManagerClientKey()
+	certificates.KubeSchedulerClientCert = req.GetKubeSchedulerClientCert()
+	certificates.KubeSchedulerClientKey = req.GetKubeSchedulerClientKey()
+	certificates.APIServerCert = req.GetAPIServerCert()
+	certificates.APIServerKey = req.GetAPIServerKey()
+	certificates.KubeProxyClientCert = req.GetKubeProxyClientCert()
+	certificates.KubeProxyClientKey = req.GetKubeProxyClientKey()
+	certificates.KubeletClientCert = req.GetKubeletClientCert()
+	certificates.KubeletClientKey = req.GetKubeletClientKey()
+	certificates.KubeletCert = req.GetKubeletCert()
+	certificates.KubeletKey = req.GetKubeletKey()
+	certificates.FrontProxyClientCert = req.GetFrontProxyClientCert()
+	certificates.FrontProxyClientKey = req.GetFrontProxyClientKey()
+
+	if err := certificates.CompleteCertificates(); err != nil {
+		return response.InternalError(fmt.Errorf("failed to verify certificates: %w", err))
+	}
+
+	if _, err := setup.EnsureControlPlanePKI(snap, certificates); err != nil {
+		return response.InternalError(fmt.Errorf("failed to write control plane certificates: %w", err))
+	}
+
+	if err := setup.SetupControlPlaneKubeconfigs(snap.KubernetesConfigDir(), localhostAddress, clusterConfig.APIServer.GetSecurePort(), *certificates); err != nil {
+		return response.InternalError(fmt.Errorf("failed to generate control plane kubeconfigs: %w", err))
+	}
+
+	restartFn := func(ctx context.Context) error {
+		if err := snaputil.RestartControlPlaneServices(ctx, snap); err != nil {
+			return fmt.Errorf("failed to restart control plane services: %w", err)
+		}
+		return nil
+	}
+	readyCh := startAsyncRestart(log, restartFn)
+
+	return response.ManualResponse(func(w http.ResponseWriter) (rerr error) {
+		defer func() {
+			readyCh <- rerr
+			close(readyCh)
+		}()
+
+		err := response.SyncResponse(true, apiv1.UpdateCertificatesResponse{}).Render(w, r)
+		if err != nil {
+			return fmt.Errorf("failed to render response: %w", err)
+		}
+
+		f, ok := w.(http.Flusher)
+		if !ok {
+			return fmt.Errorf("ResponseWriter is not type http.Flusher")
+		}
+
+		f.Flush()
+		return nil
+	})
+}
+
+// updateCertificatesWorker updates the certificates for a worker node.
+func updateCertificatesWorker(s state.State, r *http.Request, snap snap.Snap) response.Response {
+	log := log.FromContext(r.Context())
+
+	req := apiv1.UpdateCertificatesRequest{}
+	if err := utils.NewStrictJSONDecoder(r.Body).Decode(&req); err != nil {
+		return response.BadRequest(fmt.Errorf("failed to parse request: %w", err))
+	}
+
+	clusterConfig, err := databaseutil.GetClusterConfig(r.Context(), s)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to recover cluster config: %w", err))
+	}
+
+	nodeIP := net.ParseIP(s.Address().Hostname())
+	if nodeIP == nil {
+		return response.InternalError(fmt.Errorf("failed to parse node IP address %q", s.Address().Hostname()))
+	}
+
+	var localhostAddress string
+	if nodeIP.To4() == nil {
+		localhostAddress = "[::1]"
+	} else {
+		localhostAddress = "127.0.0.1"
+	}
+
+	var certificates pki.WorkerNodePKI
+	certificates.CACert = clusterConfig.Certificates.GetCACert()
+	certificates.ClientCACert = clusterConfig.Certificates.GetClientCACert()
+
+	certificates.KubeletCert = req.GetKubeletCert()
+	certificates.KubeletKey = req.GetKubeletKey()
+	certificates.KubeletClientCert = req.GetKubeletClientCert()
+	certificates.KubeletClientKey = req.GetKubeletClientKey()
+	certificates.KubeProxyClientCert = req.GetKubeProxyClientCert()
+	certificates.KubeProxyClientKey = req.GetKubeProxyClientKey()
+
+	if err := certificates.CompleteCertificates(); err != nil {
+		return response.InternalError(fmt.Errorf("failed to verify certificates: %w", err))
+	}
+
+	if _, err := setup.EnsureWorkerPKI(snap, &certificates); err != nil {
+		return response.InternalError(fmt.Errorf("failed to write worker certificates: %w", err))
+	}
+
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), fmt.Sprintf("%s:%d", localhostAddress, clusterConfig.APIServer.GetSecurePort()), certificates.CACert, certificates.KubeletClientCert, certificates.KubeletClientKey); err != nil {
+		return response.InternalError(fmt.Errorf("failed to write kubeconfig %s: %w", filepath.Join(snap.KubernetesConfigDir(), "kubelet.conf"), err))
+	}
+
+	if err := setup.Kubeconfig(filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), fmt.Sprintf("%s:%d", localhostAddress, clusterConfig.APIServer.GetSecurePort()), certificates.CACert, certificates.KubeProxyClientCert, certificates.KubeProxyClientKey); err != nil {
+		return response.InternalError(fmt.Errorf("failed to write kubeconfig %s: %w", filepath.Join(snap.KubernetesConfigDir(), "proxy.conf"), err))
+	}
+
+	restartFn := func(ctx context.Context) error {
+		if err := snap.RestartService(ctx, "kubelet"); err != nil {
+			return fmt.Errorf("failed to restart kubelet: %w", err)
+		}
+
+		if err := snap.RestartService(ctx, "kube-proxy"); err != nil {
+			return fmt.Errorf("failed to restart kube-proxy: %w", err)
+		}
+		return nil
+	}
+
+	readyCh := startAsyncRestart(log, restartFn)
+
+	return response.ManualResponse(func(w http.ResponseWriter) (rerr error) {
+		defer func() {
+			readyCh <- rerr
+			close(readyCh)
+		}()
+
+		err := response.SyncResponse(true, apiv1.UpdateCertificatesResponse{}).Render(w, r)
+		if err != nil {
+			return fmt.Errorf("failed to render response: %w", err)
+		}
+
+		f, ok := w.(http.Flusher)
+		if !ok {
+			return fmt.Errorf("ResponseWriter is not type http.Flusher")
+		}
+
+		f.Flush()
+		return nil
+	})
+}
+
+// startAsyncRestart initiates an asynchronous service restart process after receiving a ready signal.
+func startAsyncRestart(logger log.Logger, restartFn func(context.Context) error) chan error {
+	readyCh := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		select {
+		case err := <-readyCh:
+			if err != nil {
+				logger.Error(err, "Operation failed before restart")
+				return
+			}
+		case <-ctx.Done():
+			logger.Error(ctx.Err(), "Timeout waiting for operation")
+			return
+		}
+
+		if err := restartFn(ctx); err != nil {
+			logger.Error(err, "Failed to restart services")
+		}
+	}()
+	return readyCh
+}

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -99,6 +99,11 @@ func (e *Endpoints) Endpoints() []rest.Endpoint {
 			Path: apiv1.RefreshCertificatesRunRPC,
 			Post: rest.EndpointAction{Handler: e.postRefreshCertsRun},
 		},
+		{
+			Name: "UpdateCertificates",
+			Path: apiv1.UpdateCertificatesRPC,
+			Post: rest.EndpointAction{Handler: e.postUpdateCertificates},
+		},
 		// Kubeconfig
 		{
 			Name: "Kubeconfig",


### PR DESCRIPTION
## Overview
Add the `update-certs` command to allow the user to update the node certificates

## Rationale
This pull request adds a new endpoint that can be leveraged by users using external CAs and other deployment mechanisms (like Juju) to update the certificates on the running node. This is particularly useful if the cluster is using external certificates that are nearing expiration or if the `extraSANS` change due to external load balancing for the API server units.