### PR TITLE
test: reduce timeout from 20m to 5m

### DIFF
--- a/tests/integration/requirements-test.txt
+++ b/tests/integration/requirements-test.txt
@@ -6,3 +6,4 @@ tenacity==8.2.3
 pylint==3.2.5
 cryptography==44.0.1
 hvac==2.3.0
+pytest-xdist==3.6.1

--- a/tests/integration/requirements-test.txt
+++ b/tests/integration/requirements-test.txt
@@ -6,4 +6,3 @@ tenacity==8.2.3
 pylint==3.2.5
 cryptography==44.0.1
 hvac==2.3.0
-pytest-xdist==3.6.1

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -348,12 +348,12 @@ def is_node_ready(
 
 def wait_for_dns(instance: harness.Instance):
     LOG.info("Waiting for DNS to be ready")
-    instance.exec(["k8s", "x-wait-for", "dns", "--timeout", "20m"])
+    instance.exec(["k8s", "x-wait-for", "dns", "--timeout", "5m"])
 
 
 def wait_for_network(instance: harness.Instance):
     LOG.info("Waiting for network to be ready")
-    instance.exec(["k8s", "x-wait-for", "network", "--timeout", "20m"])
+    instance.exec(["k8s", "x-wait-for", "network", "--timeout", "5m"])
 
 
 def hostname(instance: harness.Instance) -> str:

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -34,13 +34,13 @@ deps =
     -r {toxinidir}/requirements-test.txt
 commands =
     pytest -vv \
-	-n 3 \
 	--durations 20 \
     --tb native \
     --log-cli-level DEBUG \
     --log-format "%(asctime)s %(levelname)s %(message)s" \
     --log-date-format "%Y-%m-%d %H:%M:%S" \
     --disable-warnings \
+    --durations \
     {posargs} \
     {toxinidir}/tests
 passenv =

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -35,13 +35,14 @@ deps =
 commands =
     pytest -vv \
 	-n 3 \
-        --tb native \
-        --log-cli-level DEBUG \
-        --log-format "%(asctime)s %(levelname)s %(message)s" \
-        --log-date-format "%Y-%m-%d %H:%M:%S" \
-        --disable-warnings \
-        {posargs} \
-        {toxinidir}/tests
+	--durations 20 \
+    --tb native \
+    --log-cli-level DEBUG \
+    --log-format "%(asctime)s %(levelname)s %(message)s" \
+    --log-date-format "%Y-%m-%d %H:%M:%S" \
+    --disable-warnings \
+    {posargs} \
+    {toxinidir}/tests
 passenv =
     TEST_*
 

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -34,6 +34,7 @@ deps =
     -r {toxinidir}/requirements-test.txt
 commands =
     pytest -vv \
+	-n 3 \
         --tb native \
         --log-cli-level DEBUG \
         --log-format "%(asctime)s %(levelname)s %(message)s" \


### PR DESCRIPTION
## Description

Waiting for 20 minutes is excessive, if the service isn't up within 5m it's most likely not going to come up.

## Solution

Reduce the timeout from 20m to 5m.

## Backport

No

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
