### PR TITLE
[Backport release-1.32] ci: Run all tests on Kubernetes component / feature updates (#1171)

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -90,6 +90,10 @@ jobs:
             if git diff HEAD HEAD~1 --name-only | grep "tests/"; then
               tags="up_to_weekly"
             fi
+            # Run all tests if there are any changes to the Kubernetes components / features.
+            if git diff HEAD HEAD~1 --name-only | grep "k8sd/features/.*/"; then
+              tags="up_to_weekly"
+            fi
             # Run all tests on backports.
             if echo ${{ github.base_ref }} | grep "release-"; then
               tags="up_to_weekly"


### PR DESCRIPTION
## Description

If the Kubernetes components / features are updated, we should be more thorough with the tests we run.

## Solution

If there are any updates to ``src/k8s/pkg/k8sd/features/.*/``, we're now running more tests (``up_to_weekly``).

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
