### PR TITLE
fix: Include latest channel if testing against main

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -110,7 +110,7 @@ jobs:
           TEST_GH_REF: ${{ github.ref_name }}
           TEST_GH_BASE_REF: ${{ github.base_ref }}
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }} -k test_version_upgrades
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -110,7 +110,7 @@ jobs:
           TEST_GH_REF: ${{ github.ref_name }}
           TEST_GH_BASE_REF: ${{ github.base_ref }}
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }} -k test_version_upgrades
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
       - name: Prepare inspection reports
         if: failure()
         run: |

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -37,12 +37,14 @@ def test_version_upgrades(
         if len(channels) != 2:
             pytest.fail("'recent' requires the number of releases as second argument")
         _, num_channels = channels
+        ref = config.GH_BASE_REF or config.GH_REF
         channels = snap.get_most_stable_channels(
             int(num_channels),
             config.FLAVOR,
             cp.arch,
-            include_latest=False,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
+            # Include `latest/edge/<flavor>` only if this is not a release branch.
+            include_latest=ref == util.MAIN_BRANCH,
         )
         current_channel = channels[0]
 


### PR DESCRIPTION
Ensures the following upgrades:

For PRs against main:
1.32-<flavor>/stable -> latest/edge/<flavor> -> PR

For PRs against release-1.XX:
1.XX-<flavor>/stable -> 1.XY-<flavor> -> PR

