### PR TITLE
[Backport release-1.31] ci: markdown lint calculate changed files through git

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,6 +1,10 @@
 name: "Docs: Markdown lint"
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '!docs/canonicalk8s/_parts/**'
 
 permissions:
   contents: read
@@ -12,9 +16,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: DavidAnson/markdownlint-cli2-action@v16
-        if: steps.changed-markdown-files.outputs.any_changed == 'true'
         with:
           config: "docs/src/.markdownlint.json"
-          globs: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
-          separator: ","
+          globs: |
+            docs/**/*.md
+            !docs/canonicalk8s/_parts/**


### PR DESCRIPTION
# Description
Backport of #1201 to `release-1.31`.