### PR TITLE
ci: add a test ensuring that there are no k8s version mismatches

### DIFF
--- a/tests/branch_management/tests/conftest.py
+++ b/tests/branch_management/tests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Canonical, Ltd.
+# Copyright 2025 Canonical, Ltd.
 #
 from pathlib import Path
 from typing import Optional


### PR DESCRIPTION
We'll check the k8s version from the following files and ensure that there are no mismatches:

* build-scripts/components/kubernetes/version
* docs/canonicalk8s/_parts/install.md
* docs/canonicalk8s/reuse/substitutions.yaml
* README.md

Implements KU-2196

## Description

What issue is this PR trying to solve?

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
