### PR TITLE
ci: Bump CISA KEV CVEs priority

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -72,3 +72,4 @@ jobs:
           jira-url: ${{ secrets.CVE_JIRA_WEBHOOK_URL }}
           jira-auth-token: ${{ secrets.CVE_JIRA_WEBHOOK_TOKEN }}
           minimum-level: "HIGH"
+          bump-cisa-cves: true


### PR DESCRIPTION
## Description

Using this option will bump the CVEs in the CISA KEV list at least "HIGH" priority.

## Solution

## Issue

## Backport

Should this PR be backported? If so, to which release?

No.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [ ] Covered by integration tests - N/A
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - N/A

If any item on the checklist is not complete, please provide justification why.