### PR TITLE
test: Skips upgrade test to 1.33 and newer

### DIFF
--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -67,6 +67,7 @@ def get_most_stable_channels(
     arch: str,
     include_latest: bool = True,
     min_release: Optional[str] = None,
+    max_release: Optional[str] = None,
 ) -> List[str]:
     """Get an ascending list of latest channels based on the number of channels
     flavour and architecture."""
@@ -85,6 +86,11 @@ def get_most_stable_channels(
         if min_release:
             _min_release = major_minor(min_release)
             if _min_release and version_key < _min_release:
+                continue
+
+        if max_release is not None:
+            _max_release = major_minor(max_release)
+            if _max_release is not None and version_key > _max_release:
                 continue
 
         if version_key not in channel_map or RISK_LEVELS.index(

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -27,11 +27,15 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
                 "'recent' requires the number of releases as second argument and the flavour as third argument"
             )
         _, num_channels, flavour = channels
+        # Currently, it fails to refresh the snap to the 1.33 channel or newer.
+        # Just test upgrade to at most 1.32.
         channels = snap.get_most_stable_channels(
             int(num_channels),
             flavour,
             cp.arch,
+            include_latest=False,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
+            max_release="1.32",
         )
         if len(channels) < 2:
             pytest.fail(


### PR DESCRIPTION
## Description

It seems that at the moment there are some issues with ``test_version_upgrades``, causing it to fail. Specifically, it fails while upgrading from 1.32 to 1.33.

## Solution

Filters out upgrade versions newer than 1.32 and latest.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
