### PR TITLE
[Backport release-1.31] switch to noble (24.04) runners (#1121), Fix test_mixed_versions_join (#1165), Skips upgrade test to 1.33 and newer (#1178)

### DIFF
--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -94,7 +94,7 @@ jobs:
           TEST_FLAVOR: ${{ matrix.patch }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration'
+          cd tests/integration && tox -e integration
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/integration-informing.yaml
+++ b/.github/workflows/integration-informing.yaml
@@ -60,7 +60,7 @@ jobs:
         os: ["ubuntu:20.04"]
         patch: ["moonray"]
       fail-fast: false
-    runs-on: ["self-hosted", "Linux", "AMD64", "jammy", "large"]
+    runs-on: ["self-hosted", "Linux", "AMD64", "noble", "large"]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
         run: pip install tox
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.21/stable
+          sudo snap install lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.21/stable
+          sudo snap install lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
-    runs-on: ["self-hosted", "Linux", "AMD64", "jammy", "large"]
+    runs-on: ["self-hosted", "Linux", "AMD64", "noble", "large"]
     needs: build
 
     steps:
@@ -87,7 +87,7 @@ jobs:
         run: pip install tox
       - name: Install lxd
         run: |
-          sudo snap refresh lxd --channel 5.21/stable
+          sudo snap install lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -111,7 +111,7 @@ jobs:
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}]'
         run: |
-          cd tests/integration && sg lxd -c 'tox -e integration'
+          cd tests/integration && tox -e integration
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -17,7 +17,7 @@ jobs:
         release: ["latest/edge"]
       fail-fast: false # TODO: remove once arm64 works
 
-    runs-on: ${{ matrix.arch == 'arm64' && ["self-hosted", "Linux", "ARM64", "jammy", "large"] || ["self-hosted", "Linux", "AMD64", "jammy", "large"] }}
+    runs-on: ${{ matrix.arch == 'arm64' && ["self-hosted", "Linux", "ARM64", "jammy", "large"] || ["self-hosted", "Linux", "AMD64", "noble", "large"] }}
 
     steps:
       - name: Checking out repo
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y tox
-          sudo snap refresh lxd --channel 5.21/stable
+          sudo snap install lxd --channel 5.21/stable
           sudo lxd init --auto
           sudo usermod --append --groups lxd $USER
           sg lxd -c 'lxc version'

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -67,6 +67,7 @@ def get_most_stable_channels(
     arch: str,
     include_latest: bool = True,
     min_release: Optional[str] = None,
+    max_release: Optional[str] = None,
 ) -> List[str]:
     """Get an ascending list of latest channels based on the number of channels
     flavour and architecture."""
@@ -85,6 +86,11 @@ def get_most_stable_channels(
         if min_release is not None:
             _min_release = major_minor(min_release)
             if _min_release is not None and version_key < _min_release:
+                continue
+
+        if max_release is not None:
+            _max_release = major_minor(max_release)
+            if _max_release is not None and version_key > _max_release:
                 continue
 
         if version_key not in channel_map or RISK_LEVELS.index(

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -456,7 +456,7 @@ def previous_track(snap_version: str) -> str:
     LOG.debug("Determining previous track for %s", snap_version)
 
     if not snap_version:
-        assumed = "latest"
+        assumed = "1.32-classic"
         LOG.info(
             "Cannot determine previous track for undefined snap -- assume %s",
             snap_version,
@@ -465,7 +465,7 @@ def previous_track(snap_version: str) -> str:
         return assumed
 
     if snap_version.startswith("/") or _as_int(snap_version) is not None:
-        assumed = "latest"
+        assumed = "1.32-classic"
         LOG.info(
             "Cannot determine previous track for %s -- assume %s", snap_version, assumed
         )

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -26,11 +26,15 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
                 "'recent' requires the number of releases as second argument and the flavour as third argument"
             )
         _, num_channels, flavour = channels
+        # Currently, it fails to refresh the snap to the 1.33 channel or newer.
+        # Just test upgrade to at most 1.32.
         channels = snap.get_most_stable_channels(
             int(num_channels),
             flavour,
             cp.arch,
+            include_latest=False,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
+            max_release="1.32",
         )
         if len(channels) < 2:
             pytest.fail(


### PR DESCRIPTION
Note: no need to update ``k8s-dqlite`` in ``release-1.31``. 