### PR TITLE
Backport 1228 and 1262

### DIFF
--- a/src/k8s/pkg/k8sd/api/certificates_refresh.go
+++ b/src/k8s/pkg/k8sd/api/certificates_refresh.go
@@ -389,10 +389,10 @@ func refreshCertsRunWorker(s state.State, r *http.Request, snap snap.Snap) respo
 			return
 		}
 
-		if err := snap.RestartService(ctx, "kubelet"); err != nil {
+		if err := snap.RestartServices(ctx, []string{"kubelet"}); err != nil {
 			log.Error(err, "Failed to restart kubelet")
 		}
-		if err := snap.RestartService(ctx, "kube-proxy"); err != nil {
+		if err := snap.RestartServices(ctx, []string{"kube-proxy"}); err != nil {
 			log.Error(err, "Failed to restart kube-proxy")
 		}
 	}()

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -237,19 +237,18 @@ func (a *App) Run(ctx context.Context, customHooks *state.Hooks) error {
 // The node is ready if:
 // - the microcluster database is accessible
 // - the kubernetes endpoint is reachable.
+// - the onNodeReady hook succeeds.
 func (a *App) markNodeReady(ctx context.Context, s state.State) error {
 	log := log.FromContext(ctx).WithValues("startup", "waitForReady")
 
-	// wait for the database to be open
-	log.V(1).Info("Waiting for database to be open")
+	log.Info("Waiting for database to be open")
 	if err := control.WaitUntilReady(ctx, func() (bool, error) {
 		return s.Database().IsOpen(ctx) == nil, nil
 	}); err != nil {
 		return fmt.Errorf("failed to wait for database to be open: %w", err)
 	}
 
-	// check kubernetes endpoint
-	log.V(1).Info("Waiting for kubernetes endpoint")
+	log.Info("Waiting for kubernetes endpoint")
 	if err := control.WaitUntilReady(ctx, func() (bool, error) {
 		client, err := a.snap.KubernetesNodeClient("")
 		if err != nil {
@@ -263,7 +262,12 @@ func (a *App) markNodeReady(ctx context.Context, s state.State) error {
 		return fmt.Errorf("failed to wait for kubernetes endpoint: %w", err)
 	}
 
-	log.V(1).Info("Marking node as ready")
+	log.Info("Running onNodeReady hook")
+	if err := a.onNodeReady(ctx, s); err != nil {
+		return fmt.Errorf("failed to execute onNodeReady hook: %w", err)
+	}
+
+	log.Info("Marking node as ready")
 	a.readyWg.Done()
 	return nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_node_ready.go
+++ b/src/k8s/pkg/k8sd/app/hooks_node_ready.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/microcluster/v2/state"
+)
+
+// onNodeReady is called when the node is ready, right after the wait group is released.
+// The node is ready if:
+// - the microcluster database is accessible
+// - the kubernetes endpoint is reachable.
+// Note that this is not a microcluster hook, but a custom k8sd hook.
+func (a *App) onNodeReady(ctx context.Context, s state.State) error {
+	log := log.FromContext(ctx).WithValues("hook", "onNodeReady")
+
+	// Check if a refresh was performed and if so, run the custom post-refresh hook
+	log.Info("Checking if snap is post-refresh")
+	isPostRefresh, err := utils.FileExists(a.snap.PostRefreshLockPath())
+	if err != nil {
+		return fmt.Errorf("failed to check if snap is post-refresh: %w", err)
+	}
+	if isPostRefresh {
+		log.Info("Snap is post-refresh - running post-refresh hook")
+		if err := a.postRefreshHook(ctx, s); err != nil {
+			return fmt.Errorf("failed to run post-refresh hook: %w", err)
+		}
+
+		log.Info("Post-refresh hook completed successfully - removing lock file.")
+		if err := os.Remove(a.snap.PostRefreshLockPath()); err != nil {
+			return fmt.Errorf("failed to remove post-refresh lock file: %w", err)
+		}
+	} else {
+		log.Info("Snap is not post-refresh")
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -6,13 +6,28 @@ import (
 
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/log"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
 	"github.com/canonical/microcluster/v2/state"
 )
 
+// postRefreshHook is executed after the node is ready after a `snap refresh` operation
+// See nodeReadyHook for details on when a node is considered ready.
+// Note that the postRefreshHook is NOT executed after a `snap install` operation which is
+// different to the underlying snap hook.
 func (a *App) postRefreshHook(ctx context.Context, s state.State) error {
 	log := log.FromContext(ctx).WithValues("hook", "post-refresh")
 	log.Info("Running post-refresh hook")
+
+	isWorker, err := snaputil.IsWorker(a.snap)
+	if err != nil {
+		return fmt.Errorf("failed to check if node is a worker: %w", err)
+	}
+
+	if isWorker {
+		log.Info("Node is a worker, skipping post-refresh hook")
+		return nil
+	}
 
 	config, err := databaseutil.GetClusterConfig(ctx, s)
 	if err != nil {

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -140,19 +140,9 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 			log.Error(err, "failed to cleanup control plane certificates")
 		}
 
-		log.Info("Stopping worker services")
-		if err := snaputil.StopWorkerServices(ctx, snap); err != nil {
-			log.Error(err, "Failed to stop worker services")
-		}
-
-		log.Info("Stopping control plane services")
-		if err := snaputil.StopControlPlaneServices(ctx, snap); err != nil {
-			log.Error(err, "Failed to stop control-plane services")
-		}
-
-		log.Info("Stopping k8s-dqlite")
-		if err := snaputil.StopK8sDqliteServices(ctx, snap); err != nil {
-			log.Error(err, "Failed to stop k8s-dqlite service")
+		log.Info("Stopping all services except k8sd")
+		if err := snaputil.StopK8sServices(ctx, snap, "--no-wait"); err != nil {
+			log.Error(err, "failed to stop k8s services")
 		}
 
 		log.Info("Cleaning up containerd paths")

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -155,7 +155,10 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 			log.Error(err, "Failed to stop k8s-dqlite service")
 		}
 
+		log.Info("Cleaning up containerd paths")
 		tryCleanupContainerdPaths(log, snap)
+	} else {
+		log.Info("Skipping service stop and certificate cleanup")
 	}
 
 	return nil
@@ -167,6 +170,7 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 func tryCleanupContainerdPaths(log log.Logger, s snap.Snap) {
 	for lockpath, dirpath := range setup.ContainerdLockPathsForSnap(s) {
 		// Ensure lockfile exists:
+		log.Info("Cleaning up containerd data directory", "directory", dirpath)
 		if _, err := os.Stat(lockpath); os.IsNotExist(err) {
 			log.Info("WARN: failed to find containerd lockfile, no cleanup will be perfomed", "lockfile", lockpath, "directory", dirpath)
 			continue

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"database/sql"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/canonical/k8s/pkg/k8sd/database"
@@ -24,20 +23,6 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 			log.FromContext(ctx).Error(err, "Failed to mark node as ready")
 		}
 	}()
-
-	// Check if a refresh was performed and if so, run the custom post-refresh hook
-	isPostRefresh, err := utils.FileExists(a.snap.PostRefreshLockPath())
-	if err != nil {
-		return fmt.Errorf("failed to check if snap is post-refresh: %w", err)
-	}
-	if isPostRefresh {
-		if err := a.postRefreshHook(ctx, s); err != nil {
-			return fmt.Errorf("failed to run post-refresh hook: %w", err)
-		}
-		if err := os.Remove(a.snap.PostRefreshLockPath()); err != nil {
-			return fmt.Errorf("failed to remove post-refresh lock file: %w", err)
-		}
-	}
 
 	// start node config controller
 	if a.nodeConfigController != nil {

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
@@ -90,7 +90,7 @@ func (c *ControlPlaneConfigurationController) reconcile(ctx context.Context, con
 		}
 
 		if certificatesChanged || argsChanged {
-			if err := c.snap.RestartService(ctx, "kube-apiserver"); err != nil {
+			if err := c.snap.RestartServices(ctx, []string{"kube-apiserver"}); err != nil {
 				return fmt.Errorf("failed to restart kube-apiserver to apply configuration: %w", err)
 			}
 		}
@@ -104,7 +104,7 @@ func (c *ControlPlaneConfigurationController) reconcile(ctx context.Context, con
 		}
 
 		if mustRestart {
-			if err := c.snap.RestartService(ctx, "kube-controller-manager"); err != nil {
+			if err := c.snap.RestartServices(ctx, []string{"kube-controller-manager"}); err != nil {
 				return fmt.Errorf("failed to restart kube-controller-manager to apply configuration: %w", err)
 			}
 		}

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
@@ -176,7 +176,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				g := NewWithT(t)
 
-				s.RestartServiceCalledWith = nil
+				s.RestartServicesCalledWith = nil
 
 				configProvider.config = tc.config
 
@@ -188,8 +188,15 @@ func TestControlPlaneConfigController(t *testing.T) {
 
 				// TODO: this should be changed to call g.Eventually()
 				<-time.After(50 * time.Millisecond)
-
-				g.Expect(s.RestartServiceCalledWith).To(ConsistOf(tc.expectServiceRestarts))
+				if tc.expectServiceRestarts != nil {
+					var flat []string
+					for _, sub := range s.RestartServicesCalledWith {
+						flat = append(flat, sub...)
+					}
+					g.Expect(flat).To(ContainElements(tc.expectServiceRestarts))
+				} else {
+					g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
+				}
 
 				t.Run("APIServerArgs", func(t *testing.T) {
 					for earg, eval := range tc.expectKubeAPIServerArgs {
@@ -283,7 +290,7 @@ func TestControlPlaneConfigController(t *testing.T) {
 		// TODO: this should be changed to call g.Eventually()
 		<-time.After(50 * time.Millisecond)
 
-		g.Expect(s.RestartServiceCalledWith).To(BeEmpty())
+		g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
 
 		t.Run("APIServerArgs", func(t *testing.T) {
 			for _, arg := range []string{"--etcd-servers", "--etcd-cafile", "--etcd-certfile", "--etcd-keyfile"} {

--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -113,7 +113,7 @@ func (c *NodeConfigurationController) reconcile(ctx context.Context, configMap *
 	if mustRestartKubelet {
 		// This may fail if other controllers try to restart the services at the same time, hence the retry.
 		if err := control.RetryFor(ctx, 5, 5*time.Second, func() error {
-			if err := c.snap.RestartService(ctx, "kubelet"); err != nil {
+			if err := c.snap.RestartServices(ctx, []string{"kubelet"}); err != nil {
 				return fmt.Errorf("failed to restart kubelet to apply node configuration: %w", err)
 			}
 			return nil

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -202,7 +202,7 @@ func TestConfigPropagation(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s.RestartServiceCalledWith = nil
+			s.RestartServicesCalledWith = nil
 
 			g := NewWithT(t)
 
@@ -229,9 +229,9 @@ func TestConfigPropagation(t *testing.T) {
 			}
 
 			if tc.expectRestart {
-				g.Expect(s.RestartServiceCalledWith).To(Equal([]string{"kubelet"}))
+				g.Expect(s.RestartServicesCalledWith[0]).To(Equal([]string{"kubelet"}))
 			} else {
-				g.Expect(s.RestartServiceCalledWith).To(BeEmpty())
+				g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
 			}
 		})
 	}

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -19,9 +19,9 @@ type Snap interface {
 	GID() int         // GID is the group ID to set on config files.
 	Hostname() string // Hostname is the name of the node.
 
-	StartService(ctx context.Context, serviceName string) error   // snapctl start $service
-	StopService(ctx context.Context, serviceName string) error    // snapctl stop $service
-	RestartService(ctx context.Context, serviceName string) error // snapctl restart $service
+	StartServices(ctx context.Context, services []string, extraSnapArgs ...string) error   // snap start $service
+	StopServices(ctx context.Context, services []string, extraSnapArgs ...string) error    // snap stop $service
+	RestartServices(ctx context.Context, services []string, extraSnapArgs ...string) error // snap restart $service
 
 	SnapctlGet(ctx context.Context, args ...string) ([]byte, error) // snapctl get $args...
 	SnapctlSet(ctx context.Context, args ...string) error           // snapctl set $args...

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -54,12 +54,12 @@ type Mock struct {
 
 // Snap is a mock implementation for snap.Snap.
 type Snap struct {
-	StartServiceCalledWith   []string
-	StartServiceErr          error
-	StopServiceCalledWith    []string
-	StopServiceErr           error
-	RestartServiceCalledWith []string
-	RestartServiceErr        error
+	StartServicesCalledWith   [][]string
+	StartServicesErr          error
+	StopServicesCalledWith    [][]string
+	StopServicesErr           error
+	RestartServicesCalledWith [][]string
+	RestartServicesErr        error
 
 	RefreshCalledWith []types.RefreshOpts
 	RefreshErr        error
@@ -75,31 +75,40 @@ type Snap struct {
 	Mock Mock
 }
 
-func (s *Snap) StartService(ctx context.Context, name string) error {
-	if len(s.StartServiceCalledWith) == 0 {
-		s.StartServiceCalledWith = []string{name}
+func (s *Snap) StartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	if len(s.StartServicesCalledWith) == 0 {
+		s.StartServicesCalledWith = [][]string{names}
 	} else {
-		s.StartServiceCalledWith = append(s.StartServiceCalledWith, name)
+		s.StartServicesCalledWith = append(s.StartServicesCalledWith, names)
 	}
-	return s.StartServiceErr
+	if len(extraSnapArgs) > 0 {
+		s.StartServicesCalledWith = append(s.StartServicesCalledWith, extraSnapArgs)
+	}
+	return s.StartServicesErr
 }
 
-func (s *Snap) StopService(ctx context.Context, name string) error {
-	if len(s.StopServiceCalledWith) == 0 {
-		s.StopServiceCalledWith = []string{name}
+func (s *Snap) StopServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	if len(s.StopServicesCalledWith) == 0 {
+		s.StopServicesCalledWith = [][]string{names}
 	} else {
-		s.StopServiceCalledWith = append(s.StopServiceCalledWith, name)
+		s.StopServicesCalledWith = append(s.StopServicesCalledWith, names)
 	}
-	return s.StopServiceErr
+	if len(extraSnapArgs) > 0 {
+		s.StopServicesCalledWith = append(s.StopServicesCalledWith, extraSnapArgs)
+	}
+	return s.StopServicesErr
 }
 
-func (s *Snap) RestartService(ctx context.Context, name string) error {
-	if len(s.RestartServiceCalledWith) == 0 {
-		s.RestartServiceCalledWith = []string{name}
+func (s *Snap) RestartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	if len(s.RestartServicesCalledWith) == 0 {
+		s.RestartServicesCalledWith = [][]string{names}
 	} else {
-		s.RestartServiceCalledWith = append(s.RestartServiceCalledWith, name)
+		s.RestartServicesCalledWith = append(s.RestartServicesCalledWith, names)
 	}
-	return s.RestartServiceErr
+	if len(extraSnapArgs) > 0 {
+		s.RestartServicesCalledWith = append(s.RestartServicesCalledWith, extraSnapArgs)
+	}
+	return s.RestartServicesErr
 }
 
 func (s *Snap) Refresh(ctx context.Context, opts types.RefreshOpts) (string, error) {

--- a/src/k8s/pkg/snap/pebble.go
+++ b/src/k8s/pkg/snap/pebble.go
@@ -51,19 +51,24 @@ func NewPebble(opts PebbleOpts) *pebble {
 	return s
 }
 
-// StartService starts a k8s service. The name can be either prefixed or not.
-func (s *pebble) StartService(ctx context.Context, name string) error {
-	return s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", "pebble"), "start", name})
+// buildPebbleCommand builds a pebble command with the given subcommand and names.
+func (s *pebble) buildPebbleCommand(subcommand string, names []string, extraPebbleArgs ...string) []string {
+	return append([]string{filepath.Join(s.snapDir, "bin", "pebble"), subcommand}, append(names, extraPebbleArgs...)...)
 }
 
-// StopService stops a k8s service. The name can be either prefixed or not.
-func (s *pebble) StopService(ctx context.Context, name string) error {
-	return s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", "pebble"), "stop", name})
+// StartServices starts a k8s service. The name can be either prefixed or not.
+func (s *pebble) StartServices(ctx context.Context, names []string, extraPebbleArgs ...string) error {
+	return s.runCommand(ctx, s.buildPebbleCommand("start", names, extraPebbleArgs...))
 }
 
-// RestartService restarts a k8s service. The name can be either prefixed or not.
-func (s *pebble) RestartService(ctx context.Context, name string) error {
-	return s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", "pebble"), "restart", name})
+// StopServices stops a k8s service. The name can be either prefixed or not.
+func (s *pebble) StopServices(ctx context.Context, names []string, extraPebbleArgs ...string) error {
+	return s.runCommand(ctx, s.buildPebbleCommand("stop", names, extraPebbleArgs...))
+}
+
+// RestartServices restarts a k8s service. The name can be either prefixed or not.
+func (s *pebble) RestartServices(ctx context.Context, names []string, extraPebbleArgs ...string) error {
+	return s.runCommand(ctx, s.buildPebbleCommand("restart", names, extraPebbleArgs...))
 }
 
 func (s *pebble) Refresh(ctx context.Context, to types.RefreshOpts) (string, error) {
@@ -86,10 +91,9 @@ func (s *pebble) Refresh(ctx context.Context, to types.RefreshOpts) (string, err
 				log.FromContext(ctx).Error(err, "Warning: failed to update the kubernetes binary")
 			}
 			// restart services if already running.
-			for _, service := range []string{"kube-apiserver", "kubelet", "kube-controller-manager", "kube-proxy", "kube-scheduler"} {
-				if err := s.RestartService(ctx, service); err != nil {
-					log.FromContext(ctx).WithValues("service", service).Error(err, "Warning: failed to restart after updating kubernetes binary")
-				}
+			services := []string{"kube-apiserver", "kubelet", "kube-controller-manager", "kube-proxy", "kube-scheduler"}
+			if err := s.RestartServices(ctx, services); err != nil {
+				log.FromContext(ctx).WithValues("services", services).Error(err, "Warning: failed to restart after updating kubernetes binary")
 			}
 		}()
 		return "0", nil

--- a/src/k8s/pkg/snap/pebble_test.go
+++ b/src/k8s/pkg/snap/pebble_test.go
@@ -20,7 +20,7 @@ func TestPebble(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.StartService(context.Background(), "test-service")
+		err := snap.StartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("testdir/bin/pebble start test-service"))
 
@@ -28,7 +28,7 @@ func TestPebble(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -41,7 +41,7 @@ func TestPebble(t *testing.T) {
 			SnapCommonDir: "testdir",
 			RunCommand:    mockRunner.Run,
 		})
-		err := snap.StopService(context.Background(), "test-service")
+		err := snap.StopServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("testdir/bin/pebble stop test-service"))
 
@@ -49,7 +49,7 @@ func TestPebble(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -63,7 +63,7 @@ func TestPebble(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.RestartService(context.Background(), "test-service")
+		err := snap.RestartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("testdir/bin/pebble restart test-service"))
 
@@ -71,7 +71,7 @@ func TestPebble(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "service")
+			err := snap.StartServices(context.Background(), []string{"service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -71,22 +71,36 @@ func NewSnap(opts SnapOpts) *snap {
 	return s
 }
 
-// StartService starts a k8s service. The name can be either prefixed or not.
-func (s *snap) StartService(ctx context.Context, name string) error {
-	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Starting service", "service", name)
-	return s.runCommand(ctx, []string{"snapctl", "start", "--enable", serviceName(name)})
+// buildServiceCommand creates a snap command for managing services.
+func (s *snap) buildServiceCommand(action string, names []string, extraSnapArgs ...string) []string {
+	cmd := []string{"snap", action}
+	for _, name := range names {
+		cmd = append(cmd, serviceName(name))
+	}
+	return append(cmd, extraSnapArgs...)
 }
 
-// StopService stops a k8s service. The name can be either prefixed or not.
-func (s *snap) StopService(ctx context.Context, name string) error {
-	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Stopping service", "service", name)
-	return s.runCommand(ctx, []string{"snapctl", "stop", "--disable", serviceName(name)})
+// StartServices starts k8s services. The names can be either prefixed or not.
+func (s *snap) StartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Starting services", "services", names)
+	extraSnapArgs = append([]string{"--enable"}, extraSnapArgs...)
+	cmd := s.buildServiceCommand("start", names, extraSnapArgs...)
+	return s.runCommand(ctx, cmd)
 }
 
-// RestartService restarts a k8s service. The name can be either prefixed or not.
-func (s *snap) RestartService(ctx context.Context, name string) error {
-	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Restarting service", "service", name)
-	return s.runCommand(ctx, []string{"snapctl", "restart", serviceName(name)})
+// StopServices stops k8s services. The names can be either prefixed or not.
+func (s *snap) StopServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Stopping services", "services", names)
+	extraSnapArgs = append([]string{"--disable"}, extraSnapArgs...)
+	cmd := s.buildServiceCommand("stop", names, extraSnapArgs...)
+	return s.runCommand(ctx, cmd)
+}
+
+// RestartServices restarts k8s services. The names can be either prefixed or not.
+func (s *snap) RestartServices(ctx context.Context, names []string, extraSnapArgs ...string) error {
+	log.FromContext(ctx).V(1).WithCallDepth(1).Info("Restarting services", "services", names)
+	cmd := s.buildServiceCommand("restart", names, extraSnapArgs...)
+	return s.runCommand(ctx, cmd)
 }
 
 // Refresh refreshes the snap to a different track, revision or custom snap.

--- a/src/k8s/pkg/snap/snap_test.go
+++ b/src/k8s/pkg/snap/snap_test.go
@@ -71,15 +71,20 @@ func TestSnap(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.StartService(context.Background(), "test-service")
+		err := snap.StartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snapctl start --enable k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start k8s.test-service --enable"))
+
+		mockRunner.CalledWithCommand = []string{}
+		err = snap.StartServices(context.Background(), []string{"test-service"}, "--no-wait")
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap start k8s.test-service --enable --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -92,15 +97,20 @@ func TestSnap(t *testing.T) {
 			SnapCommonDir: "testdir",
 			RunCommand:    mockRunner.Run,
 		})
-		err := snap.StopService(context.Background(), "test-service")
+		err := snap.StopServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snapctl stop --disable k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop k8s.test-service --disable"))
+
+		mockRunner.CalledWithCommand = []string{}
+		err = snap.StopServices(context.Background(), []string{"test-service"}, "--no-wait")
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap stop k8s.test-service --disable --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "test-service")
+			err := snap.StartServices(context.Background(), []string{"test-service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
@@ -114,15 +124,20 @@ func TestSnap(t *testing.T) {
 			RunCommand:    mockRunner.Run,
 		})
 
-		err := snap.RestartService(context.Background(), "test-service")
+		err := snap.RestartServices(context.Background(), []string{"test-service"})
 		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snapctl restart k8s.test-service"))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap restart k8s.test-service"))
+
+		mockRunner.CalledWithCommand = []string{}
+		err = snap.RestartServices(context.Background(), []string{"test-service"}, "--no-wait")
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(mockRunner.CalledWithCommand).To(ConsistOf("snap restart k8s.test-service --no-wait"))
 
 		t.Run("Fail", func(t *testing.T) {
 			g := NewWithT(t)
 			mockRunner.Err = fmt.Errorf("some error")
 
-			err := snap.StartService(context.Background(), "service")
+			err := snap.StartServices(context.Background(), []string{"service"})
 			g.Expect(err).To(HaveOccurred())
 		})
 	})

--- a/src/k8s/pkg/snap/util/services.go
+++ b/src/k8s/pkg/snap/util/services.go
@@ -8,15 +8,15 @@ import (
 )
 
 var (
-	// WorkerServices contains all k8s services that run on a worker node except of k8sd.
-	workerServices = []string{
+	// workerK8sServices contains all k8s services that run on a worker node except of k8sd.
+	workerK8sServices = []string{
 		"containerd",
 		"k8s-apiserver-proxy",
 		"kubelet",
 		"kube-proxy",
 	}
-	// controlPlaneServices contains all k8s services that run on a control plane except of k8sd.
-	controlPlaneServices = []string{
+	// controlPlaneK8sServices contains all k8s services that run on a control plane except of k8sd.
+	controlPlaneK8sServices = []string{
 		"containerd",
 		"kube-controller-manager",
 		"kube-proxy",
@@ -24,76 +24,86 @@ var (
 		"kubelet",
 		"kube-apiserver",
 	}
+
+	// k8sServices contains all k8s services except k8sd.
+	k8sServices = []string{
+		"containerd",
+		"kube-apiserver",
+		"kube-controller-manager",
+		"kube-scheduler",
+		"kube-proxy",
+		"kubelet",
+		"k8s-dqlite",
+		"k8s-apiserver-proxy",
+	}
 )
 
 // RestartControlPlaneServices restarts the control plane services.
 // RestartControlPlaneServices will return on the first failing service.
-func RestartControlPlaneServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range controlPlaneServices {
-		if err := snap.RestartService(ctx, service); err != nil {
-			return fmt.Errorf("failed to restart service %s: %w", service, err)
-		}
+func RestartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.RestartServices(ctx, controlPlaneK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to restart service %v: %w", controlPlaneK8sServices, err)
 	}
 	return nil
 }
 
 // StartWorkerServices starts the worker services.
 // StartWorkerServices will return on the first failing service.
-func StartWorkerServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range workerServices {
-		if err := snap.StartService(ctx, service); err != nil {
-			return fmt.Errorf("failed to start service %s: %w", service, err)
-		}
+func StartWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StartServices(ctx, workerK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", workerK8sServices, err)
 	}
 	return nil
 }
 
 // StartControlPlaneServices starts the control plane services.
 // StartControlPlaneServices will return on the first failing service.
-func StartControlPlaneServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range controlPlaneServices {
-		if err := snap.StartService(ctx, service); err != nil {
-			return fmt.Errorf("failed to start service %s: %w", service, err)
-		}
+func StartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StartServices(ctx, controlPlaneK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", controlPlaneK8sServices, err)
 	}
 	return nil
 }
 
 // StartK8sDqliteServices starts the k8s-dqlite datastore service.
-func StartK8sDqliteServices(ctx context.Context, snap snap.Snap) error {
-	if err := snap.StartService(ctx, "k8s-dqlite"); err != nil {
-		return fmt.Errorf("failed to start service %s: %w", "k8s-dqlite", err)
+func StartK8sDqliteServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StartServices(ctx, []string{"k8s-dqlite"}, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to start service %v: %w", "k8s-dqlite", err)
 	}
 	return nil
 }
 
 // StopWorkerServices starts the worker services.
 // StopWorkerServices will return on the first failing service.
-func StopWorkerServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range workerServices {
-		if err := snap.StopService(ctx, service); err != nil {
-			return fmt.Errorf("failed to stop service %s: %w", service, err)
-		}
+func StopWorkerServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, workerK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", workerK8sServices, err)
 	}
 	return nil
 }
 
 // StopControlPlaneServices stops the control plane services.
 // StopControlPlaneServices will return on the first failing service.
-func StopControlPlaneServices(ctx context.Context, snap snap.Snap) error {
-	for _, service := range controlPlaneServices {
-		if err := snap.StopService(ctx, service); err != nil {
-			return fmt.Errorf("failed to stop service %s: %w", service, err)
-		}
+func StopControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, controlPlaneK8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", controlPlaneK8sServices, err)
 	}
 	return nil
 }
 
 // StopK8sDqliteServices stops the control plane services.
 // StopK8sDqliteServices will return on the first failing service.
-func StopK8sDqliteServices(ctx context.Context, snap snap.Snap) error {
-	if err := snap.StopService(ctx, "k8s-dqlite"); err != nil {
-		return fmt.Errorf("failed to stop service %s: %w", "k8s-dqlite", err)
+func StopK8sDqliteServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, []string{"k8s-dqlite"}, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", "k8s-dqlite", err)
+	}
+	return nil
+}
+
+// StopK8sServices stops all k8s services except of k8sd.
+func StopK8sServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {
+	if err := snap.StopServices(ctx, k8sServices, extraSnapArgs...); err != nil {
+		return fmt.Errorf("failed to stop service %v: %w", k8sServices, err)
 	}
 	return nil
 }

--- a/src/k8s/pkg/snap/util/services_test.go
+++ b/src/k8s/pkg/snap/util/services_test.go
@@ -16,16 +16,17 @@ func TestStartWorkerServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StartServiceErr = fmt.Errorf("service start failed")
+	mock.StartServicesErr = fmt.Errorf("service start failed")
 
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
-		mock.StartServiceErr = nil
+		mock.StartServicesErr = nil
 		g.Expect(StartWorkerServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StartServiceCalledWith).To(ConsistOf(workerServices))
+		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(workerK8sServices))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
-		mock.StartServiceErr = fmt.Errorf("service start failed")
+		mock.StartServicesErr = fmt.Errorf("service start failed")
 		g.Expect(StartWorkerServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -36,16 +37,17 @@ func TestStartControlPlaneServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StartServiceErr = fmt.Errorf("service start failed")
+	mock.StartServicesErr = fmt.Errorf("service start failed")
 
 	t.Run("AllServicesStartSuccess", func(t *testing.T) {
-		mock.StartServiceErr = nil
+		mock.StartServicesErr = nil
 		g.Expect(StartControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StartServiceCalledWith).To(ConsistOf(controlPlaneServices))
+		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf(controlPlaneK8sServices))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
-		mock.StartServiceErr = fmt.Errorf("service start failed")
+		mock.StartServicesErr = fmt.Errorf("service start failed")
 		g.Expect(StartControlPlaneServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -56,16 +58,17 @@ func TestStartK8sDqliteServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StartServiceErr = fmt.Errorf("service start failed")
+	mock.StartServicesErr = fmt.Errorf("service start failed")
 
 	t.Run("ServiceStartSuccess", func(t *testing.T) {
-		mock.StartServiceErr = nil
+		mock.StartServicesErr = nil
 		g.Expect(StartK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StartServiceCalledWith).To(ConsistOf("k8s-dqlite"))
+		g.Expect(mock.StartServicesCalledWith).To(HaveLen(1))
+		g.Expect(mock.StartServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
 	t.Run("ServiceStartFailure", func(t *testing.T) {
-		mock.StartServiceErr = fmt.Errorf("service start failed")
+		mock.StartServicesErr = fmt.Errorf("service start failed")
 		g.Expect(StartK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -76,16 +79,17 @@ func TestStopControlPlaneServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StopServiceErr = fmt.Errorf("service stop failed")
+	mock.StopServicesErr = fmt.Errorf("service stop failed")
 
 	t.Run("AllServicesStopSuccess", func(t *testing.T) {
-		mock.StopServiceErr = nil
+		mock.StopServicesErr = nil
 		g.Expect(StopControlPlaneServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StopServiceCalledWith).To(ConsistOf(controlPlaneServices))
+		g.Expect(mock.StopServicesCalledWith).To(HaveLen(1))
+		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(controlPlaneK8sServices))
 	})
 
 	t.Run("ServiceStopFailure", func(t *testing.T) {
-		mock.StopServiceErr = fmt.Errorf("service stop failed")
+		mock.StopServicesErr = fmt.Errorf("service stop failed")
 		g.Expect(StopControlPlaneServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }
@@ -96,16 +100,38 @@ func TestStopK8sDqliteServices(t *testing.T) {
 	}
 	g := NewWithT(t)
 
-	mock.StopServiceErr = fmt.Errorf("service stop failed")
+	mock.StopServicesErr = fmt.Errorf("service stop failed")
 
 	t.Run("ServiceStopSuccess", func(t *testing.T) {
-		mock.StopServiceErr = nil
+		mock.StopServicesErr = nil
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).To(Succeed())
-		g.Expect(mock.StopServiceCalledWith).To(ConsistOf("k8s-dqlite"))
+		g.Expect(mock.StopServicesCalledWith).To(HaveLen(1))
+		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf("k8s-dqlite"))
 	})
 
 	t.Run("ServiceStopFailure", func(t *testing.T) {
-		mock.StopServiceErr = fmt.Errorf("service stop failed")
+		mock.StopServicesErr = fmt.Errorf("service stop failed")
+		g.Expect(StopK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
+	})
+}
+
+func TestStopK8sServices(t *testing.T) {
+	mock := &mock.Snap{
+		Mock: mock.Mock{},
+	}
+	g := NewWithT(t)
+
+	mock.StopServicesErr = fmt.Errorf("service stop failed")
+
+	t.Run("ServiceStopSuccess", func(t *testing.T) {
+		mock.StopServicesErr = nil
+		g.Expect(StopK8sServices(context.Background(), mock)).To(Succeed())
+		g.Expect(mock.StopServicesCalledWith).To(HaveLen(1))
+		g.Expect(mock.StopServicesCalledWith[0]).To(ConsistOf(k8sServices))
+	})
+
+	t.Run("ServiceStopFailure", func(t *testing.T) {
+		mock.StopServicesErr = fmt.Errorf("service stop failed")
 		g.Expect(StopK8sDqliteServices(context.Background(), mock)).NotTo(Succeed())
 	})
 }

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -113,8 +113,7 @@ def registry(h: harness.Harness) -> Optional[Registry]:
     if config.USE_LOCAL_MIRROR:
         yield Registry(h)
     else:
-        # local image mirror disabled, avoid initializing the
-        # registry mirror instance.
+        LOG.info("Local registry mirror disabled!")
         yield None
 
 

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -7,9 +7,15 @@ import pytest
 from test_util import harness, tags, util
 
 
-@pytest.mark.node_count(3)
+# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
+# @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
 def test_wrong_token_race(instances: List[harness.Instance]):
+    # Note(ben): k8s-dqlite sometimes takes very long to shutdown (to be investigated) and
+    # since microcluster has a 30s fixed timeout for the remove hooks this test sometimes fails.
+    # The timeout will be configurable in https://github.com/canonical/microcluster/pull/365)
+    # The k8s-dqlite issue will be investigated separately.
+    pytest.xfail("This test is currently flaky because of a k8s-dqlite shutdown issue.")
     cluster_node = instances[0]
 
     join_token = util.get_join_token(cluster_node, instances[1])
@@ -17,6 +23,7 @@ def test_wrong_token_race(instances: List[harness.Instance]):
 
     new_join_token = util.get_join_token(cluster_node, instances[2])
 
+    util.wait_until_k8s_ready(cluster_node, instances[:2])
     cluster_node.exec(["k8s", "remove-node", instances[1].id])
 
     another_join_token = util.get_join_token(cluster_node, instances[2])

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -7,8 +7,7 @@ import pytest
 from test_util import harness, tags, util
 
 
-# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
-# @pytest.mark.node_count(3)
+@pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
 def test_wrong_token_race(instances: List[harness.Instance]):
     # Note(ben): k8s-dqlite sometimes takes very long to shutdown (to be investigated) and

--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -10,11 +10,6 @@ from test_util import harness, tags, util
 @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
 def test_wrong_token_race(instances: List[harness.Instance]):
-    # Note(ben): k8s-dqlite sometimes takes very long to shutdown (to be investigated) and
-    # since microcluster has a 30s fixed timeout for the remove hooks this test sometimes fails.
-    # The timeout will be configurable in https://github.com/canonical/microcluster/pull/365)
-    # The k8s-dqlite issue will be investigated separately.
-    pytest.xfail("This test is currently flaky because of a k8s-dqlite shutdown issue.")
     cluster_node = instances[0]
 
     join_token = util.get_join_token(cluster_node, instances[1])

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -26,9 +26,10 @@ def test_loadbalancer_ipv4(instances: List[harness.Instance]):
     _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv4)
 
 
-@pytest.mark.node_count(2)
+# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
+# @pytest.mark.node_count(2)
+# @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.PULL_REQUEST)
-@pytest.mark.disable_k8s_bootstrapping()
 def test_loadbalancer_ipv6_only(instances: List[harness.Instance]):
     pytest.xfail(
         "Cilium ipv6 only unsupported: https://github.com/cilium/cilium/issues/15082"

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -26,14 +26,14 @@ def test_loadbalancer_ipv4(instances: List[harness.Instance]):
     _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv4)
 
 
-# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
-# @pytest.mark.node_count(2)
-# @pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.xfail(
+    run=False,
+    reason="Cilium ipv6 only unsupported: https://github.com/cilium/cilium/issues/15082",
+)
+@pytest.mark.node_count(2)
+@pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.PULL_REQUEST)
 def test_loadbalancer_ipv6_only(instances: List[harness.Instance]):
-    pytest.xfail(
-        "Cilium ipv6 only unsupported: https://github.com/cilium/cilium/issues/15082"
-    )
     _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv6)
 
 

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -10,8 +10,9 @@ from test_util import config, harness, snap, tags, util
 LOG = logging.getLogger(__name__)
 
 
-@pytest.mark.node_count(1)
-@pytest.mark.no_setup()
+# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
+# @pytest.mark.node_count(1)
+# @pytest.mark.no_setup()
 @pytest.mark.skipif(
     not config.STRICT_INTERFACE_CHANNELS, reason="No strict channels configured"
 )

--- a/tests/integration/tests/test_strict_interfaces.py
+++ b/tests/integration/tests/test_strict_interfaces.py
@@ -10,16 +10,14 @@ from test_util import config, harness, snap, tags, util
 LOG = logging.getLogger(__name__)
 
 
-# Note(ben): Commented out as otherwise the setup would still happen for xfail tests.
-# @pytest.mark.node_count(1)
-# @pytest.mark.no_setup()
+@pytest.mark.xfail(run=False, reason="Strict channel tests are currently skipped.")
+@pytest.mark.node_count(1)
+@pytest.mark.no_setup()
 @pytest.mark.skipif(
     not config.STRICT_INTERFACE_CHANNELS, reason="No strict channels configured"
 )
 @pytest.mark.tags(tags.WEEKLY)
 def test_strict_interfaces(instances: List[harness.Instance], tmp_path):
-    pytest.xfail("Strict channel tests are currently skipped.")
-
     channels = config.STRICT_INTERFACE_CHANNELS
     cp = instances[0]
     current_channel = channels[0]

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -48,11 +48,14 @@ class Harness:
 
     name: str
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
         """Creates a new instance on the infrastructure and returns an object
         which can be used to interact with it.
 
-        dualstack: If True, the instance will be created with dualstack support.
+        network_type: ipv4, ipv6 or dualstack.
+        name_suffix: a suffix to be appended to the instance name.
 
         If the operation fails, a HarnessError is raised.
         """

--- a/tests/integration/tests/test_util/harness/juju.py
+++ b/tests/integration/tests/test_util/harness/juju.py
@@ -53,7 +53,9 @@ class JujuHarness(Harness):
                 self.constraints,
             )
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
         if network_type:
             raise HarnessError("Currently only IPv4 is supported by Juju harness")
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -70,8 +70,12 @@ class LXDHarness(Harness):
             "Configured LXD substrate (profile %s, image %s)", self.profile, self.image
         )
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
-        instance_id = f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}"
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
+        instance_id = (
+            f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
+        )
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         launch_lxd_command = [

--- a/tests/integration/tests/test_util/harness/multipass.py
+++ b/tests/integration/tests/test_util/harness/multipass.py
@@ -36,11 +36,15 @@ class MultipassHarness(Harness):
 
         LOG.debug("Configured Multipass substrate (image %s)", self.image)
 
-    def new_instance(self, network_type: str = "IPv4") -> Instance:
+    def new_instance(
+        self, network_type: str = "IPv4", name_suffix: str = ""
+    ) -> Instance:
         if network_type:
             raise HarnessError("Currently only IPv4 is supported by Multipass harness")
 
-        instance_id = f"k8s-integration-{os.urandom(3).hex()}-{self.next_id()}"
+        instance_id = (
+            f"k8s-integration-{self.next_id()}-{os.urandom(3).hex()}{name_suffix}"
+        )
 
         LOG.debug("Creating instance %s with image %s", instance_id, self.image)
         try:

--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -54,7 +54,7 @@ class Registry:
         self.instance: Instance = None
         self.harness: Harness = h
         self._mirrors: List[Mirror] = self.get_configured_mirrors()
-        self.instance = self.harness.new_instance()
+        self.instance = self.harness.new_instance(name_suffix="-registry")
 
         arch = self.instance.arch
         self.instance.exec(

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -34,6 +34,7 @@ TRACK_RE = re.compile(r"^(\d+)\.(\d+)(\S*)$")
 # SONOBUOY_VERSION is the version of sonobuoy to use for CNCF conformance tests.
 SONOBUOY_VERSION = os.getenv("TEST_SONOBUOY_VERSION") or "v0.57.3"
 
+
 def run(command: list, **kwargs) -> subprocess.CompletedProcess:
     """Log and run command."""
     kwargs.setdefault("check", True)
@@ -277,7 +278,6 @@ def wait_until_k8s_ready(
     If the instance name is different from the hostname, the instance name should be passed to the
     node_names dictionary, e.g. {"instance_id": "node_name"}.
     """
-    instance_id_node_name_map = {}
     for instance in instances:
         node_name = node_names.get(instance.id)
         if node_name is None:


### PR DESCRIPTION
Manual backport of: 
* https://github.com/canonical/k8s-snap/pull/1262 - bugfix 
* https://github.com/canonical/k8s-snap/pull/1228 - bugfix
* https://github.com/canonical/k8s-snap/pull/1279 - not strictly required but only touches test-code and makes the test run faster

This could not be auto-created because there was a merge conflict. Putting both PRs in on backport to make the CI pass.
