### PR TITLE
test: update external certs

### DIFF
--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -1,4 +1,4 @@
-name: Run k8s-snap e2e tests
+name: Charm e2e tests
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,19 +16,55 @@ on:
         type: string
       # Download k8s-snap using either a GH action artifact or a snap channel.
       artifact:
-        description: The name of a GH action artifact.
+        description: The name of a GH action artifact
         type: string
       channel:
-        description: k8s snap channel.
+        description: k8s snap channel
         type: string
       test-tags:
         description: Integration test filter tags (e.g. pull_request, up_to_weekly)
         default: pull_request
         type: string
       flavor:
-        description: Test flavor (e.g. moonray or strict)
+        description: Test flavor (e.g. moonray or strict), leave empty for classic
         default: ""
         type: string
+      extra-test-args:
+        description: |
+          Additional pytest arguments, use "-k <test_name>" to run a specific test
+        default: ""
+        type: string
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: Job runner architecture (amd64 or arm64)
+        default: amd64
+        type: string
+      os:
+        description: LXD image to use when running e2e tests
+        default: ubuntu:24.04
+        type: string
+      channel:
+        description: k8s snap channel
+        type: string
+        default: latest/edge
+      test-tags:
+        description: Integration test filter tags (e.g. pull_request, up_to_weekly)
+        default: pull_request
+        type: string
+      flavor:
+        description: Test flavor (e.g. moonray or strict). Leave empty for classic
+        default: ""
+        type: string
+      extra-test-args:
+        description: Additional pytest arguments
+        default: ""
+        type: string
+      tmate_enabled:
+        type: boolean
+        description: Start a tmate session before running the tests
+        required: false
+        default: false
 
 jobs:
   test-integration:
@@ -55,6 +91,9 @@ jobs:
         uses: ./.github/actions/install-lxd
       - name: Install tox
         run: sudo apt-get install -y tox
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
       - name: Run e2e tests
         env:
           TEST_SNAP: ${{ steps.download-snap.outputs.snap-path }}
@@ -72,7 +111,7 @@ jobs:
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -5,8 +5,8 @@ on:
     - cron: "0 0 * * *" # Runs every midnight
   pull_request:
     paths:
-      - .github/workflows/nightly-test.yaml
       - .github/workflows/e2e-tests.yaml
+      - .github/workflows/nightly-test.yaml
       - .github/workflows/security-scan.yaml
 
 permissions:

--- a/build-scripts/hack/requirements.txt
+++ b/build-scripts/hack/requirements.txt
@@ -1,2 +1,3 @@
+packaging==24.2
 pyyaml==6.0.1
 tenacity==9.0.0

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.20
+	github.com/canonical/k8s-snap-api v1.0.23
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.20 h1:2dUQFkYoi+VRE09oah+5RfeoP3e8mbm/G1d0F+a0/G0=
-github.com/canonical/k8s-snap-api v1.0.20/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.0.23 h1:P2yYaUnLB1FUjpiOjad3LfuqZRfsdoHMWwmpdmqNmm4=
+github.com/canonical/k8s-snap-api v1.0.23/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18 h1:h5VJaUnE4gAKPolBTJ11HMRTEN5JyA+oR4gHkoK//6o=

--- a/src/k8s/pkg/docgen/godoc.go
+++ b/src/k8s/pkg/docgen/godoc.go
@@ -6,6 +6,7 @@ import (
 	"go/doc"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"reflect"
 	"strings"
 )
@@ -49,7 +50,11 @@ func getStructTypeFromDoc(packageDoc *doc.Package, structName string) (*ast.Stru
 
 func parsePackageDir(packageDir string) (*ast.Package, error) {
 	fset := token.NewFileSet()
-	packages, err := parser.ParseDir(fset, packageDir, nil, parser.ParseComments)
+	// NOTE(Hue): We only want to parse non-test files.
+	nonTestPackagesFilter := func(info fs.FileInfo) bool {
+		return !strings.HasSuffix(info.Name(), "_test.go")
+	}
+	packages, err := parser.ParseDir(fset, packageDir, nonTestPackagesFilter, parser.ParseComments)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse go package: %s", packageDir)
 	}

--- a/src/k8s/pkg/k8sd/api/cluster_config.go
+++ b/src/k8s/pkg/k8sd/api/cluster_config.go
@@ -60,6 +60,9 @@ func (e *Endpoints) getClusterConfig(s state.State, r *http.Request) response.Re
 	}
 
 	return response.SyncResponse(true, &apiv1.GetClusterConfigResponse{
-		Config: config.ToUserFacing(),
+		Config:      config.ToUserFacing(),
+		Datastore:   config.Datastore.ToUserFacing(),
+		PodCIDR:     config.Network.PodCIDR,
+		ServiceCIDR: config.Network.ServiceCIDR,
 	})
 }

--- a/src/k8s/pkg/k8sd/api/node.go
+++ b/src/k8s/pkg/k8sd/api/node.go
@@ -1,10 +1,16 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
 	"github.com/canonical/k8s/pkg/k8sd/api/impl"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/v2/state"
 )
@@ -17,7 +23,26 @@ func (e *Endpoints) getNodeStatus(s state.State, r *http.Request) response.Respo
 		return response.InternalError(err)
 	}
 
+	taints, err := getNodeTaints(snap)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("failed to get node taints: %w", err))
+	}
+
 	return response.SyncResponse(true, &apiv1.NodeStatusResponse{
 		NodeStatus: status,
+		Taints:     taints,
 	})
+}
+
+// getNodeTaints retrieves the taints of the local node.
+func getNodeTaints(snap snap.Snap) ([]string, error) {
+	taintsStr, err := snaputil.GetServiceArgument(snap, "kubelet", "--register-with-taints")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get kubelet taints: %w", err)
+	}
+
+	return strings.Split(taintsStr, ","), nil
 }

--- a/src/k8s/pkg/k8sd/setup/kubelet_test.go
+++ b/src/k8s/pkg/k8sd/setup/kubelet_test.go
@@ -3,6 +3,7 @@ package setup_test
 import (
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/canonical/k8s/pkg/k8sd/setup"
@@ -266,9 +267,12 @@ func TestKubelet(t *testing.T) {
 		// Create a mock snap
 		s := mustSetupSnapAndDirectories(t, setKubeletMock)
 
+		taints := []string{"foo=bar:NoSchedule"}
+		taintsStr := strings.Join(taints, ",")
 		extraArgs := map[string]*string{
-			"--cluster-domain": utils.Pointer("override.local"),
-			"--cloud-provider": nil,
+			"--cluster-domain":       utils.Pointer("override.local"),
+			"--cloud-provider":       nil,
+			"--register-with-taints": utils.Pointer(taintsStr),
 		}
 
 		// Call the kubelet worker setup function
@@ -292,7 +296,7 @@ func TestKubelet(t *testing.T) {
 			{key: "--kubeconfig", expectedVal: filepath.Join(s.Mock.KubernetesConfigDir, "kubelet.conf")},
 			{key: "--node-labels", expectedVal: expectedWorkerLabels},
 			{key: "--read-only-port", expectedVal: "0"},
-			{key: "--register-with-taints", expectedVal: ""},
+			{key: "--register-with-taints", expectedVal: taintsStr},
 			{key: "--root-dir", expectedVal: s.Mock.KubeletRootDir},
 			{key: "--serialize-image-pulls", expectedVal: "false"},
 			{key: "--tls-cipher-suites", expectedVal: kubeletTLSCipherSuites},

--- a/tests/integration/templates/bootstrap-node-taints.yaml
+++ b/tests/integration/templates/bootstrap-node-taints.yaml
@@ -1,0 +1,35 @@
+# Contains the bootstrap configuration for the node taints test.
+control-plane-taints: 
+  - "taint1=:PreferNoSchedule"
+  - "taint2=value:PreferNoSchedule"
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  ingress:
+    enabled: true
+  load-balancer:
+    enabled: true
+  local-storage:
+    enabled: true
+  gateway:
+    enabled: true
+  metrics-server:
+    enabled: true
+extra-node-config-files:
+  bootstrap-extra-file.yaml: extra-args-test-file-content
+extra-node-kube-apiserver-args:
+  --request-timeout: 2m
+extra-node-kube-controller-manager-args:
+  --leader-elect-retry-period: 3s
+extra-node-kube-scheduler-args:
+  --authorization-webhook-cache-authorized-ttl: 11s
+extra-node-kube-proxy-args:
+  --config-sync-period: 14m
+extra-node-kubelet-args:
+  --authentication-token-webhook-cache-ttl: 3m
+extra-node-containerd-args:
+  --log-level: debug
+extra-node-k8s-dqlite-args:
+  --watch-storage-available-size-interval: 6s

--- a/tests/integration/templates/worker-join-node-taints.yaml
+++ b/tests/integration/templates/worker-join-node-taints.yaml
@@ -1,0 +1,3 @@
+# Contains the join configuration for the worker nodes in the node taints test.
+extra-node-kubelet-args:
+  "--register-with-taints": "workerTaint1=:PreferNoSchedule,workerTaint2=workerValue:PreferNoSchedule"

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -177,7 +177,7 @@ def check_nginx_pod_runs(instance: harness.Instance):
 
 def delete_nginx_pod(instance: harness.Instance):
     manifest = MANIFESTS_DIR / "nginx-pod.yaml"
-    instance.exec(["k8s", "kubectl", "delete", "-f", "-"], input=manifest.read_bytes())
+    instance.exec(["k8s", "kubectl", "delete", "-f", str(manifest)])
 
 
 @pytest.mark.node_count(3)
@@ -314,7 +314,7 @@ def test_vault_certificates(instances: List[harness.Instance]):
     bootstrap_certs.update(cp_certs)
     bootstrap_certs.update(worker_certs)
 
-    create_and_assign_certs(client, bootstrap_certs.items(), bootstrap_certs)
+    create_and_assign_certs(client, bootstrap_certs.items(), bootstrap_config)
 
     # For BootstrapConfig, only this key has a different format.
     bootstrap_config["kube-ControllerManager-client-key"] = bootstrap_config[
@@ -396,7 +396,7 @@ def test_vault_certificates(instances: List[harness.Instance]):
         input=str.encode(yaml.dump(new_cp_certs)),
     )
     new_worker_certs = {}
-    create_and_assign_certs(client, worker_certs.items(), new_cp_certs)
+    create_and_assign_certs(client, worker_certs.items(), new_worker_certs)
     worker_node.exec(
         ["k8s", "refresh-certs", "--external-certificates", "-"],
         input=str.encode(yaml.dump(new_worker_certs)),

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -380,8 +380,8 @@ def test_vault_certificates(instances: List[harness.Instance]):
     # Refresh all cluster's nodes PKI.
     leader_cp_certs = {}
     cp_certs["apiserver-kubelet-client"] = CertOpts(
-            common_name="apiserver-kubelet-client",
-            role=MASTERS_ROLE,
+        common_name="apiserver-kubelet-client",
+        role=MASTERS_ROLE,
     )
     worker_certs["kubelet"] = CertOpts(
         common_name=f"system:node:{bootstrap_node_hostname}",

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -379,6 +379,10 @@ def test_vault_certificates(instances: List[harness.Instance]):
 
     # Refresh all cluster's nodes PKI.
     leader_cp_certs = {}
+    cp_certs["apiserver-kubelet-client"] = CertOpts(
+            common_name="apiserver-kubelet-client",
+            role=MASTERS_ROLE,
+    )
     worker_certs["kubelet"] = CertOpts(
         common_name=f"system:node:{bootstrap_node_hostname}",
         role=NODES_ROLE,

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -177,7 +177,7 @@ def check_nginx_pod_runs(instance: harness.Instance):
 
 def delete_nginx_pod(instance: harness.Instance):
     manifest = MANIFESTS_DIR / "nginx-pod.yaml"
-    instance.exec(["k8s", "kubectl", "delete", "-f", str(manifest)])
+    instance.exec(["k8s", "kubectl", "delete", "-f", "-"], input=manifest.read_bytes())
 
 
 @pytest.mark.node_count(3)

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -5,7 +5,7 @@ import collections
 import itertools
 import logging
 import time
-from typing import List
+from typing import Iterable, List
 
 import hvac
 import pytest
@@ -41,7 +41,7 @@ APISERVER_DNS_NAMES = [
     "kubernetes",
     "kubernetes.default",
     "kubernetes.default.svc",
-    "kukubernetes.default.svc.cluster",
+    "kubernetes.default.svc.cluster",
     "kubernetes.default.svc.cluster.local",
 ]
 APISERVER_IP_SANS = ["127.0.0.1", "10.152.183.1"]
@@ -144,6 +144,15 @@ def create_certificate(client: hvac.Client, opts: CertOpts):
     return cert, private_key
 
 
+def create_and_assign_certs(
+    client: hvac.Client, cert_opts: Iterable, config_dict: dict
+):
+    for prefix, options in cert_opts:
+        cert, key = create_certificate(client, options)
+        config_dict[f"{prefix}-crt"] = cert
+        config_dict[f"{prefix}-key"] = key
+
+
 def check_nginx_pod_runs(instance: harness.Instance):
     manifest = MANIFESTS_DIR / "nginx-pod.yaml"
     instance.exec(
@@ -164,6 +173,11 @@ def check_nginx_pod_runs(instance: harness.Instance):
             "180s",
         ]
     )
+
+
+def delete_nginx_pod(instance: harness.Instance):
+    manifest = MANIFESTS_DIR / "nginx-pod.yaml"
+    instance.exec(["k8s", "kubectl", "delete", "-f", "-"], input=manifest.read_bytes())
 
 
 @pytest.mark.node_count(3)
@@ -300,10 +314,7 @@ def test_vault_certificates(instances: List[harness.Instance]):
     bootstrap_certs.update(cp_certs)
     bootstrap_certs.update(worker_certs)
 
-    for prefix, options in bootstrap_certs.items():
-        cert, key = create_certificate(client, options)
-        bootstrap_config[f"{prefix}-crt"] = cert
-        bootstrap_config[f"{prefix}-key"] = key
+    create_and_assign_certs(client, bootstrap_certs.items(), bootstrap_certs)
 
     # For BootstrapConfig, only this key has a different format.
     bootstrap_config["kube-ControllerManager-client-key"] = bootstrap_config[
@@ -329,10 +340,9 @@ def test_vault_certificates(instances: List[harness.Instance]):
         role=NODES_ROLE,
     )
     cp_join_config = {}
-    for prefix, options in itertools.chain(cp_certs.items(), worker_certs.items()):
-        cert, key = create_certificate(client, options)
-        cp_join_config[f"{prefix}-crt"] = cert
-        cp_join_config[f"{prefix}-key"] = key
+    create_and_assign_certs(
+        client, itertools.chain(cp_certs.items(), worker_certs.items()), cp_join_config
+    )
 
     join_token = util.get_join_token(instance, cp_node)
     cp_node.exec(
@@ -352,10 +362,7 @@ def test_vault_certificates(instances: List[harness.Instance]):
         role=NODES_ROLE,
     )
     worker_config = {}
-    for prefix, options in worker_certs.items():
-        cert, key = create_certificate(client, options)
-        worker_config[f"{prefix}-crt"] = cert
-        worker_config[f"{prefix}-key"] = key
+    create_and_assign_certs(client, worker_certs.items(), worker_config)
 
     join_token = util.get_join_token(instance, worker_node, "--worker")
     worker_node.exec(
@@ -367,4 +374,33 @@ def test_vault_certificates(instances: List[harness.Instance]):
     util.wait_for_dns(instance)
 
     # If we deploy a Pod and it becomes Active, the cluster should be functional.
+    check_nginx_pod_runs(instance)
+    delete_nginx_pod(instance)
+
+    # Refresh the PKIs across the cluster.
+    leader_cp_certs = {}
+    create_and_assign_certs(
+        client, itertools.chain(cp_certs.items(), worker_certs.items()), leader_cp_certs
+    )
+    instance.exec(
+        ["k8s", "refresh-certs", "--external-certificates", "-"],
+        input=str.encode(yaml.dump(leader_cp_certs)),
+    )
+
+    new_cp_certs = {}
+    create_and_assign_certs(
+        client, itertools.chain(cp_certs.items(), worker_certs.items()), new_cp_certs
+    )
+    cp_node.exec(
+        ["k8s", "refresh-certs", "--external-certificates", "-"],
+        input=str.encode(yaml.dump(new_cp_certs)),
+    )
+    new_worker_certs = {}
+    create_and_assign_certs(client, worker_certs.items(), new_cp_certs)
+    worker_node.exec(
+        ["k8s", "refresh-certs", "--external-certificates", "-"],
+        input=str.encode(yaml.dump(new_worker_certs)),
+    )
+
+    # Deploy the Pod again to verify the cluster functionality.
     check_nginx_pod_runs(instance)

--- a/tests/integration/tests/test_node_taints.py
+++ b/tests/integration/tests/test_node_taints.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+import json
+import logging
+from typing import Any, List
+
+import pytest
+from test_util import config, harness, tags, util
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-node-taints.yaml").read_text()
+)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_node_taints(instances: List[harness.Instance]):
+    """Test node taints are returned by the GetNodeStatus RPC."""
+    cp_node = instances[0]
+    worker_node = instances[1]
+    join_token = util.get_join_token(cp_node, worker_node, "--worker")
+    util.join_cluster(
+        worker_node,
+        join_token,
+        (config.MANIFESTS_DIR / "worker-join-node-taints.yaml").read_text(),
+    )
+
+    util.wait_until_k8s_ready(cp_node, instances)
+    nodes = util.ready_nodes(cp_node)
+    assert len(nodes) == 2, "worker should have joined cluster"
+
+    cp_taints = get_node_taints(cp_node)
+    worker_taints = get_node_taints(worker_node)
+
+    # NOTE(Hue): these come from the bootstrap and join configs
+    cp_exp_taints = [
+        "taint1=:PreferNoSchedule",
+        "taint2=value:PreferNoSchedule",
+    ]
+    worker_exp_taints = [
+        "workerTaint1=:PreferNoSchedule",
+        "workerTaint2=workerValue:PreferNoSchedule",
+    ]
+
+    assert len(cp_taints) == len(cp_exp_taints), "cp node taints count do not match"
+    assert len(worker_taints) == len(
+        worker_exp_taints
+    ), "worker node taints count do not match"
+    assert set(cp_taints) == set(cp_exp_taints), "cp node taints do not match"
+    assert set(worker_taints) == set(
+        worker_exp_taints
+    ), "worker node taints do not match"
+
+
+def get_node_taints(instance: harness.Instance) -> Any:
+    """Get taints from the node status."""
+    resp = instance.exec(
+        [
+            "curl",
+            "-H",
+            "Content-Type: application/json",
+            "--unix-socket",
+            "/var/snap/k8s/common/var/lib/k8sd/state/control.socket",
+            "http://localhost/1.0/k8sd/node",
+        ],
+        capture_output=True,
+    )
+    assert resp.returncode == 0, "Failed to get node status."
+    response = json.loads(resp.stdout.decode())
+    assert response["error_code"] == 0, "Failed to get node status."
+    assert response["error"] == "", "Failed to get node status."
+
+    metadata = response.get("metadata")
+    assert metadata is not None, "Metadata not found in the node status response."
+    taints = metadata.get("taints")
+    assert taints is not None, "Node taints not found in the node status response."
+
+    return taints

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -412,8 +412,15 @@ def get_join_token(
 
 
 # Join an existing cluster.
-def join_cluster(instance: harness.Instance, join_token: str):
-    instance.exec(["k8s", "join-cluster", join_token])
+def join_cluster(
+    instance: harness.Instance, join_token: str, cfg: Optional[str] = None
+):
+    if cfg:
+        instance.exec(
+            ["k8s", "join-cluster", join_token, "--file", "-"], input=str.encode(cfg)
+        )
+    else:
+        instance.exec(["k8s", "join-cluster", join_token])
 
 
 def is_ipv6(ip: str) -> bool:

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -96,7 +96,7 @@ def test_version_upgrades(
             LOG.info(f"Upgraded {instance.id} on channel {channel}")
 
 
-@pytest.mark.node_count(4)
+@pytest.mark.node_count(3)
 @pytest.mark.no_setup()
 @pytest.mark.skipif(
     not config.VERSION_DOWNGRADE_CHANNELS, reason="No downgrade channels configured"
@@ -124,7 +124,13 @@ def test_version_downgrades_with_rollback(
     cp = instances[0]
     cp1 = instances[1]
     cp2 = instances[2]
-    w0 = instances[3]
+    # TODO: add a worker node once the snap refresh is fixed on worker nodes
+    # and the patch lands on all the release channels covered by this test.
+    #
+    # At the moment, the following fails:
+    # https://github.com/canonical/k8s-snap/blob/96124bd7f1e82e96e23a4c4d11fcff86045f403c/snap/hooks/configure#L7
+    #
+    # w0 = instances[3]
     current_channel = channels[0]
 
     if current_channel.lower() == "recent":
@@ -161,11 +167,11 @@ def test_version_downgrades_with_rollback(
 
     join_token_cp1 = util.get_join_token(cp, cp1)
     join_token_cp2 = util.get_join_token(cp, cp2)
-    join_token_w0 = util.get_join_token(cp, w0, "--worker")
+    # join_token_w0 = util.get_join_token(cp, w0, "--worker")
 
     util.join_cluster(cp1, join_token_cp1)
     util.join_cluster(cp2, join_token_cp2)
-    util.join_cluster(w0, join_token_w0)
+    # util.join_cluster(w0, join_token_w0)
 
     util.wait_until_k8s_ready(cp, instances)
 


### PR DESCRIPTION
## Description

Introduce testing for the external certificate updates using the `refresh-certs` command.

## Solution

This pull request enhances the existing nightly tests for validating the external certificates functionality in the snap by adding the `refresh-certs` command to update the external certificates as part of the process.

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
