### PR TITLE
chore: Allow renovate to update go packages in the project

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+    "extends": [
+      "config:go"
+    ],
+    "go": {
+      "enabled": true,
+      "baseDir": "src/k8s"
+    }
+}


### PR DESCRIPTION
## Description

Automatically update go dependencies when they go out of sync with upstream.

## Solution

Create a renovate config to allow renovate to update the dependencies within the k8sd app.


## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
