### PR TITLE
ci: markdown lint calculate changed files through git

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,6 +1,10 @@
 name: "Docs: Markdown lint"
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '!docs/canonicalk8s/_parts/**'
 
 permissions:
   contents: read
@@ -12,9 +16,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: DavidAnson/markdownlint-cli2-action@v16
-        if: steps.changed-markdown-files.outputs.any_changed == 'true'
         with:
           config: "docs/canonicalk8s/.sphinx/.markdownlint.json"
-          globs: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
-          separator: ","
+          globs: |
+            docs/**/*.md
+            !docs/canonicalk8s/_parts/**


### PR DESCRIPTION
## Description

Updates the markdown lint job to pass globs instead of using `changed-files`.

## Backport

release-1.32
release-1.31

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
