### PR TITLE
CI: remove inclusive language check

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -29,12 +29,12 @@ jobs:
         with:
           working-directory: docs/canonicalk8s
 
-      - name: Inclusive Language Check
-        id: woke-step
-        if: success() || failure()
-        uses: canonical/documentation-workflows/inclusive-language@main
-        with:
-          working-directory: docs/canonicalk8s
+      # - name: Inclusive Language Check
+      #   id: woke-step
+      #   if: success() || failure()
+      #   uses: canonical/documentation-workflows/inclusive-language@main
+      #   with:
+      #     working-directory: docs/canonicalk8s
 
       #  continue-on-error: true
       # - if: ${{ github.event_name == 'pull_request' && steps.spell-check.outcome == 'failure' }}

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -38,8 +38,6 @@ project's needs with
 Canonical Kubernetes documentation <self>
 ```
 
----
-
 ```{toctree}
 :hidden:
 :titlesonly:


### PR DESCRIPTION
In the documentation workflows where we pull the inclusive language check from, there was some issues  from an update with Vale not pulling the correct dictionaries. Until this is fixed, disable the check. Added small doc change to activate the doc check pipeline