### PR TITLE
fix: juju links in docs

### DIFF
--- a/docs/canonicalk8s/charm/howto/install/charm.md
+++ b/docs/canonicalk8s/charm/howto/install/charm.md
@@ -90,7 +90,7 @@ Use `juju status` to watch these units approach the active/idle state.
 
 [Installing]:    ./index
 [channels]:      ../../explanation/channels
-[credentials]:   https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/credential/
+[credentials]:   https://documentation.ubuntu.com/juju/latest/reference/credential/
 [juju]:          https://juju.is/docs/juju/install-juju
 [charm]:         https://juju.is/docs/juju/charmed-operator
 [localhost]:     install-lxd

--- a/docs/canonicalk8s/charm/howto/upgrade-minor.md
+++ b/docs/canonicalk8s/charm/howto/upgrade-minor.md
@@ -211,7 +211,7 @@ to ensure that the cluster is fully functional.
 [backup-restore]:      ../../snap/howto/backup-restore
 [charmhub]:            https://charmhub.io/k8s
 [cluster-validation]:  ./validate
-[juju-docs]:           https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-models/#manage-models
+[juju-docs]:           https://documentation.ubuntu.com/juju/latest/howto/manage-models/#manage-models
 [release-notes]:       ../reference/releases
 [upgrade-notes]:       ../reference/upgrade-notes
 [upstream-notes]:      https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation

--- a/docs/canonicalk8s/charm/howto/upgrade-patch.md
+++ b/docs/canonicalk8s/charm/howto/upgrade-patch.md
@@ -202,6 +202,6 @@ to ensure that the cluster is fully functional.
 [backup-restore]:     ../../snap/howto/backup-restore
 [charmhub]:            https://charmhub.io/k8s
 [cluster-validation]: ./validate
-[juju-docs]:          https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-models/#manage-models
+[juju-docs]:          https://documentation.ubuntu.com/juju/latest/howto/manage-models/#how-to-manage-models
 [release-notes]:      ../reference/releases
 [upstream-notes]:     https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG

--- a/docs/canonicalk8s/charm/reference/az.md
+++ b/docs/canonicalk8s/charm/reference/az.md
@@ -48,7 +48,7 @@ underlying AZ changes from the Juju POV, the operator will not update the
 label to reflect this new AZ.
 
 <!-- LINKS -->
-[zone]: https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/zone/
-[placement directive]: https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/placement-directive/#placement-directive-zone
-[constraint]: https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/constraint/#zones
+[zone]: https://documentation.ubuntu.com/juju/latest/reference/zone/
+[placement directive]: https://documentation.ubuntu.com/juju/latest/reference/placement-directive/#zone-zone
+[constraint]: https://documentation.ubuntu.com/juju/latest/reference/constraint/#zones
 [Kubernetes well-known topology label]: https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone


### PR DESCRIPTION
## Description

Switch Juju docs to `documentation.ubuntu.com`

