### PR TITLE
cilium: Enables cilium session affinity

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -188,6 +188,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		"k8sServicePort": apiserver.GetSecurePort(),
 		// This flag enables the runtime device detection which is set to true by default in Cilium 1.16+
 		"enableRuntimeDeviceDetection": true,
+		"sessionAffinity":              true,
 	}
 
 	// If we are deploying with IPv6 only, we need to set the routing mode to native


### PR DESCRIPTION
## Description

Session affinity is disabled by default in the cilium helm chart. Note that there are a few session affinity related Conformance tests which are failing because of this fact:

```
[sig-network] Services should be able to switch session affinity for NodePort service [LinuxOnly] [Conformance]
[sig-network] Services should have session affinity work for service with type clusterIP [LinuxOnly] [Conformance]
[sig-network] Services should have session affinity work for NodePort service [LinuxOnly] [Conformance]
[sig-network] Services should be able to switch session affinity for service with type clusterIP [LinuxOnly] [Conformance]
```

## Solution

Enabling this should resolve the failures for the tests mentioned above.

Note that the ``sessionAffinity`` helm chart option was introduced in 1.12.0.

## Issue

Include a link to the Github issue number if applicable.

## Backport

``release-1.32``.

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
