### PR TITLE
fix: Reset reconciled state before reconciling

### DIFF
--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -154,7 +154,7 @@ func (c *FeatureController) reconcileLoop(
 	setFeatureStatus func(ctx context.Context, name types.FeatureName, status types.FeatureStatus) error,
 	featureName types.FeatureName,
 	triggerCh chan struct{},
-	reconciledCh chan<- struct{},
+	reconciledCh chan struct{},
 	apply func(cfg types.ClusterConfig) (types.FeatureStatus, error),
 ) {
 	for {
@@ -162,6 +162,9 @@ func (c *FeatureController) reconcileLoop(
 		case <-ctx.Done():
 			return
 		case <-triggerCh:
+			// reset "reconciled" state before reconciling
+			utils.MaybeReceive(reconciledCh)
+
 			if err := c.reconcile(ctx, getClusterConfig, apply, func(ctx context.Context, status types.FeatureStatus) error {
 				return setFeatureStatus(ctx, featureName, status)
 			}); err != nil {

--- a/src/k8s/pkg/utils/chan.go
+++ b/src/k8s/pkg/utils/chan.go
@@ -7,3 +7,11 @@ func MaybeNotify(ch chan<- struct{}) {
 	default:
 	}
 }
+
+// MaybeReceive tries to receive from a channel, but does not block if that fails.
+func MaybeReceive(ch <-chan struct{}) {
+	select {
+	case <-ch:
+	default:
+	}
+}


### PR DESCRIPTION
### Overview
This PR resets the "is reconciled" state before starting a new reconciliation, by making sure the `reconciledCh` is empty.
This channel is basically a thread-safe boolean.
It's worth noting that while this PR improves how we're informed about the reconciliation state of the features, it's still prone to race conditions, as the whole operation of "triggering a reconciliation and emptying the `reconciledCh`" is not atomic (we might trigger a reconciliation, immediately successfully read from the `reconciledCh` afterwards and think that the reconciliation that WE triggered was successful, but that might not be the case. What we've read from the `reconciledCh` might have been for a previous successful reconciliation that is yet to be emptied in the next reconciliation loop). 