### PR TITLE
CI: use lxd vms by default

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -33,7 +33,7 @@ on:
 jobs:
   test-integration:
     name: Integration Test ${{ inputs.os }} ${{ inputs.arch }} ${{ inputs.artifact }}
-    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-large' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-xlarge' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -68,6 +68,15 @@ LXD_PROFILE = (
     or (DIR / ".." / ".." / "lxd-profile.yaml").read_text()
 )
 
+# Use LXD vms instead of containers.
+LXD_VMS = os.getenv("TEST_LXD_VMS", "1") == "1"
+
+# The number of cpus for LXD VMs.
+LXD_VM_CPUS = os.getenv("TEST_LXD_VM_CPUS") or "2"
+
+# The amount of memory for LXD VMs.
+LXD_VM_MEMORY = os.getenv("TEST_LXD_VM_MEMORY") or "2GB"
+
 # LXD_DUALSTACK_NETWORK is the network to use for LXD containers with dualstack configured.
 LXD_DUALSTACK_NETWORK = os.getenv("TEST_LXD_DUALSTACK_NETWORK") or "dualstack-br0"
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -85,6 +85,11 @@ class LXDHarness(Harness):
             self.profile,
         ]
 
+        if config.LXD_VMS:
+            launch_lxd_command += ["--vm"]
+            launch_lxd_command += ["-c", f"limits.cpu={config.LXD_VM_CPUS}"]
+            launch_lxd_command += ["-c", f"limits.memory={config.LXD_VM_MEMORY}"]
+
         if network_type.lower() not in ["ipv4", "dualstack", "ipv6"]:
             raise HarnessError(
                 f"unknown network type {network_type}, need to be one of 'IPv4', 'IPv6', 'dualstack'"
@@ -132,7 +137,7 @@ class LXDHarness(Harness):
             raise HarnessError(f"Failed to create LXD container {instance_id}") from e
 
         instance = Instance(self, instance_id)
-        stubbornly(retries=3, delay_s=5).on(instance).exec(
+        stubbornly(retries=20, delay_s=5).on(instance).exec(
             ["snap", "wait", "system", "seed.loaded"]
         )
         return instance


### PR DESCRIPTION
We're having issues on ubuntu 22.04 hosts with 24.04 lxd containers, which are no longer able to define cgroup cpusets. As a result, kubelet is no longer able to run.

Since lxd privileged containers are about to become unsupported anyway, we'll use lxd vms instead.

We're adding config options to allow using lxd containers or specify the amount of vm resources.