### PR TITLE
docs:  snap landing pages rework

### DIFF
--- a/docs/canonicalk8s/snap/explanation/index.md
+++ b/docs/canonicalk8s/snap/explanation/index.md
@@ -11,7 +11,8 @@ Overview <self>
 
 ## {{product}} fundamentals
 
-Understand what is {{product}} and how to choose a deployment and management method that best suits your orchestration needs.
+Understand what is {{product}} and how to choose a deployment and management
+method that best suits your orchestration needs.
 
 ```{toctree}
 :titlesonly:
@@ -31,7 +32,8 @@ channels
 
 ## Cluster management
 
-Understand the steps taken by {{product}} to ease the task of cluster management.
+Understand the steps taken by {{product}} to ease the task of cluster
+management.
 
 ```{toctree}
 :titlesonly:
@@ -53,7 +55,8 @@ load-balancer
 
 ## Security and compliance
 
-Understand how security plays a vital role in {{product}} and what has been done to strive for compliance with industry standards.
+Understand how security plays a vital role in {{product}} and what has been
+done to strive for compliance with industry standards.
 
 ```{toctree}
 :titlesonly:

--- a/docs/canonicalk8s/snap/explanation/index.md
+++ b/docs/canonicalk8s/snap/explanation/index.md
@@ -11,7 +11,7 @@ Overview <self>
 
 ## {{product}} fundamentals
 
-Understand what is {{product}} and how to choose a deployment and management
+Understand what {{product}} is and how to choose a deployment and management
 method that best suits your orchestration needs.
 
 ```{toctree}

--- a/docs/canonicalk8s/snap/explanation/index.md
+++ b/docs/canonicalk8s/snap/explanation/index.md
@@ -9,21 +9,57 @@ get the most out of Kubernetes.
 Overview <self>
 ```
 
+## {{product}} fundamentals
+
+Understand what is {{product}} and how to choose a deployment and management method that best suits your orchestration needs.
+
 ```{toctree}
 :titlesonly:
 about
 installation-methods.md
-channels
 clustering
+```
+
+## Snaps
+
+Understand which snap channel is right for your deployment.
+
+```{toctree}
+:titlesonly:
+channels
+```
+
+## Cluster management
+
+Understand the steps taken by {{product}} to ease the task of cluster management.
+
+```{toctree}
+:titlesonly:
 high-availability
-certificates
+Upgrades <upgrade.md>
+package-management
+epa
+```
+
+## Networking
+
+Understand the networking capabilities in {{product}}.
+
+```{toctree}
+:titlesonly:
 ingress
 load-balancer
-Upgrades <upgrade.md>
-epa
+```
+
+## Security and compliance
+
+Understand how security plays a vital role in {{product}} and what has been done to strive for compliance with industry standards.
+
+```{toctree}
+:titlesonly:
 security
 cis
-package-management
+certificates
 ```
 
 ---

--- a/docs/canonicalk8s/snap/howto/index.md
+++ b/docs/canonicalk8s/snap/howto/index.md
@@ -10,26 +10,97 @@ adapt the steps to fit your specific requirements.
 Overview <self>
 ```
 
-```{toctree}
-:glob:
-:titlesonly:
+## Installation
 
-install/index
+Installation follows a very similar pattern on all platforms, but some minor differences must be addressed in each case. You may also want to customize the installation of your {{product}} nodes.
+
+```{toctree}
+:titlesonly:
+Install <install/index>
+```
+
+## Networking
+
+{{product}} comes with default networking features for a fully functioning cluster. More advanced features can be enabled by a few configuration steps.
+
+```{toctree}
+:titlesonly:
 networking/index
-storage/index
+```
+
+## Security
+
+Harden your cluster according to industry standards.
+
+```{toctree}
+:titlesonly:
 security/index
+```
+
+## Storage
+
+Specific storage needs of your cluster can be met by setting up persistent storage or replacing the default datastore with an external one such as `etcd`.
+
+```{toctree}
+:titlesonly:
+storage/index
 Use an external datastore <external-datastore>
-Set up cluster observability  <observability>
-Back up and restore <backup-restore>
+```
+
+## Cluster upgrades and refreshes
+
+```{toctree}
+:titlesonly:
+Manage upgrades <upgrades>
 Refresh Kubernetes Certificates <refresh-certs>
 Use intermediate CAs with Vault <intermediate-ca.md>
-Recover a cluster after quorum loss <restore-quorum>
-Manage upgrades <upgrades>
-Set up Enhanced Platform Awareness <epa>
+```
+
+## Manage images
+
+Manage cluster images directly through containerd.
+
+```{toctree}
+:titlesonly:
 Manage images <image-management.md>
-Contribute to Canonical Kubernetes <contribute>
-Get support <support>
+```
+
+## Cluster back up and restore
+
+```{toctree}
+:titlesonly:
+Back up and restore <backup-restore>
+```
+
+## Monitoring and troubleshooting
+
+Sometimes things go wrong and you need to troubleshoot. Having observability set up on your cluster can greatly increase the rate at which a problem is identified and solved.
+
+```{toctree}
+:titlesonly:
+Set up cluster observability  <observability>
+Recover a cluster after quorum loss <restore-quorum>
 Troubleshooting <troubleshooting>
+Get support <support>
+```
+
+## Enhanced Platform Awareness
+
+EPA utilizes server hardware capabilities in the {{product}} cluster. It exposes technologies
+such as HugePages, CPU pinning, SR-IOV and more.
+
+```{toctree}
+:titlesonly:
+Set up Enhanced Platform Awareness <epa>
+```
+
+## Contribute
+
+Contribute to the {{product}} project! Add to the code, documentation or both!
+
+```{toctree}
+:titlesonly:
+Contribute <contribute>
 ```
 
 ---

--- a/docs/canonicalk8s/snap/howto/index.md
+++ b/docs/canonicalk8s/snap/howto/index.md
@@ -31,15 +31,6 @@ cluster. More advanced features can be enabled by a few configuration steps.
 networking/index
 ```
 
-## Security
-
-Harden your cluster according to industry standards.
-
-```{toctree}
-:titlesonly:
-security/index
-```
-
 ## Storage
 
 Specific storage needs of your cluster can be met by setting up persistent
@@ -49,6 +40,15 @@ storage or replacing the default datastore with an external one such as `etcd`.
 :titlesonly:
 storage/index
 Use an external datastore <external-datastore>
+```
+
+## Security
+
+Harden your cluster according to industry standards.
+
+```{toctree}
+:titlesonly:
+security/index
 ```
 
 ## Cluster upgrades and refreshes
@@ -93,8 +93,7 @@ Get support <support>
 ## Enhanced Platform Awareness
 
 EPA utilizes server hardware capabilities in the {{product}} cluster. It
-exposes technologies
-such as HugePages, CPU pinning, SR-IOV and more.
+exposes technologies such as HugePages, CPU pinning, SR-IOV and more.
 
 ```{toctree}
 :titlesonly:

--- a/docs/canonicalk8s/snap/howto/index.md
+++ b/docs/canonicalk8s/snap/howto/index.md
@@ -12,7 +12,9 @@ Overview <self>
 
 ## Installation
 
-Installation follows a very similar pattern on all platforms, but some minor differences must be addressed in each case. You may also want to customize the installation of your {{product}} nodes.
+Installation follows a very similar pattern on all platforms, but some minor
+differences must be addressed in each case. You may also want to customize the
+installation of your {{product}} nodes.
 
 ```{toctree}
 :titlesonly:
@@ -21,7 +23,8 @@ Install <install/index>
 
 ## Networking
 
-{{product}} comes with default networking features for a fully functioning cluster. More advanced features can be enabled by a few configuration steps.
+{{product}} comes with default networking features for a fully functioning
+cluster. More advanced features can be enabled by a few configuration steps.
 
 ```{toctree}
 :titlesonly:
@@ -39,7 +42,8 @@ security/index
 
 ## Storage
 
-Specific storage needs of your cluster can be met by setting up persistent storage or replacing the default datastore with an external one such as `etcd`.
+Specific storage needs of your cluster can be met by setting up persistent
+storage or replacing the default datastore with an external one such as `etcd`.
 
 ```{toctree}
 :titlesonly:
@@ -74,7 +78,9 @@ Back up and restore <backup-restore>
 
 ## Monitoring and troubleshooting
 
-Sometimes things go wrong and you need to troubleshoot. Having observability set up on your cluster can greatly increase the rate at which a problem is identified and solved.
+Sometimes things go wrong and you need to troubleshoot. Having observability
+set up on your cluster can greatly increase the rate at which a problem is
+identified and solved.
 
 ```{toctree}
 :titlesonly:
@@ -86,7 +92,8 @@ Get support <support>
 
 ## Enhanced Platform Awareness
 
-EPA utilizes server hardware capabilities in the {{product}} cluster. It exposes technologies
+EPA utilizes server hardware capabilities in the {{product}} cluster. It
+exposes technologies
 such as HugePages, CPU pinning, SR-IOV and more.
 
 ```{toctree}

--- a/docs/canonicalk8s/snap/howto/install/index.md
+++ b/docs/canonicalk8s/snap/howto/install/index.md
@@ -1,10 +1,5 @@
 # Install {{product}}
 
-```{toctree}
-:hidden:
-Install <self>
-```
-
 There's more than one way to install {{product}}. You'll find links to
 the current How-to guides below.
 

--- a/docs/canonicalk8s/snap/howto/networking/index.md
+++ b/docs/canonicalk8s/snap/howto/networking/index.md
@@ -1,10 +1,5 @@
 # Networking
 
-```{toctree}
-:hidden:
-Networking <self>
-```
-
 Networking is a core part of a working Kubernetes cluster. These topics cover
 how to configure and use key capabilities of {{product}}.
 

--- a/docs/canonicalk8s/snap/howto/security/index.md
+++ b/docs/canonicalk8s/snap/howto/security/index.md
@@ -1,10 +1,5 @@
 # Security
 
-```{toctree}
-:hidden:
-Hardening <self>
-```
-
 Administrators are provided with detailed instructions and compliance guidance to
 harden their clusters in accordance with DISA STIG and CIS recommendations.
 

--- a/docs/canonicalk8s/snap/howto/storage/index.md
+++ b/docs/canonicalk8s/snap/howto/storage/index.md
@@ -1,10 +1,5 @@
 # Storage
 
-```{toctree}
-:hidden:
-Storage <self>
-```
-
 Most Kubernetes clusters will need some type of persistent storage for running
 workloads. These guides contain information on setting up storage, or using the
 default storage built-in to {{product}}.

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -37,7 +37,8 @@ config-files/index
 
 ## Release notes
 
-New features, bug fixes, deprecations and more are included in the release notes for each version.
+New features, bug fixes, deprecations and more are included in the release
+notes for each version.
 
 ```{toctree}
 :titlesonly:

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -8,21 +8,83 @@ information such as the command reference or release notes.
 Overview <self>
 ```
 
+## System components
+
 ```{toctree}
 :titlesonly:
 
-releases
-config-files/index
-commands
-ports-and-services
-annotations
-certificates
-proxy
-troubleshooting
 architecture
 dqlite
+```
+
+## Command reference
+
+Commands provided by the {{product}} snap.
+
+```{toctree}
+:titlesonly:
+commands
+```
+
+## Cluster configuration
+
+Configuration files used during cluster creation.
+
+```{toctree}
+:titlesonly:
+config-files/index
+```
+
+## Release notes
+
+New features, bug fixes, deprecations and more are included in the release notes for each version.
+
+```{toctree}
+:titlesonly:
+releases
+```
+
+## Annotations
+
+A list of annotations that can be applied to a node on cluster bootstrap.
+
+```{toctree}
+:titlesonly:
+annotations
+```
+
+## Troubleshooting
+
+Common issues faced by users and their solutions.
+
+```{toctree}
+:titlesonly:
+troubleshooting
+```
+
+## Security
+
+```{toctree}
+:titlesonly:
+certificates
+```
+
+## Networking
+
+```{toctree}
+:titlesonly:
+proxy
+ports-and-services
+```
+
+## Contributing
+
+```{toctree}
+:titlesonly:
 Community <community>
 ```
+
+---
 
 ## Other documentation types
 

--- a/docs/canonicalk8s/snap/tutorial/index.md
+++ b/docs/canonicalk8s/snap/tutorial/index.md
@@ -1,7 +1,8 @@
 # Tutorials
 
 This section contains a step-by-step guide to help you start exploring how to
-install and use {{product}}. Our tutorials aim to provide a learning experience as you first get started with {{product}}.
+install and use {{product}}. Our tutorials aim to provide a learning experience
+as you first get started with {{product}}.
 
 ```{toctree}
 :hidden:
@@ -10,7 +11,8 @@ Overview <self>
 
 ## Getting started
 
-This tutorial walks through the installation of {{product}} and deploys a sample workload.
+This tutorial walks through the installation of {{product}} and deploys a
+sample workload.
 
 ```{toctree}
 :glob:

--- a/docs/canonicalk8s/snap/tutorial/index.md
+++ b/docs/canonicalk8s/snap/tutorial/index.md
@@ -1,17 +1,30 @@
 # Tutorials
 
 This section contains a step-by-step guide to help you start exploring how to
-install and use {{product}}.
+install and use {{product}}. Our tutorials aim to provide a learning experience as you first get started with {{product}}.
 
 ```{toctree}
 :hidden:
 Overview <self>
 ```
 
+## Getting started
+
+This tutorial walks through the installation of {{product}} and deploys a sample workload.
+
 ```{toctree}
 :glob:
 :titlesonly:
 getting-started
+```
+
+## Cluster operations
+
+Now that you have a {{product}} cluster, learn about what you can do with it!
+
+```{toctree}
+:glob:
+:titlesonly:
 Basic operations with kubectl <kubectl>
 add-remove-nodes
 ```


### PR DESCRIPTION
Rework the landing pages to conform to the recommended pattern. The landing pages should provide more information than just list the contents of the tree. 

This will also affect the order in which the pages will appear in the navigation bar at the side. 