### PR TITLE
docs: fix broken link issue #1187

### DIFF
--- a/docs/canonicalk8s/snap/explanation/load-balancer.md
+++ b/docs/canonicalk8s/snap/explanation/load-balancer.md
@@ -78,7 +78,7 @@ When you expose a service with a load balancer, the following steps occur:
 <!-- LINKS -->
 
 [Ingress]: ingress
-[default load balancer]: ../howto/networking/default-loadbalancer
+[default load balancer]: /snap/howto/networking/default-loadbalancer
 [kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/
 [ARP]: https://en.wikipedia.org/wiki/Address_Resolution_Protocol
 [NDP]: https://en.wikipedia.org/wiki/Neighbor_Discovery_Protocol


### PR DESCRIPTION
## Description

Update a broken link in the load balancer explanation page 

## Solution

Link updated

## Issue

#1187 

## Backport

1.32

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
