### PR TITLE
test: Skip airgapped tests

### DIFF
--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -70,6 +70,10 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_proxy(instances: List[harness.Instance]):
+    pytest.xfail(
+        "Airgapped test may have networking-related side effects, causing other tests to fail. Skipped."
+    )
+
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     instance_ip = util.get_default_ip(instance)
@@ -108,6 +112,10 @@ def test_airgapped_with_proxy(instances: List[harness.Instance]):
 def test_airgapped_with_proxy_setup_and_image_mirror(
     instances: List[harness.Instance], registry: registry.Registry
 ):
+    pytest.xfail(
+        "Airgapped test may have networking-related side effects, causing other tests to fail. Skipped."
+    )
+
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     registry_ip = util.get_default_ip(registry.instance)


### PR DESCRIPTION

## Description

A few tests have been introduced recently, adding airgapped scenarios. However, it seems that it may have some networking-related side effects, causing other tests to fail, no longer being to pull images afterwards:

```
Mar 11 01:44:51 k8s-integration-99c42d-1 registry[1280]: time="2025-03-11T01:44:51.314497836Z" level=error msg="response completed with error" err.code="manifest unknown" err.detail="unknown tag=1.27.0" err.message="manifest unknown" go.version=go1.20.8 http.request.host="10.94.42.78:5000" http.request.id=94e2d706-b8d2-4d13-b23e-ec6e8ffad355 http.request.method=HEAD http.request.remoteaddr="10.94.42.193:47676" http.request.uri="/v2/containerd/nginx/manifests/1.27.0?ns=ghcr.io" http.request.useragent="containerd/v1.6.37" http.response.contenttype="application/json; charset=utf-8" http.response.duration=15.998554ms http.response.status=404 http.response.written=96 vars.name="containerd/nginx" vars.reference=1.27.0
Mar 11 01:44:51 k8s-integration-99c42d-1 registry[1280]: 10.94.42.193 - - [11/Mar/2025:01:44:51 +0000] "HEAD /v2/containerd/nginx/manifests/1.27.0?ns=ghcr.io HTTP/1.1" 404 96 "" "containerd/v1.6.37"
```

When the tests were introduced, only those tests ran (through the use of the ``-k`` argument), and the integration passed. After which, it was resumed running all the tests (by removing the ``-k`` argument).

The tests do not affect regular pull requests as they're tagged as nightly.

## Solution

Skipping the tests for now.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
