### PR TITLE
ci: compare Trivy CVEs with CISA KEV list

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -34,6 +34,11 @@ jobs:
       # Need to fetch the GH actions first.
       - name: Checking out repo
         uses: actions/checkout@v4
+      - name: Save trivy-scan.sh script
+        run: |
+          # We'll need to scan other branches, let's create a copy of
+          # therivy scan script.
+          cp tests/trivy-scan.sh $GITHUB_WORKSPACE/trivy-scan.sh
       - name: Download k8s-snap
         id: download-snap
         uses: ./.github/actions/download-k8s-snap
@@ -46,37 +51,10 @@ jobs:
           ref: ${{ inputs.checkout-ref }}
           # Persist downloaded artifacts
           clean: 'false'
-      # TODO: move the following steps to a separate script
-      - name: Setup Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner
         run: |
-          mkdir -p manual-trivy/sarifs
-          pushd manual-trivy
-          VER=$(curl --silent -qI https://github.com/aquasecurity/trivy/releases/latest | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}');
-          wget https://github.com/aquasecurity/trivy/releases/download/${VER}/trivy_${VER#v}_Linux-64bit.tar.gz
-          tar -zxvf ./trivy_${VER#v}_Linux-64bit.tar.gz
-          popd
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: "fs"
-          ignore-unfixed: true
-          format: "sarif"
-          output: "trivy-k8s-repo-scan--results.sarif"
-          severity: "MEDIUM,HIGH,CRITICAL"
-        env:
-          TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db"
-      - name: Gather Trivy repo scan results
-        run: |
-          cp trivy-k8s-repo-scan--results.sarif ./manual-trivy/sarifs/
-      - name: Run Trivy vulnerability scanner on the snap
-        run: |
-          for var in $(env | grep -o '^TRIVY_[^=]*'); do
-            unset "$var"
-          done
-          cp ${{ steps.download-snap.outputs.snap-path }} ./k8s-test.snap
-          unsquashfs k8s-test.snap
-          ./manual-trivy/trivy --db-repository public.ecr.aws/aquasecurity/trivy-db rootfs ./squashfs-root/ --format sarif > ./manual-trivy/sarifs/snap.sarif
+          $GITHUB_WORKSPACE/trivy-scan.sh ${{ steps.download-snap.outputs.snap-path }
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: "./manual-trivy/sarifs"
+          sarif_file: "./.trivy/sarifs"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ k8s_*.txt
 /docs/canonicalk8s/.sphinx/node_modules
 /docs/canonicalk8s/.sphinx/styles/*
 /docs/canonicalk8s/.sphinx/vale.ini
+
+*.assert
+.trivy
+squashfs-root

--- a/tests/trivy-scan.sh
+++ b/tests/trivy-scan.sh
@@ -12,28 +12,75 @@ if [[ ! -f $SNAP_PATH ]]; then
 fi
 
 # Setup Trivy vulnerability scanner
-mkdir -p manual-trivy/sarifs
-pushd manual-trivy
+mkdir -p .trivy/sarifs
+pushd .trivy
 VER=$(curl --silent -qI https://github.com/aquasecurity/trivy/releases/latest | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}');
 wget https://github.com/aquasecurity/trivy/releases/download/${VER}/trivy_${VER#v}_Linux-64bit.tar.gz
 tar -zxvf ./trivy_${VER#v}_Linux-64bit.tar.gz
 popd
 
-# Run Trivy vulnerability scanner in repo mode
-./manual-trivy/trivy fs . \
+# Run Trivy vulnerability scanner in repo mode.
+#
+# We'll have two runs:
+# * one with SARIF output, used by GitHub
+# * one with "json" output
+#   * SARIF is also a json but not as well structured
+#   * the list of vulnerabilities is easier to parse and compare with the CISA list
+#   * the second run will not filter the records based on severity
+./.trivy/trivy fs . \
   --format sarif \
   --db-repository public.ecr.aws/aquasecurity/trivy-db \
   --severity "MEDIUM,HIGH,CRITICAL" \
   --ignore-unfixed \
-  > ./manual-trivy/sarifs/trivy-k8s-repo-scan--results.sarif
+  > ./.trivy/sarifs/trivy-k8s-repo-scan--results.sarif
 
+./.trivy/trivy fs . \
+  --format json \
+  --db-repository public.ecr.aws/aquasecurity/trivy-db \
+  --ignore-unfixed \
+  > ./.trivy/sarifs/trivy-k8s-repo-scan--results.json
+
+
+# Run Trivy vulnerability scanner in rootfs mode, scanning the snap
 for var in $(env | grep -o '^TRIVY_[^=]*'); do
   unset "$var"
 done
-cp "${SNAP_PATH}" ./k8s-test.snap
-rm -rf ./squashfs-root
-unsquashfs k8s-test.snap
-./manual-trivy/trivy rootfs ./squashfs-root/ \
+cp "${SNAP_PATH}" ./.trivy/k8s-test.snap
+rm -rf ./.trivy/squashfs-root
+pushd ./.trivy
+unsquashfs ./k8s-test.snap
+popd
+./.trivy/trivy rootfs ./.trivy/squashfs-root/ \
   --format sarif \
   --db-repository public.ecr.aws/aquasecurity/trivy-db \
-  > ./manual-trivy/sarifs/snap.sarif
+  > ./.trivy/sarifs/snap.sarif
+
+./.trivy/trivy rootfs ./.trivy/squashfs-root/ \
+  --format json \
+  --db-repository public.ecr.aws/aquasecurity/trivy-db \
+  > ./.trivy/sarifs/snap.json
+
+# Obtain CISA Known Exploited Vulnerabilities list.
+curl -s -o ./.trivy/kev.json \
+  https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+
+function get_cisa_kev_cves() {
+  local kevJson=$1
+  local trivyJsonReport=$2
+
+  set +x
+  local kev_cves=$(jq -r '.vulnerabilities[].cveID' $kevJson | sort -u)
+  local found_cves=$(jq -r '.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[].VulnerabilityID' $trivyJsonReport | sort -u)
+  local matches="$(echo "$found_cves" | grep -F -f <(echo "$kev_cves") || true)"
+  set -x
+
+  if [ -n "$matches" ]; then
+    echo "KEV listed vulnerabilities found in $2:"
+    echo "$matches"
+    exit 1
+  fi
+}
+
+# Compare the trivy reports with the CISA KEV list
+get_cisa_kev_cves ./.trivy/kev.json ./.trivy/sarifs/trivy-k8s-repo-scan--results.json
+get_cisa_kev_cves ./.trivy/kev.json ./.trivy/sarifs/snap.json


### PR DESCRIPTION
This change will compare the list of CVEs outputed by Trivy scans with the list of Known Exploited Vulnerabilities from CISA.

Inspired by https://github.com/canonical/ams/pull/873/files

While at it, we'll deduplicate the security scan job, using the trivy-scan.sh script.

## Description

What issue is this PR trying to solve?

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
