### PR TITLE
test: change harness instance naming

### DIFF
--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -71,7 +71,7 @@ class LXDHarness(Harness):
         )
 
     def new_instance(self, network_type: str = "IPv4") -> Instance:
-        instance_id = f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}"
+        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         launch_lxd_command = [

--- a/tests/integration/tests/test_util/harness/multipass.py
+++ b/tests/integration/tests/test_util/harness/multipass.py
@@ -40,7 +40,7 @@ class MultipassHarness(Harness):
         if network_type:
             raise HarnessError("Currently only IPv4 is supported by Multipass harness")
 
-        instance_id = f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}"
+        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:


### PR DESCRIPTION
At the moment, the harness instances are named like this:

```
instance_id = f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}"
# example
k8s-integration-d8ebed-24
...
k8s-integration-795f32-25
```

Let's move the id number in front so that instances belonging to the same test will reside next to each other, making them easier to find in the inspection reports:

```
instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}"
# example
k8s-integration-24-d8ebed
k8s-integration-25-795f32
```