### PR TITLE
fix: ensure lock directory exists before creating file

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -8,4 +8,5 @@ k8s::common::setup_env
 # the case in the snap hook. Hence, we use a lock file
 # to indicate that an update has been performed and
 # run a custom post-refresh hook in the k8sd service.
+mkdir -p "$SNAP_COMMON/lock"
 touch "$SNAP_COMMON/lock/post-refresh"


### PR DESCRIPTION

## Description

it's possible that the lock directory does not exist when the post-refresh hook is run. This adds a mkdir before touch so that the snap installation process is not interrupted by a failure that can be avoided.

## Solution

add a mkdir to post-refresh hook

## Issue

https://github.com/canonical/k8s-snap/actions/runs/13977437421/job/39134587370#step:9:17123

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
