### PR TITLE
fix: ensure worker token base64 decoding handles padding correctly

### DIFF
--- a/src/k8s/pkg/k8sd/types/worker.go
+++ b/src/k8s/pkg/k8sd/types/worker.go
@@ -21,7 +21,7 @@ type InternalWorkerNodeToken struct {
 // internalWorkerNodeTokenSerializeMagicString is used to validate serialized worker node tokens.
 const internalWorkerNodeTokenSerializeMagicString = "m!!"
 
-var encoding = base64.RawStdEncoding
+var encoding = base64.StdEncoding
 
 type serializableWorkerNodeInfo struct {
 	InternalWorkerNodeToken

--- a/src/k8s/pkg/k8sd/types/worker_test.go
+++ b/src/k8s/pkg/k8sd/types/worker_test.go
@@ -25,3 +25,25 @@ func TestWorkerTokenEncode(t *testing.T) {
 	g.Expect(err).To(Not(HaveOccurred()))
 	g.Expect(decoded).To(Equal(token))
 }
+
+func TestWorkerTokenEncodeWithPadding(t *testing.T) {
+	token := &types.InternalWorkerNodeToken{
+		Token:         "padded-token",
+		Secret:        "padded-secret",
+		JoinAddresses: []string{"192.168.1.23:6400"},
+		Fingerprint:   "6bf8e523089120059a4e4be99ae1250545e755d66cfa0cc32d438ea49e7575d3",
+	}
+
+	g := NewWithT(t)
+	s, err := token.Encode()
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(s).ToNot(BeEmpty())
+
+	// Ensure that the encoded string has a valid Base64 format (with padding)
+	g.Expect(len(s)%4).To(Equal(0), "Base64-encoded string should have padding")
+
+	decoded := &types.InternalWorkerNodeToken{}
+	err = decoded.Decode(s)
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(decoded).To(Equal(token))
+}


### PR DESCRIPTION
## Description

In some cases, a worker token was wrongly interpreted as an control-plane/microcluster token because the decoding mechanism used `base64.RawStdEncoding` which caused a decoding error if the worker node contained [padding](https://medium.com/@partha.pratimnayak/understanding-base64-encoding-7764b4ecce3c).
   
## Solution

Ensure that Base64 encoding of the worker token uses standard encoding with padding to avoid decoding errors. 

## Issue

Include a link to the Github issue number if applicable.

## Backport

This is a bugfix which we need to backport to 1.32

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
