### PR TITLE
ci: simplify names

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,4 +1,4 @@
-name: Run k8s-snap e2e tests
+name: Run e2e tests
 
 permissions:
   contents: read
@@ -32,7 +32,7 @@ on:
 
 jobs:
   test-integration:
-    name: "${{ inputs.os }} :: (${{ inputs.arch }}) :: ${{ inputs.artifact }}"
+    name: Tests
     runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-noble-large' || 'self-hosted-linux-amd64-noble-large' }}
     steps:
       - name: Check out code

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   test-integration:
-    name: Integration Test ${{ inputs.os }} ${{ inputs.arch }} ${{ inputs.artifact }}
+    name: "${{ inputs.os }} :: (${{ inputs.arch }}) :: ${{ inputs.artifact }}"
     runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-noble-large' || 'self-hosted-linux-amd64-noble-large' }}
     steps:
       - name: Check out code

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -99,7 +99,7 @@ jobs:
           echo "test-tags=$tags" >> "$GITHUB_OUTPUT"
 
   test-integration:
-    name: Test ${{ matrix.os }}
+    name: Test Integration
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +113,7 @@ jobs:
       artifact: k8s.snap
 
   test-integration-informing:
-    name: Test informing ${{ matrix.os }} ${{ matrix.patch }}
+    name: Test Informing
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -1,4 +1,4 @@
-name: Lint and integration tests
+name: Lint and integration
 
 on:
   push:
@@ -99,7 +99,7 @@ jobs:
           echo "test-tags=$tags" >> "$GITHUB_OUTPUT"
 
   test-integration:
-    name: Test Integration
+    name: Integration
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +113,7 @@ jobs:
       artifact: k8s.snap
 
   test-integration-informing:
-    name: Test Informing
+    name: Informing
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-integration:
-    name: Integration Test ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.release }}
+    name: Integration Test
     strategy:
       matrix:
         os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -1,4 +1,4 @@
-name: Nightly Tests
+name: Nightly
 
 on:
   schedule:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test-integration:
-    name: Integration Test
+    name: Integration
     strategy:
       matrix:
         os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]


### PR DESCRIPTION
## Description

What issue is this PR trying to solve?

There is a lot of duplicated information in the action names right now. this aims to simplify the names.

The duplication is caused by callers (lint_and_integration.yaml, nightly-test.yaml) duplicating information that the callee (e2e-tests.yaml) already outputs.

## Solution

**Original**

Nightly Tests / Integration Test ubuntu:20.04 amd64 / Integration Test ubuntu:20.04 amd64
Lint and integration tests / Test ubuntu:24.04 / Integration Test ubuntu:24.04 amd64 k8s.snap

**Simplified**

Nightly / Integration (ubuntu:20.04, arm64, latest/edge) / Tests
Lint and Integration / Integration (ubuntu:20.04, arm64, latest/edge, k8s.snap) / Tests

Removes redundant words and platform mentions while preserving essential context.

## Issue

None.

## Backport

No.

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
