### PR TITLE
test: cleanup etcd instances immediately after the test

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -323,3 +323,6 @@ def etcd_cluster(
     cluster = EtcdCluster(h, initial_node_count=etcd_count)
 
     yield cluster
+
+    LOG.info(f"Cleaning up {etcd_count} etcd instances")
+    cluster.cleanup()

--- a/tests/integration/tests/test_util/etcd.py
+++ b/tests/integration/tests/test_util/etcd.py
@@ -250,6 +250,11 @@ class EtcdCluster:
         instance.exec(["systemctl", "enable", "etcd-s1.service"])
         instance.exec(["systemctl", "start", "etcd-s1.service"])
 
+    def cleanup(self):
+        for instance in self.instances:
+            self.harness.delete_instance(instance.id)
+        self.instances = []
+
     @property
     def ca_cert(self) -> str:
         """


### PR DESCRIPTION
This change will ensure that etcd instances are cleaned up immediately after the test instead of waiting until the end of the test suite.

By doing so, we avoid the situation in which subsequent tests run out of resources due to the leaked instances.