### PR TITLE
ci: Changes PR linter event trigger

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -1,7 +1,7 @@
 name: "Lint PR"
 
 on:
-  pull_request:
+  pull_request_target:
     # will run on adding or removing labels, converting to draft or ready, etc.
     types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
 


### PR DESCRIPTION
## Description

According to the documentation [1], ``pull_request_target`` events should be used in a fork-based workflow.

If ``pull_request`` is being used intead, it will only work with PRs from the same repository. With this configuration, if a PR is sent from a fork, an error will occur.

Note that, according to the documentation, PRs that introduce this GitHub action won't trigger the action (including this one), and PRs that change the action's configuration will not be reflected in the updating PRs.

[1] https://github.com/amannn/action-semantic-pull-request?tab=readme-ov-file#event-triggers

## Solution

Updates even trigger from ``pull_request`` to ``pull_request_target``.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [ ] Covered by integration tests - N/A
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - N/A

If any item on the checklist is not complete, please provide justification why.
