### PR TITLE
test: Skips the flaky CNCF test

### DIFF
--- a/tests/integration/tests/test_cncf_conformace.py
+++ b/tests/integration/tests/test_cncf_conformace.py
@@ -17,8 +17,12 @@ def test_cncf_conformance(instances: List[harness.Instance]):
     cluster_node = cluster_setup(instances)
     install_sonobuoy(cluster_node)
 
+    # TODO: Remove the test skip once the following issue has been resolved,
+    # and if sonobuoy version has been updated if the test was changed:
+    # https://github.com/kubernetes/kubernetes/issues/131150
+    skipped = "validates resource limits of pods that are allowed to run"
     cluster_node.exec(
-        ["./sonobuoy", "run", "--plugin", "e2e", "--wait"],
+        ["./sonobuoy", "run", "--plugin", "e2e", "--e2e-skip", skipped, "--wait"],
     )
     cluster_node.exec(
         ["./sonobuoy", "retrieve", "-f", "sonobuoy_e2e.tar.gz"],


### PR DESCRIPTION


## Description

The test ``validates resource limits of pods that are allowed to run [Conformance]`` currently fails randomly due to a scheduling error. If a node is labeled, and immediately afterwards a Pod targeting that node label is created, the Pod has a chance of failing to be scheduled properly, causing the test to fail.

## Solution

We're skipping the test until this issue is addressed.

## Issue

xref: https://github.com/kubernetes/kubernetes/issues/131150

## Backport

Should this PR be backported? If so, to which release? No.

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - N/A

