### PR TITLE
test: Disable airgapped tests

### DIFF
--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -72,6 +72,8 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_proxy(instances: List[harness.Instance]):
+    pytest.xfail("airgapped tests are currently failing on Github runners")
+
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     instance_ip = util.get_default_ip(instance)
@@ -110,6 +112,7 @@ def test_airgapped_with_proxy(instances: List[harness.Instance]):
 def test_airgapped_with_proxy_setup_and_image_mirror(
     h: harness.Harness, instances: List[harness.Instance]
 ):
+    pytest.xfail("airgapped tests are currently failing on Github runners")
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     registry = reg.Registry(h)


### PR DESCRIPTION
Right now, the airgapped tests fail on the Github runners for unknown reasons. This blocks several other work items so we disable them for now to unblock other work

