### PR TITLE
ci: update the PR test job, dropping 20.04 and 22.04

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
+        os: ["ubuntu:24.04"]
     needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
     uses: ./.github/workflows/e2e-tests.yaml
     with:

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Integration
     strategy:
       matrix:
-        os: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
+        os: ["ubuntu:22.04", "ubuntu:24.04"]
         arch: ["amd64", "arm64"]
         channel: ["latest/edge"]
       fail-fast: false # TODO: remove once we no longer have flaky tests.


### PR DESCRIPTION
At the moment, we're running the e2e tests on 20.04, 22.04 and 24.04.

To reduce the test runner load and the time it takes for a job to be picked up, we'll only run 24.04 tests as part of the PR job.

Other versions and architectures (arm64) will be covered by the nightly tests.

While at it, we'll also drop 20.04 from the nightly job. It's going to hit EOL in two months and the charm tests dropped 20.04 as well.

## Description

What issue is this PR trying to solve?

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

<!-- TODO(Niamh): Update when we decide on this in PR #1113-->
- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
