### PR TITLE
docs: Update architecture reference page

### DIFF
--- a/docs/canonicalk8s/assets/k8s-container.puml
+++ b/docs/canonicalk8s/assets/k8s-container.puml
@@ -14,7 +14,7 @@ System(CharmK8s, "Charm K8s", $descr="Orchestrating the lifecycle management of 
 System(Externaldatastore, "External datastore", $descr="etcd", $tags="", $link="")
 
 System_Boundary("K8sSnapDistribution_boundary", "K8s Snap Distribution", $tags="") {
-  Container(K8sSnapDistribution.KubernetesControlPlane, "Kubernetes Control Plane", $techn="", $descr="API server, kubelet, kube-proxy, scheduler, kube-controller", $tags="", $link="")
+  Container(K8sSnapDistribution.KubernetesCoreComponents, "Kubernetes Core Components", $techn="", $descr="API server, kubelet, kube-proxy, scheduler, kube-controller", $tags="", $link="")
   Container(K8sSnapDistribution.ContainerRuntime, "Container Runtime", $techn="", $descr="Containerd", $tags="", $link="")
   Container(K8sSnapDistribution.K8sd, "K8sd", $techn="", $descr="Daemon implementing the features available in the k8s snap", $tags="", $link="")
   Container(K8sSnapDistribution.K8sddatastore, "Cluster Datastore", $techn="", $descr="Uses dqlite to store cluster configuration", $tags="", $link="")
@@ -27,11 +27,11 @@ Rel(K8sAdmin, K8sSnapDistribution.Kubectl, "Uses to manage the cluster", $techn=
 Rel(K8sUser, K8sSnapDistribution.Kubectl, "Interacts with workloads hosted in K8s", $techn="", $tags="", $link="")
 Rel(CharmK8s, K8sSnapDistribution.K8sd, "Orchestrates the lifecycle management of K8s", $techn="", $tags="", $link="")
 Rel(K8sSnapDistribution.K8sd, K8sSnapDistribution.K8sddatastore, "Stores data in", $techn="", $tags="", $link="")
-Rel(K8sSnapDistribution.KubernetesControlPlane, K8sSnapDistribution.Kubernetesdatastore, "Stores data in", $techn="", $tags="", $link="")
+Rel(K8sSnapDistribution.KubernetesCoreComponents, K8sSnapDistribution.Kubernetesdatastore, "Stores data in", $techn="", $tags="", $link="")
 Rel(K8sSnapDistribution.Kubernetesdatastore, Externaldatastore, "May be replaced by", $techn="", $tags="", $link="")
-Rel(K8sSnapDistribution.K8sd, K8sSnapDistribution.KubernetesControlPlane, "Configures", $techn="", $tags="", $link="")
-Rel(K8sSnapDistribution.KubernetesControlPlane, K8sSnapDistribution.ContainerRuntime, "Uses", $techn="", $tags="", $link="")
-Rel(K8sSnapDistribution.Kubectl, K8sSnapDistribution.KubernetesControlPlane, "Sends API requests", $techn="", $tags="", $link="")
+Rel(K8sSnapDistribution.K8sd, K8sSnapDistribution.KubernetesCoreComponents, "Configures", $techn="", $tags="", $link="")
+Rel(K8sSnapDistribution.KubernetesCoreComponents, K8sSnapDistribution.ContainerRuntime, "Uses", $techn="", $tags="", $link="")
+Rel(K8sSnapDistribution.Kubectl, K8sSnapDistribution.KubernetesCoreComponents, "Sends API requests", $techn="", $tags="", $link="")
 Rel(K8sSnapDistribution.K8sd, K8sSnapDistribution.ContainerRuntime, "Configures", $techn="", $tags="", $link="")
 
 SHOW_LEGEND(true)

--- a/docs/canonicalk8s/assets/k8sd-component.puml
+++ b/docs/canonicalk8s/assets/k8sd-component.puml
@@ -14,7 +14,7 @@ Container(K8sSnapDistribution.Runtime, "Runtime", $techn="", $descr="Containerd 
 System(CharmK8s, "Charm K8s", $descr="Orchestrating the lifecycle management of K8s", $tags="", $link="")
 Container(K8sSnapDistribution.ClusterDatastore, "Cluster datastore", $techn="", $descr="Uses dqlite to store cluster configuration", $tags="", $link="")
 Container(K8sSnapDistribution.KubernetesDatastore, "Kubernetes datastore", $techn="", $descr="Uses k8s-dqlite or etcd to store cluster data", $tags="", $link="")
-Container(K8sSnapDistribution.KubernetesControlPlane, "Kubernetes Control Plane", $techn="", $descr="API server, kubelet, kube-proxy, scheduler, kube-controller", $tags="", $link="")
+Container(K8sSnapDistribution.KubernetesCoreComponents, "Kubernetes Core Components", $techn="", $descr="API server, kubelet, kube-proxy, scheduler, kube-controller", $tags="", $link="")
 
 Container_Boundary("K8sSnapDistribution.K8sd_boundary", "K8sd", $tags="") {
   Component(K8sSnapDistribution.K8sd.CLI, "CLI", $techn="CLI", $descr="The CLI offered", $tags="", $link="")
@@ -24,10 +24,10 @@ Container_Boundary("K8sSnapDistribution.K8sd_boundary", "K8sd", $tags="") {
 
 Rel(K8sAdmin, K8sSnapDistribution.K8sd.CLI, "Sets up and configured the cluster", $techn="", $tags="", $link="")
 Rel(CharmK8s, K8sSnapDistribution.K8sd.APIviaHTTP, "Orchestrates the lifecycle management of K8s when deployed with Juju", $techn="", $tags="", $link="")
-Rel(K8sSnapDistribution.K8sd.CLustermanagement, K8sSnapDistribution.KubernetesControlPlane, "Configures", $techn="", $tags="", $link="")
-Rel(K8sSnapDistribution.KubernetesControlPlane, K8sSnapDistribution.KubernetesDatastore, "Keeps state in", $techn="", $tags="", $link="")
+Rel(K8sSnapDistribution.K8sd.CLustermanagement, K8sSnapDistribution.KubernetesCoreComponents, "Configures", $techn="", $tags="", $link="")
+Rel(K8sSnapDistribution.KubernetesCoreComponents, K8sSnapDistribution.KubernetesDatastore, "Keeps state in", $techn="", $tags="", $link="")
 Rel(K8sSnapDistribution.K8sd.CLustermanagement, K8sSnapDistribution.ClusterDatastore, "Keeps state in", $techn="", $tags="", $link="")
-Rel(K8sSnapDistribution.K8sd.APIviaHTTP, K8sSnapDistribution.KubernetesControlPlane, "Configures", $techn="", $tags="", $link="")
+Rel(K8sSnapDistribution.K8sd.APIviaHTTP, K8sSnapDistribution.KubernetesCoreComponents, "Configures", $techn="", $tags="", $link="")
 Rel(K8sSnapDistribution.K8sd.APIviaHTTP, K8sSnapDistribution.Runtime, "Configures", $techn="", $tags="", $link="")
 Rel(K8sSnapDistribution.K8sd.APIviaHTTP, K8sSnapDistribution.K8sd.CLustermanagement, "Uses", $techn="", $tags="", $link="")
 Rel(K8sSnapDistribution.K8sd.CLI, K8sSnapDistribution.K8sd.APIviaHTTP, "CLI is based on the API primitives", $techn="", $tags="", $link="")

--- a/docs/canonicalk8s/charm/explanation/architecture.md
+++ b/docs/canonicalk8s/charm/explanation/architecture.md
@@ -1,0 +1,13 @@
+# Architecture
+
+```{include} /snap/explanation/architecture.md
+:start-after: '## Canonical K8s charms'
+```
+
+## Further reading
+
+To learn more about the `k8s` snap architecture, see the
+{{product}} [snap architecture explanation] page.
+
+<!-- LINKS -->
+[snap architecture explanation]: /snap/explanation/architecture

--- a/docs/canonicalk8s/charm/explanation/index.md
+++ b/docs/canonicalk8s/charm/explanation/index.md
@@ -21,6 +21,7 @@ method that best suits your orchestration needs.
 ```{toctree}
 :titlesonly:
 about
+architecture
 installation-methods.md
 ```
 

--- a/docs/canonicalk8s/charm/index.md
+++ b/docs/canonicalk8s/charm/index.md
@@ -83,7 +83,7 @@ and constructive feedback.
 [Code of Conduct]: https://ubuntu.com/community/ethos/code-of-conduct
 [community]: reference/community
 [contribute]: /snap/howto/contribute
-[releases]: /snap/reference/releases
+[releases]: /charm/reference/releases
 [overview page]: /charm/explanation/about
 [arch]: /charm/explanation/architecture
 [Juju]: https://juju.is

--- a/docs/canonicalk8s/charm/index.md
+++ b/docs/canonicalk8s/charm/index.md
@@ -82,9 +82,9 @@ and constructive feedback.
 
 [Code of Conduct]: https://ubuntu.com/community/ethos/code-of-conduct
 [community]: reference/community
-[contribute]: ../snap/howto/contribute
-[releases]: ../snap/reference/releases
-[overview page]: explanation/about
-[arch]: reference/architecture
+[contribute]: /snap/howto/contribute
+[releases]: /snap/reference/releases
+[overview page]: /charm/explanation/about
+[arch]: /charm/explanation/architecture
 [Juju]: https://juju.is
-[k8s snap package]: ../snap/index
+[k8s snap package]: /snap/index

--- a/docs/canonicalk8s/charm/reference/architecture.md
+++ b/docs/canonicalk8s/charm/reference/architecture.md
@@ -1,5 +1,5 @@
 # K8s charm architecture
 
-```{include} ../../snap/reference/architecture.md
+```{include} /snap/reference/architecture.md
    :start-after: '## Canonical K8s charms'
 ```

--- a/docs/canonicalk8s/charm/reference/index.md
+++ b/docs/canonicalk8s/charm/reference/index.md
@@ -12,7 +12,7 @@ Overview <self>
 
 ```{toctree}
 :titlesonly:
-Architecture <architecture>
+Architecture diagrams <architecture>
 ```
 
 ## Charms

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -1,0 +1,154 @@
+# Architecture
+
+A system architecture document is the starting point for many interested
+participants in a project, whether you intend contributing or simply want to
+understand how the software is structured. This documentation lays out the
+current design of {{product}}, following the [C4 model].
+
+## System context
+
+This overview of {{product}} demonstrates the interactions of
+Kubernetes with users and with other systems.
+
+![cluster5][]
+
+Two actors interact with the Kubernetes snap:
+
+- **K8s admin**: The administrator of the cluster interacts directly with the
+Kubernetes API server. Out of the box our K8s distribution offers admin
+access to the cluster. That initial user is able to configure the cluster to
+match their needs and of course create other users that may or may not have
+admin privileges. The K8s admin is also able to maintain workloads running
+in the cluster. If you deploy {{product}} from a snap, this is how the cluster
+is manually orchestrated.
+
+- **K8s user**: A user consuming the workloads hosted in the cluster. Users do
+not have access to the Kubernetes API server. They need to access the cluster
+through the options (nodeport, ingress, load-balancer) offered by the
+administrator who deployed the workload they are interested in.
+
+There are non-human users of the K8s snap, for example the [`k8s-operator
+charm`][K8s charm]. The K8s charm needs to drive the Kubernetes cluster and to
+orchestrate the multi-node clustering operations.
+
+A set of external systems need to be easily integrated with our K8s
+distribution. We have identified the following:
+
+- **Load Balancer**: Although the K8s snap distribution comes with a
+load balancer, we expect the end customer environment will have a load balancer
+and thus we need to integrate with it.
+- **Storage**: Kubernetes typically expects storage to be external to the
+cluster. The K8s snap comes with a local storage option but we still need to
+offer integration with any storage solution.
+- **Identity management**: Out of the box the K8s snap offers credentials for
+an admin user. The admin user can complete the integration with any identity
+management system available or do user management manually.
+- **External datastore**: By default, Kubernetes uses etcd to keep track of
+state. Our K8s snap comes with `dqlite` as its datastore. We should however
+be able to use any end client owned datastore installation. That should
+include an external `etcd`.
+
+## The k8s snap
+
+Looking more closely at what is contained within the K8s snap itself:
+
+![cluster1][]
+
+The `k8s` snap distribution includes the following:
+
+- **Kubectl**: through which users and other systems interact with Kubernetes
+and drive the cluster operations.
+- **K8s control plane**: These are all the Kubernetes services as well as core
+workloads built from upstream and shipped in the snap.
+- **Kubernetes datastore**: uses dqlite to store data on the state of the
+cluster. It can be replaced by an external datastore.
+- **Cluster datastore**: uses dqlite as a replicated database to store cluster
+configuration. It is used
+by `k8sd` in order to carry out the orchestration of the additional Kubernetes
+components included in {{product}} we deem important.
+- **Runtime**: `containerd` is the shipped container runtime.
+- **K8sd**: implements the operations logic and exposes that
+functionality via CLIs and APIs.
+
+## K8sd
+
+K8sd is the component that implements and exposes the operations functionality
+needed for managing the Kubernetes cluster.
+
+![cluster2][]
+
+At the core of the `k8sd` functionality we have the cluster manager that is
+responsible for configuring the services, workload and features we deem
+important for a Kubernetes cluster. Namely:
+
+- Kubernetes systemd services
+- DNS
+- CNI
+- ingress
+- gateway API
+- load-balancer
+- local-storage
+- metrics-server
+
+The cluster manager is also responsible for implementing the formation of the
+cluster. This includes operations such as joining/removing nodes into the
+cluster and reporting status.
+
+This functionality is exposed via the following interfaces:
+
+- The **CLI**: The CLI is available to only the root user on the K8s snap and
+all CLI commands are mapped to respective REST calls.
+
+- The **API**: The API over HTTP serves the CLI and is also used to
+programmatically drive the Kubernetes cluster.
+
+## Canonical K8s charms
+
+Canonical `k8s` Charms encompass two primary components: the [`k8s` charm][K8s
+charm] and the [`k8s-worker` charm][K8s-worker charm].
+
+![cluster4][]
+
+Charms are instantiated on a machine as a Juju unit, and a collection of units
+constitutes an application. Both `k8s` and `k8s-worker` units are responsible
+for installing and managing its machine's `k8s` snap, however the charm type
+determines the node's role in the Kubernetes cluster. The `k8s` charm manages
+`control-plane` nodes, whereas the `k8s-worker` charm manages Kubernetes
+`worker` nodes. The administrator manages the cluster via the `juju` client,
+directing the `juju` controller to reach the model's eventually consistent
+state. For more detail on Juju's concepts, see the [Juju docs][].
+
+The administrator may choose any supported cloud-types (OpenStack, MAAS, AWS,
+GCP, Azure...) on which to manage the machines making up the Kubernetes
+cluster. Juju selects a single leader unit per application to act as a
+centralised figure with the model. The `k8s` leader oversees Kubernetes
+bootstrapping and enlistment of new nodes. Follower `k8s` units will join the
+cluster using secrets shared through relation data from the leader. The entire
+lifecycle of the deployment is orchestrated by the `k8s` charm, with tokens and
+cluster-related information being exchanged through Juju relation data.
+
+Furthermore, the `k8s-worker` unit functions exclusively as a worker within the
+cluster, establishing a relation with the `k8s` leader unit and requesting
+tokens and cluster-related information through relation data. The `k8s` leader
+is responsible for issuing these tokens and revoking them if a unit
+administratively departs the cluster.
+
+The `k8s` charm also supports the integration of other compatible charms,
+enabling integrations such as connectivity with an external `etcd` datastore
+and the sharing of observability data with the [`Canonical Observability Stack
+(COS)`][COS docs]. This modular and integrated approach facilitates a robust
+and flexible {{product}} deployment managed through Juju.
+
+<!-- IMAGES -->
+
+[cluster1]: https://assets.ubuntu.com/v1/58712341-snap.svg
+[cluster2]: https://assets.ubuntu.com/v1/d74833fe-k8sd.svg
+[cluster4]: https://assets.ubuntu.com/v1/53a083a9-charms.svg
+[cluster5]: https://assets.ubuntu.com/v1/bcfe150f-overview.svg
+
+<!-- LINKS -->
+[C4 model]:           https://c4model.com/
+[K8s charm]:          https://charmhub.io/k8s
+[K8s-Worker charm]:   https://charmhub.io/k8s-worker
+[Juju docs]:          https://juju.is/docs/juju
+[COS docs]:           https://ubuntu.com/observability

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -104,7 +104,7 @@ programmatically drive the Kubernetes cluster.
 
 ## Canonical K8s charms
 
-Canonical `k8s` Charms encompass two primary components: the [`k8s` charm][K8s
+Canonical `k8s` charms encompass two primary components: the [`k8s` charm][K8s
 charm] and the [`k8s-worker` charm][K8s-worker charm].
 
 ![cluster4][]

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -24,29 +24,28 @@ is manually orchestrated.
 
 - **K8s user**: A user consuming the workloads hosted in the cluster. Users do
 not have access to the Kubernetes API server. They need to access the cluster
-through the options (nodeport, ingress, load-balancer) offered by the
+through the options (NodePort, Ingress, load-balancer) offered by the
 administrator who deployed the workload they are interested in.
 
 There are non-human users of the K8s snap, for example the [`k8s-operator
-charm`][K8s charm]. The K8s charm needs to drive the Kubernetes cluster and to
-orchestrate the multi-node clustering operations.
+charm`][K8s charm]. The K8s charm uses the snap to drive the Kubernetes cluster
+and orchestrates multi-node clustering operations.
 
-A set of external systems need to be easily integrated with our K8s
-distribution. We have identified the following:
+A set of external systems are easily integrated with our K8s
+distribution:
 
 - **Load Balancer**: Although the K8s snap distribution comes with a
-load balancer, we expect the end customer environment will have a load balancer
-and thus we need to integrate with it.
+load balancer, we allow the end customer environment to bring their own load
+balancer solution.
 - **Storage**: Kubernetes typically expects storage to be external to the
-cluster. The K8s snap comes with a local storage option but we still need to
-offer integration with any storage solution.
+cluster. The K8s snap comes with a local storage option but also
+allows integrations with alternative storage solutions.
 - **Identity management**: Out of the box the K8s snap offers credentials for
 an admin user. The admin user can complete the integration with any identity
 management system available or do user management manually.
 - **External datastore**: By default, Kubernetes uses etcd to keep track of
-state. Our K8s snap comes with `dqlite` as its datastore. We should however
-be able to use any end client owned datastore installation. That should
-include an external `etcd`.
+state. Our K8s snap comes with [Dqlite] as its datastore. However, we permit
+end client owned datastore installation such as the use of an external `etcd`.
 
 ## The k8s snap
 
@@ -60,12 +59,12 @@ The `k8s` snap distribution includes the following:
 and drive the cluster operations.
 - **K8s control plane**: These are all the Kubernetes services as well as core
 workloads built from upstream and shipped in the snap.
-- **Kubernetes datastore**: uses dqlite to store data on the state of the
+- **Kubernetes datastore**: uses Dqlite to store data on the state of the
 cluster. It can be replaced by an external datastore.
-- **Cluster datastore**: uses dqlite as a replicated database to store cluster
-configuration. It is used
+- **Cluster datastore**: uses Dqlite managed by [Microcluster] as a replicated
+database to store cluster configuration. It is used
 by `k8sd` in order to carry out the orchestration of the additional Kubernetes
-components included in {{product}} we deem important.
+components included in {{product}} such as cluster membership management.
 - **Runtime**: `containerd` is the shipped container runtime.
 - **K8sd**: implements the operations logic and exposes that
 functionality via CLIs and APIs.
@@ -78,14 +77,14 @@ needed for managing the Kubernetes cluster.
 ![cluster2][]
 
 At the core of the `k8sd` functionality we have the cluster manager that is
-responsible for configuring the services, workload and features we deem
+responsible for configuring the services, workloads and features we deem
 important for a Kubernetes cluster. Namely:
 
 - Kubernetes systemd services
 - DNS
 - CNI
-- ingress
-- gateway API
+- Ingress
+- Gateway API
 - load-balancer
 - local-storage
 - metrics-server
@@ -152,3 +151,5 @@ and flexible {{product}} deployment managed through Juju.
 [K8s-Worker charm]:   https://charmhub.io/k8s-worker
 [Juju docs]:          https://juju.is/docs/juju
 [COS docs]:           https://ubuntu.com/observability
+[Dqlite]:             https://github.com/canonical/k8s-dqlite
+[Microcluster]:       https://github.com/canonical/microcluster

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -140,8 +140,8 @@ and flexible {{product}} deployment managed through Juju.
 
 <!-- IMAGES -->
 
-[cluster1]: https://assets.ubuntu.com/v1/58712341-snap.svg
-[cluster2]: https://assets.ubuntu.com/v1/d74833fe-k8sd.svg
+[cluster1]: https://assets.ubuntu.com/v1/de97f360-snap10-04.svg
+[cluster2]: https://assets.ubuntu.com/v1/24ea67c0-k8sd10-04.svg
 [cluster4]: https://assets.ubuntu.com/v1/53a083a9-charms.svg
 [cluster5]: https://assets.ubuntu.com/v1/bcfe150f-overview.svg
 

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -57,7 +57,7 @@ The `k8s` snap distribution includes the following:
 
 - **Kubectl**: through which users and other systems interact with Kubernetes
 and drive the cluster operations.
-- **K8s control plane**: These are all the Kubernetes services as well as core
+- **K8s core components**: These are all the Kubernetes services as well as core
 workloads built from upstream and shipped in the snap.
 - **Kubernetes datastore**: uses Dqlite to store data on the state of the
 cluster. It can be replaced by an external datastore.
@@ -65,7 +65,7 @@ cluster. It can be replaced by an external datastore.
 database to store cluster configuration. It is used
 by `k8sd` in order to carry out the orchestration of the additional Kubernetes
 components included in {{product}} such as cluster membership management.
-- **Runtime**: `containerd` is the shipped container runtime.
+- **Container runtime**: `containerd` is the shipped container runtime.
 - **K8sd**: implements the operations logic and exposes that
 functionality via CLIs and APIs.
 

--- a/docs/canonicalk8s/snap/explanation/index.md
+++ b/docs/canonicalk8s/snap/explanation/index.md
@@ -17,6 +17,7 @@ method that best suits your orchestration needs.
 ```{toctree}
 :titlesonly:
 about
+architecture
 installation-methods.md
 clustering
 ```

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -160,6 +160,6 @@ lxc delete k8s-vm
 ```
 
 [LXD]: https://canonical.com/lxd
-[default-bridged-networking]: https://ubuntu.com/blog/lxd-networking-lxdbr0-explained
+[default-bridged-networking]: https://documentation.ubuntu.com/lxd/en/latest/reference/network_bridge/
 [Microbot]: https://github.com/dontrebootme/docker-microbot
 [channels]: ../../explanation/channels

--- a/docs/canonicalk8s/snap/index.md
+++ b/docs/canonicalk8s/snap/index.md
@@ -80,9 +80,9 @@ and constructive feedback.
 <!-- LINKS -->
 
 [Code of Conduct]: https://ubuntu.com/community/ethos/code-of-conduct
-[community]: ./reference/community
-[contribute]: ./howto/contribute
-[releases]: ./reference/releases
-[overview page]: ./explanation/about
-[architecture documentation]: ./reference/architecture
-[Juju charm]: ../charm/index
+[community]: /snap/reference/community
+[contribute]: /snap/howto/contribute
+[releases]: /snap/reference/releases
+[overview page]: /snap/explanation/about
+[architecture documentation]: /snap/explanation/architecture
+[Juju charm]: /charm/index

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -86,8 +86,6 @@ charm] and the [`k8s-worker` charm][K8s-worker charm].
 
 ![cluster4][]
 
-<!-- Charms are instantiated on a machine as a Juju unit, and a collection of units
-constitutes an application. -->
 The {{product}} charms include the following:
 
 - **`k8s`** : installs and manages the `k8s` snap on control plane node. Also

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -1,4 +1,4 @@
-# Architecture
+# Architecture diagrams
 
 A system architecture document is the starting point for many interested
 participants in a project, whether you intend contributing or simply want to
@@ -12,45 +12,28 @@ Kubernetes with users and with other systems.
 
 ![cluster5][]
 
-Two actors interact with the Kubernetes snap:
+Actors that interact with the K8s snap:
 
-- **K8s admin**: The administrator of the cluster interacts directly with the
-  Kubernetes API server. Out of the box our K8s distribution offers admin
-  access to the cluster. That initial user is able to configure the cluster to
-  match their needs and of course create other users that may or may not have
-  admin privileges. The K8s admin is also able to maintain workloads running
-  in the cluster. If you deploy {{product}} from a snap, this is how the cluster
- is manually orchestrated.
+- K8s admin - interacts directly with the Kubernetes API server. {{product}}
+provides out of the box admin access to the cluster to configure the cluster to
+their needs.
+- K8s user
 
-- **K8s user**: A user consuming the workloads hosted in the cluster. Users do
-  not have access to the Kubernetes API server. They need to access the cluster
-  through the options (nodeport, ingress, load-balancer) offered by the
-  administrator who deployed the workload they are interested in.
+Non-human users of the K8s snap:
 
-There are non-human users of the K8s snap, for example the [`k8s-operator
-charm`][K8s charm]. The K8s charm needs to drive the Kubernetes cluster and to
-orchestrate the multi-node clustering operations.
+- [`k8s-operator charm`][K8s charm].
 
-A set of external systems need to be easily integrated with our K8s
-distribution. We have identified the following:
+Although {{product}} provides its own implementation of the following services,
+external systems that can be easily integrated:
 
-- **Load Balancer**: Although the K8s snap distribution comes with a
-   load balancer we expect the end customer environment to have a load balancer
-   and thus we need to integrate with it.
-- **Storage**: Kubernetes typically expects storage to be external to the
-  cluster. The K8s snap comes with a local storage option but we still need to
-  offer proper integration with any storage solution.
-- **Identity management**: Out of the box the K8s snap offers credentials for
-  an admin user. The admin user can complete the integration with any identity
-  management system available or do user management manually.
-- **External datastore**: By default, Kubernetes uses etcd to keep track of
-  state. Our K8s snap comes with `dqlite` as its datastore. We should however
-  be able to use any end client owned datastore installation. That should
-  include an external `postgresql` or `etcd`.
+- Load Balancer
+- Storage
+- Identity management
+- External datastore
 
 ## The k8s snap
 
-Looking more closely at what is contained within the K8s snap itself:
+What is contained within the K8s snap itself:
 
 ![cluster1][]
 
@@ -75,9 +58,7 @@ needed for managing the Kubernetes cluster.
 
 ![cluster2][]
 
-At the core of the `k8sd` functionality we have the cluster manager that is
-responsible for configuring the services, workload and features we deem
-important for a Kubernetes cluster. Namely:
+Functionality provided by `k8sd` cluster manager is:
 
 - Kubernetes systemd services
 - DNS
@@ -107,8 +88,26 @@ charm] and the [`k8s-worker` charm][K8s-worker charm].
 
 ![cluster4][]
 
-Charms are instantiated on a machine as a Juju unit, and a collection of units
-constitutes an application. Both `k8s` and `k8s-worker` units are responsible
+<!-- Charms are instantiated on a machine as a Juju unit, and a collection of units
+constitutes an application. -->
+
+Roles:
+
+**`k8s`**
+
+- Installs and manages the `k8s` snap
+- Manages control plane node
+
+**`k8s-worker`**
+
+- Installs and manages the `k8s` snap
+- Manages worker node
+
+**Administrator**
+
+- Manages the cluster via the Juju client
+
+Both `k8s` and `k8s-worker` units are responsible
 for installing and managing its machine's `k8s` snap, however the charm type
 determines the node's role in the Kubernetes cluster. The `k8s` charm manages
 `control-plane` nodes, whereas the `k8s-worker` charm manages Kubernetes

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -1,9 +1,7 @@
 # Architecture diagrams
 
-A system architecture document is the starting point for many interested
-participants in a project, whether you intend contributing or simply want to
-understand how the software is structured. This documentation lays out the
-current design of {{product}}, following the [C4 model].
+This documentation lays out the
+current architecture diagrams of {{product}}, following the [C4 model].
 
 ## System context
 
@@ -20,11 +18,11 @@ provides out of the box admin access to configure the cluster.
 
 Non-human users of the K8s snap:
 
-- [`k8s-operator charm`][K8s charm]: drives the Kubernetes cluster and
-orchestrates multi-node clustering operations.
+- [`k8s-operator charm`][K8s charm]: uses the snap to drive the Kubernetes
+cluster and orchestrate multi-node clustering operations.
 
 Although {{product}} provides its own implementation of the following services,
-external systems that can be easily integrated:
+external systems can be easily integrated:
 
 - **Load Balancer**
 - **Storage**
@@ -43,9 +41,9 @@ The `k8s` snap distribution includes the following:
 and drive the cluster operations.
 - **K8s control plane**: the Kubernetes services, as well as core
 workloads built from upstream and shipped in the snap.
-- **Kubernetes datastore**: uses dqlite to store data on the state of the
+- **Kubernetes datastore**: uses [Dqlite] to store data on the state of the
 cluster. It can be replaced by an external datastore.
-- **Cluster datastore**: uses dqlite as a replicated database to store cluster
+- **Cluster datastore**: uses Dqlite as a replicated database to store cluster
 configuration.
 - **Runtime**: `containerd` is the shipped container runtime.
 - **K8sd**: implements the operations logic and exposes that
@@ -63,8 +61,8 @@ Functionality provided by `k8sd` cluster manager is:
 - Kubernetes systemd services
 - DNS
 - CNI
-- ingress
-- gateway API
+- Ingress
+- Gateway API
 - load-balancer
 - local-storage
 - metrics-server
@@ -74,10 +72,10 @@ Functionality provided by `k8sd` cluster manager is:
 This functionality is exposed via the following interfaces:
 
 - The **CLI**: The CLI is available to only the root user on the K8s snap and
-  all CLI commands are mapped to respective REST calls.
+all CLI commands are mapped to respective REST calls.
 
 - The **API**: The API over HTTP serves the CLI and is also used to
-  programmatically drive the Kubernetes cluster.
+programmatically drive the Kubernetes cluster.
 
 ## Canonical K8s charms
 
@@ -88,9 +86,9 @@ charm] and the [`k8s-worker` charm][K8s-worker charm].
 
 The {{product}} charms include the following:
 
-- **`k8s`** : installs and manages the `k8s` snap on control plane node. Also
-supports integration with other compatible charms.
-- **`k8s-worker`**: installs and manages the `k8s` snap on worker node.
+- **`k8s`** : installs and manages the `k8s` snap on control plane nodes. The
+charm also supports integrations with other compatible charms.
+- **`k8s-worker`**: installs and manages the `k8s` snap on worker nodes.
 - **Administrator**: manages the cluster via the Juju client.
 - **K8sd API Manager**: Makes API calls to the `k8s` snap
 - **Relation Databags for `k8s` and `k8s-worker`**: Juju databags for sharing
@@ -109,3 +107,4 @@ information between the `k8s` and `k8s-worker` charms
 [K8s-Worker charm]:   https://charmhub.io/k8s-worker
 [Juju docs]:          https://juju.is/docs/juju
 [COS docs]:           https://ubuntu.com/observability
+[Dqlite]:             https://github.com/canonical/k8s-dqlite

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -39,13 +39,13 @@ The `k8s` snap distribution includes the following:
 
 - **Kubectl**: through which users and other systems interact with Kubernetes
 and drive the cluster operations.
-- **K8s control plane**: the Kubernetes services, as well as core
+- **K8s core components**: the Kubernetes services, as well as core
 workloads built from upstream and shipped in the snap.
 - **Kubernetes datastore**: uses [Dqlite] to store data on the state of the
 cluster. It can be replaced by an external datastore.
 - **Cluster datastore**: uses Dqlite as a replicated database to store cluster
 configuration.
-- **Runtime**: `containerd` is the shipped container runtime.
+- **Container runtime**: `containerd` is the shipped container runtime.
 - **K8sd**: implements the operations logic and exposes that
 functionality via CLIs and APIs.
 

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -14,42 +14,42 @@ Kubernetes with users and with other systems.
 
 Actors that interact with the K8s snap:
 
-- K8s admin - interacts directly with the Kubernetes API server. {{product}}
-provides out of the box admin access to the cluster to configure the cluster to
-their needs.
-- K8s user
+- **K8s admin**:  interacts directly with the Kubernetes API server. {{product}}
+provides out of the box admin access to configure the cluster.
+- **K8s user** : consumes the workloads hosted in the cluster.
 
 Non-human users of the K8s snap:
 
-- [`k8s-operator charm`][K8s charm].
+- [`k8s-operator charm`][K8s charm]: drives the Kubernetes cluster and
+orchestrates multi-node clustering operations.
 
 Although {{product}} provides its own implementation of the following services,
 external systems that can be easily integrated:
 
-- Load Balancer
-- Storage
-- Identity management
-- External datastore
+- **Load Balancer**
+- **Storage**
+- **Identity management**
+- **External datastore**
 
 ## The k8s snap
 
-What is contained within the K8s snap itself:
+Contained within the K8s snap itself:
 
 ![cluster1][]
 
 The `k8s` snap distribution includes the following:
 
 - **Kubectl**: through which users and other systems interact with Kubernetes
-  and drive the cluster operations.
-- **K8s services**: These are all the Kubernetes services as well as core
-  workloads built from upstream and shipped in the snap.
-- State is backed up by **dqlite** by default, which keeps that state of the
-  Kubernetes cluster as well as the state we maintain for the needs of the
-  cluster operations. The cluster state may optionally be stored in a
-  different, external datastore.
-- **Runtime**: `containerd` and `runc` are the shipped container runtimes.
-- **K8sd**: which implements the operations logic and exposes that
-  functionality via CLIs and APIs.
+and drive the cluster operations.
+- **K8s control plane**: the Kubernetes services, as well as core
+workloads built from upstream and shipped in the snap.
+- **Kubernetes datastore**: uses dqlite to store data on the state of the
+cluster. It can be replaced by an external datastore.
+- **Cluster datastore**: uses dqlite as a replicated database to store cluster
+configuration.
+- **Runtime**: `containerd` is the shipped container runtime.
+- **K8sd**: implements the operations logic and exposes that
+functionality via CLIs and APIs.
 
 ## K8sd
 
@@ -68,10 +68,8 @@ Functionality provided by `k8sd` cluster manager is:
 - load-balancer
 - local-storage
 - metrics-server
-
-The cluster manager is also responsible for implementing the formation of the
-cluster. This includes operations such as joining/removing nodes into the
-cluster and reporting status.
+- implementing the formation of the cluster
+- reporting cluster status
 
 This functionality is exposed via the following interfaces:
 
@@ -83,58 +81,22 @@ This functionality is exposed via the following interfaces:
 
 ## Canonical K8s charms
 
-Canonical `k8s` Charms encompass two primary components: the [`k8s` charm][K8s
+Canonical `k8s` charms are the [`k8s` charm][K8s
 charm] and the [`k8s-worker` charm][K8s-worker charm].
 
 ![cluster4][]
 
 <!-- Charms are instantiated on a machine as a Juju unit, and a collection of units
 constitutes an application. -->
+The {{product}} charms include the following:
 
-Roles:
-
-**`k8s`**
-
-- Installs and manages the `k8s` snap
-- Manages control plane node
-
-**`k8s-worker`**
-
-- Installs and manages the `k8s` snap
-- Manages worker node
-
-**Administrator**
-
-- Manages the cluster via the Juju client
-
-Both `k8s` and `k8s-worker` units are responsible
-for installing and managing its machine's `k8s` snap, however the charm type
-determines the node's role in the Kubernetes cluster. The `k8s` charm manages
-`control-plane` nodes, whereas the `k8s-worker` charm manages Kubernetes
-`worker` nodes. The administrator manages the cluster via the `juju` client,
-directing the `juju` controller to reach the model's eventually consistent
-state. For more detail on Juju's concepts, see the [Juju docs][].
-
-The administrator may choose any supported cloud-types (OpenStack, MAAS, AWS,
-GCP, Azure...) on which to manage the machines making up the Kubernetes
-cluster. Juju selects a single leader unit per application to act as a
-centralised figure with the model. The `k8s` leader oversees Kubernetes
-bootstrapping and enlistment of new nodes. Follower `k8s` units will join the
-cluster using secrets shared through relation data from the leader. The entire
-lifecycle of the deployment is orchestrated by the `k8s` charm, with tokens and
-cluster-related information being exchanged through Juju relation data.
-
-Furthermore, the `k8s-worker` unit functions exclusively as a worker within the
-cluster, establishing a relation with the `k8s` leader unit and requesting
-tokens and cluster-related information through relation data. The `k8s` leader
-is responsible for issuing these tokens and revoking them if a unit
-administratively departs the cluster.
-
-The `k8s` charm also supports the integration of other compatible charms,
-enabling integrations such as connectivity with an external `etcd` datastore
-and the sharing of observability data with the [`Canonical Observability Stack
-(COS)`][COS docs]. This modular and integrated approach facilitates a robust
-and flexible {{product}} deployment managed through Juju.
+- **`k8s`** : installs and manages the `k8s` snap on control plane node. Also
+supports integration with other compatible charms.
+- **`k8s-worker`**: installs and manages the `k8s` snap on worker node.
+- **Administrator**: manages the cluster via the Juju client.
+- **K8sd API Manager**: Makes API calls to the `k8s` snap
+- **Relation Databags for `k8s` and `k8s-worker`**: Juju databags for sharing
+information between the `k8s` and `k8s-worker` charms
 
 <!-- IMAGES -->
 

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -96,8 +96,8 @@ information between the `k8s` and `k8s-worker` charms
 
 <!-- IMAGES -->
 
-[cluster1]: https://assets.ubuntu.com/v1/58712341-snap.svg
-[cluster2]: https://assets.ubuntu.com/v1/d74833fe-k8sd.svg
+[cluster1]: https://assets.ubuntu.com/v1/de97f360-snap10-04.svg
+[cluster2]: https://assets.ubuntu.com/v1/24ea67c0-k8sd10-04.svg
 [cluster4]: https://assets.ubuntu.com/v1/53a083a9-charms.svg
 [cluster5]: https://assets.ubuntu.com/v1/bcfe150f-overview.svg
 

--- a/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
+++ b/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
@@ -139,6 +139,8 @@ CSRs
 cyclictest
 daemonset
 DaemonSet
+databags
+Databags
 datastore
 datastores
 dbus


### PR DESCRIPTION
## Description

Our current architecture reference page goes between reference and explanation in terms of the Diataxis framework. 

## Solution

Create another architecture page under explanation. 
Remove the explanation material from the reference architecture page. 
Create the same pages under charms.
Update links to architecture page.

## Back port

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [ ] Covered by integration tests - N/A
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary - N/A

If any item on the checklist is not complete, please provide justification why.
