### PR TITLE
feat: Enables cilium protocol differentiation 

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -147,9 +147,10 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, m helm.Client, s state.St
 			"enabled": true,
 		},
 		"cni": map[string]any{
-			"confPath":  "/etc/cni/net.d",
-			"binPath":   "/opt/cni/bin",
-			"exclusive": config.cniExclusive,
+			"confPath":     "/etc/cni/net.d",
+			"binPath":      "/opt/cni/bin",
+			"exclusive":    config.cniExclusive,
+			"chainingMode": "portmap",
 		},
 		"sctp": map[string]any{
 			"enabled": config.sctpEnabled,
@@ -187,6 +188,11 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, m helm.Client, s state.St
 		// This flag enables the runtime device detection which is set to true by default in Cilium 1.16+
 		"enableRuntimeDeviceDetection": true,
 		"sessionAffinity":              true,
+		"loadBalancer": map[string]any{
+			"protocolDifferentiation": map[string]any{
+				"enabled": true,
+			},
+		},
 	}
 
 	// If we are deploying with IPv6 only, we need to set the routing mode to native


### PR DESCRIPTION
## Description

A few CNCF Conformance tests would fail on a Canonical Kubernetes cluster. This PR will address those failures by enabling a few Cilium features.

## Solution

Starting with cilium 1.17 [1][2], it now supports protocol differentiation. Setting the ``loadBalancer.protocolDifferentiation.enabled`` will result in ``bpf-lb-proto-diff`` being set in cilium's configmap, which corresponds to this feature. We need this feature in order for the following Conformance test to pass:

```
[sig-network] HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol [LinuxOnly] [Conformance] [sig-network, Conformance]
```

However, that is not enough for the test to pass. We also need to support `HostPort`s. According to the documentation [3], because we're the standard kube-proxy and not cilium's replacement (``kubeProxyReplacement=false``), we need to also set the Helm chart option ``cni.chainingMode=portmap``.

[1] https://github.com/cilium/cilium/issues/9207
[2] https://github.com/cilium/cilium/pull/33434
[3] https://github.com/cilium/cilium/blob/v1.17.1/Documentation/installation/cni-chaining-portmap.rst#portmap-hostport

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
