### PR TITLE
test: re-enable airgapped tests

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -128,7 +128,7 @@ def registry(h: harness.Harness) -> Optional[Registry]:
 @pytest.fixture(scope="function")
 def function_scoped_registry(h: harness.Harness) -> Registry:
     registry = Registry(h)
-    yield Registry(h)
+    yield registry
     registry.cleanup()
 
 

--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -108,11 +108,13 @@ def test_airgapped_with_proxy(instances: List[harness.Instance]):
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_airgapped_with_image_mirror(
-    h: harness.Harness, instances: List[harness.Instance]
+    h: harness.Harness,
+    instances: List[harness.Instance],
+    function_scoped_registry: reg.Registry,
 ):
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
-    registry = reg.Registry(h)
+    registry = function_scoped_registry
     registry_ip = util.get_default_ip(registry.instance)
 
     setup_proxy(proxy)

--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -68,9 +68,6 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
     )
 
 
-@pytest.mark.xfail(
-    run=False, reason="airgapped tests are currently failing on Github runners"
-)
 @pytest.mark.node_count(2)
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)
@@ -107,9 +104,6 @@ def test_airgapped_with_proxy(instances: List[harness.Instance]):
     util.wait_until_k8s_ready(instance, [instance])
 
 
-@pytest.mark.xfail(
-    run=False, reason="airgapped tests are currently failing on Github runners"
-)
 @pytest.mark.node_count(2)
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.NIGHTLY)

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -156,6 +156,13 @@ STRICT_INTERFACE_CHANNELS = (
 # for every test instance. Note that k8s-snap is currently based on core20.
 PRELOAD_SNAPS = (os.getenv("TEST_PRELOAD_SNAPS") or "1") == "1"
 
+# The following snaps will be downloaded once per test run and preloaded
+# into the harness instances to reduce the number of downloads.
+DEFAULT_PRELOADED_SNAPS = ["snapd", "core20"]
+PRELOADED_SNAPS = (
+    os.getenv("TEST_PRELOADED_SNAPS", "").strip().split() or DEFAULT_PRELOADED_SNAPS
+)
+
 # Setup a local image mirror to reduce the number of image pulls. The mirror
 # will be configured to run in a session scoped harness instance (e.g. LXD container)
 USE_LOCAL_MIRROR = (os.getenv("TEST_USE_LOCAL_MIRROR") or "1") == "1"
@@ -178,3 +185,6 @@ GH_REF = os.getenv("TEST_GH_REF")
 
 # The GitHub base_ref.
 GH_BASE_REF = os.getenv("TEST_GH_BASE_REF")
+
+# SONOBUOY_VERSION is the version of sonobuoy to use for CNCF conformance tests.
+SONOBUOY_VERSION = os.getenv("TEST_SONOBUOY_VERSION") or "v0.57.3"

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -221,7 +221,7 @@ class LXDHarness(Harness):
                 stdout=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError as e:
-            raise HarnessError("lxc file push command failed") from e
+            raise HarnessError("lxc file pull command failed") from e
 
     def exec(self, instance_id: str, command: list, **kwargs):
         if instance_id not in self.instances:

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -271,7 +271,9 @@ class LXDHarness(Harness):
             result = run(["df", "-h"], capture_output=True)
             LOG.info("\n%s", result.stdout.decode().strip())
 
-            if config.INSPECTION_REPORTS_DIR:
+            if config.INSPECTION_REPORTS_DIR and os.path.exists(
+                config.INSPECTION_REPORTS_DIR
+            ):
                 LOG.info("Inspection report size:")
                 result = run(
                     ["du", "-sh", config.INSPECTION_REPORTS_DIR], capture_output=True

--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -200,5 +200,8 @@ class Registry:
 
     def cleanup(self):
         if self.instance:
+            LOG.info("Cleaning up registry instance: %s", self.instance.id)
             self.harness.delete_instance(self.instance.id)
             self.instance = None
+        else:
+            LOG.info("Registry instance already cleaned up.")

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -32,13 +32,6 @@ RISKS = ["stable", "candidate", "beta", "edge"]
 TRACK_RE = re.compile(r"^(\d+)\.(\d+)(\S*)$")
 MAIN_BRANCH = "main"
 
-# SONOBUOY_VERSION is the version of sonobuoy to use for CNCF conformance tests.
-SONOBUOY_VERSION = os.getenv("TEST_SONOBUOY_VERSION") or "v0.57.3"
-
-# The following snaps will be downloaded once per test run and preloaded
-# into the harness instances to reduce the number of downloads.
-PRELOADED_SNAPS = ["snapd", "core20"]
-
 
 def run(command: list, **kwargs) -> subprocess.CompletedProcess:
     """Log and run command."""
@@ -176,8 +169,8 @@ def download_preloaded_snaps():
         LOG.info("Snap preloading disabled, skipping...")
         return
 
-    LOG.info(f"Downloading snaps for preloading: {PRELOADED_SNAPS}")
-    for snap in PRELOADED_SNAPS:
+    LOG.info(f"Downloading snaps for preloading: {config.PRELOADED_SNAPS}")
+    for snap in config.PRELOADED_SNAPS:
         run(
             [
                 "snap",
@@ -194,7 +187,7 @@ def preload_snaps(instance: harness.Instance):
         LOG.info("Snap preloading disabled.")
         return
 
-    for preloaded_snap in PRELOADED_SNAPS:
+    for preloaded_snap in config.PRELOADED_SNAPS:
         ack_file = f"{preloaded_snap}.assert"
         remote_path = os.path.join("/tmp", ack_file)
         instance.send_file(
@@ -823,7 +816,8 @@ def wait_for_daemonset(
 
 # sonobuoy_tar_gz returns the download URL of sonobuoy.
 def sonobuoy_tar_gz(architecture: str) -> str:
-    return f"https://github.com/vmware-tanzu/sonobuoy/releases/download/{SONOBUOY_VERSION}/sonobuoy_{SONOBUOY_VERSION[1:]}_linux_{architecture}.tar.gz"  # noqa
+    version = config.SONOBUOY_VERSION
+    return f"https://github.com/vmware-tanzu/sonobuoy/releases/download/{version}/sonobuoy_{version[1:]}_linux_{architecture}.tar.gz"  # noqa
 
 
 def check_snap_services_ready(


### PR DESCRIPTION
The airgap tests are known to fail and currently marked as xfail.

We'll re-enable them and make a few improvements aiming to eliminate flakiness:

* ensure that the registry instance is cleaned up at the end of the
  tests
* avoid pulling snaps unless really necessary
  * use snaps provided through TEST_SNAP
  * use preloaded snaps (snapd, core20)
    * move this to a separate helper called "preload_snaps"
