### PR TITLE
docs: how-to guide for reporting security issues

### DIFF
--- a/docs/canonicalk8s/snap/howto/security/index.md
+++ b/docs/canonicalk8s/snap/howto/security/index.md
@@ -10,5 +10,5 @@ harden their clusters in accordance with DISA STIG and CIS recommendations.
 Hardening guide <hardening.md>
 CIS assessment <cis-assessment.md>
 DISA STIG assessment <disa-stig-assessment.md>
-Report a security issue<report-security-issue>
+Report a security issue<report-security-issue.md>
 ```

--- a/docs/canonicalk8s/snap/howto/security/index.md
+++ b/docs/canonicalk8s/snap/howto/security/index.md
@@ -10,4 +10,5 @@ harden their clusters in accordance with DISA STIG and CIS recommendations.
 Hardening guide <hardening.md>
 CIS assessment <cis-assessment.md>
 DISA STIG assessment <disa-stig-assessment.md>
+Report a security issue<report-security-issue>
 ```

--- a/docs/canonicalk8s/snap/howto/security/report-security-issue.md
+++ b/docs/canonicalk8s/snap/howto/security/report-security-issue.md
@@ -4,7 +4,7 @@ While we do our best to keep up to date with the latest security issues, we
 appreciate it when members of the community report any security vulnerabilities
 or concerns found in {{product}}.
 
-## File a Private Security Report
+## File a private security report
 
 Go to the {{product}} GitHub and file a [Private Security Report]. There you
 will be prompted to include the following information:

--- a/docs/canonicalk8s/snap/howto/security/report-security-issue.md
+++ b/docs/canonicalk8s/snap/howto/security/report-security-issue.md
@@ -1,0 +1,23 @@
+# How to report a security issue in {{product}}
+
+While we do our best to keep up to date with the latest security issues, we
+appreciate it when members of the community report any security vulnerabilities
+or concerns found in {{product}}.
+
+## File a Private Security Report
+
+Go to the {{product}} GitHub and file a [Private Security Report]. There you
+will be prompted to include the following information:
+
+- A description of the problem
+- Specific steps to recreate the issue
+- The possible impact of the issue
+- The affected versions of the `k8s-snap`
+- Any known mitigations of the issue
+
+{{product}} follows the [Ubuntu Security disclosure and embargo policy]. The
+team will process all security reports according to this policy.
+
+<!-- LINKS -->
+[Private Security Report]: https://github.com/canonical/k8s-snap/security/advisories/new
+[Ubuntu Security disclosure and embargo policy]:https://ubuntu.com/security/disclosure-policy

--- a/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
+++ b/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
@@ -241,6 +241,7 @@ MicroCluster
 MicroK
 MicroK8s
 MinIO
+mitigations
 modprobe
 Moonray
 mq


### PR DESCRIPTION
Adding a how-to guide to report a security concern. This is very similar to the SECURITY.md file.