### PR TITLE
test: small e2e test improvements

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -126,7 +126,7 @@ def registry(h: harness.Harness) -> Optional[Registry]:
         yield Registry(h)
     else:
         LOG.info("Local registry mirror disabled!")
-        yield False
+        yield None
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -122,7 +122,11 @@ def log_environment_info(h: harness.Harness):
 
 @pytest.fixture(scope="session")
 def registry(h: harness.Harness) -> Optional[Registry]:
-    yield Registry(h)
+    if config.USE_LOCAL_MIRROR:
+        yield Registry(h)
+    else:
+        LOG.info("Local registry mirror disabled!")
+        yield False
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -68,12 +68,13 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
     )
 
 
+@pytest.mark.xfail(
+    run=False, reason="airgapped tests are currently failing on Github runners"
+)
 # @pytest.mark.node_count(2)
 # @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_proxy(instances: List[harness.Instance]):
-    pytest.xfail("airgapped tests are currently failing on Github runners")
-
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     instance_ip = util.get_default_ip(instance)
@@ -106,13 +107,15 @@ def test_airgapped_with_proxy(instances: List[harness.Instance]):
     util.wait_until_k8s_ready(instance, [instance])
 
 
-# @pytest.mark.node_count(2)
-# @pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.xfail(
+    run=False, reason="airgapped tests are currently failing on Github runners"
+)
+@pytest.mark.node_count(2)
+@pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_image_mirror(
     h: harness.Harness, instances: List[harness.Instance]
 ):
-    pytest.xfail("airgapped tests are currently failing on Github runners")
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     registry = reg.Registry(h)

--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -71,8 +71,8 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
 @pytest.mark.xfail(
     run=False, reason="airgapped tests are currently failing on Github runners"
 )
-# @pytest.mark.node_count(2)
-# @pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.node_count(2)
+@pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_proxy(instances: List[harness.Instance]):
     proxy, instance = instances

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -7,6 +7,10 @@ import pytest
 from test_util import harness, tags, util
 
 
+# Note(ben): k8s-dqlite sometimes takes very long to shutdown (to be investigated) and
+# since microcluster has a 30s fixed timeout for the remove hooks this test sometimes fails.
+# The timeout will be configurable in https://github.com/canonical/microcluster/pull/365)
+# The k8s-dqlite issue will be investigated separately.
 @pytest.mark.xfail(
     run=False,
     reason="This test is currently flaky because of a k8s-dqlite shutdown issue.",
@@ -14,10 +18,6 @@ from test_util import harness, tags, util
 @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
 def test_wrong_token_race(instances: List[harness.Instance]):
-    # Note(ben): k8s-dqlite sometimes takes very long to shutdown (to be investigated) and
-    # since microcluster has a 30s fixed timeout for the remove hooks this test sometimes fails.
-    # The timeout will be configurable in https://github.com/canonical/microcluster/pull/365)
-    # The k8s-dqlite issue will be investigated separately.
     cluster_node = instances[0]
 
     join_token = util.get_join_token(cluster_node, instances[1])

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -7,15 +7,17 @@ import pytest
 from test_util import harness, tags, util
 
 
-# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
-# @pytest.mark.node_count(3)
+@pytest.mark.xfail(
+    run=False,
+    reason="This test is currently flaky because of a k8s-dqlite shutdown issue.",
+)
+@pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
 def test_wrong_token_race(instances: List[harness.Instance]):
     # Note(ben): k8s-dqlite sometimes takes very long to shutdown (to be investigated) and
     # since microcluster has a 30s fixed timeout for the remove hooks this test sometimes fails.
     # The timeout will be configurable in https://github.com/canonical/microcluster/pull/365)
     # The k8s-dqlite issue will be investigated separately.
-    pytest.xfail("This test is currently flaky because of a k8s-dqlite shutdown issue.")
     cluster_node = instances[0]
 
     join_token = util.get_join_token(cluster_node, instances[1])

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -26,14 +26,14 @@ def test_loadbalancer_ipv4(instances: List[harness.Instance]):
     _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv4)
 
 
-# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
-# @pytest.mark.node_count(2)
-# @pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.xfail(
+    run=False,
+    reason="Cilium ipv6 only unsupported: https://github.com/cilium/cilium/issues/15082",
+)
+@pytest.mark.node_count(2)
+@pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.PULL_REQUEST)
 def test_loadbalancer_ipv6_only(instances: List[harness.Instance]):
-    pytest.xfail(
-        "Cilium ipv6 only unsupported: https://github.com/cilium/cilium/issues/15082"
-    )
     _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv6)
 
 

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -10,16 +10,14 @@ from test_util import config, harness, snap, tags, util
 LOG = logging.getLogger(__name__)
 
 
-# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
-# @pytest.mark.node_count(1)
-# @pytest.mark.no_setup()
+@pytest.mark.xfail(run=False, reason="Strict channel tests are currently skipped.")
+@pytest.mark.node_count(1)
+@pytest.mark.no_setup()
 @pytest.mark.skipif(
     not config.STRICT_INTERFACE_CHANNELS, reason="No strict channels configured"
 )
 @pytest.mark.tags(tags.WEEKLY)
 def test_strict_interfaces(instances: List[harness.Instance], tmp_path):
-    pytest.xfail("Strict channel tests are currently skipped.")
-
     channels = config.STRICT_INTERFACE_CHANNELS
     cp = instances[0]
     current_channel = channels[0]

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -48,11 +48,12 @@ class Harness:
 
     name: str
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
+    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
         """Creates a new instance on the infrastructure and returns an object
         which can be used to interact with it.
 
-        dualstack: If True, the instance will be created with dualstack support.
+        network_type: ipv4, ipv6 or dualstack.
+        name_suffix: a suffix to be appended to the instance name.
 
         If the operation fails, a HarnessError is raised.
         """

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -48,7 +48,9 @@ class Harness:
 
     name: str
 
-    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
         """Creates a new instance on the infrastructure and returns an object
         which can be used to interact with it.
 

--- a/tests/integration/tests/test_util/harness/juju.py
+++ b/tests/integration/tests/test_util/harness/juju.py
@@ -53,7 +53,9 @@ class JujuHarness(Harness):
                 self.constraints,
             )
 
-    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
         if network_type:
             raise HarnessError("Currently only IPv4 is supported by Juju harness")
 

--- a/tests/integration/tests/test_util/harness/juju.py
+++ b/tests/integration/tests/test_util/harness/juju.py
@@ -53,7 +53,7 @@ class JujuHarness(Harness):
                 self.constraints,
             )
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
+    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
         if network_type:
             raise HarnessError("Currently only IPv4 is supported by Juju harness")
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -70,8 +70,8 @@ class LXDHarness(Harness):
             "Configured LXD substrate (profile %s, image %s)", self.profile, self.image
         )
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
-        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}"
+    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
+        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         launch_lxd_command = [

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -70,8 +70,12 @@ class LXDHarness(Harness):
             "Configured LXD substrate (profile %s, image %s)", self.profile, self.image
         )
 
-    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
-        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
+        instance_id = (
+            f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
+        )
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         launch_lxd_command = [

--- a/tests/integration/tests/test_util/harness/multipass.py
+++ b/tests/integration/tests/test_util/harness/multipass.py
@@ -36,11 +36,11 @@ class MultipassHarness(Harness):
 
         LOG.debug("Configured Multipass substrate (image %s)", self.image)
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
+    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
         if network_type:
             raise HarnessError("Currently only IPv4 is supported by Multipass harness")
 
-        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}"
+        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:

--- a/tests/integration/tests/test_util/harness/multipass.py
+++ b/tests/integration/tests/test_util/harness/multipass.py
@@ -36,11 +36,15 @@ class MultipassHarness(Harness):
 
         LOG.debug("Configured Multipass substrate (image %s)", self.image)
 
-    def new_instance(self, network_type: str = "IPv4", name_suffix: str = "") -> Instance:
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
         if network_type:
             raise HarnessError("Currently only IPv4 is supported by Multipass harness")
 
-        instance_id = f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
+        instance_id = (
+            f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
+        )
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:

--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -55,7 +55,7 @@ class Registry:
         self.instance: Instance = None
         self.harness: Harness = h
         self._mirrors: List[Mirror] = self.get_configured_mirrors()
-        self.instance = self.harness.new_instance()
+        self.instance = self.harness.new_instance(name_suffix="-registry")
 
         arch = self.instance.arch
         self.instance.exec(


### PR DESCRIPTION
* use pytest.mark.xfail decorator to avoid initializing instances for skipped tests
* avoid creating the registry instance if the local mirror is disabled
* add a "-registry" suffix to the registry instance name