### PR TITLE
CI: parallelize harness instance init and cleanup

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -71,6 +71,12 @@ jobs:
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
           cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }}
+      - name: Collect host logs
+        if: failure()
+        run: |
+          hostReportsDir="${{ github.workspace }}/inspection-reports/host"
+          mkdir -p $hostReportsDir
+          journalctl --boot --lines=all &> $hostReportsDir/journal.log
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -315,7 +315,7 @@ def instances(
         try:
             LOG.debug(f"Generating inspection reports for test instance: {instance_id}")
             _generate_inspection_report(h, instance_id)
-        finally:
+        except Exception:
             LOG.exception("failed to collect inspection report")
 
     threads = []

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -185,10 +185,13 @@ class LXDHarness(Harness):
             "Copying file %s to instance %s at %s", source, instance_id, destination
         )
         try:
+            env = dict(os.environ)
+            env["SNAP_CONFINE_DEBUG"] = "1"
             self.exec(
                 instance_id,
                 ["mkdir", "-m=0777", "-p", Path(destination).parent.as_posix()],
                 capture_output=True,
+                env=env,
             )
             run(
                 ["lxc", "file", "push", source, f"{instance_id}{destination}"],
@@ -199,6 +202,7 @@ class LXDHarness(Harness):
             LOG.error(f"  {e.returncode=}")
             LOG.error(f"  {e.stdout.decode()=}")
             LOG.error(f"  {e.stderr.decode()=}")
+            run(["sudo", "aa-status"])
             raise HarnessError("failed to push file") from e
 
     def pull_file(self, instance_id: str, source: str, destination: str):


### PR DESCRIPTION
We'll save a significant amount of time by parallelizing the following harness instance actions:

* initialization (lxd spawn, snap install, bootstrap, etc)
* inspection report collection
* cleanup (removing snap and lxd container)

The time it takes to initialize, collect the logs and cleanup 3 instances:

* before: 166s
* after: 71s