### PR TITLE
doc: k8s-snap intermediate ca docs

### DIFF
--- a/docs/canonicalk8s/_parts/common_vault_intermediate_ca.md
+++ b/docs/canonicalk8s/_parts/common_vault_intermediate_ca.md
@@ -1,0 +1,68 @@
+## Prepare Vault
+
+For the purpose of this guide, we are going to install HashiCorp Vault using
+snap and start a Vault server in development mode.
+
+```
+sudo snap install vault
+vault server -dev &
+```
+
+Specify the Vault address through an environment variable:
+
+```
+export VAULT_ADDR=http://localhost:8200
+```
+
+Enable the PKI secrets engine and set the maximum lease time to 10 years
+(87600 hours):
+
+```
+vault secrets enable pki
+vault secrets tune -max-lease-ttl=87600h pki
+```
+
+## Generate the CA certificates
+
+Generate the root CA certificate:
+
+```
+vault write pki/root/generate/internal \
+    common_name=vault \
+    ttl=87600h
+```
+
+Generate the intermediate CA certificate. We need the resulting Certificate
+Signing Request (CSR) and private key, so for convenience we'll use JSON
+formatting and store the output in a file.
+
+```
+mkdir myca
+vault write pki/intermediate/generate/exported common_name=kubernetes \
+    -format=json > myca/intermediate.json
+```
+
+Extract the CSR and key to separate files:
+
+```
+cat myca/intermediate.json | jq -r '.data.csr' > myca/intermediate.csr
+cat myca/intermediate.json | jq -r '.data.private_key' > myca/intermediate.key
+```
+
+Sign the intermediate CA using the root CA:
+
+```
+vault write -format=json pki/root/sign-intermediate \
+    common_name=kubernetes \
+    csr=@myca/intermediate.csr \
+    ttl=87600h > myca/intermediate-signed.json
+```
+
+Extract the resulting intermediate CA certificate:
+
+```
+cat myca/intermediate-signed.json | jq -r '.data.ca_chain' \
+    > myca/intermediate-chain.crt
+cat myca/intermediate-signed.json | jq -r '.data.certificate' \
+    > myca/intermediate.crt
+```

--- a/docs/canonicalk8s/capi/howto/intermediate-ca.md
+++ b/docs/canonicalk8s/capi/howto/intermediate-ca.md
@@ -7,73 +7,7 @@ Follow this guide to prepare an intermediate Certificate Authority (CA) using
 [HashiCorp Vault] and then configure ClusterAPI to use the generated
 certificates.
 
-## Prepare Vault
-
-For the purpose of this guide, we are going to install HashiCorp Vault using
-snap and start a Vault server in development mode.
-
-```
-sudo snap install vault
-vault server -dev &
-```
-
-Specify the Vault address through an environment variable:
-
-```
-export VAULT_ADDR=http://localhost:8200
-```
-
-Enable the PKI secrets engine and set the maximum lease time to 10 years
-(87600 hours):
-
-```
-vault secrets enable pki
-vault secrets tune -max-lease-ttl=87600h pki
-```
-
-## Generate the CA certificates
-
-Generate the root CA certificate:
-
-```
-vault write pki/root/generate/internal \
-    common_name=vault \
-    ttl=87600h \
-```
-
-Generate the intermediate CA certificate. We need the resulting Certificate
-Signing Request (CSR) and private key, so for convenience we'll use JSON
-formatting and store the output in a file.
-
-```
-mkdir myca
-vault write pki/intermediate/generate/exported common_name=kubernetes \
-    -format=json > myca/intermediate.json
-```
-
-Extract the CSR and key to separate files:
-
-```
-cat myca/intermediate.json | jq -r '.data.csr' > myca/intermediate.csr
-cat myca/intermediate.json | jq -r '.data.private_key' > myca/intermediate.key
-```
-
-Sign the intermediate CA using the root CA:
-
-```
-vault write -format=json pki/root/sign-intermediate \
-    common_name=kubernetes \
-    csr=@myca/intermediate.csr \
-    ttl=87600h > myca/intermediate-signed.json
-```
-
-Extract the resulting intermediate CA certificate:
-
-```
-cat myca/intermediate-signed.json | jq -r '.data.ca_chain' \
-    > myca/intermediate-chain.crt
-cat myca/intermediate-signed.json | jq -r '.data.certificate' \
-    > myca/intermediate.crt
+```{include} /_parts/common_vault_intermediate_ca.md
 ```
 
 ## Pass intermediate CA certificates to CAPI

--- a/docs/canonicalk8s/snap/howto/index.md
+++ b/docs/canonicalk8s/snap/howto/index.md
@@ -22,6 +22,7 @@ Use an external datastore <external-datastore>
 Set up cluster observability  <observability>
 Back up and restore <backup-restore>
 Refresh Kubernetes Certificates <refresh-certs>
+Use intermediate CAs with Vault <intermediate-ca>
 Recover a cluster after quorum loss <restore-quorum>
 Manage upgrades <upgrades>
 Set up Enhanced Platform Awareness <epa>

--- a/docs/canonicalk8s/snap/howto/index.md
+++ b/docs/canonicalk8s/snap/howto/index.md
@@ -22,7 +22,7 @@ Use an external datastore <external-datastore>
 Set up cluster observability  <observability>
 Back up and restore <backup-restore>
 Refresh Kubernetes Certificates <refresh-certs>
-Use intermediate CAs with Vault <intermediate-ca>
+Use intermediate CAs with Vault <intermediate-ca.md>
 Recover a cluster after quorum loss <restore-quorum>
 Manage upgrades <upgrades>
 Set up Enhanced Platform Awareness <epa>

--- a/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
@@ -80,4 +80,4 @@ sudo k8s status
 
 <!-- LINKS -->
 
-[reference page]: /snap/reference/bootstrap-config-reference.md
+[reference page]: /snap/reference/config-files/bootstrap-config.md

--- a/docs/canonicalk8s/snap/howto/intermediate-ca.md
+++ b/docs/canonicalk8s/snap/howto/intermediate-ca.md
@@ -1,0 +1,60 @@
+# How to use intermediate CAs with Vault
+
+By default, {{product}} will generate self-signed CA certificates
+for the Kubernetes services.
+
+Follow this guide to prepare an intermediate Certificate Authority (CA) using
+[HashiCorp Vault] and then configure {{product}} to use the generated
+certificates.
+
+```{include} /_parts/common_vault_intermediate_ca.md
+```
+
+## Pass intermediate CA certificates to {{product}}
+
+The CA certificates can be specified through the [bootstrap configuration file]
+using the following fields:
+
+| Field                  | Description                |
+|------------------------|----------------------------|
+| ``ca-crt``             | API server CA certificate  |
+| ``ca-key``             | API server CA key          |
+| ``client-ca-crt``      | client CA certificate      |
+| ``client-ca-key``      | client CA key              |
+| ``front-proxy-ca-crt`` | Front Proxy CA certificate |
+| ``front-proxy-ca-key`` | Front Proxy CA key         |
+
+Let's prepare a bootstrap configuration using our newly generated intermediate
+CA certificate.
+
+```
+cat <<EOF > myca/bootstrap.yaml
+ca-crt: |
+$(cat myca/intermediate.crt | sed 's/^/    /g')
+ca-key: |
+$(cat myca/intermediate.key | sed 's/^/    /g')
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  local-storage:
+    enabled: true
+EOF
+```
+
+Now bootstrap the cluster:
+
+```
+k8s bootstrap --file myca/bootstrap.yaml
+```
+
+# Further reading
+
+See this [Vault article] for more details on how to integrate Vault as a
+Kubernetes certificate manager.
+
+<!--LINKS -->
+[HashiCorp Vault]: https://developer.hashicorp.com/vault/docs
+[bootstrap configuration file]: /snap/reference/bootstrap-config-reference.md
+[Vault article]: https://support.hashicorp.com/hc/en-us/articles/21920341210899-Create-an-Intermediate-CA-in-Kubernetes-using-Vault-as-a-certificate-manager

--- a/docs/canonicalk8s/snap/howto/intermediate-ca.md
+++ b/docs/canonicalk8s/snap/howto/intermediate-ca.md
@@ -1,7 +1,7 @@
 # How to use intermediate CAs with Vault
 
-By default, {{product}} will generate self-signed CA certificates
-for the Kubernetes services.
+By default, {{product}} will generate self-signed CA certificates for the
+Kubernetes services.
 
 Follow this guide to prepare an intermediate Certificate Authority (CA) using
 [HashiCorp Vault] and then configure {{product}} to use the generated
@@ -24,8 +24,8 @@ using the following fields:
 | ``front-proxy-ca-crt`` | Front Proxy CA certificate |
 | ``front-proxy-ca-key`` | Front Proxy CA key         |
 
-Let's prepare a bootstrap configuration using our newly generated intermediate
-CA certificate.
+Prepare a bootstrap configuration using our newly generated intermediate CA
+certificate.
 
 ```
 cat <<EOF > myca/bootstrap.yaml
@@ -46,10 +46,23 @@ EOF
 Now bootstrap the cluster:
 
 ```
-k8s bootstrap --file myca/bootstrap.yaml
+sudo k8s bootstrap --file myca/bootstrap.yaml
 ```
 
-# Further reading
+Use this command to wait for the cluster to become ready:
+
+```
+sudo k8s status --wait-ready
+```
+
+Check the following files to ensure that the expected CA certificates were
+applied:
+
+* ``/etc/kubernetes/pki/ca.crt``
+* ``/etc/kubernetes/pki/ca.key``
+
+
+## Further reading
 
 See this [Vault article] for more details on how to integrate Vault as a
 Kubernetes certificate manager.

--- a/docs/canonicalk8s/snap/howto/intermediate-ca.md
+++ b/docs/canonicalk8s/snap/howto/intermediate-ca.md
@@ -56,5 +56,5 @@ Kubernetes certificate manager.
 
 <!--LINKS -->
 [HashiCorp Vault]: https://developer.hashicorp.com/vault/docs
-[bootstrap configuration file]: /snap/reference/bootstrap-config-reference.md
+[bootstrap configuration file]: /snap/reference/config-files/bootstrap-config.md
 [Vault article]: https://support.hashicorp.com/hc/en-us/articles/21920341210899-Create-an-Intermediate-CA-in-Kubernetes-using-Vault-as-a-certificate-manager


### PR DESCRIPTION
* add a document describing how intermediate CAs can be passed to k8s-snap
* based on the similar doc for the capi provider
  * the common Vault section was moved to a separate file and reused (included)