### PR TITLE
feat: add `certs-status` command

### DIFF
--- a/docs/canonicalk8s/_parts/commands/k8s.md
+++ b/docs/canonicalk8s/_parts/commands/k8s.md
@@ -11,6 +11,7 @@ Canonical Kubernetes CLI
 ### SEE ALSO
 
 * [k8s bootstrap](k8s_bootstrap.md)	 - Bootstrap a new Kubernetes cluster
+* [k8s certs-status](k8s_certs-status.md)	 - Display certificate and certificate authority expiration details
 * [k8s completion](k8s_completion.md)	 - Generate the autocompletion script for the specified shell
 * [k8s disable](k8s_disable.md)	 - Disable core cluster features
 * [k8s enable](k8s_enable.md)	 - Enable core cluster features

--- a/docs/canonicalk8s/_parts/commands/k8s_certs-status.md
+++ b/docs/canonicalk8s/_parts/commands/k8s_certs-status.md
@@ -1,0 +1,19 @@
+## k8s certs-status
+
+Display certificate and certificate authority expiration details
+
+```
+k8s certs-status [flags]
+```
+
+### Options
+
+```
+  -h, --help               help for certs-status
+      --timeout duration   the max time to wait for the command to execute (default 1m30s)
+```
+
+### SEE ALSO
+
+* [k8s](k8s.md)	 - Canonical Kubernetes CLI
+

--- a/docs/canonicalk8s/snap/reference/commands.md
+++ b/docs/canonicalk8s/snap/reference/commands.md
@@ -10,6 +10,10 @@ These are the commands provided by the k8s snap:
    :end-before: '### SEE ALSO'
 ```
 
+```{include} /_parts/commands/k8s_certs-status.md
+   :end-before: '### SEE ALSO'
+```
+
 ```{include} /_parts/commands/k8s_config.md
    :end-before: '### SEE ALSO'
 ```

--- a/src/k8s/cmd/k8s/k8s.go
+++ b/src/k8s/cmd/k8s/k8s.go
@@ -86,6 +86,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		newEnableCmd(env),
 		newDisableCmd(env),
 		newRefreshCertsCmd(env),
+		newCertsStatusCmd(env),
 		newSetCmd(env),
 		newGetCmd(env),
 		newInspectCmd(env),

--- a/src/k8s/cmd/k8s/k8s_certs_status.go
+++ b/src/k8s/cmd/k8s/k8s_certs_status.go
@@ -1,0 +1,114 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	cmdutil "github.com/canonical/k8s/cmd/util"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+func newCertsStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
+	var opts struct {
+		timeout time.Duration
+	}
+	cmd := &cobra.Command{
+		Use:   "certs-status",
+		Short: "Display certificate and certificate authority expiration details",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			client, err := env.Snap.K8sdClient("")
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to create a k8sd client. Make sure that the k8sd service is running.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			cobra.OnFinalize(cancel)
+
+			if _, initialized, err := client.NodeStatus(cmd.Context()); err != nil {
+				cmd.PrintErrf("Error: Failed to check the current node status.\n\nThe error was: %v\n", err)
+				env.Exit(1)
+				return
+			} else if !initialized {
+				cmd.PrintErrln("Error: The node is not part of a Kubernetes cluster. You can bootstrap a new cluster with:\n\n  sudo k8s bootstrap")
+				env.Exit(1)
+				return
+			}
+
+			status, err := client.CertificatesStatus(ctx, apiv1.CertificatesStatusRequest{})
+			if err != nil {
+				cmd.PrintErrf("Error: Failed to retrieve certificate status.\n\nError: %v\n", err)
+				env.Exit(1)
+				return
+			}
+			if err := printCertificatesStatus(cmd.OutOrStdout(), status); err != nil {
+				cmd.PrintErrf("Error: Failed to display certificate status.\n\nError: %v\n", err)
+				env.Exit(1)
+				return
+			}
+		},
+	}
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
+
+	return cmd
+}
+
+// printCertificatesStatus writes certificate and certificate authority statuses to the provided
+// writer in a tabulated format. The output includes the certificate name, expiration date,
+// residual time until expiration, associated certificate authority, and whether the certificate
+// is externally managed.
+func printCertificatesStatus(writer io.Writer, status apiv1.CertificatesStatusResponse) error {
+	yesNo := func(b bool) string {
+		if b {
+			return "yes"
+		}
+		return "no"
+	}
+
+	w := tabwriter.NewWriter(writer, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintln(w, "CERTIFICATE\tEXPIRES\tRESIDUAL TIME\tCERTIFICATE AUTHORITY\tEXTERNALLY MANAGED")
+	for _, certificate := range status.Certificates {
+		expirationDate, err := time.Parse(time.RFC3339, certificate.Expires)
+		if err != nil {
+			return fmt.Errorf("failed to parse expiration date for certificate %s: %w", certificate.Name, err)
+		}
+		residualTime := duration.HumanDuration(time.Until(expirationDate).Truncate(time.Second))
+		formattedDate := expirationDate.Format("Jan 02, 2006 15:04 MST")
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			certificate.Name,
+			formattedDate,
+			residualTime,
+			certificate.CertificateAuthority,
+			yesNo(certificate.ExternallyManaged),
+		)
+	}
+
+	if len(status.CertificateAuthorities) > 0 {
+		fmt.Fprintln(w, "\nCERTIFICATE AUTHORITY\tEXPIRES\tRESIDUAL TIME\tEXTERNALLY MANAGED")
+	}
+	for _, certificate := range status.CertificateAuthorities {
+		expirationDate, err := time.Parse(time.RFC3339, certificate.Expires)
+		if err != nil {
+			return fmt.Errorf("failed to parse expiration date for certificate authority %s: %w", certificate.Name, err)
+		}
+		residualTime := duration.HumanDuration(time.Until(expirationDate).Truncate(time.Second))
+		formattedDate := expirationDate.Format("Jan 02, 2006 15:04 MST")
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			certificate.Name,
+			formattedDate,
+			residualTime,
+			yesNo(certificate.ExternallyManaged),
+		)
+	}
+
+	w.Flush()
+	return nil
+}

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.19
+	github.com/canonical/k8s-snap-api v1.0.20-0.20250304172555-9b53cca803e5
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.20-0.20250304172555-9b53cca803e5
+	github.com/canonical/k8s-snap-api v1.0.20
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.19 h1:X1CcUck3bW6YOux4p95kcSuE1Y48K6ensiSqJTlZxjk=
-github.com/canonical/k8s-snap-api v1.0.19/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.0.20-0.20250304172555-9b53cca803e5 h1:tIMaaPWKKwqR2AcL+yr3NN3+FXCdD3yCmkUErUgbPpY=
+github.com/canonical/k8s-snap-api v1.0.20-0.20250304172555-9b53cca803e5/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18 h1:h5VJaUnE4gAKPolBTJ11HMRTEN5JyA+oR4gHkoK//6o=

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.20-0.20250304172555-9b53cca803e5 h1:tIMaaPWKKwqR2AcL+yr3NN3+FXCdD3yCmkUErUgbPpY=
-github.com/canonical/k8s-snap-api v1.0.20-0.20250304172555-9b53cca803e5/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.0.20 h1:2dUQFkYoi+VRE09oah+5RfeoP3e8mbm/G1d0F+a0/G0=
+github.com/canonical/k8s-snap-api v1.0.20/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18 h1:h5VJaUnE4gAKPolBTJ11HMRTEN5JyA+oR4gHkoK//6o=

--- a/src/k8s/pkg/client/k8sd/interface.go
+++ b/src/k8s/pkg/client/k8sd/interface.go
@@ -43,6 +43,8 @@ type ClusterMaintenanceClient interface {
 	RefreshCertificatesRun(context.Context, apiv1.RefreshCertificatesRunRequest) (apiv1.RefreshCertificatesRunResponse, error)
 	// RefreshCertificatesUpdate updates the Kubernetes certificates of the node.
 	RefreshCertificatesUpdate(context.Context, apiv1.RefreshCertificatesUpdateRequest) (apiv1.RefreshCertificatesUpdateResponse, error)
+	// CertificatesStatus shows the status of the node's certificates.
+	CertificatesStatus(context.Context, apiv1.CertificatesStatusRequest) (apiv1.CertificatesStatusResponse, error)
 }
 
 // UserClient implements methods to enable accessing the cluster.

--- a/src/k8s/pkg/client/k8sd/manage.go
+++ b/src/k8s/pkg/client/k8sd/manage.go
@@ -17,3 +17,7 @@ func (c *k8sd) RefreshCertificatesRun(ctx context.Context, request apiv1.Refresh
 func (c *k8sd) RefreshCertificatesUpdate(ctx context.Context, request apiv1.RefreshCertificatesUpdateRequest) (apiv1.RefreshCertificatesUpdateResponse, error) {
 	return query(ctx, c, "POST", apiv1.RefreshCertificatesUpdateRPC, request, &apiv1.RefreshCertificatesUpdateResponse{})
 }
+
+func (c *k8sd) CertificatesStatus(ctx context.Context, request apiv1.CertificatesStatusRequest) (apiv1.CertificatesStatusResponse, error) {
+	return query(ctx, c, "GET", apiv1.CertificatesStatusRPC, request, &apiv1.CertificatesStatusResponse{})
+}

--- a/src/k8s/pkg/client/k8sd/mock/mock.go
+++ b/src/k8s/pkg/client/k8sd/mock/mock.go
@@ -45,6 +45,10 @@ type Mock struct {
 	RefreshCertificatesUpdateResponse   apiv1.RefreshCertificatesUpdateResponse
 	RefreshCertificatesUpdateErr        error
 
+	CertificatesStatusCalledWith apiv1.CertificatesStatusRequest
+	CertificatesStatusResponse   apiv1.CertificatesStatusResponse
+	CertificatesStatusErr        error
+
 	// k8sd.UserClient
 	KubeConfigCalledWith apiv1.KubeConfigRequest
 	KubeConfigResponse   apiv1.KubeConfigResponse
@@ -94,6 +98,11 @@ func (m *Mock) RefreshCertificatesRun(_ context.Context, request apiv1.RefreshCe
 func (m *Mock) RefreshCertificatesUpdate(_ context.Context, request apiv1.RefreshCertificatesUpdateRequest) (apiv1.RefreshCertificatesUpdateResponse, error) {
 	m.RefreshCertificatesUpdateCalledWith = request
 	return m.RefreshCertificatesUpdateResponse, m.RefreshCertificatesUpdateErr
+}
+
+func (m *Mock) CertificatesStatus(_ context.Context, request apiv1.CertificatesStatusRequest) (apiv1.CertificatesStatusResponse, error) {
+	m.CertificatesStatusCalledWith = request
+	return m.CertificatesStatusResponse, m.CertificatesStatusErr
 }
 
 func (m *Mock) GetClusterConfig(_ context.Context) (apiv1.GetClusterConfigResponse, error) {

--- a/src/k8s/pkg/k8sd/api/certificates_status.go
+++ b/src/k8s/pkg/k8sd/api/certificates_status.go
@@ -1,0 +1,241 @@
+package api
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/v2/state"
+
+	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func (e *Endpoints) getCertificatesStatus(s state.State, r *http.Request) response.Response {
+	snap := e.provider.Snap()
+	isWorker, err := snaputil.IsWorker(snap)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to check if node is a worker: %w", err))
+	}
+	if isWorker {
+		return getCertsStatusWorker(s, r, snap)
+	}
+	return getCertsStatusControlPlane(s, r, snap)
+}
+
+// getCertsStatusControlPlane collects certificate status information for
+// control plane nodes. It reads control plane certificates, kubeconfig
+// certificates, and certificate authority statuses.
+func getCertsStatusControlPlane(s state.State, r *http.Request, snap snap.Snap) response.Response {
+	clusterConfig, err := databaseutil.GetClusterConfig(r.Context(), s)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to retrieve cluster configuration: %w", err))
+	}
+	authorities, err := readCertificateAuthorities(&clusterConfig)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to read certificates authorities: %w", err))
+	}
+
+	certsNames := []string{"apiserver", "apiserver-kubelet-client", "front-proxy-client", "kubelet"}
+	nodeCerts, err := loadCertificateStatusesFromDir(snap.KubernetesPKIDir(), certsNames)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to read node certificates: %w", err))
+	}
+
+	kubeConfigs := []string{"admin.conf", "controller.conf", "kubelet.conf", "proxy.conf", "scheduler.conf"}
+	kubeConfigCerts, err := readKubeconfigCertificates(snap.KubernetesConfigDir(), kubeConfigs)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to read kubeconfig certificates: %w", err))
+	}
+
+	var certificates []apiv1.CertificateStatus
+	certificates = append(certificates, nodeCerts...)
+	certificates = append(certificates, kubeConfigCerts...)
+
+	if clusterConfig.Datastore.GetType() == "external" {
+		dataStoreCerts, err := loadCertificateStatusesFromDir(snap.EtcdPKIDir(), []string{"client"})
+		if err != nil {
+			return response.InternalError(fmt.Errorf("failed to read datastore certificates: %w", err))
+		}
+		certificates = append(certificates, dataStoreCerts...)
+	}
+
+	updateExternallyManaged(authorities, certificates)
+	return response.SyncResponse(true, apiv1.CertificatesStatusResponse{
+		Certificates:           certificates,
+		CertificateAuthorities: authorities,
+	})
+}
+
+// getCertsStatusWorker collects certificate status information for worker
+// nodes. It reads worker certificates and kubeconfig certificates.
+func getCertsStatusWorker(s state.State, r *http.Request, snap snap.Snap) response.Response {
+	certsNames := []string{"kubelet"}
+	nodeCerts, err := loadCertificateStatusesFromDir(snap.KubernetesPKIDir(), certsNames)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to read node certificates: %w", err))
+	}
+
+	kubeConfigs := []string{"kubelet.conf", "proxy.conf"}
+	kubeConfigCerts, err := readKubeconfigCertificates(snap.KubernetesConfigDir(), kubeConfigs)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to read kubeconfig certificates: %w", err))
+	}
+
+	var certificates []apiv1.CertificateStatus
+	certificates = append(certificates, nodeCerts...)
+	certificates = append(certificates, kubeConfigCerts...)
+
+	// NOTE: Worker certificates are inherently externally managed.
+	for i := range certificates {
+		cert := &certificates[i]
+		cert.ExternallyManaged = true
+	}
+
+	return response.SyncResponse(true, apiv1.CertificatesStatusResponse{
+		Certificates:           certificates,
+		CertificateAuthorities: []apiv1.CertificateAuthorityStatus{},
+	})
+}
+
+// readKubeconfigCertificates reads the client certificates from kubeconfig
+// files located in the specified directory. It returns a slice of
+// CertificateStatus for each valid kubeconfig file.
+func readKubeconfigCertificates(kubeconfigDir string, configs []string) ([]apiv1.CertificateStatus, error) {
+	certificates := make([]apiv1.CertificateStatus, 0, len(configs))
+
+	for _, config := range configs {
+		kubeConfig, err := clientcmd.LoadFromFile(filepath.Join(kubeconfigDir, config))
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return certificates, fmt.Errorf("failed to load kubeconfig %s: %w", config, err)
+		}
+
+		authInfo, exists := kubeConfig.AuthInfos["k8s-user"]
+		if !exists {
+			return certificates, fmt.Errorf("user 'k8s-user' not found in kubeconfig %s", config)
+		}
+
+		if authInfo.ClientCertificateData == nil {
+			return certificates, fmt.Errorf("no client certificate data found in kubeconfig %s", config)
+		}
+
+		cert, _, err := pkiutil.LoadCertificate(string(authInfo.ClientCertificateData), "")
+		if err != nil {
+			return certificates, fmt.Errorf("failed to load certificate data from kubeconfig %s: %w", config, err)
+		}
+
+		certificates = append(certificates, apiv1.CertificateStatus{
+			Name:                 config,
+			Expires:              cert.NotAfter.Format(time.RFC3339),
+			CertificateAuthority: cert.Issuer.CommonName,
+		})
+	}
+	return certificates, nil
+}
+
+// readCertificateAuthorities loads certificate authority information from the
+// given cluster configuration.
+func readCertificateAuthorities(clusterConfig *types.ClusterConfig) ([]apiv1.CertificateAuthorityStatus, error) {
+	cas := make([]apiv1.CertificateAuthorityStatus, 0, 3)
+
+	loadAndAppend := func(certPath, keyPath, name string) error {
+		cert, key, err := pkiutil.LoadCertificate(certPath, keyPath)
+		if err != nil {
+			return fmt.Errorf("failed to load %s: %w", name, err)
+		}
+		cas = append(cas, apiv1.CertificateAuthorityStatus{
+			Name:              cert.Subject.CommonName,
+			Expires:           cert.NotAfter.Format(time.RFC3339),
+			ExternallyManaged: key == nil,
+		})
+		return nil
+	}
+
+	casList := []struct {
+		CertPEM string
+		KeyPEM  string
+		Name    string
+	}{
+		{clusterConfig.Certificates.GetCACert(), clusterConfig.Certificates.GetCAKey(), "CA"},
+		{clusterConfig.Certificates.GetClientCACert(), clusterConfig.Certificates.GetClientCAKey(), "Client CA"},
+		{clusterConfig.Certificates.GetFrontProxyCACert(), clusterConfig.Certificates.GetFrontProxyCAKey(), "Front Proxy CA"},
+	}
+
+	for _, ca := range casList {
+		if err := loadAndAppend(ca.CertPEM, ca.KeyPEM, ca.Name); err != nil {
+			return cas, err
+		}
+	}
+
+	return cas, nil
+}
+
+// loadCertificateStatusesFromDir loads the certificate status information for
+// the specified certificate names from the given directory. For each
+// certificate name, it reads the certificate and key pair using
+// loadCertificatePairFromDir, then builds a CertificateStatus that includes
+// the certificate's expiration date and issuer information.
+func loadCertificateStatusesFromDir(baseDir string, certNames []string) ([]apiv1.CertificateStatus, error) {
+	var certs []apiv1.CertificateStatus
+	for _, certName := range certNames {
+		cert, _, err := loadCertificatePairFromDir(baseDir, certName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract information from certificate %s: %w", certName, err)
+		}
+		certs = append(certs, apiv1.CertificateStatus{
+			Name:                 certName,
+			Expires:              cert.NotAfter.Format(time.RFC3339),
+			CertificateAuthority: cert.Issuer.CommonName,
+		})
+	}
+	return certs, nil
+}
+
+// loadCertificatePairFromDir reads the certificate and corresponding private
+// key files for the given certificate name from the specified directory. It
+// expects the files to be named "<name>.crt" and "<name>.key".
+func loadCertificatePairFromDir(baseDir string, name string) (*x509.Certificate, *rsa.PrivateKey, error) {
+	certBytes, err := os.ReadFile(filepath.Join(baseDir, fmt.Sprintf("%s.crt", name)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read %s.crt: %w", name, err)
+	}
+	keyBytes, err := os.ReadFile(filepath.Join(baseDir, fmt.Sprintf("%s.key", name)))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read %s.key: %w", name, err)
+	}
+	cert, key, err := pkiutil.LoadCertificate(string(certBytes), string(keyBytes))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse %s certificate: %w", name, err)
+	}
+	return cert, key, nil
+}
+
+// updateExternallyManaged updates the ExternallyManaged field for each
+// certificate in the provided slice. It matches each certificate's
+// CertificateAuthority against the list of certificate authorities and,
+// if a match is found, uses the authority's ExternallyManaged value.
+func updateExternallyManaged(authorities []apiv1.CertificateAuthorityStatus, certificates []apiv1.CertificateStatus) {
+	for i := range certificates {
+		cert := &certificates[i]
+		for _, authority := range authorities {
+			if authority.Name == cert.CertificateAuthority {
+				cert.ExternallyManaged = authority.ExternallyManaged
+				break
+			}
+		}
+	}
+}

--- a/src/k8s/pkg/k8sd/api/endpoints.go
+++ b/src/k8s/pkg/k8sd/api/endpoints.go
@@ -106,6 +106,11 @@ func (e *Endpoints) Endpoints() []rest.Endpoint {
 			Path: apiv1.RefreshCertificatesUpdateRPC,
 			Post: rest.EndpointAction{Handler: e.postRefreshCertsUpdate},
 		},
+		{
+			Name: "CertsStatus",
+			Path: apiv1.CertificatesStatusRPC,
+			Get:  rest.EndpointAction{Handler: e.getCertificatesStatus},
+		},
 		// Kubeconfig
 		{
 			Name: "Kubeconfig",


### PR DESCRIPTION
> [!WARNING]  
> DO NOT MERGE until we change the version of the `k8s-snap-api` go module ([PR](https://github.com/canonical/k8s-snap-api/pull/29)).

## Description

Add a new command to display a detailed view of the certificates status on a node.

## Solution

This pull request adds the `certs-status` command, which prints the status of the node's certificates. On control plane nodes, it displays the certificate authorities along with all certificates, including those in the kubeconfigs. On worker nodes, it shows the certificates and kubeconfig certificates.
