### PR TITLE
fix: allow read unmanaged/managed PKI in `refresh-certs`

### DIFF
--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -119,6 +119,10 @@ func refreshCertsRunControlPlane(s state.State, r *http.Request, snap snap.Snap)
 		IncludeMachineAddressSANs: true,
 	})
 
+	if err := setup.ReadControlPlanePKI(snap, certificates, false); err != nil {
+		return response.InternalError(fmt.Errorf("failed to read unmanaged control plane certificates: %w", err))
+	}
+
 	certificates.CACert = clusterConfig.Certificates.GetCACert()
 	certificates.CAKey = clusterConfig.Certificates.GetCAKey()
 	certificates.ClientCACert = clusterConfig.Certificates.GetClientCACert()

--- a/src/k8s/pkg/k8sd/api/certificates_update.go
+++ b/src/k8s/pkg/k8sd/api/certificates_update.go
@@ -69,6 +69,11 @@ func refreshCertsUpdateControlPlane(s state.State, r *http.Request, snap snap.Sn
 		IPSANs:    append([]net.IP{nodeIP}, serviceIPs...),
 		NotBefore: time.Now(),
 	})
+
+	if err := setup.ReadControlPlanePKI(snap, certificates, true); err != nil {
+		return response.InternalError(fmt.Errorf("failed to read managed control plane certificates: %w", err))
+	}
+
 	certificates.CACert = clusterConfig.Certificates.GetCACert()
 	certificates.CAKey = clusterConfig.Certificates.GetCAKey()
 	certificates.ClientCACert = clusterConfig.Certificates.GetClientCACert()

--- a/src/k8s/pkg/k8sd/setup/certificates.go
+++ b/src/k8s/pkg/k8sd/setup/certificates.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // ensureFile creates fname with the specified contents, mode and owner bits.
@@ -101,8 +102,9 @@ func EnsureControlPlanePKI(snap snap.Snap, certificates *pki.ControlPlanePKI) (b
 		filepath.Join(snap.KubernetesPKIDir(), "apiserver.crt"):                certificates.APIServerCert,
 		filepath.Join(snap.KubernetesPKIDir(), "apiserver.key"):                certificates.APIServerKey,
 		filepath.Join(snap.KubernetesPKIDir(), "ca.crt"):                       certificates.CACert,
-		filepath.Join(snap.KubernetesPKIDir(), "client-ca.crt"):                certificates.ClientCACert,
 		filepath.Join(snap.KubernetesPKIDir(), "ca.key"):                       certificates.CAKey,
+		filepath.Join(snap.KubernetesPKIDir(), "client-ca.crt"):                certificates.ClientCACert,
+		filepath.Join(snap.KubernetesPKIDir(), "client-ca.key"):                certificates.ClientCAKey,
 		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.crt"):           certificates.FrontProxyCACert,
 		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.key"):           certificates.FrontProxyCAKey,
 		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-client.crt"):       certificates.FrontProxyClientCert,
@@ -123,4 +125,173 @@ func EnsureWorkerPKI(snap snap.Snap, certificates *pki.WorkerNodePKI) (bool, err
 		filepath.Join(snap.KubernetesPKIDir(), "kubelet.crt"):   certificates.KubeletCert,
 		filepath.Join(snap.KubernetesPKIDir(), "kubelet.key"):   certificates.KubeletKey,
 	})
+}
+
+// - If readManaged=false: only reads certificates where CA keys are missing (externally managed).
+func ReadControlPlanePKI(snap snap.Snap, certificates *pki.ControlPlanePKI, readManaged bool) error {
+	caKeyPath := filepath.Join(snap.KubernetesPKIDir(), "ca.key")
+	_, caKeyErr := os.Stat(caKeyPath)
+	caKeyExists := caKeyErr == nil
+
+	clientCAKeyPath := filepath.Join(snap.KubernetesPKIDir(), "client-ca.key")
+	_, clientCAKeyErr := os.Stat(clientCAKeyPath)
+	clientCAKeyExists := clientCAKeyErr == nil
+
+	frontProxyCAKeyPath := filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.key")
+	_, frontProxyCAKeyErr := os.Stat(frontProxyCAKeyPath)
+	frontProxyCAKeyExists := frontProxyCAKeyErr == nil
+
+	fileFields := map[string]struct {
+		field *string
+		read  bool
+	}{
+		// CA certificates
+		filepath.Join(snap.KubernetesPKIDir(), "ca.crt"): {
+			field: &certificates.CACert,
+			read:  true,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "client-ca.crt"): {
+			field: &certificates.ClientCACert,
+			read:  true,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.crt"): {
+			field: &certificates.FrontProxyCACert,
+			read:  true,
+		},
+
+		// CA keys
+		filepath.Join(snap.KubernetesPKIDir(), "ca.key"): {
+			field: &certificates.CAKey,
+			read:  readManaged && caKeyExists,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "client-ca.key"): {
+			field: &certificates.ClientCAKey,
+			read:  readManaged && clientCAKeyExists,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-ca.key"): {
+			field: &certificates.FrontProxyCAKey,
+			read:  readManaged && frontProxyCAKeyExists,
+		},
+
+		// Certificates
+		// NOTE: read is using the XNOR operation.
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver.crt"): {
+			field: &certificates.APIServerCert,
+			read:  readManaged == caKeyExists,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver.key"): {
+			field: &certificates.APIServerKey,
+			read:  readManaged == caKeyExists,
+		},
+
+		filepath.Join(snap.KubernetesPKIDir(), "kubelet.crt"): {
+			field: &certificates.KubeletCert,
+			read:  readManaged == caKeyExists,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "kubelet.key"): {
+			field: &certificates.KubeletKey,
+			read:  readManaged == caKeyExists,
+		},
+
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-client.crt"): {
+			field: &certificates.FrontProxyClientCert,
+			read:  readManaged == frontProxyCAKeyExists,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "front-proxy-client.key"): {
+			field: &certificates.FrontProxyClientKey,
+			read:  readManaged == frontProxyCAKeyExists,
+		},
+
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.crt"): {
+			field: &certificates.APIServerKubeletClientCert,
+			read:  readManaged == clientCAKeyExists,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "apiserver-kubelet-client.key"): {
+			field: &certificates.APIServerKubeletClientKey,
+			read:  readManaged == clientCAKeyExists,
+		},
+		filepath.Join(snap.KubernetesPKIDir(), "serviceaccount.key"): {
+			field: &certificates.ServiceAccountKey,
+			read:  true,
+		},
+	}
+
+	for filePath, info := range fileFields {
+		if !info.read {
+			continue
+		}
+
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+		if info.field != nil {
+			*info.field = string(content)
+		}
+	}
+
+	kubeconfigFields := map[string]struct {
+		certField *string
+		keyField  *string
+		read      bool
+	}{
+		"admin.conf": {
+			certField: &certificates.AdminClientCert,
+			keyField:  &certificates.AdminClientKey,
+			read:      readManaged == clientCAKeyExists,
+		},
+		"controller.conf": {
+			certField: &certificates.KubeControllerManagerClientCert,
+			keyField:  &certificates.KubeControllerManagerClientKey,
+			read:      readManaged == clientCAKeyExists,
+		},
+		"scheduler.conf": {
+			certField: &certificates.KubeSchedulerClientCert,
+			keyField:  &certificates.KubeSchedulerClientKey,
+			read:      readManaged == clientCAKeyExists,
+		},
+		"proxy.conf": {
+			certField: &certificates.KubeProxyClientCert,
+			keyField:  &certificates.KubeProxyClientKey,
+			read:      readManaged == clientCAKeyExists,
+		},
+		"kubelet.conf": {
+			certField: &certificates.KubeletClientCert,
+			keyField:  &certificates.KubeletClientKey,
+			read:      readManaged == clientCAKeyExists,
+		},
+	}
+
+	for configName, info := range kubeconfigFields {
+		if !info.read {
+			continue
+		}
+
+		configPath := filepath.Join(snap.KubernetesConfigDir(), configName)
+
+		_, err := os.Stat(configPath)
+		if err != nil {
+			return fmt.Errorf("failed to check kubeconfig %s: %w", configName, err)
+		}
+
+		kubeConfig, err := clientcmd.LoadFromFile(configPath)
+		if err != nil {
+			return fmt.Errorf("failed to load kubeconfig %s: %w", configName, err)
+		}
+
+		authInfo, exists := kubeConfig.AuthInfos["k8s-user"]
+		if !exists {
+			return fmt.Errorf("user 'k8s-user' not found in kubeconfig %s", configName)
+		}
+
+		if authInfo.ClientCertificateData != nil && info.certField != nil {
+			*info.certField = string(authInfo.ClientCertificateData)
+		}
+
+		if authInfo.ClientKeyData != nil && info.keyField != nil {
+			*info.keyField = string(authInfo.ClientKeyData)
+		}
+	}
+
+	return nil
 }

--- a/src/k8s/pkg/k8sd/setup/certificates_test.go
+++ b/src/k8s/pkg/k8sd/setup/certificates_test.go
@@ -202,3 +202,108 @@ func TestEmptyCert(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 	}
 }
+
+func TestReadControlPlanePKI(t *testing.T) {
+	g := NewWithT(t)
+	cases := []struct {
+		name             string
+		readManaged      bool
+		removeCAKeyFiles bool
+	}{
+		{"Managed", true, false},
+		{"External", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pkiDir := t.TempDir()
+			configDir := t.TempDir()
+
+			mock := &mock.Snap{
+				Mock: mock.Mock{
+					KubernetesPKIDir:    pkiDir,
+					KubernetesConfigDir: configDir,
+					UID:                 os.Getuid(),
+					GID:                 os.Getgid(),
+				},
+			}
+
+			orig := &pki.ControlPlanePKI{
+				CACert:                          "ca_cert_val",
+				CAKey:                           "ca_key_val",
+				ClientCACert:                    "client_ca_cert_val",
+				ClientCAKey:                     "client_ca_key_val",
+				FrontProxyCACert:                "front_proxy_ca_cert_val",
+				FrontProxyCAKey:                 "front_proxy_ca_key_val",
+				APIServerCert:                   "apiserver_cert_val",
+				APIServerKey:                    "apiserver_key_val",
+				KubeletCert:                     "kubelet_cert_val",
+				KubeletKey:                      "kubelet_key_val",
+				FrontProxyClientCert:            "front_proxy_client_cert_val",
+				FrontProxyClientKey:             "front_proxy_client_key_val",
+				APIServerKubeletClientCert:      "apiserver_kubelet_client_cert_val",
+				APIServerKubeletClientKey:       "apiserver_kubelet_client_key_val",
+				ServiceAccountKey:               "serviceaccount_key_val",
+				AdminClientCert:                 "admin_cert_val",
+				AdminClientKey:                  "admin_key_val",
+				KubeControllerManagerClientCert: "controller_cert_val",
+				KubeControllerManagerClientKey:  "controller_key_val",
+				KubeSchedulerClientCert:         "scheduler_cert_val",
+				KubeSchedulerClientKey:          "scheduler_key_val",
+				KubeProxyClientCert:             "proxy_cert_val",
+				KubeProxyClientKey:              "proxy_key_val",
+				KubeletClientCert:               "kubelet_cert_val",
+				KubeletClientKey:                "kubelet_key_val",
+			}
+
+			_, err := setup.EnsureControlPlanePKI(mock, orig)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			err = setup.SetupControlPlaneKubeconfigs(mock.KubernetesConfigDir(), "127.0.0.1", 8443, *orig)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tc.removeCAKeyFiles {
+				os.Remove(filepath.Join(pkiDir, "ca.key"))
+				os.Remove(filepath.Join(pkiDir, "client-ca.key"))
+				os.Remove(filepath.Join(pkiDir, "front-proxy-ca.key"))
+			}
+
+			readCerts := &pki.ControlPlanePKI{}
+
+			err = setup.ReadControlPlanePKI(mock, readCerts, tc.readManaged)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// NOTE: Always read CA certificate files and Service Account.
+			g.Expect(readCerts.CACert).To(Equal("ca_cert_val"))
+			g.Expect(readCerts.ClientCACert).To(Equal("client_ca_cert_val"))
+			g.Expect(readCerts.FrontProxyCACert).To(Equal("front_proxy_ca_cert_val"))
+			g.Expect(readCerts.ServiceAccountKey).To(Equal("serviceaccount_key_val"))
+
+			if !tc.readManaged {
+				g.Expect(readCerts.CAKey).To(BeEmpty())
+				g.Expect(readCerts.ClientCAKey).To(BeEmpty())
+				g.Expect(readCerts.FrontProxyCAKey).To(BeEmpty())
+			}
+
+			g.Expect(readCerts.APIServerCert).To(Equal("apiserver_cert_val"))
+			g.Expect(readCerts.APIServerKey).To(Equal("apiserver_key_val"))
+			g.Expect(readCerts.KubeletCert).To(Equal("kubelet_cert_val"))
+			g.Expect(readCerts.KubeletKey).To(Equal("kubelet_key_val"))
+			g.Expect(readCerts.FrontProxyClientCert).To(Equal("front_proxy_client_cert_val"))
+			g.Expect(readCerts.FrontProxyClientKey).To(Equal("front_proxy_client_key_val"))
+			g.Expect(readCerts.APIServerKubeletClientCert).To(Equal("apiserver_kubelet_client_cert_val"))
+			g.Expect(readCerts.APIServerKubeletClientKey).To(Equal("apiserver_kubelet_client_key_val"))
+
+			g.Expect(readCerts.AdminClientCert).To(Equal("admin_cert_val"))
+			g.Expect(readCerts.AdminClientKey).To(Equal("admin_key_val"))
+			g.Expect(readCerts.KubeControllerManagerClientCert).To(Equal("controller_cert_val"))
+			g.Expect(readCerts.KubeControllerManagerClientKey).To(Equal("controller_key_val"))
+			g.Expect(readCerts.KubeSchedulerClientCert).To(Equal("scheduler_cert_val"))
+			g.Expect(readCerts.KubeSchedulerClientKey).To(Equal("scheduler_key_val"))
+			g.Expect(readCerts.KubeProxyClientCert).To(Equal("proxy_cert_val"))
+			g.Expect(readCerts.KubeProxyClientKey).To(Equal("proxy_key_val"))
+			g.Expect(readCerts.KubeletClientCert).To(Equal("kubelet_cert_val"))
+			g.Expect(readCerts.KubeletClientKey).To(Equal("kubelet_key_val"))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Allow the snap to partially refresh the CAs in the Control Plane PKI.

## Solution

Currently, when refreshing certificates, we cannot refresh unmanaged or managed CAs in the cluster. For example, a user cannot refresh the client CA if they are using an external managed root CA. This capability is particularly useful in automated deployment mechanisms, like Juju.

## Backport

Should this PR be backported? If so, to which release?

**No backport needed**

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

- Integration tests will be addressed in KU-2844
