### PR TITLE
chore: update PR template, including allowed PR title prefixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,6 @@ Should this PR be backported? If so, to which release?
 
 ## Checklist
 
-<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
 - [ ] PR title formatted as `type: title`
 - [ ] Covered by unit tests
 - [ ] Covered by integration tests
@@ -27,3 +26,18 @@ Should this PR be backported? If so, to which release?
 - [ ] Backport label added if necessary 
 
 If any item on the checklist is not complete, please provide justification why.
+
+The PR title is expected to contain one of the following prefixes, following the
+[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):
+
+* feat: A new feature
+* fix: A bug fix
+* docs: Documentation only changes
+* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* refactor: A code change that neither fixes a bug nor adds a feature
+* perf: A code change that improves performance
+* test: Adding missing tests or correcting existing tests
+* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+* chore: Other changes that don't modify src or test files
+* revert: Reverts a previous commit


### PR DESCRIPTION
We now expect the PR titles to be formatted based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

The problem is that it's hard to remember the list of allowed PR title prefixes, so we'll include it in the PR template.

## Description

What issue is this PR trying to solve?

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
