### PR TITLE
[Backport 1.32] fix: Add runc 1.2.5 arm patch (#1123), Switch to noble 24.04 runners (#1121)

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -33,14 +33,14 @@ on:
 jobs:
   test-integration:
     name: Integration Test ${{ inputs.os }} ${{ inputs.arch }} ${{ inputs.artifact }}
-    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-large' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-noble-large' || 'self-hosted-linux-amd64-noble-large' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Apply patches
         if: inputs.flavor != ''
         run: |
@@ -54,7 +54,7 @@ jobs:
       - name: Install lxd
         uses: ./.github/actions/install-lxd
       - name: Install tox
-        run: pip install tox
+        run: sudo apt-get install -y tox
       - name: Run e2e tests
         env:
           TEST_SNAP: ${{ steps.download-snap.outputs.snap-path }}

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Install tox
-        run: pip install tox
+        run: sudo apt-get install -y tox
       - name: Run branch_management tests
         run: |
           tox -c tests/branch_management -e test
@@ -56,7 +56,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install tox
-        run: pip install tox
+        run: sudo apt-get install -y tox
       - name: Lint
         run: |
           cd tests/integration && tox -e lint

--- a/build-scripts/components/runc/patches/v1.2.5/0001-Disable-static-PIE-on-arm64.patch
+++ b/build-scripts/components/runc/patches/v1.2.5/0001-Disable-static-PIE-on-arm64.patch
@@ -1,0 +1,26 @@
+From d290811e554808b9f7a130a18b67464636ac449e Mon Sep 17 00:00:00 2001
+From: Lucian Petrut <lpetrut@cloudbasesolutions.com>
+Date: Thu, 27 Feb 2025 13:32:36 +0000
+Subject: [PATCH] Disable static PIE on arm64
+
+Ubuntu does not currently have the rcrt1.o file on arm64.
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 0a15fd90..d7e6209a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -45,7 +45,7 @@ LDFLAGS_STATIC := -extldflags -static
+ # Enable static PIE executables on supported platforms.
+ # This (among the other things) requires libc support (rcrt1.o), which seems
+ # to be available only for arm64 and amd64 (Debian Bullseye).
+-ifneq (,$(filter $(GOARCH),arm64 amd64))
++ifneq (,$(filter $(GOARCH),amd64))
+ 	ifeq (,$(findstring -race,$(EXTRA_FLAGS)))
+ 		GO_BUILDMODE_STATIC := -buildmode=pie
+ 		LDFLAGS_STATIC := -linkmode external -extldflags -static-pie
+-- 
+2.43.0
+


### PR DESCRIPTION
### Overview
This PR backports the following to 1.32 release branch:
- #1123
- #1121 (partially, only the switch to noble part, not the k8s-dqlite)

Also because of the chicken and egg problem, we need to backport the "switch to noble runners" as well, otherwise the tests won't pass. And if we want to have a separate PR for the switch to noble runners backport, the tests on that PR won't pass because of the runc patch issue.