### PR TITLE
fix: Don't wait for services to terminate on removed node

### DIFF
--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -344,11 +344,11 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 	// restarting the kube-proxy and kubelet, which would break the
 	// proxy connection and cause missed responses in the proxy side.
 	restartFn := func(ctx context.Context) error {
-		if err := snap.RestartService(ctx, "kubelet"); err != nil {
+		if err := snap.RestartServices(ctx, []string{"kubelet"}); err != nil {
 			return fmt.Errorf("failed to restart kubelet: %w", err)
 		}
 
-		if err := snap.RestartService(ctx, "kube-proxy"); err != nil {
+		if err := snap.RestartServices(ctx, []string{"kube-proxy"}); err != nil {
 			return fmt.Errorf("failed to restart kube-proxy: %w", err)
 		}
 		return nil

--- a/src/k8s/pkg/k8sd/api/certificates_update.go
+++ b/src/k8s/pkg/k8sd/api/certificates_update.go
@@ -180,11 +180,11 @@ func refreshCertsUpdateWorker(s state.State, r *http.Request, snap snap.Snap) re
 	}
 
 	restartFn := func(ctx context.Context) error {
-		if err := snap.RestartService(ctx, "kubelet"); err != nil {
+		if err := snap.RestartServices(ctx, []string{"kubelet"}); err != nil {
 			return fmt.Errorf("failed to restart kubelet: %w", err)
 		}
 
-		if err := snap.RestartService(ctx, "kube-proxy"); err != nil {
+		if err := snap.RestartServices(ctx, []string{"kube-proxy"}); err != nil {
 			return fmt.Errorf("failed to restart kube-proxy: %w", err)
 		}
 		return nil

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -140,19 +140,9 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 			log.Error(err, "failed to cleanup control plane certificates")
 		}
 
-		log.Info("Stopping worker services")
-		if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
-			log.Error(err, "Failed to stop worker services")
-		}
-
-		log.Info("Stopping control plane services")
-		if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
-			log.Error(err, "Failed to stop control-plane services")
-		}
-
-		log.Info("Stopping k8s-dqlite")
-		if err := snaputil.StopK8sDqliteServices(ctx, snap); err != nil {
-			log.Error(err, "Failed to stop k8s-dqlite service")
+		log.Info("Stopping all services except of k8sd")
+		if err := snaputil.StopK8sServices(ctx, snap, "--no-wait"); err != nil {
+			log.Error(err, "failed to stop k8sd service")
 		}
 
 		log.Info("Cleaning up containerd paths")

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -140,9 +140,9 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 			log.Error(err, "failed to cleanup control plane certificates")
 		}
 
-		log.Info("Stopping all services except of k8sd")
+		log.Info("Stopping all services except k8sd")
 		if err := snaputil.StopK8sServices(ctx, snap, "--no-wait"); err != nil {
-			log.Error(err, "failed to stop k8sd service")
+			log.Error(err, "failed to stop k8s services")
 		}
 
 		log.Info("Cleaning up containerd paths")

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
@@ -98,7 +98,7 @@ func (c *ControlPlaneConfigurationController) reconcile(ctx context.Context, con
 		}
 
 		if certificatesChanged || argsChanged {
-			if err := c.snap.RestartService(ctx, "kube-apiserver"); err != nil {
+			if err := c.snap.RestartServices(ctx, []string{"kube-apiserver"}); err != nil {
 				return fmt.Errorf("failed to restart kube-apiserver to apply configuration: %w", err)
 			}
 		}
@@ -112,7 +112,7 @@ func (c *ControlPlaneConfigurationController) reconcile(ctx context.Context, con
 		}
 
 		if mustRestart {
-			if err := c.snap.RestartService(ctx, "kube-controller-manager"); err != nil {
+			if err := c.snap.RestartServices(ctx, []string{"kube-controller-manager"}); err != nil {
 				return fmt.Errorf("failed to restart kube-controller-manager to apply configuration: %w", err)
 			}
 		}

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
@@ -59,7 +59,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 			expectKubeAPIServerArgs         map[string]string
 			expectKubeControllerManagerArgs map[string]string
 
-			expectServiceRestarts []string
+			expectServiceRestarts [][]string
 			expectFilesToExist    map[string]bool
 		}{
 			{
@@ -78,7 +78,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 					filepath.Join(dir, "etcd-pki", "client.crt"): false,
 					filepath.Join(dir, "etcd-pki", "client.key"): false,
 				},
-				expectServiceRestarts: []string{"kube-apiserver"},
+				expectServiceRestarts: [][]string{{"kube-apiserver"}},
 			},
 			{
 				name: "Certs",
@@ -102,7 +102,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 					filepath.Join(dir, "etcd-pki", "client.crt"): true,
 					filepath.Join(dir, "etcd-pki", "client.key"): true,
 				},
-				expectServiceRestarts: []string{"kube-apiserver"},
+				expectServiceRestarts: [][]string{{"kube-apiserver"}},
 			},
 			{
 				name: "CloudProvider",
@@ -114,7 +114,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 				expectKubeControllerManagerArgs: map[string]string{
 					"--cloud-provider": "external",
 				},
-				expectServiceRestarts: []string{"kube-controller-manager"},
+				expectServiceRestarts: [][]string{{"kube-controller-manager"}},
 			},
 			{
 				name: "NoUpdates",
@@ -170,13 +170,13 @@ func TestControlPlaneConfigController(t *testing.T) {
 				expectKubeControllerManagerArgs: map[string]string{
 					"--cloud-provider": "",
 				},
-				expectServiceRestarts: []string{"kube-apiserver", "kube-controller-manager"},
+				expectServiceRestarts: [][]string{{"kube-apiserver"}, {"kube-controller-manager"}},
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				g := NewWithT(t)
 
-				s.RestartServiceCalledWith = nil
+				s.RestartServicesCalledWith = nil
 
 				configProvider.config = tc.config
 
@@ -192,7 +192,8 @@ func TestControlPlaneConfigController(t *testing.T) {
 					g.Fail("Time out while waiting for the reconcile to complete")
 				}
 
-				g.Expect(s.RestartServiceCalledWith).To(ConsistOf(tc.expectServiceRestarts))
+				g.Expect(s.RestartServicesCalledWith).To(HaveLen(len(tc.expectServiceRestarts)))
+				g.Expect(s.RestartServicesCalledWith).To(Equal(tc.expectServiceRestarts))
 
 				t.Run("APIServerArgs", func(t *testing.T) {
 					for earg, eval := range tc.expectKubeAPIServerArgs {
@@ -286,7 +287,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 		// TODO: this should be changed to call g.Eventually()
 		<-time.After(50 * time.Millisecond)
 
-		g.Expect(s.RestartServiceCalledWith).To(BeEmpty())
+		g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
 
 		t.Run("APIServerArgs", func(t *testing.T) {
 			for _, arg := range []string{"--etcd-servers", "--etcd-cafile", "--etcd-certfile", "--etcd-keyfile"} {

--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -109,7 +109,7 @@ func (c *NodeConfigurationController) reconcile(ctx context.Context, configMap *
 	if mustRestartKubelet {
 		// This may fail if other controllers try to restart the services at the same time, hence the retry.
 		if err := control.RetryFor(ctx, 5, 5*time.Second, func() error {
-			if err := c.snap.RestartService(ctx, "kubelet"); err != nil {
+			if err := c.snap.RestartServices(ctx, []string{"kubelet"}); err != nil {
 				return fmt.Errorf("failed to restart kubelet to apply node configuration: %w", err)
 			}
 			return nil

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -203,7 +203,7 @@ func TestConfigPropagation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s.RestartServiceCalledWith = nil
+			s.RestartServicesCalledWith = nil
 
 			g := NewWithT(t)
 
@@ -232,9 +232,9 @@ func TestConfigPropagation(t *testing.T) {
 			}
 
 			if tc.expectRestart {
-				g.Expect(s.RestartServiceCalledWith).To(Equal([]string{"kubelet"}))
+				g.Expect(s.RestartServicesCalledWith[0]).To(Equal([]string{"kubelet"}))
 			} else {
-				g.Expect(s.RestartServiceCalledWith).To(BeEmpty())
+				g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
 			}
 		})
 	}

--- a/src/k8s/pkg/k8sd/controllers/node_label.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label.go
@@ -95,7 +95,7 @@ func (c *NodeLabelController) updateDqliteFailureDomain(ctx context.Context, fai
 
 	if modified {
 		log.Info("Updated k8s-dqlite failure domain", "failure domain", failureDomain, "availability zone", availabilityZone)
-		if err = c.snap.RestartService(ctx, "k8s-dqlite"); err != nil {
+		if err = c.snap.RestartServices(ctx, []string{"k8s-dqlite"}); err != nil {
 			return fmt.Errorf("failed to restart k8s-dqlite to apply failure domain: %w", err)
 		}
 	}
@@ -109,7 +109,7 @@ func (c *NodeLabelController) updateDqliteFailureDomain(ctx context.Context, fai
 	// prevent a service restart, at the moment k8sd needs to restart itself.
 	if modified {
 		log.Info("Updated k8sd failure domain", "failure domain", failureDomain, "availability zone", availabilityZone)
-		if err := c.snap.RestartService(ctx, "k8sd"); err != nil {
+		if err := c.snap.RestartServices(ctx, []string{"k8sd"}); err != nil {
 			return fmt.Errorf("failed to restart k8sd to apply failure domain: %w", err)
 		}
 		// We shouldn't actually get here.

--- a/src/k8s/pkg/k8sd/controllers/node_label_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label_test.go
@@ -113,7 +113,7 @@ func TestAvailabilityZoneLabel(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s.RestartServiceCalledWith = nil
+			s.RestartServicesCalledWith = nil
 
 			k8sDqliteFailureDomainFile := snaputil.GetDqliteFailureDomainFile(k8sDqliteStateDir)
 			k8sdFailureDomainFile := snaputil.GetDqliteFailureDomainFile(k8sdDbDir)
@@ -165,10 +165,10 @@ func TestAvailabilityZoneLabel(t *testing.T) {
 			g.Expect(k8sdFailureDomain).To(Equal(tc.expFailureDomain))
 
 			if tc.expRestart {
-				g.Expect(s.RestartServiceCalledWith).To(ContainElement("k8sd"))
-				g.Expect(s.RestartServiceCalledWith).To(ContainElement("k8s-dqlite"))
+				g.Expect(s.RestartServicesCalledWith).To(ContainElement([]string{"k8sd"}))
+				g.Expect(s.RestartServicesCalledWith).To(ContainElement([]string{"k8s-dqlite"}))
 			} else {
-				g.Expect(s.RestartServiceCalledWith).To(BeEmpty())
+				g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
 			}
 		})
 	}

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -19,9 +19,9 @@ type Snap interface {
 	GID() int         // GID is the group ID to set on config files.
 	Hostname() string // Hostname is the name of the node.
 
-	StartService(ctx context.Context, serviceName string) error   // snapctl start $service
-	StopService(ctx context.Context, serviceName string) error    // snapctl stop $service
-	RestartService(ctx context.Context, serviceName string) error // snapctl restart $service
+	StartServices(ctx context.Context, services []string, extraSnapArgs ...string) error   // snap start $service
+	StopServices(ctx context.Context, services []string, extraSnapArgs ...string) error    // snap stop $service
+	RestartServices(ctx context.Context, services []string, extraSnapArgs ...string) error // snap restart $service
 
 	SnapctlGet(ctx context.Context, args ...string) ([]byte, error) // snapctl get $args...
 	SnapctlSet(ctx context.Context, args ...string) error           // snapctl set $args...

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -54,12 +54,12 @@ type Mock struct {
 
 // Snap is a mock implementation for snap.Snap.
 type Snap struct {
-	StartServiceCalledWith   []string
-	StartServiceErr          error
-	StopServiceCalledWith    []string
-	StopServiceErr           error
-	RestartServiceCalledWith []string
-	RestartServiceErr        error
+	StartServicesCalledWith   [][]string
+	StartServicesErr          error
+	StopServicesCalledWith    [][]string
+	StopServicesErr           error
+	RestartServicesCalledWith [][]string
+	RestartServicesErr        error
 
 	RefreshCalledWith []types.RefreshOpts
 	RefreshErr        error
@@ -75,31 +75,40 @@ type Snap struct {
 	Mock Mock
 }
 
-func (s *Snap) StartService(ctx context.Context, name string) error {
-	if len(s.StartServiceCalledWith) == 0 {
-		s.StartServiceCalledWith = []string{name}
+func (s *Snap) StartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	if len(s.StartServicesCalledWith) == 0 {
+		s.StartServicesCalledWith = [][]string{names}
 	} else {
-		s.StartServiceCalledWith = append(s.StartServiceCalledWith, name)
+		s.StartServicesCalledWith = append(s.StartServicesCalledWith, names)
 	}
-	return s.StartServiceErr
+	if len(extraSnapArgs) > 0 {
+		s.StartServicesCalledWith = append(s.StartServicesCalledWith, extraSnapArgs)
+	}
+	return s.StartServicesErr
 }
 
-func (s *Snap) StopService(ctx context.Context, name string) error {
-	if len(s.StopServiceCalledWith) == 0 {
-		s.StopServiceCalledWith = []string{name}
+func (s *Snap) StopServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	if len(s.StopServicesCalledWith) == 0 {
+		s.StopServicesCalledWith = [][]string{names}
 	} else {
-		s.StopServiceCalledWith = append(s.StopServiceCalledWith, name)
+		s.StopServicesCalledWith = append(s.StopServicesCalledWith, names)
 	}
-	return s.StopServiceErr
+	if len(extraSnapArgs) > 0 {
+		s.StopServicesCalledWith = append(s.StopServicesCalledWith, extraSnapArgs)
+	}
+	return s.StopServicesErr
 }
 
-func (s *Snap) RestartService(ctx context.Context, name string) error {
-	if len(s.RestartServiceCalledWith) == 0 {
-		s.RestartServiceCalledWith = []string{name}
+func (s *Snap) RestartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	if len(s.RestartServicesCalledWith) == 0 {
+		s.RestartServicesCalledWith = [][]string{names}
 	} else {
-		s.RestartServiceCalledWith = append(s.RestartServiceCalledWith, name)
+		s.RestartServicesCalledWith = append(s.RestartServicesCalledWith, names)
 	}
-	return s.RestartServiceErr
+	if len(extraSnapArgs) > 0 {
+		s.RestartServicesCalledWith = append(s.RestartServicesCalledWith, extraSnapArgs)
+	}
+	return s.RestartServicesErr
 }
 
 func (s *Snap) Refresh(ctx context.Context, opts types.RefreshOpts) (string, error) {

--- a/src/k8s/pkg/snap/pebble.go
+++ b/src/k8s/pkg/snap/pebble.go
@@ -51,22 +51,24 @@ func NewPebble(opts PebbleOpts) *pebble {
 	return s
 }
 
+// buildPebbleCommand builds a pebble command with the given subcommand and names.
+func (s *pebble) buildPebbleCommand(subcommand string, names []string, extraPebbleArgs ...string) []string {
+	return append([]string{filepath.Join(s.snapDir, "bin", "pebble"), subcommand}, append(names, extraPebbleArgs...)...)
+}
+
 // StartServices starts a k8s service. The name can be either prefixed or not.
 func (s *pebble) StartServices(ctx context.Context, names []string, extraPebbleArgs ...string) error {
-	cmd := append([]string{filepath.Join(s.snapDir, "bin", "pebble"), "start"}, append(names, extraPebbleArgs...)...)
-	return s.runCommand(ctx, cmd)
+	return s.runCommand(ctx, s.buildPebbleCommand("start", names, extraPebbleArgs...))
 }
 
 // StopServices stops a k8s service. The name can be either prefixed or not.
 func (s *pebble) StopServices(ctx context.Context, names []string, extraPebbleArgs ...string) error {
-	cmd := append([]string{filepath.Join(s.snapDir, "bin", "pebble"), "stop"}, append(names, extraPebbleArgs...)...)
-	return s.runCommand(ctx, cmd)
+	return s.runCommand(ctx, s.buildPebbleCommand("stop", names, extraPebbleArgs...))
 }
 
 // RestartServices restarts a k8s service. The name can be either prefixed or not.
 func (s *pebble) RestartServices(ctx context.Context, names []string, extraPebbleArgs ...string) error {
-	cmd := append([]string{filepath.Join(s.snapDir, "bin", "pebble"), "restart"}, append(names, extraPebbleArgs...)...)
-	return s.runCommand(ctx, cmd)
+	return s.runCommand(ctx, s.buildPebbleCommand("restart", names, extraPebbleArgs...))
 }
 
 func (s *pebble) Refresh(ctx context.Context, to types.RefreshOpts) (string, error) {

--- a/src/k8s/pkg/snap/pebble_test.go
+++ b/src/k8s/pkg/snap/pebble_test.go
@@ -20,7 +20,7 @@ func TestPebble(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.StartService(context.Background(), "test-service")
+		err := snap.StartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("testdir/bin/pebble start test-service"))
 
@@ -28,7 +28,7 @@ func TestPebble(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -41,7 +41,7 @@ func TestPebble(t *testing.T) {
 			SnapCommonDir: "testdir",
 			RunCommand:    mockRunner.Run,
 		})
-		err := snap.StopService(context.Background(), "test-service")
+		err := snap.StopServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("testdir/bin/pebble stop test-service"))
 
@@ -49,7 +49,7 @@ func TestPebble(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -63,7 +63,7 @@ func TestPebble(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.RestartService(context.Background(), "test-service")
+		err := snap.RestartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("testdir/bin/pebble restart test-service"))
 
@@ -71,7 +71,7 @@ func TestPebble(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "service")
+			err := snap.StartServices(context.Background(), []string{"service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -71,22 +71,37 @@ func NewSnap(opts SnapOpts) *snap {
 	return s
 }
 
-// StartService starts a k8s service. The name can be either prefixed or not.
-func (s *snap) StartService(ctx context.Context, name string) error {
-	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Starting service", "service", name)
-	return s.runCommand(ctx, []string{"snapctl", "start", "--enable", serviceName(name)})
+// StartServices starts k8s services. The names can be either prefixed or not.
+func (s *snap) StartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Starting services", "services", names)
+	cmd := []string{"snap", "start", "--enable"}
+	for _, name := range names {
+		cmd = append(cmd, serviceName(name))
+	}
+	cmd = append(cmd, extraSnapArgs...)
+	return s.runCommand(ctx, cmd)
 }
 
-// StopService stops a k8s service. The name can be either prefixed or not.
-func (s *snap) StopService(ctx context.Context, name string) error {
-	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Stopping service", "service", name)
-	return s.runCommand(ctx, []string{"snapctl", "stop", "--disable", serviceName(name)})
+// StopServices stops k8s services. The names can be either prefixed or not.
+func (s *snap) StopServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Stopping services", "services", names)
+	cmd := []string{"snap", "stop", "--disable"}
+	for _, name := range names {
+		cmd = append(cmd, serviceName(name))
+	}
+	cmd = append(cmd, extraSnapArgs...)
+	return s.runCommand(ctx, cmd)
 }
 
-// RestartService restarts a k8s service. The name can be either prefixed or not.
-func (s *snap) RestartService(ctx context.Context, name string) error {
-	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Restarting service", "service", name)
-	return s.runCommand(ctx, []string{"snapctl", "restart", serviceName(name)})
+// RestartServices restarts k8s services. The names can be either prefixed or not.
+func (s *snap) RestartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Restarting services", "services", names)
+	cmd := []string{"snap", "restart"}
+	for _, name := range names {
+		cmd = append(cmd, serviceName(name))
+	}
+	cmd = append(cmd, extraSnapArgs...)
+	return s.runCommand(ctx, cmd)
 }
 
 // Refresh refreshes the snap to a different track, revision or custom snap.

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -71,7 +71,7 @@ func NewSnap(opts SnapOpts) *snap {
 	return s
 }
 
-// buildServiceCommand creates a snap command for managing services
+// buildServiceCommand creates a snap command for managing services.
 func (s *snap) buildServiceCommand(action string, names []string, extraSnapArgs ...string) []string {
 	cmd := []string{"snap", action}
 	for _, name := range names {

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -71,36 +71,35 @@ func NewSnap(opts SnapOpts) *snap {
 	return s
 }
 
-// StartServices starts k8s services. The names can be either prefixed or not.
-func (s *snap) StartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
-	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Starting services", "services", names)
-	cmd := []string{"snap", "start", "--enable"}
+// buildServiceCommand creates a snap command for managing services
+func (s *snap) buildServiceCommand(action string, names []string, extraSnapArgs ...string) []string {
+	cmd := []string{"snap", action}
 	for _, name := range names {
 		cmd = append(cmd, serviceName(name))
 	}
-	cmd = append(cmd, extraSnapArgs...)
+	return append(cmd, extraSnapArgs...)
+}
+
+// StartServices starts k8s services. The names can be either prefixed or not.
+func (s *snap) StartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Starting services", "services", names)
+	extraSnapArgs = append([]string{"--enable"}, extraSnapArgs...)
+	cmd := s.buildServiceCommand("start", names, extraSnapArgs...)
 	return s.runCommand(ctx, cmd)
 }
 
 // StopServices stops k8s services. The names can be either prefixed or not.
 func (s *snap) StopServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
 	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Stopping services", "services", names)
-	cmd := []string{"snap", "stop", "--disable"}
-	for _, name := range names {
-		cmd = append(cmd, serviceName(name))
-	}
-	cmd = append(cmd, extraSnapArgs...)
+	extraSnapArgs = append([]string{"--disable"}, extraSnapArgs...)
+	cmd := s.buildServiceCommand("stop", names, extraSnapArgs...)
 	return s.runCommand(ctx, cmd)
 }
 
 // RestartServices restarts k8s services. The names can be either prefixed or not.
 func (s *snap) RestartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
 	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Restarting services", "services", names)
-	cmd := []string{"snap", "restart"}
-	for _, name := range names {
-		cmd = append(cmd, serviceName(name))
-	}
-	cmd = append(cmd, extraSnapArgs...)
+	cmd := s.buildServiceCommand("restart", names, extraSnapArgs...)
 	return s.runCommand(ctx, cmd)
 }
 

--- a/src/k8s/pkg/snap/snap_test.go
+++ b/src/k8s/pkg/snap/snap_test.go
@@ -73,12 +73,12 @@ func TestSnap(t *testing.T) {
 
 		err := snap.StartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start --enable k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start k8s.test-service --enable"))
 
 		mockRunner.CalledWithCommand = []string{}
 		err = snap.StartServices(context.Background(), []string{"test-service"}, "--no-wait")
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start --enable k8s.test-service --no-wait"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start k8s.test-service --enable --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)
@@ -99,12 +99,12 @@ func TestSnap(t *testing.T) {
 		})
 		err := snap.StopServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop --disable k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop k8s.test-service --disable"))
 
 		mockRunner.CalledWithCommand = []string{}
 		err = snap.StopServices(context.Background(), []string{"test-service"}, "--no-wait")
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop --disable k8s.test-service --no-wait"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop k8s.test-service --disable --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)

--- a/src/k8s/pkg/snap/snap_test.go
+++ b/src/k8s/pkg/snap/snap_test.go
@@ -71,15 +71,20 @@ func TestSnap(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.StartService(context.Background(), "test-service")
+		err := snap.StartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snapctl start --enable k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start --enable k8s.test-service"))
+
+		mockRunner.CalledWithCommand = []string{}
+		err = snap.StartServices(context.Background(), []string{"test-service"}, "--no-wait")
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start --enable k8s.test-service --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -92,15 +97,20 @@ func TestSnap(t *testing.T) {
 			SnapCommonDir: "testdir",
 			RunCommand:    mockRunner.Run,
 		})
-		err := snap.StopService(context.Background(), "test-service")
+		err := snap.StopServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snapctl stop --disable k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop --disable k8s.test-service"))
+
+		mockRunner.CalledWithCommand = []string{}
+		err = snap.StopServices(context.Background(), []string{"test-service"}, "--no-wait")
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop --disable k8s.test-service --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -114,15 +124,20 @@ func TestSnap(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.RestartService(context.Background(), "test-service")
+		err := snap.RestartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snapctl restart k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap restart k8s.test-service"))
+
+		mockRunner.CalledWithCommand = []string{}
+		err = snap.RestartServices(context.Background(), []string{"test-service"}, "--no-wait")
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap restart k8s.test-service --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "service")
+			err := snap.StartServices(context.Background(), []string{"service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})

--- a/src/k8s/pkg/snap/util/services.go
+++ b/src/k8s/pkg/snap/util/services.go
@@ -8,15 +8,15 @@ import (
 )
 
 var (
-	// WorkerServices contains all k8s services that run on a worker node except of k8sd.
-	workerServices = []string{
+	// workerK8sServices contains all k8s services that run on a worker node except of k8sd.
+	workerK8sServices = []string{
 		"containerd",
 		"k8s-apiserver-proxy",
 		"kubelet",
 		"kube-proxy",
 	}
-	// controlPlaneServices contains all k8s services that run on a control plane except of k8sd.
-	controlPlaneServices = []string{
+	// controlPlaneK8sServices contains all k8s services that run on a control plane except of k8sd.
+	controlPlaneK8sServices = []string{
 		"containerd",
 		"kube-controller-manager",
 		"kube-proxy",
@@ -25,7 +25,7 @@ var (
 		"kube-apiserver",
 	}
 
-	// k8sServices contains all k8s services except of k8sd.
+	// k8sServices contains all k8s services except k8sd.
 	k8sServices = []string{
 		"containerd",
 		"kube-apiserver",
@@ -41,8 +41,8 @@ var (
 // RestartControlPlaneServices restarts the control plane services.
 // RestartControlPlaneServices will return on the first failing service.
 func RestartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
-	if err := snap.RestartServices(ctx, controlPlaneServices, extraSnapArgs...); err != nil {
-		return fmt.Errorf("failed to restart service %v: %w", controlPlaneServices, err)
+	if err := snap.RestartServices(ctx, controlPlaneK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to restart service %v: %w", controlPlaneK8sServices, err)
 	}
 	return nil
 }
@@ -50,8 +50,8 @@ func RestartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapA
 // StartWorkerServices starts the worker services.
 // StartWorkerServices will return on the first failing service.
 func StartWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
-	if err := snap.StartServices(ctx, workerServices, extraSnapArgs...); err != nil {
-		return fmt.Errorf("failed to start service %v: %w", workerServices, err)
+	if err := snap.StartServices(ctx, workerK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", workerK8sServices, err)
 	}
 	return nil
 }
@@ -59,8 +59,8 @@ func StartWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...s
 // StartControlPlaneServices starts the control plane services.
 // StartControlPlaneServices will return on the first failing service.
 func StartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
-	if err := snap.StartServices(ctx, controlPlaneServices, extraSnapArgs...); err != nil {
-		return fmt.Errorf("failed to start service %v: %w", controlPlaneServices, err)
+	if err := snap.StartServices(ctx, controlPlaneK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", controlPlaneK8sServices, err)
 	}
 	return nil
 }
@@ -76,8 +76,8 @@ func StartK8sDqliteServices(ctx context.Context, snap snap.Snap, extraSnapArgs .
 // StopWorkerServices starts the worker services.
 // StopWorkerServices will return on the first failing service.
 func StopWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
-	if err := snap.StopServices(ctx, workerServices, extraSnapArgs...); err != nil {
-		return fmt.Errorf("failed to stop service %v: %w", workerServices, err)
+	if err := snap.StopServices(ctx, workerK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", workerK8sServices, err)
 	}
 	return nil
 }
@@ -85,8 +85,8 @@ func StopWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...st
 // StopControlPlaneServices stops the control plane services.
 // StopControlPlaneServices will return on the first failing service.
 func StopControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
-	if err := snap.StopServices(ctx, controlPlaneServices, extraSnapArgs...); err != nil {
-		return fmt.Errorf("failed to stop service %v: %w", controlPlaneServices, err)
+	if err := snap.StopServices(ctx, controlPlaneK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", controlPlaneK8sServices, err)
 	}
 	return nil
 }

--- a/src/k8s/pkg/snap/util/services.go
+++ b/src/k8s/pkg/snap/util/services.go
@@ -24,76 +24,86 @@ var (
 		"kubelet",
 		"kube-apiserver",
 	}
+
+	// k8sServices contains all k8s services except of k8sd.
+	k8sServices = []string{
+		"containerd",
+		"kube-apiserver",
+		"kube-controller-manager",
+		"kube-scheduler",
+		"kube-proxy",
+		"kubelet",
+		"k8s-dqlite",
+		"k8s-apiserver-proxy",
+	}
 )
 
 // RestartControlPlaneServices restarts the control plane services.
 // RestartControlPlaneServices will return on the first failing service.
-func RestartControlPlaneServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range controlPlaneServices {
-		if err := snap.RestartService(ctx, service); err != nil {
-			return fmt.Errorf("failed to restart service %s: %w", service, err)
-		}
+func RestartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.RestartServices(ctx, controlPlaneServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to restart service %v: %w", controlPlaneServices, err)
 	}
 	return nil
 }
 
 // StartWorkerServices starts the worker services.
 // StartWorkerServices will return on the first failing service.
-func StartWorkerServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range workerServices {
-		if err := snap.StartService(ctx, service); err != nil {
-			return fmt.Errorf("failed to start service %s: %w", service, err)
-		}
+func StartWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StartServices(ctx, workerServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", workerServices, err)
 	}
 	return nil
 }
 
 // StartControlPlaneServices starts the control plane services.
 // StartControlPlaneServices will return on the first failing service.
-func StartControlPlaneServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range controlPlaneServices {
-		if err := snap.StartService(ctx, service); err != nil {
-			return fmt.Errorf("failed to start service %s: %w", service, err)
-		}
+func StartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StartServices(ctx, controlPlaneServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", controlPlaneServices, err)
 	}
 	return nil
 }
 
 // StartK8sDqliteServices starts the k8s-dqlite datastore service.
-func StartK8sDqliteServices(ctx context.Context, snap snap.Snap) error {
-	if err := snap.StartService(ctx, "k8s-dqlite"); err != nil {
-		return fmt.Errorf("failed to start service %s: %w", "k8s-dqlite", err)
+func StartK8sDqliteServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StartServices(ctx, []string{"k8s-dqlite"}, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", "k8s-dqlite", err)
 	}
 	return nil
 }
 
 // StopWorkerServices starts the worker services.
 // StopWorkerServices will return on the first failing service.
-func StopWorkerServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range workerServices {
-		if err := snap.StopService(ctx, service); err != nil {
-			return fmt.Errorf("failed to stop service %s: %w", service, err)
-		}
+func StopWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, workerServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", workerServices, err)
 	}
 	return nil
 }
 
 // StopControlPlaneServices stops the control plane services.
 // StopControlPlaneServices will return on the first failing service.
-func StopControlPlaneServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range controlPlaneServices {
-		if err := snap.StopService(ctx, service); err != nil {
-			return fmt.Errorf("failed to stop service %s: %w", service, err)
-		}
+func StopControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, controlPlaneServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", controlPlaneServices, err)
 	}
 	return nil
 }
 
 // StopK8sDqliteServices stops the control plane services.
 // StopK8sDqliteServices will return on the first failing service.
-func StopK8sDqliteServices(ctx context.Context, snap snap.Snap) error {
-	if err := snap.StopService(ctx, "k8s-dqlite"); err != nil {
-		return fmt.Errorf("failed to stop service %s: %w", "k8s-dqlite", err)
+func StopK8sDqliteServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, []string{"k8s-dqlite"}, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", "k8s-dqlite", err)
+	}
+	return nil
+}
+
+// StopK8sServices stops all k8s services except of k8sd.
+func StopK8sServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, k8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", k8sServices, err)
 	}
 	return nil
 }

--- a/src/k8s/pkg/snap/util/services_test.go
+++ b/src/k8s/pkg/snap/util/services_test.go
@@ -21,7 +21,7 @@ func TestStartWorkerServices(t *testing.T) {
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartWorkerServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StartServicesCalledWith)).To(Equal(1))
+		g.Expect(len(mock.StartServicesCalledWith)).To(HaveLen(1))
 		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(workerServices))
 	})
 
@@ -42,7 +42,7 @@ func TestStartControlPlaneServices(t *testing.T) {
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StartServicesCalledWith)).To(Equal(1))
+		g.Expect(len(mock.StartServicesCalledWith)).To(HaveLen(1))
 		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
 	})
 
@@ -63,7 +63,7 @@ func TestStartK8sDqliteServices(t *testing.T) {
 	t.Run("ServiceStartSuccess", func(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StartServicesCalledWith)).To(Equal(1))
+		g.Expect(len(mock.StartServicesCalledWith)).To(HaveLen(1))
 		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
@@ -84,7 +84,7 @@ func TestStopControlPlaneServices(t *testing.T) {
 	t.Run("AllServicesStopSuccess", func(t *testing.T) {
 		mock.StopServicesErr = nil
 		g.Expect(StopControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StopServicesCalledWith)).To(Equal(1))
+		g.Expect(len(mock.StopServicesCalledWith)).To(HaveLen(1))
 		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
 	})
 
@@ -105,7 +105,7 @@ func TestStopK8sDqliteServices(t *testing.T) {
 	t.Run("ServiceStopSuccess", func(t *testing.T) {
 		mock.StopServicesErr = nil
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StopServicesCalledWith)).To(Equal(1))
+		g.Expect(len(mock.StopServicesCalledWith)).To(HaveLen(1))
 		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
@@ -125,7 +125,7 @@ func TestStopK8sServices(t *testing.T) {
 	t.Run("ServiceStopSuccess", func(t *testing.T) {
 		mock.StopServicesErr = nil
 		g.Expect(StopK8sServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StopServicesCalledWith)).To(Equal(1))
+		g.Expect(len(mock.StopServicesCalledWith)).To(HaveLen(1))
 		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(k8sServices))
 	})
 

--- a/src/k8s/pkg/snap/util/services_test.go
+++ b/src/k8s/pkg/snap/util/services_test.go
@@ -16,16 +16,17 @@ func TestStartWorkerServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StartServiceErr = fmt.Errorf("service start failed")
+	mock.StartServicesErr = fmt.Errorf("service start failed")
 
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
-		mock.StartServiceErr = nil
+		mock.StartServicesErr = nil
 		g.Expect(StartWorkerServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StartServiceCalledWith).To(ConsistOf(workerServices))
+		g.Expect(len(mock.StartServicesCalledWith)).To(Equal(1))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(workerServices))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
-		mock.StartServiceErr = fmt.Errorf("service start failed")
+		mock.StartServicesErr = fmt.Errorf("service start failed")
 		g.Expect(StartWorkerServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -36,16 +37,17 @@ func TestStartControlPlaneServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StartServiceErr = fmt.Errorf("service start failed")
+	mock.StartServicesErr = fmt.Errorf("service start failed")
 
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
-		mock.StartServiceErr = nil
+		mock.StartServicesErr = nil
 		g.Expect(StartControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StartServiceCalledWith).To(ConsistOf(controlPlaneServices))
+		g.Expect(len(mock.StartServicesCalledWith)).To(Equal(1))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
-		mock.StartServiceErr = fmt.Errorf("service start failed")
+		mock.StartServicesErr = fmt.Errorf("service start failed")
 		g.Expect(StartControlPlaneServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -56,16 +58,17 @@ func TestStartK8sDqliteServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StartServiceErr = fmt.Errorf("service start failed")
+	mock.StartServicesErr = fmt.Errorf("service start failed")
 
 	t.Run("ServiceStartSuccess", func(t *testing.T) {
-		mock.StartServiceErr = nil
+		mock.StartServicesErr = nil
 		g.Expect(StartK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StartServiceCalledWith).To(ConsistOf("k8s-dqlite"))
+		g.Expect(len(mock.StartServicesCalledWith)).To(Equal(1))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
-		mock.StartServiceErr = fmt.Errorf("service start failed")
+		mock.StartServicesErr = fmt.Errorf("service start failed")
 		g.Expect(StartK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -76,16 +79,17 @@ func TestStopControlPlaneServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StopServiceErr = fmt.Errorf("service stop failed")
+	mock.StopServicesErr = fmt.Errorf("service stop failed")
 
 	t.Run("AllServicesStopSuccess", func(t *testing.T) {
-		mock.StopServiceErr = nil
+		mock.StopServicesErr = nil
 		g.Expect(StopControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StopServiceCalledWith).To(ConsistOf(controlPlaneServices))
+		g.Expect(len(mock.StopServicesCalledWith)).To(Equal(1))
+		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
 	})
 
 	t.Run("ServiceStopFailure", func(t *testing.T) {
-		mock.StopServiceErr = fmt.Errorf("service stop failed")
+		mock.StopServicesErr = fmt.Errorf("service stop failed")
 		g.Expect(StopControlPlaneServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -96,20 +100,40 @@ func TestStopK8sDqliteServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StopServiceErr = fmt.Errorf("service stop failed")
+	mock.StopServicesErr = fmt.Errorf("service stop failed")
 
 	t.Run("ServiceStopSuccess", func(t *testing.T) {
-		mock.StopServiceErr = nil
+		mock.StopServicesErr = nil
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StopServiceCalledWith).To(ConsistOf("k8s-dqlite"))
+		g.Expect(len(mock.StopServicesCalledWith)).To(Equal(1))
+		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
 	t.Run("ServiceStopFailure", func(t *testing.T) {
-		mock.StopServiceErr = fmt.Errorf("service stop failed")
+		mock.StopServicesErr = fmt.Errorf("service stop failed")
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
+func TestStopK8sServices(t *testing.T) {
+	mock := &mock.Snap{
+		Mock: mock.Mock{},
+	}
+	g := NewWithT(t)
 
+	mock.StopServicesErr = fmt.Errorf("service stop failed")
+
+	t.Run("ServiceStopSuccess", func(t *testing.T) {
+		mock.StopServicesErr = nil
+		g.Expect(StopK8sServices(context.Background(), mock)).To(Succeed())
+		g.Expect(len(mock.StopServicesCalledWith)).To(Equal(1))
+		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(k8sServices))
+	})
+
+	t.Run("ServiceStopFailure", func(t *testing.T) {
+		mock.StopServicesErr = fmt.Errorf("service stop failed")
+		g.Expect(StopK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
+	})
+}
 func TestServiceArgsFromMap(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/src/k8s/pkg/snap/util/services_test.go
+++ b/src/k8s/pkg/snap/util/services_test.go
@@ -21,7 +21,7 @@ func TestStartWorkerServices(t *testing.T) {
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartWorkerServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StartServicesCalledWith)).To(HaveLen(1))
+		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
 		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(workerServices))
 	})
 
@@ -42,7 +42,7 @@ func TestStartControlPlaneServices(t *testing.T) {
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StartServicesCalledWith)).To(HaveLen(1))
+		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
 		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
 	})
 
@@ -63,7 +63,7 @@ func TestStartK8sDqliteServices(t *testing.T) {
 	t.Run("ServiceStartSuccess", func(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StartServicesCalledWith)).To(HaveLen(1))
+		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
 		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
@@ -84,7 +84,7 @@ func TestStopControlPlaneServices(t *testing.T) {
 	t.Run("AllServicesStopSuccess", func(t *testing.T) {
 		mock.StopServicesErr = nil
 		g.Expect(StopControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StopServicesCalledWith)).To(HaveLen(1))
+		g.Expect(mock.StopServicesCalledWith).To(HaveLen(1))
 		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
 	})
 
@@ -105,7 +105,7 @@ func TestStopK8sDqliteServices(t *testing.T) {
 	t.Run("ServiceStopSuccess", func(t *testing.T) {
 		mock.StopServicesErr = nil
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StopServicesCalledWith)).To(HaveLen(1))
+		g.Expect(mock.StopServicesCalledWith).To(HaveLen(1))
 		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
@@ -125,7 +125,7 @@ func TestStopK8sServices(t *testing.T) {
 	t.Run("ServiceStopSuccess", func(t *testing.T) {
 		mock.StopServicesErr = nil
 		g.Expect(StopK8sServices(context.Background(), mock)).To(Succeed())
-		g.Expect(len(mock.StopServicesCalledWith)).To(HaveLen(1))
+		g.Expect(mock.StopServicesCalledWith).To(HaveLen(1))
 		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(k8sServices))
 	})
 

--- a/src/k8s/pkg/snap/util/services_test.go
+++ b/src/k8s/pkg/snap/util/services_test.go
@@ -114,6 +114,7 @@ func TestStopK8sDqliteServices(t *testing.T) {
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
+
 func TestStopK8sServices(t *testing.T) {
 	mock := &mock.Snap{
 		Mock: mock.Mock{},
@@ -134,6 +135,7 @@ func TestStopK8sServices(t *testing.T) {
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
+
 func TestServiceArgsFromMap(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/src/k8s/pkg/snap/util/services_test.go
+++ b/src/k8s/pkg/snap/util/services_test.go
@@ -22,7 +22,7 @@ func TestStartWorkerServices(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartWorkerServices(context.Background(), mock)).To(Succeed())
 		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
-		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(workerServices))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(workerK8sServices))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
@@ -43,7 +43,7 @@ func TestStartControlPlaneServices(t *testing.T) {
 		mock.StartServicesErr = nil
 		g.Expect(StartControlPlaneServices(context.Background(), mock)).To(Succeed())
 		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
-		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(controlPlaneK8sServices))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestStopControlPlaneServices(t *testing.T) {
 		mock.StopServicesErr = nil
 		g.Expect(StopControlPlaneServices(context.Background(), mock)).To(Succeed())
 		g.Expect(mock.StopServicesCalledWith).To(HaveLen(1))
-		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(controlPlaneServices))
+		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(controlPlaneK8sServices))
 	})
 
 	t.Run("ServiceStopFailure", func(t *testing.T) {

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -7,15 +7,9 @@ import pytest
 from test_util import harness, tags, util
 
 
-# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
-# @pytest.mark.node_count(3)
+@pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
 def test_wrong_token_race(instances: List[harness.Instance]):
-    # Note(ben): k8s-dqlite sometimes takes very long to shutdown (to be investigated) and
-    # since microcluster has a 30s fixed timeout for the remove hooks this test sometimes fails.
-    # The timeout will be configurable in https://github.com/canonical/microcluster/pull/365)
-    # The k8s-dqlite issue will be investigated separately.
-    pytest.xfail("This test is currently flaky because of a k8s-dqlite shutdown issue.")
     cluster_node = instances[0]
 
     join_token = util.get_join_token(cluster_node, instances[1])


### PR DESCRIPTION
## Description

Some services (e.g. k8s-dqlite) take a considerable amount of time to shutdown in some cases. Microcluster has a fixed 30s timeout for the remove hook which caused removing a node to fail in some scenarios.

## Solution

With this commit, the remove hook will not wait anymore on services to terminate. The cleanup on a removed node is on a best-effort basis so in that case we don't care when (and even if) a service is actually stopped.

Code changes:
* Renames/refactored `Start/Stop/RestartService` to `...Services` and accept a slice instead of single string name. If we don't want to wait for snap services to stop, we need to have a way to pass all services at once. If we would do a `--no-wait` and then sequentially call `snap service stop`, this would fail with `snap: change in-progress`. 
* Use `snap` instead of `snapctl`. `snapctl` does not provide a `--no-wait` flag. See discussion [here](https://bugs.launchpad.net/snapd/+bug/2106256)
* Add `extraSnapArgs` to services. We only want to not wait when removing a node. All other service interactions should be synchronous, so we need a way to control that.

You can see in the log timestamps of a removed node, that stopping of the services is now finishing immediately:
```
emove" node="k8s-integration-c673d2-3"
Apr 02 09:53:39 k8s-integration-c673d2-3 k8s.k8sd[2211]: I0402 09:53:39.048725    2211 app/hooks_remove.go:138] "Cleaning up control plane certificates" logger="k8sd" hook="preremove" node="k8s-integration-c673d2-3"
Apr 02 09:53:39 k8s-integration-c673d2-3 k8s.k8sd[2211]: I0402 09:53:39.049043    2211 app/hooks_remove.go:143] "Stopping all services except of k8sd" logger="k8sd" hook="preremove" node="k8s-integration-c673d2-3"
Apr 02 09:53:39 k8s-integration-c673d2-3 k8s.k8sd[5271]: 7
Apr 02 09:53:39 k8s-integration-c673d2-3 k8s.k8sd[2211]: I0402 09:53:39.080249    2211 app/hooks_remove.go:148] "Cleaning up containerd paths" logger="k8sd" hook="preremove" node="k8s-integration-c673d2-3"
```
## Backport

This fixes issues when removing a node, so we should backport this.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
