### PR TITLE
feat: reorganize common-hardening to be a more generic security posture

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -238,6 +238,8 @@ Snapcraft
 snapd
 SR-IOV
 src
+stderr
+stdout
 stackexchange
 stgraber
 STONITH

--- a/docs/canonicalk8s/_parts/common_hardening.md
+++ b/docs/canonicalk8s/_parts/common_hardening.md
@@ -2,7 +2,7 @@
 
 #### Control Plane Security
 
-Kubernetes documentation on [controlling_access][] to the API informs on topics
+Kubernetes documentation on [controlling access][controlling_access] to the API informs on topics
 such as **Transport Security**, **AAA (Authentication,Authorization,Auditing)**,
 and **Admission control**. Much of this discusses how to limit access to
 authorized users and disable access to unauthorized users.

--- a/docs/canonicalk8s/_parts/common_hardening.md
+++ b/docs/canonicalk8s/_parts/common_hardening.md
@@ -7,23 +7,12 @@ such as **Transport Security**, **AAA (Authentication,Authorization,Auditing)**,
 and **Admission Control**. Much of this discusses how to limit access to
 authorized users and disable access to unauthorized users.
 
-#### Role Based Access Control
+#### Encrypt secrets at rest
+Encrypt key-value store secrets rather than leaving it as base64 encoded values
+as described in the upstream Kubernetes documentation on
+[encrypting secrets][encryption_at_rest].
 
-Kubernetes documentation on [rbac][access_authn_authz] informs how to
-enforce RBAC policies to limit access to cluster resources, and define roles
-and permissions aligned with the principle of least privilege to prevent
-unauthorized access to critical operations.
-
-#### Secrets Encryption at Rest
-Kubernetes documentation on [encrypting secrets][encryption_at_rest] informs how
-to ensure that the key-value store encrypts secrets rather than leaving it as
-base64 encoded values.
-
-this guide indicates one should set the `--encryption-provider-config` file
-as an argument to the kubernetes apiserver.
-
-Create the `EncryptionConfiguration` file under `/var/snap/k8s/common/etc/encryption/`
-and update the kube-apiserver arguments.
+Create the `EncryptionConfiguration` file under `/var/snap/k8s/common/etc/encryption/`.
 
 ```
 sudo sh -c '
@@ -41,22 +30,24 @@ resources:
   - identity: {}
 EOL
 chmod 600 /var/snap/k8s/common/etc/encryption/enc.yaml
+```
+
+Set the `--encryption-provider-config` file as an argument to the kubernetes
+apiserver.
+
+```
+sudo sh -c '
 cat >>/var/snap/k8s/common/args/kube-apiserver <<EOL
 --encyrption-provider-config=/var/snap/k8s/common/etc/enc.yaml
 EOL'
 ```
 
-This ensures that cluster `secrets` resources are encrypted in the key-value
-store. Securing the contents of this key file is left as a separate exercise.
+Securing the contents of this key file is left as a separate exercise.
 
 
-#### Configuring Authorization Modes
-Enforce RBAC (Role-Based Access Control) policies to limit access to cluster
-resources. Define roles and permissions aligned with the principle of least
-privilege to prevent unauthorized access to critical operations.
-
-Confirm the value of the apiserver [`authorization-mode`][authorization_mode]
-value
+#### Configure authorization modes
+Enforce RBAC (Role-Based Access Control) policies and confirm the value of the
+apiserver [`authorization-mode`][authorization_mode]:
 * includes `RBAC`
 * doesn't include `AlwaysAllow`
 
@@ -71,6 +62,9 @@ By default, the value is `Node,RBAC`
 * `Node`: 
   A special-purpose authorization mode that grants permissions
   to kubelets based on the pods they are scheduled to run.
+
+ To apply RBAC to other cluster resources, see the upstream Kubernetes
+ [RBAC guide][access_authn_authz].
 
 
 #### Configure log auditing

--- a/docs/canonicalk8s/_parts/common_hardening.md
+++ b/docs/canonicalk8s/_parts/common_hardening.md
@@ -4,7 +4,7 @@
 
 Kubernetes documentation on [controlling access][controlling_access] to the API informs on topics
 such as **Transport Security**, **AAA (Authentication,Authorization,Auditing)**,
-and **Admission control**. Much of this discusses how to limit access to
+and **Admission Control**. Much of this discusses how to limit access to
 authorized users and disable access to unauthorized users.
 
 #### Role Based Access Control

--- a/docs/canonicalk8s/_parts/common_hardening.md
+++ b/docs/canonicalk8s/_parts/common_hardening.md
@@ -1,12 +1,5 @@
 ### Control plane nodes
 
-#### Control Plane Security
-
-Kubernetes documentation on [controlling access][controlling_access] to the API informs on topics
-such as **Transport Security**, **AAA (Authentication,Authorization,Auditing)**,
-and **Admission Control**. Much of this discusses how to limit access to
-authorized users and disable access to unauthorized users.
-
 #### Encrypt secrets at rest
 Encrypt key-value store secrets rather than leaving it as base64 encoded values
 as described in the upstream Kubernetes documentation on

--- a/docs/canonicalk8s/_parts/common_hardening.md
+++ b/docs/canonicalk8s/_parts/common_hardening.md
@@ -1,10 +1,83 @@
 ### Control plane nodes
 
+#### Control Plane Security
+
+Kubernetes documentation on [controlling_access][] to the API informs on topics
+such as **Transport Security**, **AAA (Authentication,Authorization,Auditing)**,
+and **Admission control**. Much of this discusses how to limit access to
+authorized users and disable access to unauthorized users.
+
+#### Role Based Access Control
+
+Kubernetes documentation on [rbac][access_authn_authz] informs how to
+enforce RBAC policies to limit access to cluster resources, and define roles
+and permissions aligned with the principle of least privilege to prevent
+unauthorized access to critical operations.
+
+#### Secrets Encryption at Rest
+Kubernetes documentation on [encrypting secrets][encryption_at_rest] informs how
+to ensure that the key-value store encrypts secrets rather than leaving it as
+base64 encoded values.
+
+this guide indicates one should set the `--encryption-provider-config` file
+as an argument to the kubernetes apiserver.
+
+Create the `EncryptionConfiguration` file under `/var/snap/k8s/common/etc/encryption/`
+and update the kube-apiserver arguments.
+
+```
+sudo sh -c '
+mkdir -p /var/snap/k8s/common/etc/encryption/
+cat >/var/snap/k8s/common/etc/encryption/enc.yaml << EOL
+kind: "EncryptionConfig"
+apiVersion: apiserver.config.k8s.io/v1
+resources:
+- resources: ["secrets"]
+  providers:
+  - aesgcm:
+      keys:
+      - name: key1
+        secret: ${BASE 64 ENCODED SECRET}
+  - identity: {}
+EOL
+chmod 600 /var/snap/k8s/common/etc/encryption/enc.yaml
+cat >>/var/snap/k8s/common/args/kube-apiserver <<EOL
+--encyrption-provider-config=/var/snap/k8s/common/etc/enc.yaml
+EOL'
+```
+
+This ensures that cluster `secrets` resources are encrypted in the key-value
+store. Securing the contents of this key file is left as a separate exercise.
+
+
+#### Configuring Authorization Modes
+Enforce RBAC (Role-Based Access Control) policies to limit access to cluster
+resources. Define roles and permissions aligned with the principle of least
+privilege to prevent unauthorized access to critical operations.
+
+Confirm the value of the apiserver [`authorization-mode`][authorization_mode]
+value
+* includes `RBAC`
+* doesn't include `AlwaysAllow`
+
+```
+sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
+    grep -q "RBAC" && echo "okay" || echo "missing"
+sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
+    grep -q "AlwaysAllow" && echo "Remove AlwaysAllow" || echo "okay"
+```
+
+By default, the value is `Node,RBAC`
+* `Node`: 
+  A special-purpose authorization mode that grants permissions
+  to kubelets based on the pods they are scheduled to run.
+
+
 #### Configure log auditing
 
 ```{note}
 Configuring log auditing requires the cluster administrator's input and
-may incurr performance penalties in the form of disk I/O.
+may incur performance penalties in the form of disk I/O.
 ```
 
 Create an audit-policy.yaml file under `/var/snap/k8s/common/etc/` and specify
@@ -26,7 +99,7 @@ Enable auditing at the API server level by adding the following arguments.
 
 ```
 sudo sh -c 'cat >>/var/snap/k8s/common/args/kube-apiserver <<EOL
---audit-log-path=/var/log/apiserver/audit.log
+--audit-log-path=/var/log/kubernetes/audit.log
 --audit-log-maxage=30
 --audit-log-maxbackup=10
 --audit-log-maxsize=100
@@ -231,3 +304,7 @@ sudo systemctl restart snap.k8s.kubelet
 <!-- Links -->
 [upstream instructions]:https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
 [rate limits]:https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1
+[controlling_access]: https://kubernetes.io/docs/concepts/security/controlling-access/
+[access_authn_authz]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+[encryption_at_rest]: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
+[authorization_mode]: https://kubernetes.io/docs/reference/access-authn-authz/authorization/#authorization-modules

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -1248,7 +1248,7 @@ on the control plane node and set the --audit-log-path
 parameter to a suitable path and
 file where you would like audit logs to be written.
 
-`--audit-log-path=/var/log/apiserver/audit.log`
+`--audit-log-path=/var/log/kubernetes/audit.log`
 
 
 **Audit (as root):**
@@ -1260,7 +1260,7 @@ file where you would like audit logs to be written.
 **Expected output:**
 
 ```
---audit-log-path=/var/log/apiserver/audit.log
+--audit-log-path=/var/log/kubernetes/audit.log
 ```
 
 ##### CIS Control 1.2.19

--- a/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
@@ -2068,6 +2068,11 @@ The final line of the output will be `PASS`.
 >
 > The k8s-snap does not configure auditing by default.
 >
+> The default posture of the kube-apiserver actually disables auditing
+> when the configuration is left unset, despite what [V-242402] states.
+> the audit log is only sent to **stdout** (not studio) if the value is set to
+> '-'
+>
 > Please review the [post-deployment hardening] guide for a full description on
 > how to enable auditing for the kube-apiserver.
 >

--- a/docs/canonicalk8s/snap/howto/security/hardening.md
+++ b/docs/canonicalk8s/snap/howto/security/hardening.md
@@ -15,7 +15,7 @@ comprehensive list of manual tests.
 
 Please evaluate the implications of each configuration before applying it.
 
-## Platform Hardening Recommendations
+## Platform hardening recommendations
 
 These steps are common to the hardening process for not only CIS and DISA STIG
 compliance, but also good suggestions if one is willing to incur the performance

--- a/docs/canonicalk8s/snap/howto/security/hardening.md
+++ b/docs/canonicalk8s/snap/howto/security/hardening.md
@@ -15,10 +15,11 @@ comprehensive list of manual tests.
 
 Please evaluate the implications of each configuration before applying it.
 
-## Post-deployment hardening steps
+## Platform Hardening Recommendations
 
-These steps are common to the hardening process for both CIS and DISA STIG
-compliance.
+These steps are common to the hardening process for not only CIS and DISA STIG
+compliance, but also good suggestions if one is willing to incur the performance
+costs for the benefit of an increased security posture.
 
 ```{include} /_parts/common_hardening.md
 ```

--- a/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
+++ b/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
@@ -320,6 +320,8 @@ Snapcraft
 snapd
 SR-IOV
 src
+stderr
+stdout
 stackexchange
 stgraber
 STIGs


### PR DESCRIPTION
The spec **SEC0030** requires us to have “security documentation that enables our users to be in control and informed of the security posture, and usage of our products”. We have worked on the content in the SSDLC Documentation effort. 

Let’s turn it into a page that we can publish.