### PR TITLE
ci: retry launchpad clone

### DIFF
--- a/src/k8s/hack/dynamic-dqlite.sh
+++ b/src/k8s/hack/dynamic-dqlite.sh
@@ -17,7 +17,10 @@ if [ ! -f "${BUILD_DIR}/libtirpc/src/libtirpc.la" ]; then
   (
     cd "${BUILD_DIR}"
     rm -rf libtirpc
-    git clone "${REPO_LIBTIRPC}" --depth 1 --branch "${TAG_LIBTIRPC}" > /dev/null
+    for i in $(seq 1 5); do
+      git clone "${REPO_LIBTIRPC}" --depth 1 --branch "${TAG_LIBTIRPC}" >/dev/null && break
+      sleep 5
+    done
     cd libtirpc
     chmod +x autogen.sh
     ./autogen.sh > /dev/null

--- a/src/k8s/hack/static-dqlite.sh
+++ b/src/k8s/hack/static-dqlite.sh
@@ -47,7 +47,10 @@ if [ ! -f "${BUILD_DIR}/libtirpc/src/libtirpc.la" ]; then
   (
     cd "${BUILD_DIR}"
     rm -rf libtirpc
-    git clone "${REPO_LIBTIRPC}" --depth 1 --branch "${TAG_LIBTIRPC}" > /dev/null
+    for i in $(seq 1 5); do
+      git clone "${REPO_LIBTIRPC}" --depth 1 --branch "${TAG_LIBTIRPC}" libtirpc >/dev/null && break
+      sleep 5
+    done
     cd libtirpc
     chmod +x autogen.sh
     ./autogen.sh > /dev/null


### PR DESCRIPTION
Launchpad occasionally returns 500 error during clone which fails the whole CI. This adds a simple retry to try and prevent the fail if possible.