### PR TITLE
bug: reject unknown bootstrap arguments

### DIFF
--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -47,6 +47,7 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Short:  "Bootstrap a new Kubernetes cluster",
 		Long:   "Generate certificates, configure service arguments and start the Kubernetes services.",
 		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat), hookCheckLXD()),
+		Args:   cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			snapdClient, err := snapd.NewClient()
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_config.go
+++ b/src/k8s/cmd/k8s/k8s_config.go
@@ -18,6 +18,7 @@ func newKubeConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Use:    "config",
 		Hidden: true,
 		Short:  "Generate an admin kubeconfig that can be used to access the Kubernetes cluster",
+		Args:   cobra.NoArgs,
 		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			if opts.timeout < minTimeout {

--- a/src/k8s/cmd/k8s/k8s_generate_docs.go
+++ b/src/k8s/cmd/k8s/k8s_generate_docs.go
@@ -19,6 +19,7 @@ func newGenerateDocsCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Use:    "generate-docs",
 		Hidden: true,
 		Short:  "Generate markdown documentation",
+		Args:   cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			outPath := path.Join(opts.outputDir, "commands")
 			if err := doc.GenMarkdownTree(cmd.Parent(), outPath); err != nil {

--- a/src/k8s/cmd/k8s/k8s_local_node_status.go
+++ b/src/k8s/cmd/k8s/k8s_local_node_status.go
@@ -14,6 +14,7 @@ func newLocalNodeStatusCommand(env cmdutil.ExecutionEnvironment) *cobra.Command 
 		Short:  "Retrieve the current status of the local node",
 		Hidden: true,
 		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
+		Args:   cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			client, err := env.Snap.K8sdClient("")
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_refresh_certs.go
+++ b/src/k8s/cmd/k8s/k8s_refresh_certs.go
@@ -19,6 +19,7 @@ func newRefreshCertsCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "refresh-certs",
 		Short:  "Refresh the certificates of the running node",
+		Args:   cobra.NoArgs,
 		PreRun: chainPreRunHooks(hookRequireRoot(env)),
 		Run: func(cmd *cobra.Command, args []string) {
 			ttl, err := utils.TTLToSeconds(opts.expiresIn)

--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -19,6 +19,7 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Use:    "status",
 		Short:  "Retrieve the current status of the cluster",
 		Long:   "Retrieve the current status of the cluster as well as deployment status of core features.",
+		Args:   cobra.NoArgs,
 		PreRun: chainPreRunHooks(hookRequireRoot(env), hookInitializeFormatter(env, &opts.outputFormat)),
 		Run: func(cmd *cobra.Command, args []string) {
 			if opts.timeout < minTimeout {

--- a/src/k8s/cmd/k8s/k8s_x_cleanup.go
+++ b/src/k8s/cmd/k8s/k8s_x_cleanup.go
@@ -17,6 +17,7 @@ func newXCleanupCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cleanupNetworkCmd := &cobra.Command{
 		Use:   string(features.Network),
 		Short: "Cleanup left-over network resources",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
 			defer cancel()

--- a/src/k8s/cmd/k8s/k8s_x_list_images.go
+++ b/src/k8s/cmd/k8s/k8s_x_list_images.go
@@ -13,6 +13,7 @@ func newListImagesCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		Hidden:  true,
 		Aliases: []string{"list-images"},
 		Short:   "List all images used by this build",
+		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Println(strings.Join(images.Images(), "\n"))
 		},

--- a/src/k8s/cmd/k8s/k8s_x_print_shim_pids.go
+++ b/src/k8s/cmd/k8s/k8s_x_print_shim_pids.go
@@ -9,6 +9,7 @@ var xPrintShimPidsCmd = &cobra.Command{
 	Use:    "x-print-shim-pids",
 	Short:  "Print list of PIDs started by the containerd shim and pause processes",
 	Hidden: true,
+	Args:   cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		pids, err := shims.RunningContainerdShimPIDs(cmd.Context())
 		if err != nil {

--- a/src/k8s/cmd/k8s/k8s_x_snapd_config.go
+++ b/src/k8s/cmd/k8s/k8s_x_snapd_config.go
@@ -18,6 +18,7 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	disableCmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable the use of snap get/set to manage the cluster configuration",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := snapdconfig.Disable(cmd.Context(), env.Snap); err != nil {
 				cmd.PrintErrf("Error: failed to disable snapd configuration: %v\n", err)
@@ -28,6 +29,7 @@ func newXSnapdConfigCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	reconcileCmd := &cobra.Command{
 		Use:   "reconcile",
 		Short: "Reconcile the cluster configuration changes from k8s {set,get} <-> snap {set,get} k8s",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			mode, empty, err := snapdconfig.ParseMeta(cmd.Context(), env.Snap)
 			if err != nil {

--- a/src/k8s/cmd/k8s/k8s_x_wait_for.go
+++ b/src/k8s/cmd/k8s/k8s_x_wait_for.go
@@ -17,6 +17,7 @@ func newXWaitForCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	waitForDNSCmd := &cobra.Command{
 		Use:   string(features.DNS),
 		Short: "Wait for DNS to be ready",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
 			defer cancel()
@@ -37,6 +38,7 @@ func newXWaitForCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	waitForNetworkCmd := &cobra.Command{
 		Use:   string(features.Network),
 		Short: "Wait for Network to be ready",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
 			defer cancel()


### PR DESCRIPTION
We're updating the "k8s bootstrap" command to throw an error when receiving unknown positional arguments.

For example, when passing a bootstrap config as a positional argument instead of a named argument, the command will now error out instead of ignoring the parameter, which can be confusing to end users.