### PR TITLE
ci: add sbom retry

### DIFF
--- a/build-scripts/hack/generate-sbom.py
+++ b/build-scripts/hack/generate-sbom.py
@@ -126,7 +126,7 @@ def k8s_snap_c_dqlite_components(manifest, extra_files):
     for component in repos:
         repo_url = repos[component]
         repo_tag = tags[component]
-        with util.git_repo(repo_url, repo_tag) as dir:
+        with util.git_repo(repo_url + "gibberish", repo_tag) as dir:
             repo_commit = util.parse_output(["git", "rev-parse", "HEAD"], cwd=dir)
 
         manifest["snap"]["k8s-snap"][component] = {

--- a/build-scripts/hack/generate-sbom.py
+++ b/build-scripts/hack/generate-sbom.py
@@ -126,7 +126,7 @@ def k8s_snap_c_dqlite_components(manifest, extra_files):
     for component in repos:
         repo_url = repos[component]
         repo_tag = tags[component]
-        with util.git_repo(repo_url + "gibberish", repo_tag) as dir:
+        with util.git_repo(repo_url, repo_tag) as dir:
             repo_commit = util.parse_output(["git", "rev-parse", "HEAD"], cwd=dir)
 
         manifest["snap"]["k8s-snap"][component] = {

--- a/build-scripts/hack/generate-sbom.py
+++ b/build-scripts/hack/generate-sbom.py
@@ -15,9 +15,10 @@ import logging
 import sys
 import tarfile
 import tempfile
-import yaml
 from pathlib import Path
+
 import util
+import yaml
 
 logging.basicConfig(level=logging.INFO)
 
@@ -125,7 +126,7 @@ def k8s_snap_c_dqlite_components(manifest, extra_files):
     for component in repos:
         repo_url = repos[component]
         repo_tag = tags[component]
-        with util.git_repo(repo_url + "gibberish", repo_tag) as dir:
+        with util.git_repo(repo_url, repo_tag) as dir:
             repo_commit = util.parse_output(["git", "rev-parse", "HEAD"], cwd=dir)
 
         manifest["snap"]["k8s-snap"][component] = {
@@ -145,10 +146,14 @@ def rock_cilium(manifest, extra_files):
     with util.git_repo(CILIUM_ROCK_REPO, CILIUM_ROCK_TAG) as d:
         rock_repo_commit = util.parse_output(["git", "rev-parse", "HEAD"], cwd=d)
         rockcraft = (d / f"{CILIUM_VERSION}/cilium/rockcraft.yaml").read_text()
-        operator_rockcraft = (d / f"{CILIUM_VERSION}/cilium-operator-generic/rockcraft.yaml").read_text()
+        operator_rockcraft = (
+            d / f"{CILIUM_VERSION}/cilium-operator-generic/rockcraft.yaml"
+        ).read_text()
 
         extra_files[f"cilium/{CILIUM_VERSION}/rockcraft.yaml"] = rockcraft
-        extra_files[f"cilium-operator-generic/{CILIUM_VERSION}/rockcraft.yaml"] = operator_rockcraft
+        extra_files[f"cilium-operator-generic/{CILIUM_VERSION}/rockcraft.yaml"] = (
+            operator_rockcraft
+        )
 
         rockcraft_yaml = yaml.safe_load(rockcraft)
         repo_url = rockcraft_yaml["parts"]["cilium"]["source"]
@@ -237,7 +242,9 @@ def rock_metrics_server(manifest, extra_files):
         # TODO(ben): This should not be hard coded.
         rockcraft = (d / f"{METRICS_SERVER_VERSION}/rockcraft.yaml").read_text()
 
-        extra_files[f"metrics-server/{METRICS_SERVER_VERSION}/rockcraft.yaml"] = rockcraft
+        extra_files[f"metrics-server/{METRICS_SERVER_VERSION}/rockcraft.yaml"] = (
+            rockcraft
+        )
 
         rockcraft_yaml = yaml.safe_load(rockcraft)
         repo_url = rockcraft_yaml["parts"]["metrics-server"]["source"]

--- a/build-scripts/hack/generate-sbom.py
+++ b/build-scripts/hack/generate-sbom.py
@@ -125,7 +125,7 @@ def k8s_snap_c_dqlite_components(manifest, extra_files):
     for component in repos:
         repo_url = repos[component]
         repo_tag = tags[component]
-        with util.git_repo(repo_url, repo_tag) as dir:
+        with util.git_repo(repo_url + "gibberish", repo_tag) as dir:
             repo_commit = util.parse_output(["git", "rev-parse", "HEAD"], cwd=dir)
 
         manifest["snap"]["k8s-snap"][component] = {

--- a/build-scripts/hack/requirements.txt
+++ b/build-scripts/hack/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml==6.0.1
+tenacity==9.0.0

--- a/build-scripts/hack/util.py
+++ b/build-scripts/hack/util.py
@@ -6,7 +6,13 @@ from pathlib import Path
 from typing import Any, Generator
 from urllib.request import urlopen
 
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_fixed,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -43,6 +49,7 @@ def _clone_with_retry(cmd: list[str]):
         retry=retry_if_exception_type(subprocess.CalledProcessError),
         wait=wait_fixed(5),
         stop=stop_after_attempt(15),
+        before_sleep=before_sleep_log(LOG, logging.WARNING),
     )
     def _run():
         parse_output(cmd)

--- a/build-scripts/hack/util.py
+++ b/build-scripts/hack/util.py
@@ -11,7 +11,8 @@ from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
-    wait_fixed,
+    wait_exponential,
+    wait_random,
 )
 
 LOG = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ def git_repo(
 def _clone_with_retry(cmd: list[str]):
     @retry(
         retry=retry_if_exception_type(subprocess.CalledProcessError),
-        wait=wait_fixed(5),
+        wait=wait_exponential(multiplier=1, min=1, max=60) + wait_random(0, 3),
         stop=stop_after_attempt(15),
         before_sleep=before_sleep_log(LOG, logging.WARNING),
     )

--- a/build-scripts/hack/util.py
+++ b/build-scripts/hack/util.py
@@ -12,7 +12,11 @@ LOG = logging.getLogger(__name__)
 
 @contextlib.contextmanager
 def git_repo(
-    repo_url: str, repo_tag: str, shallow: bool = True, retry: int = 5
+    repo_url: str,
+    repo_tag: str,
+    shallow: bool = True,
+    retry_n: int = 5,
+    retry_delay: int = 5,
 ) -> Generator[Path, Any, Any]:
     """
     Clone a git repository on a temporary directory and return the directory.
@@ -31,17 +35,17 @@ def git_repo(
         if shallow:
             cmd.extend(["--depth", "1"])
         LOG.info("Cloning %s @ %s (shallow=%s)", repo_url, repo_tag, shallow)
-        for attempt in range(0, retry):
+        for attempt in range(0, retry_n):
             try:
                 parse_output(cmd)
                 break
             except subprocess.CalledProcessError as e:
-                if attempt == retry - 1:
+                if attempt == retry_n - 1:
                     raise e
                 LOG.warning(
-                    f"Failed to clone {repo_url} @ {repo_tag}, retrying in {retry}s"
+                    f"Failed to clone {repo_url} @ {repo_tag}, retrying in {retry_delay}s"
                 )
-                time.sleep(5)
+                time.sleep(retry_delay)
         yield Path(tmpdir)
 
 

--- a/build-scripts/hack/util.py
+++ b/build-scripts/hack/util.py
@@ -47,7 +47,7 @@ def git_repo(
 @retry(
     retry=retry_if_exception_type(subprocess.CalledProcessError),
     wait=wait_exponential(multiplier=1, min=1, max=180),
-    stop=stop_after_attempt(5),
+    stop=stop_after_attempt(10),
     before_sleep=before_sleep_log(LOG, logging.WARNING),
 )
 def _run_with_retry(cmd: list[str]):

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -227,7 +227,16 @@ def instances(
     for _, snap in zip(range(node_count), snap_versions(request)):
         # Create <node_count> instances and setup the k8s snap in each.
         instance = h.new_instance(network_type=network_type)
-        instances.append(instance)
+
+        instance.exec("mkdir -p /etc/systemd/system/snapd.service.d".split())
+        instance.exec("touch /etc/systemd/system/snapd.service.d/override.conf".split())
+        # write file
+        instance.exec(
+            'sh -c \'echo -e "[Service]\\nEnvironment=SNAPD_STANDBY_WAIT=1m" '
+            "> /etc/systemd/system/snapd.service.d/override.conf'".split()
+        )
+        instance.exec("systemctl daemon-reload".split())
+        instance.exec("systemctl restart snapd.service".split())
 
         if config.PRELOAD_SNAPS:
             for preloaded_snap in PRELOADED_SNAPS:

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -227,16 +227,7 @@ def instances(
     for _, snap in zip(range(node_count), snap_versions(request)):
         # Create <node_count> instances and setup the k8s snap in each.
         instance = h.new_instance(network_type=network_type)
-
-        instance.exec("mkdir -p /etc/systemd/system/snapd.service.d".split())
-        instance.exec("touch /etc/systemd/system/snapd.service.d/override.conf".split())
-        # write file
-        instance.exec(
-            'sh -c \'echo -e "[Service]\\nEnvironment=SNAPD_STANDBY_WAIT=1m" '
-            "> /etc/systemd/system/snapd.service.d/override.conf'".split()
-        )
-        instance.exec("systemctl daemon-reload".split())
-        instance.exec("systemctl restart snapd.service".split())
+        instances.append(instance)
 
         if config.PRELOAD_SNAPS:
             for preloaded_snap in PRELOADED_SNAPS:


### PR DESCRIPTION
The SBOM step clones launchpad repositories. These clones sometimes result in a failed SBOM step, even though a retry could have prevented the failure. This implements a retry mechanism by adding retry_n and retry_delay with 5 as the default values.