### PR TITLE
chore: create pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Should this PR be backported? If so, to which release?
 
 ## Checklist
 
-<!-- Update when we decide on this in PR #1113-->
+<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
 - [ ] PR title formatted as `type: title`
 - [ ] Covered by unit tests
 - [ ] Covered by integration tests

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,9 +13,10 @@ Include a link to the ticket or issue number if applicable.
 ## Checklist
 
 <!-- Update when we decide on this in PR #1113-->
-- [ ] PR title is formatted as `type: title`
+- [ ] PR title formatted as `type: title`
 - [ ] Covered by unit tests
 - [ ] Covered by integration tests
 - [ ] Documentation updated
+- [ ] CLA signed
 
 If any item on the checklist is not complete, please provide justification why.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+
+What issue is this PR trying to solve?
+
+## Solution
+
+A clear and concise description of how your changes address the above issue.
+
+## Issue
+
+Include a link to the ticket or issue number if applicable.
+
+## Checklist
+
+<!-- Update when we decide on this in PR #1113-->
+- [ ] PR title is formatted as `type: title`
+- [ ] Covered by unit tests
+- [ ] Covered by integration tests
+- [ ] Documentation updated
+
+If any item on the checklist is not complete, please provide justification why.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,13 @@ A clear and concise description of how your changes address the above issue.
 
 ## Issue
 
-Include a link to the ticket or issue number if applicable.
+Include a link to the Github issue number if applicable.
+
+## Backport
+
+Should this PR be backported? If so, to which release?
+
+<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->
 
 ## Checklist
 
@@ -18,5 +24,6 @@ Include a link to the ticket or issue number if applicable.
 - [ ] Covered by integration tests
 - [ ] Documentation updated
 - [ ] CLA signed
+- [ ] Backport label added if necessary 
 
 If any item on the checklist is not complete, please provide justification why.


### PR DESCRIPTION
Adding the pull request template aims to make our commits more informative. It also should make sure testing and documentation are considered on every PR.