### PR TITLE
fix: Temporarily disable snap/k8sd config sync during snap upgrade

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+. "$SNAP/k8s/lib.sh"
+
+k8s::common::setup_env
+
+# Enable the snap config reconciler after the snap refresh completes.
+# The reconcile command will synchronize the k8sd configuration with the snap config
+# and then set the meta orb to "snapd," effectively re-enabling the sync process.
+echo "Re-enabling snapd config sync after snap refresh"
+k8s::cmd::k8s x-snapd-config reconcile

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+. "$SNAP/k8s/lib.sh"
+
+k8s::common::setup_env
+
+# disable snap set/get on snap refresh as microcluster need to sync first.
+# the sync will be enabled again after the refresh.
+echo "Disabling snapd config sync during snap refresh"
+k8s::cmd::k8s x-snapd-config disable


### PR DESCRIPTION
## Description

The snap and k8sd configurations are synchronized via k8s x-snapd-config in the configure hook. However, this process requires access to the k8sd API, which may be unavailable during an upgrade. For instance, in a clustered setup with microcluster, the upgrade process can be blocked until all nodes are on the same version, causing the reconciliation to time out.

## Solution

We now explicitly disable the config sync during the snap upgrade to avoid such scenarios.
After the refresh the sync is enabled again by doing a reconcilation.

We use the pre/post-hooks of the snap to inject that logic in the snap lifecycle. Read more on hooks [here](https://snapcraft.io/docs/supported-snap-hooks#heading--the-configure-hook)

## Backport

* 1.32


## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - not applicable
- [ ] Covered by integration tests - already tested as part of the upgrade tests
- [ ] Documentation updated - not documented by design
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
