### PR TITLE
test: Use multi-node cluster as part of upgrade/rollback tests

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -108,6 +108,18 @@ def h() -> harness.Harness:
     _harness_clean(h)
 
 
+@pytest.fixture(autouse=True)
+def log_environment_info(h: harness.Harness):
+    """Log any relevant environment information before and after each test.
+    This allows us to identify leaked resources.
+    """
+    LOG.info("Environment info before test:")
+    h.log_environment_info()
+    yield
+    LOG.info("Environment info after test:")
+    h.log_environment_info()
+
+
 @pytest.fixture(scope="session")
 def registry(h: harness.Harness) -> Optional[Registry]:
     yield Registry(h)
@@ -277,6 +289,9 @@ def instances(
         for instance in instances:
             LOG.debug("Generating inspection reports for test instances")
             _generate_inspection_report(h, instance.id)
+
+    LOG.info("Environment info before cleanup:")
+    h.log_environment_info()
 
     # Cleanup after each test.
     # We cannot execute _harness_clean() here as this would also

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -51,30 +51,30 @@ def _harness_clean(h: harness.Harness):
 def _generate_inspection_report(h: harness.Harness, instance_id: str):
     LOG.debug("Generating inspection report for %s", instance_id)
 
-    inspection_path = Path(config.INSPECTION_REPORTS_DIR)
-    result = h.exec(
-        instance_id,
-        [
-            "/snap/k8s/current/k8s/scripts/inspect.sh",
-            "--all-namespaces",
-            "--core-dump-dir",
-            config.CORE_DUMP_DIR,
-            "/inspection-report.tar.gz",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    (inspection_path / instance_id).mkdir(parents=True, exist_ok=True)
-    report_log = inspection_path / instance_id / "inspection_report_logs.txt"
-    with report_log.open("w") as f:
-        f.write("stdout:\n")
-        f.write(result.stdout)
-        f.write("stderr:\n")
-        f.write(result.stderr)
-
     try:
+        inspection_path = Path(config.INSPECTION_REPORTS_DIR)
+        result = h.exec(
+            instance_id,
+            [
+                "/snap/k8s/current/k8s/scripts/inspect.sh",
+                "--all-namespaces",
+                "--core-dump-dir",
+                config.CORE_DUMP_DIR,
+                "/inspection-report.tar.gz",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        (inspection_path / instance_id).mkdir(parents=True, exist_ok=True)
+        report_log = inspection_path / instance_id / "inspection_report_logs.txt"
+        with report_log.open("w") as f:
+            f.write("stdout:\n")
+            f.write(result.stdout)
+            f.write("stderr:\n")
+            f.write(result.stderr)
+
         h.pull_file(
             instance_id,
             "/inspection-report.tar.gz",

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -26,8 +26,6 @@ def test_no_remove(instances: List[harness.Instance]):
     util.join_cluster(joining_worker, join_token_worker)
 
     util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "nodes should have joined cluster"
 
     assert "control-plane" in util.get_local_node_status(cluster_node)
     assert "control-plane" in util.get_local_node_status(joining_cp)

--- a/tests/integration/tests/test_cleanup.py
+++ b/tests/integration/tests/test_cleanup.py
@@ -110,8 +110,6 @@ containerd-base-dir: /home/ubuntu
 
     # Ensure that the cluster actually becomes available.
     util.wait_until_k8s_ready(main, instances)
-    nodes = util.ready_nodes(main)
-    assert len(nodes) == 2, "nodes should have joined cluster"
 
     for instance in instances:
         util.remove_k8s_snap(instance)

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -26,9 +26,6 @@ def test_control_plane_nodes(instances: List[harness.Instance]):
     util.join_cluster(joining_node, join_token)
 
     util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 2, "node should have joined cluster"
-
     assert "control-plane" in util.get_local_node_status(cluster_node)
     assert "control-plane" in util.get_local_node_status(joining_node)
 
@@ -52,8 +49,6 @@ def test_mixed_version_join(instances: List[harness.Instance]):
     util.join_cluster(joining_node, join_token)
 
     util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 2, "node should have joined cluster"
 
     assert "control-plane" in util.get_local_node_status(cluster_node)
     assert "control-plane" in util.get_local_node_status(joining_node)
@@ -83,8 +78,6 @@ def test_worker_nodes(instances: List[harness.Instance]):
     util.join_cluster(other_joining_node, join_token_2)
 
     util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "workers should have joined cluster"
 
     assert "control-plane" in util.get_local_node_status(cluster_node)
     assert "worker" in util.get_local_node_status(joining_node)
@@ -144,8 +137,6 @@ extra-sans:
     util.wait_until_k8s_ready(
         cluster_node, instances, node_names={joining_cp.id: "my-node"}
     )
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 3, "nodes should have joined cluster"
 
     cluster_node.exec(["k8s", "remove-node", "my-node"])
     nodes = util.ready_nodes(cluster_node)
@@ -169,8 +160,6 @@ def test_cert_refresh(instances: List[harness.Instance]):
     util.join_cluster(joining_worker, join_token_worker)
 
     util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 2, "nodes should have joined cluster"
     assert "control-plane" in util.get_local_node_status(cluster_node)
     assert "worker" in util.get_local_node_status(joining_worker)
 

--- a/tests/integration/tests/test_config_propagation.py
+++ b/tests/integration/tests/test_config_propagation.py
@@ -23,12 +23,9 @@ def test_config_propagation(instances: List[harness.Instance]):
     assert join_token != join_token_2
 
     util.join_cluster(joining_cplane_node, join_token)
-
     util.join_cluster(joining_worker_node, join_token_2)
 
     util.wait_until_k8s_ready(initial_node, instances)
-    nodes = util.ready_nodes(initial_node)
-    assert len(nodes) == 3, "all nodes should have joined cluster"
 
     initial_node.exec(["k8s", "set", "dns.cluster-domain=integration.local"])
 

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -218,8 +218,6 @@ def test_vault_intermediate_ca(instances: List[harness.Instance]):
     util.join_cluster(worker_node, join_token)
 
     util.wait_until_k8s_ready(instance, instances)
-    nodes = util.ready_nodes(instance)
-    assert len(nodes) == 3, "node should have joined cluster"
     util.wait_for_dns(instance)
 
     # If we deploy a Pod and it becomes Active, the cluster should be functional.
@@ -366,8 +364,6 @@ def test_vault_certificates(instances: List[harness.Instance]):
     )
 
     util.wait_until_k8s_ready(instance, instances)
-    nodes = util.ready_nodes(instance)
-    assert len(nodes) == 3, "node should have joined cluster"
     util.wait_for_dns(instance)
 
     # If we deploy a Pod and it becomes Active, the cluster should be functional.

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -119,7 +119,4 @@ def test_ipv6_only_on_dualstack_infra(instances: List[harness.Instance]):
             ["curl", address], shell=True
         )
 
-    # This might take a while
-    util.stubbornly(retries=config.DEFAULT_WAIT_RETRIES, delay_s=20).until(
-        util.ready_nodes(main) == 3
-    )
+    util.wait_until_k8s_ready(main, instances)

--- a/tests/integration/tests/test_node_availability_zone.py
+++ b/tests/integration/tests/test_node_availability_zone.py
@@ -47,8 +47,6 @@ def test_node_availability_zone(
     util.join_cluster(joining_cplane_node_2, join_token_2)
 
     util.wait_until_k8s_ready(initial_node, instances)
-    nodes = util.ready_nodes(initial_node)
-    assert len(nodes) == 3, "all nodes should have joined cluster"
 
     def _get_az(instance, same_az, suffix):
         if same_az:
@@ -105,6 +103,4 @@ def test_node_availability_zone(
             ).exec(["cat", "/var/snap/k8s/common/var/lib/k8s-dqlite/failure-domain"])
 
         # Make sure that the nodes remain available.
-        util.stubbornly(retries=5, delay_s=10).until(
-            lambda p: util.ready_nodes(initial_node) == 3
-        )
+        util.wait_until_k8s_ready(initial_node, instances)

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -112,3 +112,9 @@ class Harness:
         If the operation fails, a HarnessError is raised.
         """
         raise NotImplementedError
+
+    def log_environment_info(self):
+        """Log any relevant environment information before and after each test.
+        This allows us to identify leaked resources.
+        """
+        pass

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -254,6 +254,29 @@ class LXDHarness(Harness):
 
         self.instances.discard(instance_id)
 
+    def log_environment_info(self):
+        """Log any relevant environment information before and after each test.
+        This allows us to identify leaked resources.
+        """
+        try:
+            LOG.info("LXC containers:")
+            result = run(["lxc", "list"], capture_output=True)
+            LOG.info("\n%s", result.stdout.decode().strip())
+
+            LOG.info("Disk usage:")
+            result = run(["df", "-h"], capture_output=True)
+            LOG.info("\n%s", result.stdout.decode().strip())
+
+            if config.INSPECTION_REPORTS_DIR:
+                LOG.info("Inspection report size:")
+                result = run(
+                    ["du", "-sh", config.INSPECTION_REPORTS_DIR], capture_output=True
+                )
+                LOG.info("\n%s", result.stdout.decode().strip())
+        except Exception:
+            # Suppress any (unlikely) error.
+            LOG.exception("Failed to obtain environment info")
+
     def cleanup(self):
         for instance_id in self.instances.copy():
             self.delete_instance(instance_id)

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -101,13 +101,18 @@ def test_version_upgrades(
             LOG.info(f"Upgraded {instance.id} on channel {channel}")
 
 
-@pytest.mark.node_count(1)
+@pytest.mark.node_count(4)
 @pytest.mark.no_setup()
 @pytest.mark.skipif(
     not config.VERSION_DOWNGRADE_CHANNELS, reason="No downgrade channels configured"
 )
 @pytest.mark.tags(tags.NIGHTLY)
-def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp_path):
+def test_version_downgrades_with_rollback(
+    instances: List[harness.Instance],
+    tmp_path,
+    containerd_cfgdir: str,
+    registry: Registry,
+):
     """
     This test will downgrade the snap through the channels, and at each downgrade, attempt a rollback.
 
@@ -122,6 +127,9 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
     """
     channels = config.VERSION_DOWNGRADE_CHANNELS
     cp = instances[0]
+    cp1 = instances[1]
+    cp2 = instances[2]
+    w0 = instances[3]
     current_channel = channels[0]
 
     if current_channel.lower() == "recent":
@@ -152,56 +160,78 @@ def test_version_downgrades_with_rollback(instances: List[harness.Instance], tmp
     util.setup_k8s_snap(cp, tmp_path, current_channel)
     cp.exec(["k8s", "bootstrap"])
 
+    for instance in instances[1:]:
+        util.setup_k8s_snap(instance, tmp_path, current_channel)
+
+    if config.USE_LOCAL_MIRROR:
+        for instance in instances:
+            registry.apply_configuration(instance, containerd_cfgdir)
+
+    join_token_cp1 = util.get_join_token(cp, cp1)
+    join_token_cp2 = util.get_join_token(cp, cp2)
+    join_token_w0 = util.get_join_token(cp, w0, "--worker")
+
+    util.join_cluster(cp1, join_token_cp1)
+    util.join_cluster(cp2, join_token_cp2)
+    util.join_cluster(w0, join_token_w0)
+
     util.wait_until_k8s_ready(cp, instances)
-    LOG.info(f"Installed {cp.id} on channel {current_channel}")
+    nodes = util.ready_nodes(cp)
+    assert len(nodes) == 4, "all nodes should have joined cluster"
 
     for channel in channels[1:]:
-        LOG.info(
-            f"Initiating downgrade + rollback segment from {current_channel} → {channel}"
-        )
-        out = cp.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
-        latest_version = out.stdout.decode().strip().split("\n")[-1]
-        LOG.info(f"Current snap version: {latest_version}")
+        for instance in instances:
+            LOG.info(
+                "Initiating downgrade + rollback segment from "
+                f"{current_channel} → {channel} - {instance.id}"
+            )
+            out = instance.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
+            latest_version = out.stdout.decode().strip().split("\n")[-1]
+            LOG.info(f"Current snap version: {latest_version}")
 
-        LOG.debug(f"Step 1. Downgrade {cp.id} from {current_channel} → {channel}")
-        # note: the `--classic` flag will be ignored by snapd for strict snaps.
-        cp.exec(
-            ["snap", "refresh", config.SNAP_NAME, "--channel", channel, "--classic"]
-        )
-        util.wait_until_k8s_ready(cp, instances)
+            LOG.debug(
+                f"Step 1. Downgrade {instance.id} from {current_channel} → {channel}"
+            )
+            # note: the `--classic` flag will be ignored by snapd for strict snaps.
+            instance.exec(
+                ["snap", "refresh", config.SNAP_NAME, "--channel", channel, "--classic"]
+            )
+            util.wait_until_k8s_ready(cp, instances)
 
         last_channel = current_channel
         current_channel = channel
 
-        LOG.debug(f"Step 2. Roll back from {current_channel} → {last_channel}")
-        # note: the `--classic` flag will be ignored by snapd for strict snaps.
-        cp.exec(
-            [
-                "snap",
-                "refresh",
-                config.SNAP_NAME,
-                "--channel",
-                last_channel,
-                "--classic",
-            ]
-        )
-        util.wait_until_k8s_ready(cp, instances)
+        for instance in instances:
+            LOG.debug(f"Step 2. Roll back from {current_channel} → {last_channel}")
+            # note: the `--classic` flag will be ignored by snapd for strict snaps.
+            instance.exec(
+                [
+                    "snap",
+                    "refresh",
+                    config.SNAP_NAME,
+                    "--channel",
+                    last_channel,
+                    "--classic",
+                ]
+            )
+            util.wait_until_k8s_ready(cp, instances)
 
-        LOG.debug(
-            f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
-        )
-        cp.exec(
-            [
-                "snap",
-                "refresh",
-                config.SNAP_NAME,
-                "--channel",
-                current_channel,
-                "--classic",
-            ]
-        )
-        util.wait_until_k8s_ready(cp, instances)
+        for instance in instances:
+            LOG.debug(
+                f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
+            )
+            instance.exec(
+                [
+                    "snap",
+                    "refresh",
+                    config.SNAP_NAME,
+                    "--channel",
+                    current_channel,
+                    "--classic",
+                ]
+            )
+            util.wait_until_k8s_ready(cp, instances)
 
-        LOG.info("Rollback segment complete. Proceeding to next downgrade segment.")
+            LOG.info("Rollback segment complete. Proceeding to next downgrade segment.")
 
     LOG.info("Rollback test complete. All downgrade segments verified.")

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -98,7 +98,7 @@ def test_version_upgrades(
             LOG.info(f"Upgraded {instance.id} on channel {channel}")
 
 
-@pytest.mark.node_count(4)
+@pytest.mark.node_count(3)
 @pytest.mark.no_setup()
 @pytest.mark.skipif(
     not config.VERSION_DOWNGRADE_CHANNELS, reason="No downgrade channels configured"
@@ -126,7 +126,13 @@ def test_version_downgrades_with_rollback(
     cp = instances[0]
     cp1 = instances[1]
     cp2 = instances[2]
-    w0 = instances[3]
+    # TODO: add a worker node once the snap refresh is fixed on worker nodes
+    # and the patch lands on all the release channels covered by this test.
+    #
+    # At the moment, the following fails:
+    # https://github.com/canonical/k8s-snap/blob/96124bd7f1e82e96e23a4c4d11fcff86045f403c/snap/hooks/configure#L7
+    #
+    # w0 = instances[3]
     current_channel = channels[0]
 
     if current_channel.lower() == "recent":
@@ -163,15 +169,15 @@ def test_version_downgrades_with_rollback(
 
     join_token_cp1 = util.get_join_token(cp, cp1)
     join_token_cp2 = util.get_join_token(cp, cp2)
-    join_token_w0 = util.get_join_token(cp, w0, "--worker")
+    # join_token_w0 = util.get_join_token(cp, w0, "--worker")
 
     util.join_cluster(cp1, join_token_cp1)
     util.join_cluster(cp2, join_token_cp2)
-    util.join_cluster(w0, join_token_w0)
+    # util.join_cluster(w0, join_token_w0)
 
     util.wait_until_k8s_ready(cp, instances)
     nodes = util.ready_nodes(cp)
-    assert len(nodes) == 4, "all nodes should have joined cluster"
+    assert len(nodes) == len(instances), "all nodes should have joined cluster"
 
     for channel in channels[1:]:
         for instance in instances:

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -73,8 +73,6 @@ def test_version_upgrades(
     util.join_cluster(w0, join_token_w0)
 
     util.wait_until_k8s_ready(cp, instances)
-    nodes = util.ready_nodes(cp)
-    assert len(nodes) == 4, "all nodes should have joined cluster"
 
     LOG.info(f"Installed {len(instances)} nodes on channel {current_channel}")
 
@@ -176,8 +174,6 @@ def test_version_downgrades_with_rollback(
     # util.join_cluster(w0, join_token_w0)
 
     util.wait_until_k8s_ready(cp, instances)
-    nodes = util.ready_nodes(cp)
-    assert len(nodes) == len(instances), "all nodes should have joined cluster"
 
     for channel in channels[1:]:
         for instance in instances:

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -57,15 +57,12 @@ def test_version_upgrades(
     )
 
     # Setup the k8s snap from the bootstrap channel and setup basic configuration.
-    util.setup_k8s_snap(cp, tmp_path, current_channel)
-    cp.exec(["k8s", "bootstrap"])
-
-    for instance in instances[1:]:
+    for instance in instances:
         util.setup_k8s_snap(instance, tmp_path, current_channel)
-
-    if config.USE_LOCAL_MIRROR:
-        for instance in instances:
+        if config.USE_LOCAL_MIRROR:
             registry.apply_configuration(instance, containerd_cfgdir)
+
+    cp.exec(["k8s", "bootstrap"])
 
     join_token_cp1 = util.get_join_token(cp, cp1)
     join_token_cp2 = util.get_join_token(cp, cp2)
@@ -157,15 +154,12 @@ def test_version_downgrades_with_rollback(
     )
 
     # Setup the k8s snap from the bootstrap channel and setup basic configuration.
-    util.setup_k8s_snap(cp, tmp_path, current_channel)
-    cp.exec(["k8s", "bootstrap"])
-
-    for instance in instances[1:]:
+    for instance in instances:
         util.setup_k8s_snap(instance, tmp_path, current_channel)
-
-    if config.USE_LOCAL_MIRROR:
-        for instance in instances:
+        if config.USE_LOCAL_MIRROR:
             registry.apply_configuration(instance, containerd_cfgdir)
+
+    cp.exec(["k8s", "bootstrap"])
 
     join_token_cp1 = util.get_join_token(cp, cp1)
     join_token_cp2 = util.get_join_token(cp, cp2)


### PR DESCRIPTION
To make the upgrade and rollback tests more comprehensive, we'll use a multi-node cluster with 3 control plane nodes and one worker node.

Other fixes introduced by this PR:
* avoid using duplicate names for the inspection report artifacts
* improve cluster status checks, avoiding test flakiness and redundant code while improving logging