### PR TITLE
CI: Add charm e2e tests

### DIFF
--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -75,15 +75,17 @@ jobs:
           # https://github.com/canonical/k8s-operator/blob/eba756ddc723e9aa5242c7804712807495356c6f/tests/integration/helpers.py#L334-L342
 
           arch=${{ inputs.arch }}
-          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
-          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}.charm
 
           juju download k8s \
             --channel ${{ inputs.charm-channel }} \
-            --filepath $k8sCharmFile
+            --filepath $k8sCharmFile \
+            --base ubuntu@22.04
           juju download k8s-worker \
             --channel ${{ inputs.charm-channel }} \
-            --filepath $k8sWorkerChamFile
+            --filepath $k8sWorkerChamFile \
+            --base ubuntu@22.04
       - name: Bootstrap Juju controller (lxd)
         run: |
           juju bootstrap localhost lxd

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -1,0 +1,94 @@
+name: Run k8s-snap e2e tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: Job runner architecture (amd64 or arm64)
+        default: amd64
+        type: string
+      # Download k8s-snap using either a GH action artifact or a snap channel.
+      artifact:
+        description: The name of a GH action artifact.
+        type: string
+      channel:
+        description: k8s snap channel.
+        type: string
+      charm-channel:
+        description: k8s charm channel.
+        type: string
+        default: latest/edge
+
+jobs:
+  charm-e2e-tests:
+    name: Test ${{ inputs.arch }} ${{ inputs.artifact }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-large' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Download k8s-snap
+        id: download-snap
+        uses: ./.github/actions/download-k8s-snap
+        with:
+          channel: ${{ inputs.channel }}
+          artifact: ${{ inputs.artifact }}
+      - name: Install lxd
+        uses: ./.github/actions/install-lxd
+      - name: Install tox
+        run: pip install tox
+      - name: Generate snap tarball
+        run: |
+          mkdir snap_installation
+          mv ${{ inputs.artifact }} snap_installation/k8s.snap
+          cat > snap_installation/snap_installation.yaml <<EOF
+          amd64:
+            - install-type: file
+              name: k8s
+              filename: ./k8s.snap
+              dangerous: true
+              classic: true
+          arm64:
+            - install-type: file
+              name: k8s
+              filename: ./k8s.snap
+              dangerous: true
+              classic: true
+          EOF
+          tar cvzf snap_installation.tar.gz -C snap_installation/ .
+      - name: Install charmcraft
+        run: |
+          sudo snap install charmcraft --classic
+      - name: Install juju
+        run: |
+          sudo snap install juju --classic
+      - name: Download charm ${{ inputs.charm-channel }}
+        run: |
+          juju download k8s \
+            --channel ${{ inputs.charm-channel }} \
+            --filepath k8s.charm
+      - name: Bootstrap Juju controller (lxd)
+        run: |
+          juju bootstrap localhost lxd
+      - uses: actions/checkout@v4
+        with:
+          repository: canonical/k8s-operator
+          ref: main
+          path: k8s-operator
+      - name: Run e2e tests
+        run: |
+          charmFile=${GITHUB_WORKSPACE}/k8s.charm
+          snapInstallRes=${GITHUB_WORKSPACE}/snap_installation.tar.gz
+          cd k8s-operator
+          sudo --user "$USER" --preserve-env --preserve-env=PATH \
+            -- env -- \
+            tox -e integration \
+            -- \
+            --lxd-containers --charm-file $charmFile \
+            --snap-installation-resource $snapInstallRes

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -106,4 +106,4 @@ jobs:
             --charm-file $k8sCharmFile \
             --charm-file $k8sWorkerChamFile \
             --snap-installation-resource $snapInstallRes \
-            -k test_nodes_ready
+            'tests/integration/test_k8s.py::test_nodes_ready'

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -106,4 +106,4 @@ jobs:
             --charm-file $k8sCharmFile \
             --charm-file $k8sWorkerChamFile \
             --snap-installation-resource $snapInstallRes \
-            -k test_k8s
+            -k test_nodes_ready

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -109,7 +109,6 @@ jobs:
             -- env -- \
             tox -e integration \
             -- \
-            --series noble \
             --charm-file $k8sCharmFile \
             --charm-file $k8sWorkerChamFile \
             --snap-installation-resource $snapInstallRes

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -47,20 +47,6 @@ jobs:
         run: |
           mkdir snap_installation
           mv ${{ steps.download-snap.outputs.snap-path }} snap_installation/k8s.snap
-          cat > snap_installation/snap_installation.yaml <<EOF
-          amd64:
-            - install-type: file
-              name: k8s
-              filename: ./k8s.snap
-              dangerous: true
-              classic: true
-          arm64:
-            - install-type: file
-              name: k8s
-              filename: ./k8s.snap
-              dangerous: true
-              classic: true
-          EOF
           tar cvzf snap_installation.tar.gz -C snap_installation/ .
       - name: Install charmcraft
         run: |

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -99,6 +99,7 @@ jobs:
           arch=${{ inputs.arch }}
           k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-24.04-${arch}.charm
           k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-24.04-${arch}.charm
+          snapInstallRes=${GITHUB_WORKSPACE}/snap_installation.tar.gz
 
           ls -lh $charmFile
           ls -lh $snapInstallRes

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -60,6 +60,8 @@ jobs:
           # ${charmName}_ prefix and include the arch and ubuntu base.
           # https://github.com/canonical/k8s-operator/blob/eba756ddc723e9aa5242c7804712807495356c6f/tests/integration/helpers.py#L334-L342
 
+          # The charm base (e.g. ubuntu@22.04) must match the one used by other
+          # related charms (e.g. ceph) used by the k8s-operator tests.
           arch=${{ inputs.arch }}
           k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}.charm
           k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}.charm
@@ -82,6 +84,7 @@ jobs:
           path: k8s-operator
       - name: Disable lxd ipv6
         run: |
+          # The charm tests can't handle ipv6 dualstack.
           lxc network set lxdbr0 ipv6.address none
       - name: Run e2e tests
         run: |
@@ -102,4 +105,5 @@ jobs:
             -- \
             --charm-file $k8sCharmFile \
             --charm-file $k8sWorkerChamFile \
-            --snap-installation-resource $snapInstallRes
+            --snap-installation-resource $snapInstallRes \
+            -k test_k8s

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Generate snap tarball
         run: |
           mkdir snap_installation
-          mv ${{ inputs.artifact }} snap_installation/k8s.snap
+          mv ${{ steps.download-snap.outputs.snap-path }} snap_installation/k8s.snap
           cat > snap_installation/snap_installation.yaml <<EOF
           amd64:
             - install-type: file

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -68,11 +68,22 @@ jobs:
       - name: Install juju
         run: |
           sudo snap install juju --classic
-      - name: Download charm ${{ inputs.charm-channel }}
+      - name: Download charms ${{ inputs.charm-channel }} ${{ inputs.arch }}
         run: |
+          # The operator tests expect the charm file name to have the
+          # ${charmName}_ prefix and include the arch and ubuntu base.
+          https://github.com/canonical/k8s-operator/blob/eba756ddc723e9aa5242c7804712807495356c6f/tests/integration/helpers.py#L334-L342
+
+          arch=${{ inputs.arch }}
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+
           juju download k8s \
             --channel ${{ inputs.charm-channel }} \
-            --filepath k8s.charm
+            --filepath $k8sCharmFile
+          juju download k8s-worker \
+            --channel ${{ inputs.charm-channel }} \
+            --filepath $k8sWorkerChamFile
       - name: Bootstrap Juju controller (lxd)
         run: |
           juju bootstrap localhost lxd
@@ -83,9 +94,12 @@ jobs:
           path: k8s-operator
       - name: Run e2e tests
         run: |
-          charmFile=${GITHUB_WORKSPACE}/k8s.charm
-          snapInstallRes=${GITHUB_WORKSPACE}/snap_installation.tar.gz
           set -x
+
+          arch=${{ inputs.arch }}
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+
           ls -lh $charmFile
           ls -lh $snapInstallRes
           cd k8s-operator
@@ -93,5 +107,6 @@ jobs:
             -- env -- \
             tox -e integration \
             -- \
-            --charm-file $charmFile \
+            --charm-file $k8sCharmFile \
+            --charm-file $k8sWorkerChamFile \
             --snap-installation-resource $snapInstallRes

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -75,8 +75,8 @@ jobs:
           # https://github.com/canonical/k8s-operator/blob/eba756ddc723e9aa5242c7804712807495356c6f/tests/integration/helpers.py#L334-L342
 
           arch=${{ inputs.arch }}
-          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-24.04-${arch}.charm
-          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-24.04-${arch}.charm
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
 
           juju download k8s \
             --channel ${{ inputs.charm-channel }} \
@@ -97,8 +97,8 @@ jobs:
           set -x
 
           arch=${{ inputs.arch }}
-          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-24.04-${arch}.charm
-          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-24.04-${arch}.charm
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
           snapInstallRes=${GITHUB_WORKSPACE}/snap_installation.tar.gz
 
           ls -lh $charmFile

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -93,5 +93,5 @@ jobs:
             -- env -- \
             tox -e integration \
             -- \
-            --lxd-containers --charm-file $charmFile \
+            --charm-file $charmFile \
             --snap-installation-resource $snapInstallRes

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -72,11 +72,11 @@ jobs:
         run: |
           # The operator tests expect the charm file name to have the
           # ${charmName}_ prefix and include the arch and ubuntu base.
-          https://github.com/canonical/k8s-operator/blob/eba756ddc723e9aa5242c7804712807495356c6f/tests/integration/helpers.py#L334-L342
+          # https://github.com/canonical/k8s-operator/blob/eba756ddc723e9aa5242c7804712807495356c6f/tests/integration/helpers.py#L334-L342
 
           arch=${{ inputs.arch }}
-          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
-          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-24.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-24.04-${arch}.charm
 
           juju download k8s \
             --channel ${{ inputs.charm-channel }} \
@@ -97,16 +97,18 @@ jobs:
           set -x
 
           arch=${{ inputs.arch }}
-          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
-          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-24.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-24.04-${arch}.charm
 
           ls -lh $charmFile
           ls -lh $snapInstallRes
+
           cd k8s-operator
           sudo --user "$USER" --preserve-env --preserve-env=PATH \
             -- env -- \
             tox -e integration \
             -- \
+            --series noble \
             --charm-file $k8sCharmFile \
             --charm-file $k8sWorkerChamFile \
             --snap-installation-resource $snapInstallRes

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -85,6 +85,9 @@ jobs:
         run: |
           charmFile=${GITHUB_WORKSPACE}/k8s.charm
           snapInstallRes=${GITHUB_WORKSPACE}/snap_installation.tar.gz
+          set -x
+          ls -lh $charmFile
+          ls -lh $snapInstallRes
           cd k8s-operator
           sudo --user "$USER" --preserve-env --preserve-env=PATH \
             -- env -- \

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -85,8 +85,8 @@ jobs:
           set -x
 
           arch=${{ inputs.arch }}
-          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
-          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}_ubuntu-24.04-${arch}.charm
+          k8sCharmFile=${GITHUB_WORKSPACE}/k8s_ubuntu-22.04-${arch}.charm
+          k8sWorkerChamFile=${GITHUB_WORKSPACE}/k8s-worker_ubuntu-22.04-${arch}.charm
           snapInstallRes=${GITHUB_WORKSPACE}/snap_installation.tar.gz
 
           ls -lh $charmFile

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   charm-e2e-tests:
     name: Test ${{ inputs.arch }} ${{ inputs.artifact }}
-    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-large' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-xlarge' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -80,6 +80,9 @@ jobs:
           repository: canonical/k8s-operator
           ref: main
           path: k8s-operator
+      - name: Disable lxd ipv6
+        run: |
+          lxc network set lxdbr0 ipv6.address none
       - name: Run e2e tests
         run: |
           set -x

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -140,7 +140,7 @@ jobs:
   #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
 
   charm-e2e-tests:
-    name: Charmm e2e tests
+    name: Charm e2e tests
     strategy:
       fail-fast: false
     # needs: [build-snap, go-lint-and-unit, python-lint]

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -139,13 +139,35 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
 
+  get-charm-channel:
+    name: Determine the charm channel
+    outputs:
+      charm-channel: ${{ steps.parse-branch.outputs.charm-channel }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse branch name
+        id: parse-branch
+        env:
+          # Use either the base (destination) branch name for PRs or
+          # "ref_name" on push.
+          BRANCH_NAME: ${{ github.base_ref || github.ref_name }}
+        run: |
+          release=$(echo $BRANCH_NAME | grep -Po "release-\d+\.\d+" | cut -d "-" -f 2)
+          if [[ -n $release ]]; then
+            # Stable releases don't have an "edge" track, we'll use beta.
+            channel="$release/beta"
+          else
+            channel=latest/edge
+          fi
+          echo "charm-channel=$channel" >> "$GITHUB_OUTPUT"
+
   charm-e2e-tests:
     name: Charm e2e tests
     strategy:
       fail-fast: false
-    needs: [build-snap, go-lint-and-unit, python-lint]
+    needs: [build-snap, go-lint-and-unit, python-lint, get-charm-channel]
     uses: ./.github/workflows/charm-e2e-tests.yaml
     with:
       arch: amd64
       artifact: k8s.snap
-      charm-channel: latest/edge
+      charm-channel: ${{ needs.get-charm-channel.outputs.charm-channel }}

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -27,114 +27,126 @@ jobs:
     with:
       flavor: ${{ matrix.patch }}
 
-  test-branches:
-    name: Test Branch Management
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-      - name: Install tox
-        run: pip install tox
-      - name: Run branch_management tests
-        run: |
-          tox -c tests/branch_management -e test
+  # test-branches:
+  #   name: Test Branch Management
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.8'
+  #     - name: Install tox
+  #       run: pip install tox
+  #     - name: Run branch_management tests
+  #       run: |
+  #         tox -c tests/branch_management -e test
 
-  python-lint:
-    name: Python lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: Install tox
-        run: pip install tox
-      - name: Lint
-        run: |
-          cd tests/integration && tox -e lint
+  # python-lint:
+  #   name: Python lint
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@v4
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.10'
+  #     - name: Install tox
+  #       run: pip install tox
+  #     - name: Lint
+  #       run: |
+  #         cd tests/integration && tox -e lint
 
-  go-lint-and-unit:
-    name: Go lint and unit tests
-    uses: ./.github/workflows/go.yaml
-    permissions:
-      contents: read  # for actions/checkout to fetch code
-      pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
-      checks: write # for golangci/golangci-lint-action to checks to allow the action to annotate code in the PR.
+  # go-lint-and-unit:
+  #   name: Go lint and unit tests
+  #   uses: ./.github/workflows/go.yaml
+  #   permissions:
+  #     contents: read  # for actions/checkout to fetch code
+  #     pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
+  #     checks: write # for golangci/golangci-lint-action to checks to allow the action to annotate code in the PR.
 
-  get-e2e-tags:
-    name: Get e2e test tags
-    runs-on: ubuntu-latest
-    outputs:
-      test-tags: ${{ steps.get-e2e-tags.outputs.test-tags }}
-    needs: [build-snap, go-lint-and-unit, python-lint]
-    steps:
-      - name: Checking out repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: Get e2e test tags
-        id: get-e2e-tags
-        run: |
-          tags="pull_request"
-          if ${{ github.event_name == 'pull_request' }}; then
-            # Run all tests if there are test changes. In case of a PR, we'll
-            # get a merge commit that includes all changes.
-            if git diff HEAD HEAD~1 --name-only | grep "tests/"; then
-              tags="up_to_weekly"
-            fi
-            # Run all tests on backports.
-            if echo ${{ github.base_ref }} | grep "release-"; then
-              tags="up_to_weekly"
-            fi
-          fi
+  # get-e2e-tags:
+  #   name: Get e2e test tags
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     test-tags: ${{ steps.get-e2e-tags.outputs.test-tags }}
+  #   needs: [build-snap, go-lint-and-unit, python-lint]
+  #   steps:
+  #     - name: Checking out repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 2
+  #     - name: Get e2e test tags
+  #       id: get-e2e-tags
+  #       run: |
+  #         tags="pull_request"
+  #         if ${{ github.event_name == 'pull_request' }}; then
+  #           # Run all tests if there are test changes. In case of a PR, we'll
+  #           # get a merge commit that includes all changes.
+  #           if git diff HEAD HEAD~1 --name-only | grep "tests/"; then
+  #             tags="up_to_weekly"
+  #           fi
+  #           # Run all tests on backports.
+  #           if echo ${{ github.base_ref }} | grep "release-"; then
+  #             tags="up_to_weekly"
+  #           fi
+  #         fi
 
-          echo "test-tags=$tags" >> "$GITHUB_OUTPUT"
+  #         echo "test-tags=$tags" >> "$GITHUB_OUTPUT"
 
-  test-integration:
-    name: Test ${{ matrix.os }}
+  # test-integration:
+  #   name: Test ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
+  #   needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
+  #   uses: ./.github/workflows/e2e-tests.yaml
+  #   with:
+  #     arch: amd64
+  #     os: ${{ matrix.os }}
+  #     test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
+  #     artifact: k8s.snap
+
+  # test-integration-informing:
+  #   name: Test informing ${{ matrix.os }} ${{ matrix.patch }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: ["ubuntu:24.04"]
+  #       patch: ["moonray"]
+  #   needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
+  #   if: success() && github.event_name == 'pull_request'
+  #   uses: ./.github/workflows/e2e-tests.yaml
+  #   with:
+  #     arch: amd64
+  #     os: ${{ matrix.os }}
+  #     test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
+  #     artifact: k8s-${{ matrix.patch }}.snap
+  #     flavor: ${{ matrix.patch }}
+
+  # security-scan:
+  #   name: Security scan
+  #   needs: build-snap
+  #   uses: ./.github/workflows/security-scan.yaml
+  #   with:
+  #     artifact: ${{ needs.build-snap.outputs.snap-artifact}}
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+
+  charm-e2e-tests:
+    name: Charmm e2e tests
     strategy:
       fail-fast: false
-      matrix:
-        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
-    needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
-    uses: ./.github/workflows/e2e-tests.yaml
+    # needs: [build-snap, go-lint-and-unit, python-lint]
+    needs: [build-snap]
+    uses: ./.github/workflows/charm-e2e-tests.yaml
     with:
       arch: amd64
-      os: ${{ matrix.os }}
-      test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
       artifact: k8s.snap
-
-  test-integration-informing:
-    name: Test informing ${{ matrix.os }} ${{ matrix.patch }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu:24.04"]
-        patch: ["moonray"]
-    needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
-    if: success() && github.event_name == 'pull_request'
-    uses: ./.github/workflows/e2e-tests.yaml
-    with:
-      arch: amd64
-      os: ${{ matrix.os }}
-      test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
-      artifact: k8s-${{ matrix.patch }}.snap
-      flavor: ${{ matrix.patch }}
-
-  security-scan:
-    name: Security scan
-    needs: build-snap
-    uses: ./.github/workflows/security-scan.yaml
-    with:
-      artifact: ${{ needs.build-snap.outputs.snap-artifact}}
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      charm-channel: latest/edge

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -18,136 +18,134 @@ permissions:
   contents: read
 
 jobs:
-  # build-snap:
-  #   name: Build k8s-snap ${{ matrix.patch }}
-  #   uses: ./.github/workflows/build-snap.yaml
-  #   strategy:
-  #     matrix:
-  #       patch: ["", "moonray"]
-  #   with:
-  #     flavor: ${{ matrix.patch }}
+  build-snap:
+    name: Build k8s-snap ${{ matrix.patch }}
+    uses: ./.github/workflows/build-snap.yaml
+    strategy:
+      matrix:
+        patch: ["", "moonray"]
+    with:
+      flavor: ${{ matrix.patch }}
 
-  # test-branches:
-  #   name: Test Branch Management
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Setup Python
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: '3.8'
-  #     - name: Install tox
-  #       run: pip install tox
-  #     - name: Run branch_management tests
-  #       run: |
-  #         tox -c tests/branch_management -e test
+  test-branches:
+    name: Test Branch Management
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Install tox
+        run: pip install tox
+      - name: Run branch_management tests
+        run: |
+          tox -c tests/branch_management -e test
 
-  # python-lint:
-  #   name: Python lint
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@v4
-  #     - name: Setup Python
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: '3.10'
-  #     - name: Install tox
-  #       run: pip install tox
-  #     - name: Lint
-  #       run: |
-  #         cd tests/integration && tox -e lint
+  python-lint:
+    name: Python lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install tox
+        run: pip install tox
+      - name: Lint
+        run: |
+          cd tests/integration && tox -e lint
 
-  # go-lint-and-unit:
-  #   name: Go lint and unit tests
-  #   uses: ./.github/workflows/go.yaml
-  #   permissions:
-  #     contents: read  # for actions/checkout to fetch code
-  #     pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
-  #     checks: write # for golangci/golangci-lint-action to checks to allow the action to annotate code in the PR.
+  go-lint-and-unit:
+    name: Go lint and unit tests
+    uses: ./.github/workflows/go.yaml
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for marocchino/sticky-pull-request-comment to create or update PR comment
+      checks: write # for golangci/golangci-lint-action to checks to allow the action to annotate code in the PR.
 
-  # get-e2e-tags:
-  #   name: Get e2e test tags
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     test-tags: ${{ steps.get-e2e-tags.outputs.test-tags }}
-  #   needs: [build-snap, go-lint-and-unit, python-lint]
-  #   steps:
-  #     - name: Checking out repo
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 2
-  #     - name: Get e2e test tags
-  #       id: get-e2e-tags
-  #       run: |
-  #         tags="pull_request"
-  #         if ${{ github.event_name == 'pull_request' }}; then
-  #           # Run all tests if there are test changes. In case of a PR, we'll
-  #           # get a merge commit that includes all changes.
-  #           if git diff HEAD HEAD~1 --name-only | grep "tests/"; then
-  #             tags="up_to_weekly"
-  #           fi
-  #           # Run all tests on backports.
-  #           if echo ${{ github.base_ref }} | grep "release-"; then
-  #             tags="up_to_weekly"
-  #           fi
-  #         fi
+  get-e2e-tags:
+    name: Get e2e test tags
+    runs-on: ubuntu-latest
+    outputs:
+      test-tags: ${{ steps.get-e2e-tags.outputs.test-tags }}
+    needs: [build-snap, go-lint-and-unit, python-lint]
+    steps:
+      - name: Checking out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Get e2e test tags
+        id: get-e2e-tags
+        run: |
+          tags="pull_request"
+          if ${{ github.event_name == 'pull_request' }}; then
+            # Run all tests if there are test changes. In case of a PR, we'll
+            # get a merge commit that includes all changes.
+            if git diff HEAD HEAD~1 --name-only | grep "tests/"; then
+              tags="up_to_weekly"
+            fi
+            # Run all tests on backports.
+            if echo ${{ github.base_ref }} | grep "release-"; then
+              tags="up_to_weekly"
+            fi
+          fi
 
-  #         echo "test-tags=$tags" >> "$GITHUB_OUTPUT"
+          echo "test-tags=$tags" >> "$GITHUB_OUTPUT"
 
-  # test-integration:
-  #   name: Test ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
-  #   needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
-  #   uses: ./.github/workflows/e2e-tests.yaml
-  #   with:
-  #     arch: amd64
-  #     os: ${{ matrix.os }}
-  #     test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
-  #     artifact: k8s.snap
+  test-integration:
+    name: Test ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
+    needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      arch: amd64
+      os: ${{ matrix.os }}
+      test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
+      artifact: k8s.snap
 
-  # test-integration-informing:
-  #   name: Test informing ${{ matrix.os }} ${{ matrix.patch }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: ["ubuntu:24.04"]
-  #       patch: ["moonray"]
-  #   needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
-  #   if: success() && github.event_name == 'pull_request'
-  #   uses: ./.github/workflows/e2e-tests.yaml
-  #   with:
-  #     arch: amd64
-  #     os: ${{ matrix.os }}
-  #     test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
-  #     artifact: k8s-${{ matrix.patch }}.snap
-  #     flavor: ${{ matrix.patch }}
+  test-integration-informing:
+    name: Test informing ${{ matrix.os }} ${{ matrix.patch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu:24.04"]
+        patch: ["moonray"]
+    needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
+    if: success() && github.event_name == 'pull_request'
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      arch: amd64
+      os: ${{ matrix.os }}
+      test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
+      artifact: k8s-${{ matrix.patch }}.snap
+      flavor: ${{ matrix.patch }}
 
-  # security-scan:
-  #   name: Security scan
-  #   needs: build-snap
-  #   uses: ./.github/workflows/security-scan.yaml
-  #   with:
-  #     artifact: ${{ needs.build-snap.outputs.snap-artifact}}
-  #   permissions:
-  #     contents: read # for actions/checkout to fetch code
-  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  security-scan:
+    name: Security scan
+    needs: build-snap
+    uses: ./.github/workflows/security-scan.yaml
+    with:
+      artifact: ${{ needs.build-snap.outputs.snap-artifact}}
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
 
   charm-e2e-tests:
     name: Charm e2e tests
     strategy:
       fail-fast: false
-    # needs: [build-snap, go-lint-and-unit, python-lint]
-    # needs: [build-snap]
+    needs: [build-snap, go-lint-and-unit, python-lint]
     uses: ./.github/workflows/charm-e2e-tests.yaml
     with:
       arch: amd64
-      # artifact: k8s.snap
-      channel: latest/edge
+      artifact: k8s.snap
       charm-channel: latest/edge

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -18,14 +18,14 @@ permissions:
   contents: read
 
 jobs:
-  build-snap:
-    name: Build k8s-snap ${{ matrix.patch }}
-    uses: ./.github/workflows/build-snap.yaml
-    strategy:
-      matrix:
-        patch: ["", "moonray"]
-    with:
-      flavor: ${{ matrix.patch }}
+  # build-snap:
+  #   name: Build k8s-snap ${{ matrix.patch }}
+  #   uses: ./.github/workflows/build-snap.yaml
+  #   strategy:
+  #     matrix:
+  #       patch: ["", "moonray"]
+  #   with:
+  #     flavor: ${{ matrix.patch }}
 
   # test-branches:
   #   name: Test Branch Management
@@ -144,9 +144,10 @@ jobs:
     strategy:
       fail-fast: false
     # needs: [build-snap, go-lint-and-unit, python-lint]
-    needs: [build-snap]
+    # needs: [build-snap]
     uses: ./.github/workflows/charm-e2e-tests.yaml
     with:
       arch: amd64
-      artifact: k8s.snap
+      # artifact: k8s.snap
+      channel: latest/edge
       charm-channel: latest/edge


### PR DESCRIPTION
We'll run the k8s-operator (charm) e2e tests for every PR to ensure that we aren't breaking the charm.

For now, we'll only run ``test_k8s.py::test_nodes_ready`` on amd64.