### PR TITLE
[Backport release-1.31] ci: remove compromised dependency

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -12,13 +12,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tj-actions/changed-files@v44
-        id: changed-markdown-files
-        with:
-          files: |
-            docs/**/*.md
-          files_ignore: |
-            docs/src/_parts/**
       - uses: DavidAnson/markdownlint-cli2-action@v16
         if: steps.changed-markdown-files.outputs.any_changed == 'true'
         with:


### PR DESCRIPTION
# Description

Backport of https://github.com/canonical/k8s-snap/pull/1189 to `release-1.31`.