### PR TITLE
fix: Move snapd sync to custom post-refresh hook

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -3,8 +3,9 @@
 
 k8s::common::setup_env
 
-# Enable the snap config reconciler after the snap refresh completes.
-# The reconcile command will synchronize the k8sd configuration with the snap config
-# and then set the meta orb to "snapd," effectively re-enabling the sync process.
-echo "Re-enabling snapd config sync after snap refresh"
-k8s::cmd::k8s x-snapd-config reconcile
+# Indicate that an update has been performed.
+# Many actions require k8sd to be active which is not
+# the case in the snap hook. Hence, we use a lock file
+# to indicate that an update has been performed and
+# run a custom post-refresh hook in the k8sd service.
+touch "$SNAP_COMMON/lock/post-refresh"

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
+	"github.com/canonical/microcluster/v2/state"
+)
+
+func (a *App) postRefreshHook(ctx context.Context, s state.State) error {
+	log := log.FromContext(ctx).WithValues("hook", "post-refresh")
+	log.Info("Running post-refresh hook")
+
+	config, err := databaseutil.GetClusterConfig(ctx, s)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster config: %w", err)
+	}
+
+	log.Info("Re-enable snapd/k8sd config sync and reconcile.")
+	if err := snapdconfig.SetSnapdFromK8sd(ctx, config.ToUserFacing(), a.snap); err != nil {
+		return fmt.Errorf("failed to set snapd configuration from k8sd: %w", err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"database/sql"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
@@ -23,6 +24,20 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 			log.FromContext(ctx).Error(err, "Failed to mark node as ready")
 		}
 	}()
+
+	// Check if a refresh was performed and if so, run the custom post-refresh hook
+	isPostRefresh, err := utils.FileExists(a.snap.PostRefreshLockPath())
+	if err != nil {
+		return fmt.Errorf("failed to check if snap is post-refresh: %w", err)
+	}
+	if isPostRefresh {
+		if err := a.postRefreshHook(ctx, s); err != nil {
+			return fmt.Errorf("failed to run post-refresh hook: %w", err)
+		}
+		if err := os.Remove(a.snap.PostRefreshLockPath()); err != nil {
+			return fmt.Errorf("failed to remove post-refresh lock file: %w", err)
+		}
+	}
 
 	// start node config controller
 	if a.nodeConfigController != nil {

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -28,6 +28,7 @@ type Snap interface {
 
 	Refresh(ctx context.Context, to types.RefreshOpts) (string, error)                // snap refresh --no-wait [k8s --channel $track | k8s --revision $revision | $path ]
 	RefreshStatus(ctx context.Context, changeID string) (*types.RefreshStatus, error) // snap tasks $changeID
+	PostRefreshLockPath() string                                                      // /var/snap/k8s/common/lock/post-refresh - lock file to indicate the first run after a snap refresh
 
 	CNIConfDir() string       // /etc/cni/net.d
 	CNIBinDir() string        // /opt/cni/bin

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -42,6 +42,7 @@ type Mock struct {
 	ServiceArgumentsDir         string
 	ServiceExtraConfigDir       string
 	LockFilesDir                string
+	PostRefreshLockPath         string
 	NodeTokenFile               string
 	KubernetesClient            *kubernetes.Client
 	KubernetesNodeClient        *kubernetes.Client
@@ -112,6 +113,10 @@ func (s *Snap) Refresh(ctx context.Context, opts types.RefreshOpts) (string, err
 
 func (s *Snap) RefreshStatus(ctx context.Context, changeID string) (*types.RefreshStatus, error) {
 	return nil, nil
+}
+
+func (s *Snap) PostRefreshLockPath() string {
+	return s.Mock.PostRefreshLockPath
 }
 
 func (s *Snap) Strict() bool {

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -137,6 +137,11 @@ func (s *snap) RefreshStatus(ctx context.Context, changeID string) (*types.Refre
 	return status, nil
 }
 
+// PostRefreshLockPath returns the path to the post-refresh lock file.
+func (s *snap) PostRefreshLockPath() string {
+	return filepath.Join(s.LockFilesDir(), "post-refresh")
+}
+
 type snapcraftYml struct {
 	Confinement string `yaml:"confinement"`
 }


### PR DESCRIPTION




## Description

We disable the snapd/k8sd sync on upgrades because k8sd is not available at that time. Right now, we re-enable the sync in the snap `post-refresh` hook
The snapd/k8sd sync requires access to k8sd to obtain/sync the values. The snap `post-refresh` hook [is executed before the services started](https://snapcraft.io/docs/supported-snap-hooks#heading--post-refresh) and therefore wait until timeout.

## Solution

This commit introduces a custom post-refresh hook that runs after k8sd started and moves the config sync into that hook. In the future, other machinery also depends on k8sd after a refresh (e.g. feature upgrades) so it makes sense to have this kind of common entry point to extend later.

I verified the upgrade from rev 2500 to this version (`latest/edge/ben-refresh-hook`) works for a three node cluster. Once this fix is merged, we can also re-enable the upgrade/downgrade tests until latest/edge.

![image](https://github.com/user-attachments/assets/1484670f-051c-46d2-862b-bbe2f764b479)

## Issue
-

## Backport

The post-refresh mechanism was [backported to ](https://github.com/canonical/k8s-snap/pull/1164) 1.32, so we also need to backport this fix.

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [ ] Covered by integration tests - already covered by upgrade tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
