### PR TITLE
test: Disable failing TICS test

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -48,69 +48,6 @@ jobs:
       channel: ${{ matrix.channel }}
       checkout-ref: ${{ matrix.branch }}
 
-  TICS:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          # Latest branches
-          - { branch: main }
-    steps:
-      - name: Checking out repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{matrix.branch}}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: './src/k8s/go.mod'
-      - name: go mod download
-        working-directory: src/k8s
-        run: go mod download
-      - name: TICS scan
-        # TODO: move the following to a script.
-        run: |
-          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
-
-          set -x
-          # Install python dependencies
-          pip install -r tests/integration/requirements-test.txt
-          pip install -r tests/integration/requirements-dev.txt
-          # Needed by pylint (TICSQServer), used in build-scripts, k8s/scripts/cis
-          pip install requests jinja2 semver
-
-          # Integration tests are importing a local test_util module. Needed for pylint.
-          export PYTHONPATH="$PYTHONPATH:$(pwd)/tests/integration/tests"
-
-          cd src/k8s
-
-          # TICS requires us to have the test results in cobertura xml format under the
-          # directory use below
-          sudo make go.unit
-          go install github.com/boumenot/gocover-cobertura@latest
-          gocover-cobertura < coverage.txt > coverage.xml
-          mkdir .coverage
-          mv ./coverage.xml ./.coverage/
-
-          # Install the TICS and staticcheck
-          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
-          . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
-
-          # We need to have our project built
-          # We load the dqlite libs here instead of doing through make because TICS
-          # will try to build parts of the project itself
-          sudo add-apt-repository -y ppa:dqlite/dev
-          sudo apt install dqlite-tools-v2 libdqlite1.17-dev
-          sudo make clean
-          go build -a ./...
-
-          TICSQServer -project k8s-snap -tmpdir /tmp/tics -branchdir $HOME/work/k8s-snap/k8s-snap/
-
   Mattermost:
     name: Notify Mattermost
     # Notify on success or failure but only if the event is a scheduled run.


### PR DESCRIPTION
There seems to be an issue with TICS and the test is constantly failing right now.
We remove the test for now. I added a card to investigate this in the upcoming pulse.

