### PR TITLE
docs: use lxd vms instead of containers

### DIFF
--- a/docs/canonicalk8s/charm/howto/install/install-lxd.md
+++ b/docs/canonicalk8s/charm/howto/install/install-lxd.md
@@ -1,16 +1,17 @@
 # How to install to localhost/LXD
 
 The main [install instructions][install] cover most situations for installing
-{{product}} using a charm. However, there are two scenarios which
-require some extra steps. These are:
+{{product}} using a charm. However, using LXD requires special consideration.
 
-- deploying to the 'localhost' cloud
+Juju can leverage LXD by:
+
+- deploying to the default 'localhost' cloud
+- explicitly adding a Juju cloud that uses the ``lxd`` type
 - deploying to a container on a machine (i.e. when installing a bundle or using
   the 'to:' directive to install to an existing machine)
 
-LXD is about to remove the support for privileged containers and some
-Kubernetes services, such as the Cilium CNI, cannot run inside unprivileged
-containers.
+LXD privileged containers are no longer supported and some Kubernetes services,
+such as the Cilium CNI, cannot run inside unprivileged containers.
 
 As such, we recommend using LXD virtual machines, which also ensure that the
 Kubernetes environment is well isolated.
@@ -25,3 +26,10 @@ juju deploy k8s --channel=$channel \
   --constraints='cores=2 mem=4G root-disk=40G virt-type=virtual-machine'
 ```
 
+The constraints can also be defined per model using
+``juju set-model-constraints`` or per applications through
+``juju set-constraints`` so that all the deployed units will use the specified
+constraints.
+
+<!-- LINKS -->
+[install]: ./charm

--- a/docs/canonicalk8s/charm/howto/install/install-lxd.md
+++ b/docs/canonicalk8s/charm/howto/install/install-lxd.md
@@ -8,122 +8,20 @@ require some extra steps. These are:
 - deploying to a container on a machine (i.e. when installing a bundle or using
   the 'to:' directive to install to an existing machine)
 
-The container running the charm, or more accurately, the LXD instance
-controlling the container, needs to have a particular configuration in order
-for the Kubernetes components to operate properly.
+LXD is about to remove the support for privileged containers and some
+Kubernetes services, such as the Cilium CNI, cannot run inside unprivileged
+containers.
 
+As such, we recommend using LXD virtual machines, which also ensure that the
+Kubernetes environment is well isolated.
 
-## Apply the {{product}} LXD profile
+We can use Juju constraints to request virtual machines to be used instead
+of containers and specify the amount of resources to allocate.
 
-On the machine running the 'localhost' cloud, we can determine the existing
-profiles by running the command:
-
-```
-lxc profile list
-```
-
-For example, suppose we have created a model called `myk8s`. This will
-output a table like this:
+For example, we can pass the following constraints when deploying ``k8s``:
 
 ```
-+-----------------+---------------------+---------+
-|      NAME       |     DESCRIPTION     | USED BY |
-+-----------------+---------------------+---------+
-| default         | Default LXD profile | 2       |
-+-----------------+---------------------+---------+
-| juju-controller |                     | 1       |
-+-----------------+---------------------+---------+
-| juju-myk8s      |                     | 0       |
-+-----------------+---------------------+---------+
+juju deploy k8s --channel=$channel \
+  --constraints='cores=2 mem=4G root-disk=40G virt-type=virtual-machine'
 ```
 
-Each model created by Juju will generate a new profile for LXD. We can inspect
-and edit the profiles easily by using `lxc` commands.
-
-## Fetching the profile
-
-A working LXD profile is kept in the source repository for the {{product}}
-'k8s' snap. You can retrieve this profile by running the command:
-
-<!-- markdownlint-disable -->
-```
-wget https://raw.githubusercontent.com/canonical/k8s-snap/main/tests/integration/lxd-profile.yaml -O k8s.profile
-```
-<!-- markdownlint-restore -->
-
-To pipe the content of the file into the k8s LXD profile, run:
-
-```
-cat k8s.profile | lxc profile edit juju-myk8s
-```
-
-Remove the copied content from your directory:
-
-```
-rm k8s.profile
-```
-
-The profile editor will syntax-check the profile as part of the editing
-process, but you can confirm the contents have changed by running:
-
-```
-lxc profile show juju-myk8s
-```
-
-```{note} For an explanation of the settings in this file,
-   [see below](explain-rules-charm)
-```
-
-## Deploying to a container
-
-We can now deploy {{product}} into the LXD-based model as described in
-the [charm][] guide.
-
-(explain-rules-charm)=
-
-## Explanation of custom LXD rules
-
-**boot.autostart: “true”**: Always start the container when LXD starts. This is
-needed to start the container when the host boots.
-
-**linux.kernel_modules**: Comma separated list of kernel modules to load before
-starting the container
-
-**lxc.apparmor.profile=unconfined**: Disable [AppArmor]. Allow the container to
-talk to a bunch of subsystems of the host (e.g. `/sys`). By default AppArmor
-will block nested hosting of containers, however Kubernetes needs to host
-Containers. Containers need to be confined based on their profiles thus we rely
-on confining them and not the hosts. If you can account for the needs of the
-Containers you could tighten the AppArmor profile instead of disabling it
-completely, as suggested in S.Graber's notes[^1].
-
-**lxc.cap.drop=**: Do not drop any capabilities [^2]. For justification see
-above.
-
-**lxc.mount.auto=proc:rw sys:rw**: Mount proc and sys rw. For privileged
-containers, lxc over-mounts part of /proc as read-only to avoid damage to the
-host. Kubernetes will complain with messages like `Failed to start
-ContainerManager open /proc/sys/kernel/panic: permission denied`
-
-**lxc.cgroup.devices.allow=a**: "a" stands for "all." This means that the
-container is allowed to access all devices. It's a wildcard character
-indicating permission for all devices. For justification see above.
-
-**security.nesting: “true”**: Support running LXD (nested) inside the
-container.
-
-**security.privileged: “true”**: Runs the container in privileged mode, not
-using kernel namespaces [^3], [^4]. This is needed because hosted Containers may
-need to access for example storage devices (See comment in [^5]).
-
-<!-- LINKS -->
-<!-- markdownlint-disable MD034 -->
-[^1]: https://stgraber.org/2012/05/04/
-[^2]: https://stgraber.org/2014/01/01/lxc-1-0-security-features/
-[^3]: https://unix.stackexchange.com/questions/177030/what-is-an-unprivileged-lxc-container/177031#177031
-[^4]: http://blog.benoitblanchon.fr/lxc-unprivileged-container/
-[^5]: https://wiki.ubuntu.com/LxcSecurity
-
-[AppArmor]: https://apparmor.net/
-[charm]:    ./charm
-[install]:  ./charm

--- a/docs/canonicalk8s/charm/howto/install/install-lxd.md
+++ b/docs/canonicalk8s/charm/howto/install/install-lxd.md
@@ -10,11 +10,15 @@ Juju can leverage LXD by:
 - deploying to a container on a machine (i.e. when installing a bundle or using
   the 'to:' directive to install to an existing machine)
 
+```{warning}
 LXD privileged containers are no longer supported and some Kubernetes services,
 such as the Cilium CNI, cannot run inside unprivileged containers.
+```
 
 As such, we recommend using LXD virtual machines, which also ensure that the
 Kubernetes environment is well isolated.
+
+## Deploy an LXD VM
 
 We can use Juju constraints to request virtual machines to be used instead
 of containers and specify the amount of resources to allocate.

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -4,10 +4,10 @@
 great way, for example, to test out clustered {{product}} without the
 need for multiple physical hosts.
 
-Why an LXD virtual machine and not a container? LXD is about to remove the
-support for privileged containers and some Kubernetes services, such as the
-Cilium CNI, cannot run inside unprivileged containers. Furthermore, by using
-virtual machine we ensure that the Kubernetes environment is well isolated.
+Why an LXD virtual machine and not a container? LXD privileged containers are
+no longer supported and some Kubernetes services, such as the Cilium CNI,
+cannot run inside unprivileged containers. Furthermore, by using virtual
+machine we ensure that the Kubernetes environment is well isolated.
 
 ## Install LXD
 

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -11,7 +11,7 @@ machine we ensure that the Kubernetes environment is well isolated.
 
 ## Install LXD
 
-You can install [LXD] via snaps:
+Install [LXD] via snaps:
 
 ```
 sudo snap install lxd

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -23,7 +23,7 @@ sudo lxd init
 We can now create the VM that {{product}} will run in.
 
 ```
-lxc launch ubuntu:22.04 k8s --vm -c limits.cpu=2 -c limits.memory=4GB
+lxc launch ubuntu:22.04 k8s-vm --vm -c limits.cpu=2 -c limits.memory=4GB
 ```
 
 ## Install {{product}} in an LXD VM
@@ -51,14 +51,14 @@ Simply note the interface IP address from the command:
 
 <!-- markdownlint-disable -->
 ```
-lxc list k8s
+lxc list k8s-vm
 ```
 ```
-+------+---------+------------------------+------------------------------------------------+-----------------+-----------+
-| NAME |  STATE  |         IPV4           |                     IPV6                       |      TYPE       | SNAPSHOTS |
-+------+---------+------------------------+------------------------------------------------+-----------------+-----------+
-| k8s  | RUNNING | 10.122.174.30 (enp5s0) | fd42:80c6:c3e:445a:216:3eff:fe8d:add9 (enp5s0) | VIRTUAL-MACHINE | 0         |
-+------+---------+------------------------+------------------------------------------------+-----------------+-----------+
++--------+---------+------------------------+------------------------------------------------+-----------------+-----------+
+|  NAME  |  STATE  |         IPV4           |                     IPV6                       |      TYPE       | SNAPSHOTS |
++--------+---------+------------------------+------------------------------------------------+-----------------+-----------+
+| k8s-vm | RUNNING | 10.122.174.30 (enp5s0) | fd42:80c6:c3e:445a:216:3eff:fe8d:add9 (enp5s0) | VIRTUAL-MACHINE | 0         |
++--------+---------+------------------------+------------------------------------------------+-----------------+-----------+
 ```
 
 <!-- markdownlint-restore -->
@@ -78,20 +78,20 @@ to expose. These steps can be applied to any other deployment.
 First, initialise the k8s cluster with
 
 ```
-lxc exec k8s -- sudo k8s bootstrap
+lxc exec k8s-vm -- sudo k8s bootstrap
 ```
 
 Now, let’s deploy Microbot (please note this image only works on `x86_64`).
 
 ```
-lxc exec k8s -- sudo k8s kubectl create deployment \
+lxc exec k8s-vm -- sudo k8s kubectl create deployment \
   microbot --image=dontrebootme/microbot:v1
 ```
 
 Then check that the deployment has come up.
 
 ```
-lxc exec k8s -- sudo k8s kubectl get all
+lxc exec k8s-vm -- sudo k8s kubectl get all
 ```
 
 ...should return an output similar to:
@@ -118,7 +118,7 @@ VM by using the `expose` command.
 <!-- markdownlint-disable -->
 
 ```
-lxc exec k8s -- sudo k8s kubectl expose deployment microbot --type=NodePort --port=80 --name=microbot-service
+lxc exec k8s-vm -- sudo k8s kubectl expose deployment microbot --type=NodePort --port=80 --name=microbot-service
 ```
 
 <!-- markdownlint-restore -->
@@ -126,7 +126,7 @@ lxc exec k8s -- sudo k8s kubectl expose deployment microbot --type=NodePort --po
 We can now get the assigned port. In this example, it’s `32750`:
 
 ```
-lxc exec k8s -- sudo k8s kubectl get service microbot-service
+lxc exec k8s-vm -- sudo k8s kubectl get service microbot-service
 ```
 
 ...returns output similar to:
@@ -145,18 +145,18 @@ curl 10.122.174.30:32750
 
 ## Stop/remove the VM
 
-The `k8s` VM you created will keep running in the background until it is
+The `k8s-vm` VM you created will keep running in the background until it is
 either stopped or the host computer is shut down. You can stop the running
 VM at any time by running:
 
 ```
-lxc stop k8s
+lxc stop k8s-vm
 ```
 
 And it can be permanently removed with:
 
 ```
-lxc delete k8s
+lxc delete k8s-vm
 ```
 
 [LXD]: https://canonical.com/lxd

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -1,8 +1,13 @@
 # How to install {{product}} in LXD
 
-{{product}} can also be installed inside an LXD container. This is a
+{{product}} can also be installed inside an LXD virtual machine. This is a
 great way, for example, to test out clustered {{product}} without the
 need for multiple physical hosts.
+
+Why an LXD virtual machine and not a container? LXD is about to remove the
+support for privileged containers and some Kubernetes services, such as the
+Cilium CNI, cannot run inside unprivileged containers. Furthermore, by using
+virtual machine we ensure that the Kubernetes environment is well isolated.
 
 ## Install LXD
 
@@ -13,56 +18,17 @@ sudo snap install lxd
 sudo lxd init
 ```
 
-## Add the {{product}} LXD profile
+## Start an LXD VM for {{product}}
 
-{{product}} requires some specific settings to work within LXD (these
-are explained in more detail below). These can be applied using a custom
-profile. The first step is to create a new profile:
+We can now create the VM that {{product}} will run in.
 
 ```
-lxc profile create k8s
+lxc launch ubuntu:22.04 k8s --vm -c limits.cpu=2 -c limits.memory=4GB
 ```
 
-Once created, we’ll need to add the rules.
-Get our pre-defined profile rules from GitHub and save them as `k8s.profile`.
+## Install {{product}} in an LXD VM
 
-<!-- markdownlint-disable -->
-```
-wget https://raw.githubusercontent.com/canonical/k8s-snap/main/tests/integration/lxd-profile.yaml -O k8s.profile
-```
-<!-- markdownlint-restore -->
-
-```{note} For an explanation of the settings in this file,
-[see below](explain-rules)
-```
-
-To pipe the content of the file into the k8s LXD profile, run:
-
-```
-cat k8s.profile | lxc profile edit k8s
-```
-
-Remove the copied content from your directory:
-
-```
-rm k8s.profile
-```
-
-## Start an LXD container for {{product}}
-
-We can now create the container that {{product}} will run in.
-
-```
-lxc launch -p default -p k8s ubuntu:22.04 k8s
-```
-
-This command uses the `default` profile created by LXD for any
-existing system settings (networking, storage, etc.), before
-also applying the `k8s` profile - the order is important.
-
-## Install {{product}} in an LXD container
-
-First, we’ll need to install {{product}} within the container.
+First, we’ll need to install {{product}} within the VM.
 
 ```{literalinclude} ../../../_parts/install.md
 :start-after: <!-- lxd start -->
@@ -79,31 +45,30 @@ explanation page for more details on channels, tracks and versions.
 
 Assuming you accepted the [default bridged
 networking][default-bridged-networking] when you initially setup LXD, there is
-minimal effort required to access {{product}} services inside the LXD
-container.
+minimal effort required to access {{product}} services inside the LXD VM.
 
-Simply note the `eth0` interface IP address from the command:
+Simply note the interface IP address from the command:
 
 <!-- markdownlint-disable -->
 ```
 lxc list k8s
 ```
 ```
-+------+---------+----------------------+----------------------------------------------+-----------+-----------+
-| NAME |  STATE  |         IPV4         |                     IPV6                     |   TYPE    | SNAPSHOTS |
-+------+---------+----------------------+----------------------------------------------+-----------+-----------+
-| k8s  | RUNNING | 10.122.174.30 (eth0) | fd42:80c6:c3e:445a:216:3eff:fe8d:add9 (eth0) | CONTAINER | 0         |
-+------+---------+----------------------+----------------------------------------------+-----------+-----------+
++------+---------+------------------------+------------------------------------------------+-----------------+-----------+
+| NAME |  STATE  |         IPV4           |                     IPV6                       |      TYPE       | SNAPSHOTS |
++------+---------+------------------------+------------------------------------------------+-----------------+-----------+
+| k8s  | RUNNING | 10.122.174.30 (enp5s0) | fd42:80c6:c3e:445a:216:3eff:fe8d:add9 (enp5s0) | VIRTUAL-MACHINE | 0         |
++------+---------+------------------------+------------------------------------------------+-----------------+-----------+
 ```
 
 <!-- markdownlint-restore -->
 
-and use this to access services running inside the container.
+and use this to access services running inside the VM.
 
-### Expose services to the container
+### Expose services to the VM
 
-You’ll need to expose the deployment or service to the container itself before
-you can access it via the LXD container’s IP address. This can be done using
+You’ll need to expose the deployment or service to the VM itself before
+you can access it via the LXD VM’s IP address. This can be done using
 `k8s kubectl expose`. This example will expose the deployment’s port 80 to a
 port assigned by Kubernetes.
 
@@ -148,7 +113,7 @@ replicaset.apps/microbot-6d97548556   1         1         1       21m
 <!-- markdownlint-restore -->
 
 Now that Microbot is up and running, let's make it accessible to the LXD
-container by using the `expose` command.
+VM by using the `expose` command.
 
 <!-- markdownlint-disable -->
 
@@ -171,18 +136,18 @@ NAME               TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
 microbot-service   NodePort   10.152.183.188   <none>        80:32750/TCP   27m
 ```
 
-With this, we can access Microbot from our host but using the container’s
+With this, we can access Microbot from our host but using the VM’s
 address that we noted earlier.
 
 ```
 curl 10.122.174.30:32750
 ```
 
-## Stop/remove the container
+## Stop/remove the VM
 
-The `k8s` container you created will keep running in the background until it is
+The `k8s` VM you created will keep running in the background until it is
 either stopped or the host computer is shut down. You can stop the running
-container at any time by running:
+VM at any time by running:
 
 ```
 lxc stop k8s
@@ -194,54 +159,7 @@ And it can be permanently removed with:
 lxc delete k8s
 ```
 
-<!-- markdownlint-capture -->
-<!-- markdownlint-disable -->
-(explain-rules)=
-## Explanation of custom LXD rules
-
-
-<!-- markdownlint-restore -->
-
-**linux.kernel_modules**: Comma separated list of kernel modules to load before
-starting the container
-
-**lxc.apparmor.profile=unconfined**: Disable [AppArmor]. Allow the container to
-talk to a bunch of subsystems of the host (e.g. `/sys`). By default AppArmor
-will block nested hosting of containers, however Kubernetes needs to host
-Containers. Containers need to be confined based on their profiles thus we rely
-on confining them and not the hosts. If you can account for the needs of the
-Containers you could tighten the AppArmor profile instead of disabling it
-completely, as suggested in S.Graber's notes[^1].
-
-**lxc.cap.drop=**: Do not drop any capabilities [^2]. For justification see
-above.
-
-**lxc.mount.auto=proc:rw sys:rw**: Mount proc and sys rw. For privileged
-containers, lxc over-mounts part of /proc as read-only to avoid damage to the
-host. Kubernetes will complain with messages like `Failed to start
-ContainerManager open /proc/sys/kernel/panic: permission denied`
-
-**lxc.cgroup.devices.allow=a**: "a" stands for "all." This means that the
-container is allowed to access all devices. It's a wildcard character
-indicating permission for all devices. For justification see above.
-
-**security.nesting: “true”**: Support running LXD (nested) inside the
-container.
-
-**security.privileged: “true”**: Runs the container in privileged mode, not
-using kernel namespaces [^3], [^4]. This is needed because hosted Containers may
-need to access for example storage devices (See comment in [^5]).
-
-<!-- LINKS -->
-<!-- markdownlint-disable MD034 -->
-[^1]: https://stgraber.org/2012/05/04/
-[^2]: https://stgraber.org/2014/01/01/lxc-1-0-security-features/
-[^3]: https://unix.stackexchange.com/questions/177030/what-is-an-unprivileged-lxc-container/177031#177031
-[^4]: http://blog.benoitblanchon.fr/lxc-unprivileged-container/
-[^5]: https://wiki.ubuntu.com/LxcSecurity
-
 [LXD]: https://canonical.com/lxd
 [default-bridged-networking]: https://ubuntu.com/blog/lxd-networking-lxdbr0-explained
 [Microbot]: https://github.com/dontrebootme/docker-microbot
-[AppArmor]: https://apparmor.net/
 [channels]: ../../explanation/channels

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -20,7 +20,7 @@ sudo lxd init
 
 ## Start an LXD VM for {{product}}
 
-We can now create the VM that {{product}} will run in.
+Create the VM that {{product}} will run in.
 
 ```
 lxc launch ubuntu:22.04 k8s-vm --vm -c limits.cpu=2 -c limits.memory=4GB
@@ -28,7 +28,7 @@ lxc launch ubuntu:22.04 k8s-vm --vm -c limits.cpu=2 -c limits.memory=4GB
 
 ## Install {{product}} in an LXD VM
 
-First, we’ll need to install {{product}} within the VM.
+Install {{product}} within the VM.
 
 ```{literalinclude} ../../../_parts/install.md
 :start-after: <!-- lxd start -->
@@ -123,7 +123,7 @@ lxc exec k8s-vm -- sudo k8s kubectl expose deployment microbot --type=NodePort -
 
 <!-- markdownlint-restore -->
 
-We can now get the assigned port. In this example, it’s `32750`:
+Get the assigned port. In this example, it’s `32750`:
 
 ```
 lxc exec k8s-vm -- sudo k8s kubectl get service microbot-service
@@ -136,8 +136,8 @@ NAME               TYPE       CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
 microbot-service   NodePort   10.152.183.188   <none>        80:32750/TCP   27m
 ```
 
-With this, we can access Microbot from our host but using the VM’s
-address that we noted earlier.
+With this, access Microbot from our host but using the VM’s address that we
+noted earlier.
 
 ```
 curl 10.122.174.30:32750
@@ -146,8 +146,8 @@ curl 10.122.174.30:32750
 ## Stop/remove the VM
 
 The `k8s-vm` VM you created will keep running in the background until it is
-either stopped or the host computer is shut down. You can stop the running
-VM at any time by running:
+either stopped or the host computer is shut down. Stop the running VM at any
+time by running:
 
 ```
 lxc stop k8s-vm


### PR DESCRIPTION
LXD privileged containers are about to become deprecated and Cilium doesn't currently work with unprivileged containers. That might change soon: https://github.com/canonical/lxd/pull/15009

For now, we'll update the documentation and tell the users to go with LXD vms instead of containers.

## Description

What issue is this PR trying to solve?

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
