### PR TITLE
donotmerge: try to reproduce airgap test failures

### DIFF
--- a/.github/actions/install-lxd/action.yaml
+++ b/.github/actions/install-lxd/action.yaml
@@ -9,6 +9,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Apply snap workaround
+      shell: bash
+      run: |
+        # This is supposed to help with the snap installation failures:
+        # "https://api.snapcraft.io/v2/snaps/refresh": context canceled.
+        sudo apt-get install -y xdelta3
     - name: Install lxd snap
       shell: bash
       run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -72,7 +72,7 @@ jobs:
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} -k test_airgapped
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -10,9 +10,9 @@ on:
       - autoupdate/moonray
       - 'release-[0-9]+.[0-9]+'
       - 'autoupdate/release-[0-9]+.[0-9]+-strict'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
+  # pull_request:
+  #   paths-ignore:
+  #     - 'docs/**'
 
 permissions:
   contents: read

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -229,6 +229,9 @@ def instances(
         instance = h.new_instance(network_type=network_type)
         instances.append(instance)
 
+        instance.exec(["apt-get", "update"])
+        instance.exec(["apt-get", "install", "-y", "xdelta3"])
+
         if config.PRELOAD_SNAPS:
             for preloaded_snap in PRELOADED_SNAPS:
                 ack_file = f"{preloaded_snap}.assert"

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -190,6 +190,8 @@ def setup_k8s_snap(
     cmd = ["snap", "install", "--classic"]
     which_snap = snap or config.SNAP
 
+    LOG.info("Installing k8s-snap: %s", which_snap)
+
     if not which_snap:
         pytest.fail("Set TEST_SNAP to the channel, revision, or path to the snap")
 


### PR DESCRIPTION
We've seen a few airgap test failures caused by k8s-dqlite errors that occur during bootstrap:

```
Mar 24 00:35:23 k8s-integration-12c451-5 k8s.k8sd[3413]: Error: Failed to run k8sd: failed to run microcluster: Daemon stopped with error: Failed to run post-start hook: failed to run post-refresh hook: failed to get cluster config: failed to perform cluster config transaction request: Database is not ready yet: Database is not yet initialized
Mar 24 00:35:23 k8s-integration-12c451-5 systemd[1]: snap.k8s.k8sd.service: Main process exited, code=exited, status=1/FAILURE
```

https://github.com/canonical/k8s-snap/actions/runs/14024317334/job/39260421796

The failures didn't show up locally, so this patch will try to reproduce them on the CI env.

We'll skip the other tests, only running the airgap tests as part of the nightly CI job.

## Description

What issue is this PR trying to solve?

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
