### PR TITLE
docs: Ignores stigviewer.com links in linkchecker

### DIFF
--- a/docs/canonicalk8s/custom_conf.py
+++ b/docs/canonicalk8s/custom_conf.py
@@ -142,6 +142,10 @@ redirects = {}
 ############################################################
 
 # Links to ignore when checking links
+# https://www.stigviewer.com is missing intermediate CAs, and Python SSL module
+# is not performing AIA chasing, leading to the error:
+# "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate"
+# See more: https://github.com/python/cpython/issues/62817
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
     'http://rocks.canonical.com',
@@ -149,7 +153,8 @@ linkcheck_ignore = [
     'https://ceph.io/',
     'https://charmhub.io/k8s/',
     'https://charmhub.io/k8s-worker/',
-    'http://slack.kubernetes.io/'
+    'http://slack.kubernetes.io/',
+    r'https://www\.stigviewer\.com/.*',
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
## Description

Recently, stigviewer.com renewed their certificate, but they are missing their intermediate CA certificates. Because of this, creating a request in Python results in the following error:

```
>>> import requests
>>> requests.get("https://stigviewer.com")
...
requests.exceptions.SSLError: HTTPSConnectionPool(host='stigviewer.com', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1000)')))
```

It is a known issue that Python does not perform AIA chasing for missing intermediate certificates on TLS connections [1].

[1] https://github.com/python/cpython/issues/62817

## Solution

Until this issue is resolved, we're adding https://www.stigviewer.com/.* links in an ignore list.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
