### PR TITLE
test: Reduce CI log level to INFO

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -65,6 +65,18 @@ on:
         description: Start a tmate session before running the tests
         required: false
         default: false
+      log-file-level:
+        description: Log file logging level
+        default: "DEBUG"
+        type: string
+      log-cli:
+        description: Enable logs to the console
+        default: true
+        type: boolean
+      log-cli-level:
+        description: Log CLI logging level
+        default: "INFO"
+        type: string
 
 jobs:
   test-integration:
@@ -99,6 +111,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
       - name: Run e2e tests
         env:
+          TEST_LOG_CLI: ${{ inputs.log-cli }}
+          TEST_LOG_CLI_LEVEL: ${{ inputs.log-cli-level }}
+          TEST_LOG_FILE_PATH: ${{ github.workspace }}/e2e.log
+          TEST_LOG_FILE_LEVEL: ${{ inputs.log-file-level }}
           TEST_SNAP: ${{ steps.download-snap.outputs.snap-path }}
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ inputs.os }}
@@ -114,17 +130,25 @@ jobs:
           TEST_GH_BASE_REF: ${{ github.base_ref }}
         run: |
           cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
-      - name: Prepare inspection reports
+      - name: Prepare debug suffix
         if: failure()
         run: |
           tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
-          echo "artifact_name=inspection-reports-${{ inputs.os }}-${{ inputs.arch }}" | sed 's/:/-/g' >> $GITHUB_ENV
+          RANDOM_SUFFIX=$(printf "%04X" $((RANDOM % 65536)))  # Generate a 4-character hex string
+          echo "artifact_suffix=${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.flavor }}-${RANDOM_SUFFIX}" | sed 's/:/-/g' >> $GITHUB_ENV
+
       - name: Upload inspection report artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.artifact_name }}
+          name: inspection-reports-${{ env.artifact_suffix }}
           path: ${{ github.workspace }}/inspection-reports.tar.gz
+      - name: Upload debug logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-logs-${{ env.artifact_suffix }}
+          path: ${{ github.workspace }}/e2e.log
       - name: Upload CNCF conformance report artifact
         if: ${{ failure() && contains(inputs.test-tags, 'conformance_tests') }}
         uses: actions/upload-artifact@v4

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -8,7 +8,6 @@ from typing import Generator, Iterator, List, Optional, Union
 
 import pytest
 from pytest_subunit import SubunitTerminalReporter
-from test_util import harness, tags, util
 from test_util import config as test_config
 from test_util import harness, tags, util
 from test_util.etcd import EtcdCluster
@@ -86,8 +85,10 @@ def _generate_inspection_report(h: harness.Harness, instance_id: str):
 @pytest.fixture(scope="session", autouse=True)
 def validate_test_config():
     """Validate the configuration before running tests."""
-    if config.SNAP:
-        assert Path(config.SNAP).exists(), f"Snap path {config.SNAP} does not exist."
+    if test_config.SNAP:
+        assert Path(
+            test_config.SNAP
+        ).exists(), f"Snap path {test_config.SNAP} does not exist."
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/tests/test_cncf_conformace.py
+++ b/tests/integration/tests/test_cncf_conformace.py
@@ -39,7 +39,7 @@ def test_cncf_conformance(instances: List[harness.Instance]):
     cluster_node.pull_file("/root/sonobuoy_e2e.tar.gz", "sonobuoy_e2e.tar.gz")
 
     output = resp.stdout.decode()
-    LOG.info(output)
+    LOG.debug(output)
     failed_tests = int(re.search("Failed: (\\d+)", output).group(1))
     assert failed_tests == 0, f"{failed_tests} tests failed"
 

--- a/tests/integration/tests/test_control_plane_taints.py
+++ b/tests/integration/tests/test_control_plane_taints.py
@@ -21,7 +21,7 @@ def test_control_plane_taints(instances: List[harness.Instance]):
     retries = 10
 
     while retries and not (nodes := util.get_nodes(k8s_instance)):
-        LOG.info("Waiting for Nodes")
+        LOG.debug("Waiting for Nodes")
         time.sleep(3)
         retries -= 1
     assert len(nodes) == 1, "Should have found one node in 30 sec"

--- a/tests/integration/tests/test_etcd.py
+++ b/tests/integration/tests/test_etcd.py
@@ -45,7 +45,7 @@ def test_etcd(instances: List[harness.Instance], etcd_cluster: EtcdCluster):
     )
     assert p.returncode != 0, "k8s-dqlite service is still active"
 
-    LOG.info("Add new etcd nodes")
+    LOG.debug("Add new etcd nodes")
     etcd_cluster.add_nodes(2)
 
     # Update server-urls in cluster

--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -91,11 +91,11 @@ def test_gateway(instances: List[harness.Instance]):
         input=Path(manifest).read_bytes(),
     )
 
-    LOG.info("Waiting for nginx pod to show up...")
+    LOG.debug("Waiting for nginx pod to show up...")
     util.stubbornly(retries=5, delay_s=10).on(instance).until(
         lambda p: "my-nginx" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
-    LOG.info("Nginx pod showed up.")
+    LOG.debug("Nginx pod showed up.")
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [

--- a/tests/integration/tests/test_ingress.py
+++ b/tests/integration/tests/test_ingress.py
@@ -107,11 +107,11 @@ def test_ingress(instances: List[harness.Instance]):
         input=Path(manifest).read_bytes(),
     )
 
-    LOG.info("Waiting for nginx pod to show up...")
+    LOG.debug("Waiting for nginx pod to show up...")
     util.stubbornly(retries=5, delay_s=10).on(instance).until(
         lambda p: "my-nginx" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
-    LOG.info("Nginx pod showed up.")
+    LOG.debug("Nginx pod showed up.")
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -40,7 +40,6 @@ def test_loadbalancer_ipv6_only(instances: List[harness.Instance]):
 @pytest.mark.node_count(2)
 @pytest.mark.tags(tags.PULL_REQUEST)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.dualstack()
 @pytest.mark.network_type("dualstack")
 def test_loadbalancer_ipv6_dualstack(instances: List[harness.Instance]):
     _test_loadbalancer(instances, k8s_net_type=K8sNetType.dualstack)
@@ -104,11 +103,11 @@ def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetTy
         input=Path(manifest).read_bytes(),
     )
 
-    LOG.info("Waiting for nginx pod to show up...")
+    LOG.debug("Waiting for nginx pod to show up...")
     util.stubbornly(retries=5, delay_s=10).on(instance).until(
         lambda p: "my-nginx" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
-    LOG.info("Nginx pod showed up.")
+    LOG.debug("Nginx pod showed up.")
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [

--- a/tests/integration/tests/test_metrics_server.py
+++ b/tests/integration/tests/test_metrics_server.py
@@ -18,11 +18,11 @@ def test_metrics_server(instances: List[harness.Instance]):
     util.wait_for_network(instance)
     util.wait_for_dns(instance)
 
-    LOG.info("Waiting for metrics-server pod to show up...")
+    LOG.debug("Waiting for metrics-server pod to show up...")
     util.stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "metrics-server" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"])
-    LOG.info("Metrics-server pod showed up.")
+    LOG.debug("Metrics-server pod showed up.")
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -15,7 +15,6 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.bootstrap_config(
     (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
 )
-@pytest.mark.dualstack()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_dualstack(instances: List[harness.Instance]):
     main = instances[0]

--- a/tests/integration/tests/test_node_availability_zone.py
+++ b/tests/integration/tests/test_node_availability_zone.py
@@ -59,7 +59,7 @@ def test_node_availability_zone(
     # that the cluster remains functional.
     iterations = 10
     for iteration in range(iterations):
-        LOG.info("Starting iteration: %s", iteration)
+        LOG.debug("Starting iteration: %s", iteration)
         az_suffix = f"-{iteration}"
 
         # Apply the AZ labels.
@@ -82,7 +82,7 @@ def test_node_availability_zone(
             az = _get_az(instance, same_az, az_suffix)
             failure_domain = _get_failure_domain(az)
 
-            LOG.info(
+            LOG.debug(
                 "Node: %s, az: %s, expected failure domain: %s",
                 instance.id,
                 az,

--- a/tests/integration/tests/test_nvidia_gpu_operator.py
+++ b/tests/integration/tests/test_nvidia_gpu_operator.py
@@ -34,10 +34,10 @@ def _check_nvidia_gpu_present(instance: harness.Instance) -> bool:
 
     for line in proc.stdout.split("\n"):
         if "NVIDIA Corporation" in line:
-            LOG.info(f"Found NVIDIA GPU in lspci output: {line}")
+            LOG.debug(f"Found NVIDIA GPU in lspci output: {line}")
             return True
 
-    LOG.info(f"Failed to find NVIDIA GPU in lspci output: {proc.stdout}")
+    LOG.debug(f"Failed to find NVIDIA GPU in lspci output: {proc.stdout}")
     return False
 
 
@@ -52,7 +52,7 @@ def _check_nvidia_drivers_loaded(instance: harness.Instance) -> Mapping[str, boo
             if line.startswith(mod):
                 modules_present[mod] = True
 
-    LOG.info(f"Located the following Nvidia kernel modules {modules_present}")
+    LOG.debug(f"Located the following Nvidia kernel modules {modules_present}")
     return modules_present
 
 

--- a/tests/integration/tests/test_smoke.py
+++ b/tests/integration/tests/test_smoke.py
@@ -65,7 +65,6 @@ def test_smoke(instances: List[harness.Instance]):
         )
         assert value in args.stdout.decode()
 
-    LOG.info("Verify the functionality of the CAPI endpoints.")
     instance.exec("k8s x-capi set-auth-token my-secret-token".split())
     instance.exec("k8s x-capi set-node-token my-node-token".split())
 
@@ -125,7 +124,7 @@ def test_smoke(instances: List[harness.Instance]):
     def status_output_matches(p: subprocess.CompletedProcess) -> bool:
         result_lines = p.stdout.decode().strip().split("\n")
         if len(result_lines) != len(STATUS_PATTERNS):
-            LOG.info(
+            LOG.warning(
                 f"wrong number of results lines, expected {len(STATUS_PATTERNS)}, got {len(result_lines)}"
             )
             return False
@@ -133,12 +132,12 @@ def test_smoke(instances: List[harness.Instance]):
         for i in range(len(result_lines)):
             line, pattern = result_lines[i], STATUS_PATTERNS[i]
             if not re.search(pattern, line):
-                LOG.info(f"could not match `{line.strip()}` with `{pattern}`")
+                LOG.debug(f"could not match `{line.strip()}` with `{pattern}`")
                 return False
 
         return True
 
-    LOG.info("Verifying the output of `k8s status`")
+    LOG.debug("Verifying the output of `k8s status`")
     util.stubbornly(retries=15, delay_s=10).on(instance).until(
         condition=status_output_matches,
     ).exec(["k8s", "status", "--wait-ready"])

--- a/tests/integration/tests/test_storage.py
+++ b/tests/integration/tests/test_storage.py
@@ -30,11 +30,11 @@ def test_storage(instances: List[harness.Instance]):
     util.wait_for_network(instance)
     util.wait_for_dns(instance)
 
-    LOG.info("Waiting for storage provisioner pod to show up...")
+    LOG.debug("Waiting for storage provisioner pod to show up...")
     util.stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "ck-storage" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-n", "kube-system", "-o", "json"])
-    LOG.info("Storage provisioner pod showed up.")
+    LOG.debug("Storage provisioner pod showed up.")
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
@@ -58,11 +58,11 @@ def test_storage(instances: List[harness.Instance]):
         input=Path(manifest).read_bytes(),
     )
 
-    LOG.info("Waiting for storage writer pod to show up...")
+    LOG.debug("Waiting for storage writer pod to show up...")
     util.stubbornly(retries=3, delay_s=10).on(instance).until(
         lambda p: "storage-writer-pod" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
-    LOG.info("Storage writer pod showed up.")
+    LOG.debug("Storage writer pod showed up.")
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
@@ -78,11 +78,11 @@ def test_storage(instances: List[harness.Instance]):
         ]
     )
 
-    LOG.info("Waiting for storage to get provisioned...")
+    LOG.debug("Waiting for storage to get provisioned...")
     util.stubbornly(retries=3, delay_s=1).on(instance).until(check_pvc_bound).exec(
         ["k8s", "kubectl", "get", "pvc", "-o", "json"]
     )
-    LOG.info("Storage got provisioned and pvc is bound.")
+    LOG.debug("Storage got provisioned and pvc is bound.")
 
     util.stubbornly(retries=5, delay_s=10).on(instance).until(
         lambda p: "LOREM IPSUM" in p.stdout.decode()
@@ -106,11 +106,11 @@ def test_storage(instances: List[harness.Instance]):
         input=Path(manifest).read_bytes(),
     )
 
-    LOG.info("Waiting for storage reader pod to show up...")
+    LOG.debug("Waiting for storage reader pod to show up...")
     util.stubbornly(retries=3, delay_s=10).on(instance).until(
         lambda p: "storage-reader-pod" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
-    LOG.info("Storage reader pod showed up.")
+    LOG.debug("Storage reader pod showed up.")
 
     util.stubbornly(retries=3, delay_s=1).on(instance).exec(
         [
@@ -130,4 +130,4 @@ def test_storage(instances: List[harness.Instance]):
         lambda p: "LOREM IPSUM" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "logs", "storage-reader-pod"])
 
-    LOG.info("Data can be read between pods.")
+    LOG.debug("Data can be read between pods.")

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -35,7 +35,7 @@ def test_strict_interfaces(instances: List[harness.Instance], tmp_path):
 
         # Log the current snap version on the node.
         out = cp.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
-        LOG.info(f"Current snap version: {out.stdout.decode().strip()}")
+        LOG.debug(f"Current snap version: {out.stdout.decode().strip()}")
 
         check_snap_interfaces(cp, config.SNAP_NAME)
 

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 DIR = Path(__file__).absolute().parent
 
+LOG_CLI = os.getenv("TEST_LOG_CLI", "true").lower() == "true"
+LOG_CLI_LEVEL = os.getenv("TEST_LOG_CLI_LEVEL") or "DEBUG"
+LOG_FILE_PATH = os.getenv("TEST_LOG_FILE_PATH") or None
+LOG_FILE_LEVEL = os.getenv("TEST_LOG_FILE_LEVEL") or "DEBUG"
+
 # The following defaults are used to define how long to wait for a condition to be met.
 DEFAULT_WAIT_RETRIES = int(os.getenv("TEST_DEFAULT_WAIT_RETRIES") or 120)
 DEFAULT_WAIT_DELAY_S = int(os.getenv("TEST_DEFAULT_WAIT_DELAY_S") or 5)

--- a/tests/integration/tests/test_util/etcd.py
+++ b/tests/integration/tests/test_util/etcd.py
@@ -51,7 +51,7 @@ class EtcdCluster:
         Add a new node to the etcd cluster.
         If this is the first cluster node, the required certificates will be generated.
         """
-        LOG.info("Setup etcd node")
+        LOG.debug("Setup etcd node")
         join_existing = len(self.instances) > 0
 
         instance = self.harness.new_instance()

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -227,8 +227,6 @@ class LXDHarness(Harness):
         if instance_id not in self.instances:
             raise HarnessError(f"unknown instance {instance_id}")
 
-        LOG.debug("Execute command %s in instance %s", command, instance_id)
-
         if ">" in " ".join(command) or "&&" in " ".join(command):
             command_str = " ".join(command)
         else:
@@ -263,13 +261,13 @@ class LXDHarness(Harness):
         This allows us to identify leaked resources.
         """
         try:
-            LOG.info("LXC containers:")
+            LOG.debug("LXC containers:")
             result = run(["lxc", "list"], capture_output=True)
-            LOG.info("\n%s", result.stdout.decode().strip())
+            LOG.debug("\n%s", result.stdout.decode().strip())
 
-            LOG.info("Disk usage:")
+            LOG.debug("Disk usage:")
             result = run(["df", "-h"], capture_output=True)
-            LOG.info("\n%s", result.stdout.decode().strip())
+            LOG.debug("\n%s", result.stdout.decode().strip())
 
             if config.INSPECTION_REPORTS_DIR and os.path.exists(
                 config.INSPECTION_REPORTS_DIR
@@ -278,7 +276,7 @@ class LXDHarness(Harness):
                 result = run(
                     ["du", "-sh", config.INSPECTION_REPORTS_DIR], capture_output=True
                 )
-                LOG.info("\n%s", result.stdout.decode().strip())
+                LOG.debug("\n%s", result.stdout.decode().strip())
         except Exception:
             # Suppress any (unlikely) error.
             LOG.exception("Failed to obtain environment info")

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -78,7 +78,7 @@ def test_version_upgrades(
         pytest.fail(
             f"Need at least 2 channels to upgrade, got {len(channels)} for flavor {config.FLAVOR}"
         )
-    LOG.info(f"Testing upgrades for snaps: {channels}")
+    LOG.debug(f"Testing upgrades for snaps: {channels}")
     LOG.info(
         f"Bootstrap node on {current_channel} and upgrade through channels: {channels[1:]}"
     )
@@ -101,18 +101,18 @@ def test_version_upgrades(
 
     util.wait_until_k8s_ready(cp, instances)
 
-    LOG.info(f"Installed {len(instances)} nodes on channel {current_channel}")
+    LOG.debug(f"Installed {len(instances)} nodes on channel {current_channel}")
 
     for channel in channels[1:]:
         for instance in instances:
-            LOG.info(
+            LOG.debug(
                 f"Upgrading {instance.id} from {current_channel} to channel {channel}"
             )
 
             # Log the current snap version on the node.
             out = instance.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
             latest_version = out.stdout.decode().strip().split("\n")[-1]
-            LOG.info(f"Current snap version: {latest_version}")
+            LOG.debug(f"Current snap version: {latest_version}")
 
             # note: the `--classic` flag will be ignored by snapd for strict snaps.
             cmd = [
@@ -124,13 +124,13 @@ def test_version_upgrades(
                 "--classic",
             ]
             if channel.startswith("/"):
-                LOG.info("Refreshing k8s snap by path")
+                LOG.debug("Refreshing k8s snap by path")
                 cmd = ["snap", "install", "--classic", "--dangerous", snap_path]
 
             instance.exec(cmd)
             util.wait_until_k8s_ready(cp, instances)
             current_channel = channel
-            LOG.info(f"Upgraded {instance.id} on channel {channel}")
+            LOG.debug(f"Upgraded {instance.id} on channel {channel}")
 
 
 @pytest.mark.node_count(3)
@@ -214,13 +214,13 @@ def test_version_downgrades_with_rollback(
 
     for channel in channels[1:]:
         for instance in instances:
-            LOG.info(
+            LOG.debug(
                 "Initiating downgrade + rollback segment from "
                 f"{current_channel} → {channel} - {instance.id}"
             )
             out = instance.exec(["snap", "list", config.SNAP_NAME], capture_output=True)
             latest_version = out.stdout.decode().strip().split("\n")[-1]
-            LOG.info(f"Current snap version: {latest_version}")
+            LOG.debug(f"Current snap version: {latest_version}")
 
             LOG.debug(
                 f"Step 1. Downgrade {instance.id} from {current_channel} → {channel}"
@@ -265,9 +265,11 @@ def test_version_downgrades_with_rollback(
             )
             util.wait_until_k8s_ready(cp, instances)
 
-            LOG.info("Rollback segment complete. Proceeding to next downgrade segment.")
+            LOG.debug(
+                "Rollback segment complete. Proceeding to next downgrade segment."
+            )
 
-    LOG.info("Rollback test complete. All downgrade segments verified.")
+    LOG.debug("Rollback test complete. All downgrade segments verified.")
 
 
 @pytest.mark.node_count(3)
@@ -417,7 +419,7 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
 
 
 def _waiting_for_upgraded_nodes(upgraded_nodes, expected_nodes) -> True:
-    LOG.info("Waiting for upgraded nodes %s to be: %s", upgraded_nodes, expected_nodes)
+    LOG.debug("Waiting for upgraded nodes %s to be: %s", upgraded_nodes, expected_nodes)
     return set(upgraded_nodes) == set(expected_nodes)
 
 

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -35,9 +35,6 @@ deps =
 commands =
     pytest -vv \
         --tb native \
-        --log-cli-level DEBUG \
-        --log-format "%(asctime)s %(levelname)s %(message)s" \
-        --log-date-format "%Y-%m-%d %H:%M:%S" \
         --disable-warnings \
         --subunit-path "{toxinidir}/subunit.out" \
         {toxinidir}/tests \


### PR DESCRIPTION
## Description

The integration test logs are overly verbose, especially in the CI where we need to scroll to tons of logs to actually find the failing test.

## Solution

This commit reduces the log level in the CI output to INFO and collects the DEBUG level in a log file. If the job fails, the logs are uploaded for further investigation.

The default (local) behavior is not changed, as one mostly runs only specific tests locally for debugging.
