### PR TITLE
fix: Use function-scoped registry for airgapped tests

### DIFF
--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import harness, registry, tags, util
+from test_util import harness
+from test_util import registry as reg
+from test_util import tags, util
 
 REGISTRY_PORT = 5000
 
@@ -70,10 +72,6 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_proxy(instances: List[harness.Instance]):
-    pytest.xfail(
-        "Airgapped test may have networking-related side effects, causing other tests to fail. Skipped."
-    )
-
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     instance_ip = util.get_default_ip(instance)
@@ -110,14 +108,11 @@ def test_airgapped_with_proxy(instances: List[harness.Instance]):
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_proxy_setup_and_image_mirror(
-    instances: List[harness.Instance], registry: registry.Registry
+    h: harness.Harness, instances: List[harness.Instance]
 ):
-    pytest.xfail(
-        "Airgapped test may have networking-related side effects, causing other tests to fail. Skipped."
-    )
-
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
+    registry = reg.Registry(h)
     registry_ip = util.get_default_ip(registry.instance)
 
     setup_proxy(proxy)


### PR DESCRIPTION
## Description

The airgapped tests used and modified the global registry which caused connectivity issues in in follow-up test-cases.

## Solution

The test now creates a separate registry instead.

## Issue
-

## Backport
Not required.

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [ ] Covered by integration tests - N/A
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - N/A 

If any item on the checklist is not complete, please provide justification why.
