### PR TITLE
fix: Pre-install xdelta3 to mitigate LXD rate-limit issues

### DIFF
--- a/.github/actions/install-lxd/action.yaml
+++ b/.github/actions/install-lxd/action.yaml
@@ -12,6 +12,10 @@ runs:
     - name: Install lxd snap
       shell: bash
       run: |
+        # note(ben): Temporary workaround until snapd/snapcraft issue is resolved.
+        sudo apt-get update
+        sudo apt-get install xdelta3 --yes
+
         if ! snap list lxd &> /dev/null; then
           echo "Installing lxd snap"
           sudo snap install lxd --channel ${{ inputs.channel }}

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -208,6 +208,10 @@ def setup_k8s_snap(
         LOG.info("Install k8s snap by least risky channel: %s", channel)
         cmd += [config.SNAP_NAME, "--channel", channel]
 
+    # TODO(ben): Remove this temporary workaround once the snapstore issue is resolved.
+    instance.exec(["apt", "update"])
+    instance.exec(["apt", "install", "xdelta3", "--yes"])
+
     instance.exec(cmd)
     if connect_interfaces:
         LOG.info("Ensure k8s interfaces and network requirements")


### PR DESCRIPTION
## Description

Recently, installing LXD has triggered rate-limit problems, resulting in context cancelled errors during snap install. 

## Solution

Based on feedback from the Snap Store team, pre-installing xdelta3 helps alleviate these issues.
This is a temporary solution until the snapd team resolved the issue.
