### PR TITLE
fix: command substitution in `lint-pr` action

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -17,9 +17,10 @@ jobs:
       # no-semantic label is handled by the next step.
       - name: Check if PR is WIP
         id: check_wip
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          IS_DRAFT="${{ github.event.pull_request.draft }}"
           if [[ "$PR_TITLE" == \[WIP\]* ]] || [[ "$IS_DRAFT" == "true" ]]; then
             echo "is_wip=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Description

Prevent command substitution in this CI check.

## Solution
Reproduce example:
```bash
#!/bin/bash

PR_TITLE="fix: `env | sort`"
IS_DRAFT="false"

echo "PR Title value:"
echo "$PR_TITLE"

if [[ "$PR_TITLE" == \[WIP\]* ]] || [[ "$IS_DRAFT" == "true" ]]; then
  echo "is_wip=true"
else
  echo "is_wip=false"
fi

echo "======= FIXED ======="
PR_TITLE='fix: allow read unmanaged/managed PKI in `env | sort`'
IS_DRAFT='false'

echo "PR Title value:"
echo "$PR_TITLE"

if [[ "$PR_TITLE" == \[WIP\]* ]] || [[ "$IS_DRAFT" == "true" ]]; then
  echo "is_wip=true"
else
  echo "is_wip=false"
fi
```
Output:
```
❯ ./vuln-test.sh
PR Title value:
fix: COLORTERM=truecolor
DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
DESKTOP_SESSION=ubuntu
DISPLAY=:0
... (whole ENV dumped)

is_wip=false
======= FIXED =======
PR Title value:
fix: `env | sort`

is_wip=false
```

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
