### PR TITLE
[1.32] ci: Fix `test_mixed_versions_join`

### DIFF
--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -67,6 +67,7 @@ def get_most_stable_channels(
     arch: str,
     include_latest: bool = True,
     min_release: Optional[str] = None,
+    max_release: Optional[str] = None,
 ) -> List[str]:
     """Get an ascending list of latest channels based on the number of channels
     flavour and architecture."""
@@ -85,6 +86,11 @@ def get_most_stable_channels(
         if min_release is not None:
             _min_release = major_minor(min_release)
             if _min_release is not None and version_key < _min_release:
+                continue
+
+        if max_release is not None:
+            _max_release = major_minor(max_release)
+            if _max_release is not None and version_key > _max_release:
                 continue
 
         if version_key not in channel_map or RISK_LEVELS.index(

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -498,7 +498,7 @@ def previous_track(snap_version: str) -> str:
     LOG.debug("Determining previous track for %s", snap_version)
 
     if not snap_version:
-        assumed = "latest"
+        assumed = "1.32-classic"
         LOG.info(
             "Cannot determine previous track for undefined snap -- assume %s",
             snap_version,
@@ -507,7 +507,7 @@ def previous_track(snap_version: str) -> str:
         return assumed
 
     if snap_version.startswith("/") or _as_int(snap_version) is not None:
-        assumed = "latest"
+        assumed = "1.32-classic"
         LOG.info(
             "Cannot determine previous track for %s -- assume %s", snap_version, assumed
         )

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -27,11 +27,15 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
                 "'recent' requires the number of releases as second argument and the flavour as third argument"
             )
         _, num_channels, flavour = channels
+        # Currently, it fails to refresh the snap to the 1.33 channel or newer.
+        # Just test upgrade to at most 1.32.
         channels = snap.get_most_stable_channels(
             int(num_channels),
             flavour,
             cp.arch,
+            include_latest=False,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
+            max_release="1.32",
         )
         if len(channels) < 2:
             pytest.fail(


### PR DESCRIPTION
### Overview
This PR fixes the `test_mixed_versions_join` test.
- https://github.com/canonical/k8s-snap/actions/runs/13701285429/job/38324949769?pr=1155 

### Note for reviewer
We're trying to install the previous k8s snap in this function. For our tests, since the main snap is the one built in the CI, we either need to install 1.32-classic/stable or 1.31-classic/stable.

This PR makes it so that we install 1.32-classic/stable since 1.31-classic/stable is not supported