### PR TITLE
CI: use cdkbot token for automated jobs

### DIFF
--- a/.github/workflows/auto-merge-successful-prs.yaml
+++ b/.github/workflows/auto-merge-successful-prs.yaml
@@ -20,6 +20,6 @@ jobs:
           python-version: '3.12'
       - name: Auto-merge pull requests if all status checks pass
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
             build-scripts/hack/auto-merge-successful-pr.py

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Label backports with automerge and approve
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           for pr_number in ${{ steps.create_backports.outputs.created_pull_numbers }}; do
             gh pr edit "$pr_number" --add-label "automerge"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Label backports with automerge and approve
         env:
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           for pr_number in ${{ steps.create_backports.outputs.created_pull_numbers }}; do
             gh pr edit "$pr_number" --add-label "automerge"

--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -55,3 +55,4 @@ jobs:
             automerge
           delete-branch: true
           base: ${{ matrix.branch }}
+          token: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
The backport job creates the PRs using the cdkbot token but approves them using "GITHUB_TOKEN". For this reason, the approval is ignored and the backports cannot be merged automatically.

At the same time, the job that updates components uses the GH token to create the PRs, which do get merged but the e2e tests are not executed, potentially introducing regressions. Again, we'll have to use the cdkbot token.

Since the same account can't approve its own PRs, we'll try using the GH account to approve/merge PRs.