### PR TITLE
tests: test rawfile-localpv dependencies bumps

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -72,7 +72,7 @@ jobs:
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- -k test_storage --tags ${{ inputs.test-tags }}
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "0.8.1"
+	ImageTag = "4f27006ed63281a5aea6fa2f83437c267aa30e203a2cdf351f9c20fef624a5e4-amd64"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"

--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "4f27006ed63281a5aea6fa2f83437c267aa30e203a2cdf351f9c20fef624a5e4-amd64"
+	ImageTag = "0.8.2"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"


### PR DESCRIPTION
I bumped the rawfile-localpv dependencies to resolve some CVEs in https://github.com/canonical/rawfile-localpv/pull/26. This PR is just to test that rawfile-localpv still works.