### PR TITLE
docs: use raw output for `yq`

### DIFF
--- a/docs/canonicalk8s/charm/tutorial/basic-operations.md
+++ b/docs/canonicalk8s/charm/tutorial/basic-operations.md
@@ -90,7 +90,7 @@ Use `yq` to append your cluster's kubeconfig information directly to the
 config file:
 
 ```
-juju run k8s/0 get-kubeconfig | yq '.kubeconfig' >> ~/.kube/config
+juju run k8s/0 get-kubeconfig | yq -r '.kubeconfig' >> ~/.kube/config
 ```
 
 Confirm that `kubectl` can read the kubeconfig file:


### PR DESCRIPTION
## Description

The command:

```shell
juju run k8s/0 get-kubeconfig | yq '.kubeconfig' >> ~/.kube/config
```

in [Basic Canonical Kubernetes charm operations](https://documentation.ubuntu.com/canonical-kubernetes/latest/charm/tutorial/basic-operations/#set-up-kubectl) produces an unreadable config as it escapes and quotes the given string.

This leads to `kubectl config view` failing with:

```
error: error loading config file "/home/me/.kube/config": couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }
```

## Solution

Using raw output with the `-r` flag to `yq` solves this, i.e. changing the command to:

```shell
juju run k8s/0 get-kubeconfig | yq -r '.kubeconfig' >> ~/.kube/config
```

See collapsible section below for further details of the problem and fix:

<details>

<summary>Problem and fix</summary>

```
me@dev:~$ juju status
Model        Controller      Cloud/Region         Version  SLA          Timestamp
charmed-k8s  lxd-controller  localhost/localhost  3.5.4    unsupported  13:35:41Z

App         Version  Status  Scale  Charm       Channel      Rev  Exposed  Message
k8s         1.32.1   active      1  k8s         1.32/stable  347  no       Ready
k8s-worker  1.32.1   active      1  k8s-worker  1.32/stable  342  no       Ready

Unit           Workload  Agent  Machine  Public address  Ports     Message
k8s-worker/0*  active    idle   1        10.210.110.31             Ready
k8s/0*         active    idle   0        10.210.110.35   6443/tcp  Ready

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.210.110.35  juju-2cd280-0  ubuntu@24.04      Running
1        started  10.210.110.31  juju-2cd280-1  ubuntu@24.04      Running
me@dev:~$ 
me@dev:~$ juju status
Model        Controller      Cloud/Region         Version  SLA          Timestamp
charmed-k8s  lxd-controller  localhost/localhost  3.5.4    unsupported  13:35:43Z

App         Version  Status  Scale  Charm       Channel      Rev  Exposed  Message
k8s         1.32.1   active      1  k8s         1.32/stable  347  no       Ready
k8s-worker  1.32.1   active      1  k8s-worker  1.32/stable  342  no       Ready

Unit           Workload  Agent  Machine  Public address  Ports     Message
k8s-worker/0*  active    idle   1        10.210.110.31             Ready
k8s/0*         active    idle   0        10.210.110.35   6443/tcp  Ready

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.210.110.35  juju-2cd280-0  ubuntu@24.04      Running
1        started  10.210.110.31  juju-2cd280-1  ubuntu@24.04      Running
me@dev:~$ juju run k8s/0 get-kubeconfig | yq  '.kubeconfig' > ~/.kube/config
Running operation 25 with 1 task
  - task 26 on unit-k8s-0

Waiting for task 26...
me@dev:~$ kubectl config view
error: error loading config file "/home/me/.kube/config": couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }
me@dev:~$ juju run k8s/0 get-kubeconfig | yq -r '.kubeconfig' > ~/.kube/config
Running operation 27 with 1 task
  - task 28 on unit-k8s-0

Waiting for task 28...
me@dev:~$ kubectl config view
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: DATA+OMITTED
    server: https://10.210.110.35:6443
  name: k8s
contexts:
- context:
    cluster: k8s
    user: k8s-user
  name: k8s
current-context: k8s
kind: Config
preferences: {}
users:
- name: k8s-user
  user:
    client-certificate-data: DATA+OMITTED
    client-key-data: DATA+OMITTED
```

</details>


## Issue

None

## Backport

Should this PR be backported? If so, to which release?

Current release.

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [X] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [X] Documentation updated
- [X] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

Test coverage unchanged as this is a minor docs fix. Backport label is left at the maintainers' discretion.