### PR TITLE
test: Fix version upgrade test

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -101,13 +101,10 @@ jobs:
           TEST_LXD_IMAGE: ${{ inputs.os }}
           TEST_FLAVOR: ${{ inputs.flavor }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
-          # Test the latest (up to) 6 releases for the flavour
-          # TODO(ben): upgrade nightly to run all flavours
-          TEST_VERSION_UPGRADE_CHANNELS: "recent 6 classic"
+          TEST_VERSION_UPGRADE_CHANNELS: "recent 6"
           # TODO(etienne): change to "recent" when 1.33 is stable
           TEST_VERSION_DOWNGRADE_CHANNELS: "1.32-classic/stable 1.32-classic/beta 1.31-classic/stable 1.31-classic/beta"
-          # Upgrading from 1.30 is not supported.
-          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.31"
+          TEST_VERSION_UPGRADE_MIN_RELEASE: "1.32"
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
           TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
           TEST_GH_REF: ${{ github.ref_name }}

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -34,25 +34,16 @@ def test_version_upgrades(
     current_channel = channels[0]
 
     if current_channel.lower() == "recent":
-        if len(channels) != 3:
-            pytest.fail(
-                "'recent' requires the number of releases as second argument and the flavour as third argument"
-            )
-        _, num_channels, flavour = channels
-        # Currently, it fails to refresh the snap to the 1.33 channel or newer.
-        # Just test upgrade to at most 1.32.
+        if len(channels) != 2:
+            pytest.fail("'recent' requires the number of releases as second argument")
+        _, num_channels = channels
         channels = snap.get_most_stable_channels(
             int(num_channels),
-            flavour,
+            config.FLAVOR,
             cp.arch,
             include_latest=False,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
-            max_release="1.32",
         )
-        if len(channels) < 2:
-            pytest.fail(
-                f"Need at least 2 channels to upgrade, got {len(channels)} for flavour {flavour}"
-            )
         current_channel = channels[0]
 
     # Copy the current snap into the instances.
@@ -80,6 +71,10 @@ def test_version_upgrades(
         # if not added yet, config.SNAP should be at the end.
         channels.append(snap_path)
 
+    if len(channels) < 2:
+        pytest.fail(
+            f"Need at least 2 channels to upgrade, got {len(channels)} for flavor {config.FLAVOR}"
+        )
     LOG.info(f"Testing upgrades for snaps: {channels}")
     LOG.info(
         f"Bootstrap node on {current_channel} and upgrade through channels: {channels[1:]}"


### PR DESCRIPTION
* remove flavor from version - this info is already avaiable in config.Flavor
* Don't upgrade from 1.31 - upgrades from 1.31 to 1.32 are not supported only causes issues

