### PR TITLE
docs: Update LXD privileged container info

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -4,10 +4,15 @@
 great way, for example, to test out clustered {{product}} without the
 need for multiple physical hosts.
 
-Why an LXD virtual machine and not a container? LXD privileged containers are
-no longer supported and some Kubernetes services, such as the Cilium CNI,
-cannot run inside unprivileged containers. Furthermore, by using virtual
-machine we ensure that the Kubernetes environment is well isolated.
+Why an LXD virtual machine and not a container?
+In order to run certain Kubernetes services, such as the Cilium CNI, the LXD
+container would need to be a [privileged container]. While this is possible, it
+is not the recommended pattern as it allows the root
+user in the container to be the root user on the host. Also, newer versions of
+Ubuntu and systemd require operations (such as mounting to the `/proc`
+directory) that cannot be safely handled with privileged containers. By using
+virtual machines, we ensure that the Kubernetes environment remains well
+isolated.
 
 ## Install LXD
 
@@ -163,3 +168,4 @@ lxc delete k8s-vm
 [default-bridged-networking]: https://ubuntu.com/blog/lxd-networking-lxdbr0-explained
 [Microbot]: https://github.com/dontrebootme/docker-microbot
 [channels]: ../../explanation/channels
+[privileged container]: https://documentation.ubuntu.com/server/how-to/containers/lxd-containers/index.html#uid-mappings-and-privileged-containers


### PR DESCRIPTION
## Description

The information about privileged LXD containers not being supported anymore is inaccurate. 

## Solution

Clarify while they are supported, it is not recommended. 

## Issue

#1197

## Back port

1.32

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Back port label added if necessary 

If any item on the checklist is not complete, please provide justification why.
