### PR TITLE
feat(k8sd)!: store available feature manifests on microcluster db

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
 
+# DUMMY COMMENT TO TRIGGER A CHANGE
 jobs:
   test-integration:
     name: Integration

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -18,6 +18,7 @@ var rootCmdOpts struct {
 	disableNodeConfigController         bool
 	disableNodeLabelController          bool
 	disableHelmChartController          bool
+	disableFeatureManifestController    bool
 	disableControlPlaneConfigController bool
 	disableFeatureController            bool
 	disableUpdateNodeConfigController   bool
@@ -56,6 +57,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				DisableNodeConfigController:         rootCmdOpts.disableNodeConfigController,
 				DisableNodeLabelController:          rootCmdOpts.disableNodeLabelController,
 				DisableHelmChartController:          rootCmdOpts.disableHelmChartController,
+				DisableFeatureManifestController:    rootCmdOpts.disableFeatureManifestController,
 				DisableControlPlaneConfigController: rootCmdOpts.disableControlPlaneConfigController,
 				DisableUpdateNodeConfigController:   rootCmdOpts.disableUpdateNodeConfigController,
 				DisableFeatureController:            rootCmdOpts.disableFeatureController,
@@ -88,6 +90,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeConfigController, "disable-node-config-controller", false, "Disable the Node Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeLabelController, "disable-node-label-controller", false, "Disable the Node Label Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableHelmChartController, "disable-helm-chart-controller", false, "Disable the Helm Chart Controller")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableFeatureManifestController, "disable-feature-manifest-controller", false, "Disable the Feature Manifest Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableControlPlaneConfigController, "disable-control-plane-config-controller", false, "Disable the Control Plane Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableUpdateNodeConfigController, "disable-update-node-config-controller", false, "Disable the Update Node Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableFeatureController, "disable-feature-controller", false, "Disable the Feature Controller")

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -47,6 +47,8 @@ type Config struct {
 	DisableCSRSigningController bool
 	// DisableHelmChartController is a bool flag to disable helm chart controller.
 	DisableHelmChartController bool
+	// DisableFeatureManifestController is a bool flag to disable feature manifest controller.
+	DisableFeatureManifestController bool
 	// DrainConnectionsTimeout is the amount of time to allow for all connections to drain when shutting down.
 	DrainConnectionsTimeout time.Duration
 }
@@ -69,6 +71,7 @@ type App struct {
 	controlPlaneConfigController *controllers.ControlPlaneConfigurationController
 	csrsigningController         *csrsigning.Controller
 	helmChartController          *controllers.HelmChartController
+	featureManifestController    *controllers.FeatureManifestController
 
 	// updateNodeConfigController
 	triggerUpdateNodeConfigControllerCh chan struct{}
@@ -126,6 +129,15 @@ func New(cfg Config) (*App, error) {
 		)
 	} else {
 		log.L().Info("helm-chart-controller disabled via config")
+	}
+
+	if !cfg.DisableFeatureManifestController {
+		app.featureManifestController = controllers.NewFeatureManifestController(
+			cfg.Snap,
+			app.readyWg.Wait,
+		)
+	} else {
+		log.L().Info("feature-manifest-controller disabled via config")
 	}
 
 	if !cfg.DisableNodeLabelController {

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -29,6 +29,11 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 		go a.helmChartController.Run(ctx, s)
 	}
 
+	// start feature manifest controller
+	if a.featureManifestController != nil {
+		go a.featureManifestController.Run(ctx, s)
+	}
+
 	// start node config controller
 	if a.nodeConfigController != nil {
 		go a.nodeConfigController.Run(ctx, func(ctx context.Context) (*rsa.PublicKey, error) {

--- a/src/k8s/pkg/k8sd/controllers/feature_manifest.go
+++ b/src/k8s/pkg/k8sd/controllers/feature_manifest.go
@@ -1,0 +1,78 @@
+package controllers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/canonical/k8s/pkg/k8sd/database"
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/microcluster/v2/state"
+)
+
+// FeatureManifestController is a controller that syncs feature manifests available in the snap with the microcluster database.
+type FeatureManifestController struct {
+	snap      snap.Snap
+	waitReady func()
+}
+
+// NewFeatureManifestController creates a new feature manifest controller.
+func NewFeatureManifestController(snap snap.Snap, waitReady func()) *FeatureManifestController {
+	return &FeatureManifestController{
+		snap:      snap,
+		waitReady: waitReady,
+	}
+}
+
+// Run runs the feature manifest controller.
+// The controller reconciles feature manifests available in the snap with the microcluster database until all manifests are inserted.
+func (c *FeatureManifestController) Run(ctx context.Context, s state.State) {
+	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "feature-manifest"))
+	log := log.FromContext(ctx)
+
+	log.Info("Waiting for node to be ready")
+	// wait for microcluster node to be ready
+	c.waitReady()
+
+	log.Info("Starting feature manifest controller")
+
+	for {
+		log.Info("Reconciling feature manifests")
+
+		var retryRequired bool
+
+		for _, featureManifest := range manifests.Manifests() {
+			log := log.WithValues("feature", featureManifest.GetName(), "version", featureManifest.GetVersion())
+
+			if err := c.reconcile(ctx, s, featureManifest); err != nil {
+				log.Error(err, "failed to reconcile feature manifest")
+				retryRequired = true
+			}
+		}
+
+		if !retryRequired {
+			log.Info("Reconcilation of feature manifests complete")
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+func (c *FeatureManifestController) reconcile(ctx context.Context, s state.State, manifest *types.FeatureManifest) error {
+	if err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return database.InsertFeatureManifest(ctx, tx, manifest)
+	}); err != nil {
+		return fmt.Errorf("failed to insert feature manifest: %w", err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/database/feature_manifest.go
+++ b/src/k8s/pkg/k8sd/database/feature_manifest.go
@@ -1,0 +1,62 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/microcluster/v2/cluster"
+	"gopkg.in/yaml.v2"
+)
+
+var featureStmts = map[string]int{
+	"insert": MustPrepareStatement("feature-manifests", "insert.sql"),
+	"select": MustPrepareStatement("feature-manifests", "select.sql"),
+}
+
+// GetFeatureManifest returns a feature manifest from the database by name and version.
+func GetFeatureManifest(ctx context.Context, tx *sql.Tx, name string, version string) (*types.FeatureManifest, error) {
+	selectTxStmt, err := cluster.Stmt(tx, featureStmts["select"])
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare select statement: %w", err)
+	}
+
+	var manifestBytes []byte
+
+	err = selectTxStmt.QueryRowContext(ctx, name, version).Scan(&name, &version, &manifestBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query helm chart: %w", err)
+	}
+
+	var manifest types.FeatureManifest
+
+	if err := yaml.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+
+	return &manifest, nil
+}
+
+// InsertFeatureManifest inserts a feature manifest into the database.
+func InsertFeatureManifest(ctx context.Context, tx *sql.Tx, manifest *types.FeatureManifest) error {
+	insertTxStmt, err := cluster.Stmt(tx, featureStmts["insert"])
+	if err != nil {
+		return fmt.Errorf("failed to prepare upsert statement: %w", err)
+	}
+
+	manifestBytes, err := yaml.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	if _, err := insertTxStmt.ExecContext(ctx,
+		manifest.Name,
+		manifest.Version,
+		manifestBytes,
+	); err != nil {
+		return fmt.Errorf("failed to execute upsert statement: %w", err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/database/schema.go
+++ b/src/k8s/pkg/k8sd/database/schema.go
@@ -24,6 +24,7 @@ var (
 		schemaApplyMigration("worker-tokens", "001-add-expiry.sql"),
 		schemaApplyMigration("worker-nodes", "001-delete.sql"),
 		schemaApplyMigration("helm-charts", "002-create.sql"),
+		schemaApplyMigration("feature-manifests", "002-create.sql"),
 	}
 
 	//go:embed sql/migrations

--- a/src/k8s/pkg/k8sd/database/sql/migrations/feature-manifests/002-create.sql
+++ b/src/k8s/pkg/k8sd/database/sql/migrations/feature-manifests/002-create.sql
@@ -1,0 +1,6 @@
+CREATE TABLE feature_manifests (
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    manifest BLOB NOT NULL,
+    PRIMARY KEY (name, version)
+)

--- a/src/k8s/pkg/k8sd/database/sql/queries/feature-manifests/insert.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/feature-manifests/insert.sql
@@ -1,0 +1,4 @@
+INSERT OR IGNORE INTO
+    feature_manifests(name, version, manifest)
+VALUES
+    ( ?, ?, ? )

--- a/src/k8s/pkg/k8sd/database/sql/queries/feature-manifests/select.sql
+++ b/src/k8s/pkg/k8sd/database/sql/queries/feature-manifests/select.sql
@@ -1,0 +1,7 @@
+SELECT
+    f.name, f.version, f.manifest
+FROM
+    feature_manifests AS f
+WHERE
+    ( f.name = ? ) AND ( f.version = ? )
+LIMIT 1

--- a/src/k8s/pkg/k8sd/features/calico/network/register.go
+++ b/src/k8s/pkg/k8sd/features/calico/network/register.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -25,4 +26,6 @@ func init() {
 		fmt.Sprintf("%s/pod2daemon-flexvol:%s", calicoImage.GetURI(), calicoImage.Tag),
 		fmt.Sprintf("%s/typha:%s", calicoImage.GetURI(), calicoImage.Tag),
 	)
+
+	manifests.Register(&manifest)
 }

--- a/src/k8s/pkg/k8sd/features/cilium/gateway/register.go
+++ b/src/k8s/pkg/k8sd/features/cilium/gateway/register.go
@@ -1,0 +1,9 @@
+package gateway
+
+import (
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
+)
+
+func init() {
+	manifests.Register(&manifest)
+}

--- a/src/k8s/pkg/k8sd/features/cilium/ingress/register.go
+++ b/src/k8s/pkg/k8sd/features/cilium/ingress/register.go
@@ -1,0 +1,9 @@
+package ingress
+
+import (
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
+)
+
+func init() {
+	manifests.Register(&manifest)
+}

--- a/src/k8s/pkg/k8sd/features/cilium/loadbalancer/register.go
+++ b/src/k8s/pkg/k8sd/features/cilium/loadbalancer/register.go
@@ -1,0 +1,9 @@
+package loadbalancer
+
+import (
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
+)
+
+func init() {
+	manifests.Register(&manifest)
+}

--- a/src/k8s/pkg/k8sd/features/cilium/network/register.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network/register.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -14,4 +15,6 @@ func init() {
 		fmt.Sprintf("%s:%s", ciliumAgentImage.GetURI(), ciliumAgentImage.Tag),
 		fmt.Sprintf("%s-generic:%s", ciliumOperatorImage.GetURI(), ciliumOperatorImage.Tag),
 	)
+
+	manifests.Register(&manifest)
 }

--- a/src/k8s/pkg/k8sd/features/contour/gateway/register.go
+++ b/src/k8s/pkg/k8sd/features/contour/gateway/register.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -14,4 +15,6 @@ func init() {
 		fmt.Sprintf("%s:%s", contourGatewayProvisionerContourImage.GetURI(), contourGatewayProvisionerContourImage.Tag),
 		fmt.Sprintf("%s:%s", contourGatewayProvisionerEnvoyImage.GetURI(), contourGatewayProvisionerEnvoyImage.Tag),
 	)
+
+	manifests.Register(&manifest)
 }

--- a/src/k8s/pkg/k8sd/features/contour/ingress/register.go
+++ b/src/k8s/pkg/k8sd/features/contour/ingress/register.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -14,4 +15,6 @@ func init() {
 		fmt.Sprintf("%s:%s", contourIngressEnvoyImage.GetURI(), contourIngressEnvoyImage.Tag),
 		fmt.Sprintf("%s:%s", contourIngressContourImage.GetURI(), contourIngressContourImage.Tag),
 	)
+
+	manifests.Register(&manifest)
 }

--- a/src/k8s/pkg/k8sd/features/coredns/dns/register.go
+++ b/src/k8s/pkg/k8sd/features/coredns/dns/register.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -12,4 +13,6 @@ func init() {
 	images.Register(
 		fmt.Sprintf("%s:%s", coreDNSImage.GetURI(), coreDNSImage.Tag),
 	)
+
+	manifests.Register(&manifest)
 }

--- a/src/k8s/pkg/k8sd/features/localpv/local-storage/register.go
+++ b/src/k8s/pkg/k8sd/features/localpv/local-storage/register.go
@@ -3,6 +3,7 @@ package local_storage
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -22,4 +23,6 @@ func init() {
 		fmt.Sprintf("%s:%s", csiResizerImage.GetURI(), csiResizerImage.Tag),
 		fmt.Sprintf("%s:%s", csiSnapshotterImage.GetURI(), csiSnapshotterImage.Tag),
 	)
+
+	manifests.Register(&manifest)
 }

--- a/src/k8s/pkg/k8sd/features/manifests/manifests.go
+++ b/src/k8s/pkg/k8sd/features/manifests/manifests.go
@@ -1,0 +1,22 @@
+package manifests
+
+import "github.com/canonical/k8s/pkg/k8sd/types"
+
+// registeredManifests is a list of feature manifests bundled in k8s-snap.
+var registeredManifests []*types.FeatureManifest
+
+// Manifests returns the list of registered manifests.
+func Manifests() []*types.FeatureManifest {
+	if registeredManifests == nil {
+		return nil
+	}
+	manifestList := make([]*types.FeatureManifest, len(registeredManifests))
+	copy(manifestList, registeredManifests)
+	return manifestList
+}
+
+// Register manifests that are used by k8s-snap.
+// Register is used by the `init()` method in individual packages.
+func Register(charts *types.FeatureManifest) {
+	registeredManifests = append(registeredManifests, charts)
+}

--- a/src/k8s/pkg/k8sd/features/metallb/loadbalancer/register.go
+++ b/src/k8s/pkg/k8sd/features/metallb/loadbalancer/register.go
@@ -3,6 +3,7 @@ package loadbalancer
 import (
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -16,4 +17,6 @@ func init() {
 		fmt.Sprintf("%s:%s", metalLBSpeakerImage.GetURI(), metalLBSpeakerImage.Tag),
 		fmt.Sprintf("%s:%s", frrImage.GetURI(), frrImage.Tag),
 	)
+
+	manifests.Register(&manifest)
 }

--- a/src/k8s/pkg/k8sd/features/metrics-server/register.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/register.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/k8s/pkg/k8sd/charts"
+	"github.com/canonical/k8s/pkg/k8sd/features/manifests"
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
@@ -15,4 +16,6 @@ func init() {
 	)
 
 	charts.Register(&ChartFS)
+
+	manifests.Register(&manifest)
 }


### PR DESCRIPTION
- Added the FeatureManifestController that inserts available manifests in the snap at k8sd start.
- Added a microcluster table to store feature manifests.
- Added db helpers for inserting and getting feature manifests.