### PR TITLE
docs: update proxy.md

### DIFF
--- a/docs/canonicalk8s/charm/howto/proxy.md
+++ b/docs/canonicalk8s/charm/howto/proxy.md
@@ -18,7 +18,7 @@ Juju:
 juju model-config \
     juju-http-proxy=http://squid.internal:3128 \
     juju-https-proxy=http://squid.internal:3128 \
-    juju-no-proxy=10.0.8.0/24,192.168.0.0/16,127.0.0.1,10.152.183.0/24
+    juju-no-proxy=10.0.0.0/8,192.168.0.0/16,127.0.0.1,10.152.183.0/24
 ```
 
 ```{note} The **10.152.183.0/24** CIDR needs to be covered in the juju-no-proxy


### PR DESCRIPTION
Fixes https://github.com/canonical/k8s-snap/issues/1235

In the original text the CIDR for pods isn't covered. (10.0.8.0/24 doesn't cover 10.1.0.0/16). I changed the no-proxy to 10.0.0.0/8 to address this overlook.