### PR TITLE
ci: fix security scan job

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -138,7 +138,7 @@ jobs:
     needs: build-snap
     uses: ./.github/workflows/security-scan.yaml
     with:
-      artifact: ${{ needs.build-snap.outputs.snap-artifact}}
+      artifact: ${{ needs.build-snap.outputs.snap-artifact }}
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -53,7 +53,8 @@ jobs:
           clean: 'false'
       - name: Run Trivy vulnerability scanner
         run: |
-          $GITHUB_WORKSPACE/trivy-scan.sh ${{ steps.download-snap.outputs.snap-path }}
+          cp $GITHUB_WORKSPACE/trivy-scan.sh ./tests/trivy-scan.sh
+          ./tests/trivy-scan.sh ${{ steps.download-snap.outputs.snap-path }}
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -53,7 +53,7 @@ jobs:
           clean: 'false'
       - name: Run Trivy vulnerability scanner
         run: |
-          $GITHUB_WORKSPACE/trivy-scan.sh ${{ steps.download-snap.outputs.snap-path }
+          $GITHUB_WORKSPACE/trivy-scan.sh ${{ steps.download-snap.outputs.snap-path }}
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
We're fixing the security scan job, adding a missing bracket.

Also, the trivy-scan.sh script tries to locate the project base dir based on its own location, we'll need to update the gh action accordingly.

## Description

What issue is this PR trying to solve?

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
