### PR TITLE
chore: add test to check client-ca.key is generated

### DIFF
--- a/src/k8s/pkg/k8sd/setup/certificates_test.go
+++ b/src/k8s/pkg/k8sd/setup/certificates_test.go
@@ -79,16 +79,16 @@ func TestEnsureControlPlanePKI(t *testing.T) {
 		filepath.Join(tempDir, "apiserver.crt"),
 		filepath.Join(tempDir, "apiserver.key"),
 		filepath.Join(tempDir, "ca.crt"),
+		filepath.Join(tempDir, "ca.key"),
 		filepath.Join(tempDir, "client-ca.crt"),
 		filepath.Join(tempDir, "client-ca.key"),
 		filepath.Join(tempDir, "front-proxy-ca.crt"),
+		filepath.Join(tempDir, "front-proxy-ca.key"),
 		filepath.Join(tempDir, "front-proxy-client.crt"),
 		filepath.Join(tempDir, "front-proxy-client.key"),
 		filepath.Join(tempDir, "kubelet.crt"),
 		filepath.Join(tempDir, "kubelet.key"),
 		filepath.Join(tempDir, "serviceaccount.key"),
-		filepath.Join(tempDir, "ca.key"),
-		filepath.Join(tempDir, "front-proxy-ca.key"),
 	}
 
 	for _, file := range expectedFiles {

--- a/src/k8s/pkg/k8sd/setup/certificates_test.go
+++ b/src/k8s/pkg/k8sd/setup/certificates_test.go
@@ -80,6 +80,7 @@ func TestEnsureControlPlanePKI(t *testing.T) {
 		filepath.Join(tempDir, "apiserver.key"),
 		filepath.Join(tempDir, "ca.crt"),
 		filepath.Join(tempDir, "client-ca.crt"),
+		filepath.Join(tempDir, "client-ca.key"),
 		filepath.Join(tempDir, "front-proxy-ca.crt"),
 		filepath.Join(tempDir, "front-proxy-client.crt"),
 		filepath.Join(tempDir, "front-proxy-client.key"),


### PR DESCRIPTION
## Description

The #1151 issue is already addressed in #1203. This PR adds a single test to check the `client-ca.key` is created. 