### PR TITLE
test: properly wait for k8sd controllers to finish reconciling

### DIFF
--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // channelSendTimeout is the timeout for pushing to channels for TestControlPlaneConfigController.
-const channelSendTimeout = 100 * time.Millisecond
+const channelSendTimeout = 500 * time.Millisecond
 
 type configProvider struct {
 	config types.ClusterConfig
@@ -186,8 +186,11 @@ func TestControlPlaneConfigController(t *testing.T) {
 					g.Fail("Timed out while attempting to trigger controller reconcile loop")
 				}
 
-				// TODO: this should be changed to call g.Eventually()
-				<-time.After(50 * time.Millisecond)
+				select {
+				case <-ctrl.ReconciledCh():
+				case <-time.After(channelSendTimeout):
+					g.Fail("Time out while waiting for the reconcile to complete")
+				}
 
 				g.Expect(s.RestartServiceCalledWith).To(ConsistOf(tc.expectServiceRestarts))
 


### PR DESCRIPTION
The k8sd controller unit tests will emit a test event and wait for the reconcile loop to handle it.

UpdateNodeConfigurationController uses a channel to notify that the reconciliation finished, however the other tests will just wait for about 100ms and expect the reconcile to finish.

The 100ms sleep is flaky, sometimes it takes longer for the events to be processed.

To address this, we'll use the same post-reconciliation notification in all k8sd controllers.