### PR TITLE
test: Re-enable upgrade/downgrade tests from/to latest

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -104,8 +104,7 @@ jobs:
           # Test the latest (up to) 6 releases for the flavour
           # TODO(ben): upgrade nightly to run all flavours
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
-          # TODO(etienne): change to "recent" when 1.33 is stable
-          TEST_VERSION_DOWNGRADE_CHANNELS: "1.32-classic/stable 1.32-classic/beta 1.31-classic/stable 1.31-classic/beta"
+          TEST_VERSION_DOWNGRADE_CHANNELS: "recent 6 classic"
           # Upgrading from 1.30 is not supported.
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -44,7 +44,6 @@ def test_version_upgrades(
             cp.arch,
             include_latest=False,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
-            max_release="1.32",
         )
         if len(channels) < 2:
             pytest.fail(

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -42,7 +42,6 @@ def test_version_upgrades(
             int(num_channels),
             flavour,
             cp.arch,
-            include_latest=False,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
         )
         if len(channels) < 2:


### PR DESCRIPTION
The issue that prevented the upgrade/downgrade to `latest/edge` was fixed, so that we can perform this test again now.
