### PR TITLE
fix: Add runc 1.2.5 arm patch

### DIFF
--- a/build-scripts/components/runc/patches/v1.2.5/0001-Disable-static-PIE-on-arm64.patch
+++ b/build-scripts/components/runc/patches/v1.2.5/0001-Disable-static-PIE-on-arm64.patch
@@ -1,0 +1,26 @@
+From d290811e554808b9f7a130a18b67464636ac449e Mon Sep 17 00:00:00 2001
+From: Lucian Petrut <lpetrut@cloudbasesolutions.com>
+Date: Thu, 27 Feb 2025 13:32:36 +0000
+Subject: [PATCH] Disable static PIE on arm64
+
+Ubuntu does not currently have the rcrt1.o file on arm64.
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 0a15fd90..d7e6209a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -45,7 +45,7 @@ LDFLAGS_STATIC := -extldflags -static
+ # Enable static PIE executables on supported platforms.
+ # This (among the other things) requires libc support (rcrt1.o), which seems
+ # to be available only for arm64 and amd64 (Debian Bullseye).
+-ifneq (,$(filter $(GOARCH),arm64 amd64))
++ifneq (,$(filter $(GOARCH),amd64))
+ 	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+ 		GO_BUILDMODE_STATIC := -buildmode=pie
+ 		LDFLAGS_STATIC := -linkmode external -extldflags -static-pie
+-- 
+2.43.0
+


### PR DESCRIPTION
The runc version was bumped, we need to update the arm patch, which no longer applies correctly.