### PR TITLE
[Backport 1.32] Feature upgrades machinery

### DIFF
--- a/docs/canonicalk8s/snap/reference/annotations.md
+++ b/docs/canonicalk8s/snap/reference/annotations.md
@@ -28,52 +28,59 @@ v1alpha annotations are experimental and subject to change or removal in future 
 
 ## `k8sd/v1alpha/lifecycle/skip-cleanup-kubernetes-node-on-remove`
 
-|   |   |
-|---|---|
-| **Values**| "true"\|"false"|
-| **Description**| If set, only MicroCluster and file cleanup are performed.  This is helpful when an external controller (e.g., CAPI) manages the Kubernetes node lifecycle. By default,  k8sd will remove the Kubernetes node when it is removed from the cluster. |
+|                 |                                                                                                                                                                                                                                                   |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | "true"\|"false"                                                                                                                                                                                                                                   |
+| **Description** | If set, only MicroCluster and file cleanup are performed.  This is helpful when an external controller (e.g., CAPI) manages the Kubernetes node lifecycle. By default,  k8sd will remove the Kubernetes node when it is removed from the cluster. |
 
 ## `k8sd/v1alpha/lifecycle/skip-stop-services-on-remove`
 
-|   |   |
-|---|---|
-|**Values**| "true"\|"false"|
-|**Description**|If set, the k8s services will not be stopped on the leaving node when removing the node. This is helpful when an external controller (e.g., CAPI) manages the Kubernetes node lifecycle. By default, all services are stopped on leaving nodes.|
+|                 |                                                                                                                                                                                                                                                 |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | "true"\|"false"                                                                                                                                                                                                                                 |
+| **Description** | If set, the k8s services will not be stopped on the leaving node when removing the node. This is helpful when an external controller (e.g., CAPI) manages the Kubernetes node lifecycle. By default, all services are stopped on leaving nodes. |
+
+## `k8sd/v1alpha/lifecycle/disable-separate-feature-upgrades`
+
+|            |                 |
+|------------|-----------------|
+| **Values** | "true"\|"false" |
+|**Description**|If set, the separate feature upgrade is disabled. This is useful, if an external controller (e.g. CAPI) is responsible for the Kubernetes node life cycle. By default, the feature upgrade will be done after all nodes in a cluster are upgraded.|
 
 ## `k8sd/v1alpha1/csrsigning/auto-approve`
 
-|   |   |
-|---|---|
-|**Values**| "true"\|"false"|
-|**Description**|If set, certificate signing requests created by worker nodes are auto approved.|
+|                 |                                                                                 |
+|-----------------|---------------------------------------------------------------------------------|
+| **Values**      | "true"\|"false"                                                                 |
+| **Description** | If set, certificate signing requests created by worker nodes are auto approved. |
 
 ## `k8sd/v1alpha1/cilium/cni-exclusive`
 
-|   |   |
-|---|---|
-| **Values**| "true"\|"false"|
-| **Description**| Make Cilium take ownership over the `/etc/cni/net.d` directory on the node, renaming all non-Cilium CNI configurations to `*.cilium_bak`. This ensures no Pods can be scheduled using other CNI plugins during Cilium agent downtime. Set this to "false" if you wish to use other CNIs such as Multus. |
+|                 |                                                                                                                                                                                                                                                                                                         |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | "true"\|"false"                                                                                                                                                                                                                                                                                         |
+| **Description** | Make Cilium take ownership over the `/etc/cni/net.d` directory on the node, renaming all non-Cilium CNI configurations to `*.cilium_bak`. This ensures no Pods can be scheduled using other CNI plugins during Cilium agent downtime. Set this to "false" if you wish to use other CNIs such as Multus. |
 
 ## `k8sd/v1alpha1/cilium/devices`
 
-|   |   |
-|---|---|
-|**Values**| string|
-|**Description**|List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports `+` as wildcard in device name, e.g. `eth+,ens+` |
+|                 |                                                                                                                                                                        |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | string                                                                                                                                                                 |
+| **Description** | List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports `+` as wildcard in device name, e.g. `eth+,ens+` |
 
 ## `k8sd/v1alpha1/cilium/direct-routing-device`
 
-|   |   |
-|---|---|
-|**Values**| string|
-|**Description**|Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing); if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route. Bridge type devices are ignored in automatic selection|
+|                 |                                                                                                                                                                                                                                                           |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | string                                                                                                                                                                                                                                                    |
+| **Description** | Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing); if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route. Bridge type devices are ignored in automatic selection |
 
 ## `k8sd/v1alpha1/cilium/vlan-bpf-bypass`
 
-|   |   |
-|---|---|
-|**Values**| \[] (string values comma separated)|
-|**Description**|Comma separated list of VLAN tags to bypass eBPF filtering on native devices. Cilium enables a firewall on native devices and filters all unknown traffic, including VLAN 802.1q packets, which pass through the main device with the associated tag (e.g., VLAN device eth0.4000 and its main interface eth0). Supports `0` as wildcard for bypassing all VLANs. e.g. `4001,4002`|
+|                 |                                                                                                                                                                                                                                                                                                                                                                                    |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | \[] (string values comma separated)                                                                                                                                                                                                                                                                                                                                                |
+| **Description** | Comma separated list of VLAN tags to bypass eBPF filtering on native devices. Cilium enables a firewall on native devices and filters all unknown traffic, including VLAN 802.1q packets, which pass through the main device with the associated tag (e.g., VLAN device eth0.4000 and its main interface eth0). Supports `0` as wildcard for bypassing all VLANs. e.g. `4001,4002` |
 
 ## `k8sd/v1alpha1/cilium/tunnel-port`
 
@@ -86,17 +93,17 @@ destination port.|
 
 ## `k8sd/v1alpha1/metrics-server/image-repo`
 
-|   |   |
-|---|---|
-|**Values**| string|
-|**Description**|Override the default image repository for the metrics-server.|
+|                 |                                                               |
+|-----------------|---------------------------------------------------------------|
+| **Values**      | string                                                        |
+| **Description** | Override the default image repository for the metrics-server. |
 
 ## `k8sd/v1alpha1/metrics-server/image-tag`
 
-|   |   |
-|---|---|
-|**Values**| string|
-|**Description**|Override the default image tag for the metrics-server.|
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **Values**      | string                                                 |
+| **Description** | Override the default image tag for the metrics-server. |
 
 <script>
 const el = document.getElementsByTagName("h2");

--- a/docs/moonray/doc-cheat-sheet-myst.md
+++ b/docs/moonray/doc-cheat-sheet-myst.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable -->
 ---
 orphan: true
 myst:
@@ -260,4 +259,3 @@ A link to a YouTube video:
 ```{youtube} https://www.youtube.com/watch?v=iMLiK1fX4I0
    :title: Demo
 ```
-<!-- markdownlint-restore -->

--- a/docs/moonray/doc-cheat-sheet-myst.md
+++ b/docs/moonray/doc-cheat-sheet-myst.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ---
 orphan: true
 myst:
@@ -259,3 +260,4 @@ A link to a YouTube video:
 ```{youtube} https://www.youtube.com/watch?v=iMLiK1fX4I0
    :title: Demo
 ```
+<!-- markdownlint-restore -->

--- a/k8s/crds/upgrades.k8sd.io.yaml
+++ b/k8s/crds/upgrades.k8sd.io.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: upgrades.k8sd.io
+spec:
+  group: k8sd.io  # API group for the resource
+  names:
+    kind: Upgrade
+    plural: upgrades
+    singular: upgrade
+  scope: Cluster
+  versions:
+    - name: v1alpha
+      served: true  # Serve this version in API requests
+      storage: true  # Store custom objects in this version
+      subresources:
+        status: {}  # Allows `status` updates separately
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          description: "Current upgrade phase."
+          jsonPath: ".status.phase"
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              properties:
+                upgradedNodes:
+                  description: "List of nodes that have been upgraded."
+                  type: array
+                  items:
+                    type: string
+                phase:
+                  description: "Current upgrade phase."
+                  type: string
+                  enum: ["NodeUpgrade", "FeatureUpgrade", "Completed", "Failed"]

--- a/k8s/crds/upgrades.k8sd.io.yaml
+++ b/k8s/crds/upgrades.k8sd.io.yaml
@@ -16,6 +16,10 @@ spec:
       subresources:
         status: {}  # Allows `status` updates separately
       additionalPrinterColumns:
+        - name: Strategy
+          type: string
+          description: "The strategy for this upgrade."
+          jsonPath: ".status.strategy"
         - name: Phase
           type: string
           description: "Current upgrade phase."
@@ -27,6 +31,10 @@ spec:
             status:
               type: object
               properties:
+                strategy:
+                  description: "The strategy for this upgrade."
+                  type: string
+                  enum: ["RollingUpgrade", "RollingDowngrade", "InPlace"]
                 upgradedNodes:
                   description: "List of nodes that have been upgraded."
                   type: array

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -173,7 +173,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
-	k8s.io/apiextensions-apiserver v0.31.0 // indirect
+	k8s.io/apiextensions-apiserver v0.31.0
 	k8s.io/apiserver v0.31.0 // indirect
 	k8s.io/component-base v0.31.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	dario.cat/mergo v1.0.0
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/k8s-snap-api v1.0.21
+	github.com/canonical/k8s-snap-api v1.0.25
 	github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7
 	github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18
 	github.com/go-logr/logr v1.4.2

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -53,8 +53,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.0.21 h1:wNBPMBOqTLHbwpQVX+JZz/DaSiyw5QlB9fKOSchLLXw=
-github.com/canonical/k8s-snap-api v1.0.21/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.0.25 h1:xexgkZRHHEJouqY2tC6cqp7Tzfj3Nw0vFKRdT+VGDJA=
+github.com/canonical/k8s-snap-api v1.0.25/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7 h1:lZCOt9/1KowNdnWXjfA1/51Uj7+R0fKtByos9EVrYn4=
 github.com/canonical/lxd v0.0.0-20250113143058-52441d41dab7/go.mod h1:4Ssm3YxIz8wyazciTLDR9V0aR2GPlGIHb+S0182T5pA=
 github.com/canonical/microcluster/v2 v2.1.1-0.20250127104725-631889214b18 h1:h5VJaUnE4gAKPolBTJ11HMRTEN5JyA+oR4gHkoK//6o=

--- a/src/k8s/pkg/client/kubernetes/crds.go
+++ b/src/k8s/pkg/client/kubernetes/crds.go
@@ -1,0 +1,103 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/k8s/pkg/log"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+)
+
+// ApplyCRDs applies all CRD YAML files in the specified directory.
+// TODO(ben): Add unittests
+func (c *Client) ApplyCRDs(ctx context.Context, crdsDir string) error {
+	log := log.FromContext(ctx).WithValues("kubernetes", "ApplyCRDs", "dir", crdsDir)
+
+	files, err := os.ReadDir(crdsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read CRD directory: %w", err)
+	}
+
+	for _, file := range files {
+		if file.IsDir() || filepath.Ext(file.Name()) != ".yaml" {
+			continue // Skip directories and non-YAML files
+		}
+
+		crdPath := filepath.Join(crdsDir, file.Name())
+
+		if err := c.ApplyCRD(ctx, crdPath); err != nil {
+			return fmt.Errorf("failed to apply CRD %s: %w", file.Name(), err)
+		}
+	}
+
+	log.Info("Successfully applied CRDs.", "numOfFiles", len(files))
+	return nil
+}
+
+// ApplyCRD reads and applies a single CRD YAML file.
+// TODO(ben): Add unittests
+func (c *Client) ApplyCRD(ctx context.Context, filePath string) error {
+	log := log.FromContext(ctx).WithValues("kubernetes", "ApplyCRD", "file", filePath)
+
+	yamlFile, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read YAML file: %w", err)
+	}
+
+	// Create API Extensions Client for managing CRDs
+	apiExtClient, err := apiextensionsclient.NewForConfig(c.RESTConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create API extensions client: %w", err)
+	}
+
+	// Decode YAML into an unstructured object
+	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	obj := &unstructured.Unstructured{}
+	if _, _, err := dec.Decode(yamlFile, nil, obj); err != nil {
+		return fmt.Errorf("failed to decode YAML: %w", err)
+	}
+
+	// Convert unstructured object to a CRD
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := c.convertUnstructuredToCRD(obj, crd); err != nil {
+		return fmt.Errorf("failed to convert to CRD: %w", err)
+	}
+
+	// TODO(ben): Consider using `Apply` instead.
+	existing, err := apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crd.Name, v1.GetOptions{})
+	if err == nil {
+		// CRD exists, update it
+		crd.ResourceVersion = existing.ResourceVersion
+		_, err = apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, v1.UpdateOptions{})
+	} else if apierrors.IsNotFound(err) {
+		// CRD doesn't exist, create it
+		_, err = apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, v1.CreateOptions{})
+	}
+	if err != nil {
+		return fmt.Errorf("failed to apply CRD: %w", err)
+	}
+
+	log.V(1).Info("Applied CRD", "name", crd.Name, "version", crd.APIVersion, "kind", crd.Kind)
+	return nil
+}
+
+// convertUnstructuredToCRD converts an unstructured object to a CRD object.
+func (c *Client) convertUnstructuredToCRD(obj *unstructured.Unstructured, crd *apiextensionsv1.CustomResourceDefinition) error {
+	crdBytes, err := obj.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshal unstructured object: %w", err)
+	}
+
+	if err := json.Unmarshal(crdBytes, crd); err != nil {
+		return fmt.Errorf("failed to unmarshal to CRD: %w", err)
+	}
+	return nil
+}

--- a/src/k8s/pkg/client/kubernetes/crds.go
+++ b/src/k8s/pkg/client/kubernetes/crds.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/utils/control"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -86,7 +87,34 @@ func (c *Client) ApplyCRD(ctx context.Context, filePath string) error {
 	}
 
 	log.V(1).Info("Applied CRD", "name", crd.Name, "version", crd.APIVersion, "kind", crd.Kind)
+
+	if waitErr := control.WaitUntilReady(ctx, func() (bool, error) {
+		return c.CRDExists(ctx, crd.Name)
+	}); waitErr != nil {
+		return fmt.Errorf("failed to wait for CRD to be ready: %w", waitErr)
+	}
+
+	log.Info("CRD is now available", "name", crd.Name)
 	return nil
+}
+
+// CRDExists checks if a given CRD exists in the cluster.
+func (c *Client) CRDExists(ctx context.Context, crdName string) (bool, error) {
+	apiExtClient, err := apiextensionsclient.NewForConfig(c.RESTConfig())
+	if err != nil {
+		return false, fmt.Errorf("failed to create API extensions client: %w", err)
+	}
+
+	_, err = apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, v1.GetOptions{})
+	if err == nil {
+		return true, nil // CRD exists
+	}
+
+	if apierrors.IsNotFound(err) {
+		return false, nil // CRD does not exist
+	}
+
+	return false, fmt.Errorf("failed to check CRD existence: %w", err)
 }
 
 // convertUnstructuredToCRD converts an unstructured object to a CRD object.

--- a/src/k8s/pkg/client/kubernetes/node.go
+++ b/src/k8s/pkg/client/kubernetes/node.go
@@ -6,6 +6,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -19,4 +20,23 @@ func (c *Client) DeleteNode(ctx context.Context, nodeName string) error {
 		}
 		return nil
 	})
+}
+
+// NodeVersions returns a map of node names to their parsed Kubernetes versions.
+func (c *Client) NodeVersions(ctx context.Context) (map[string]*versionutil.Version, error) {
+	nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	nodeVersions := make(map[string]*versionutil.Version)
+	for _, node := range nodes.Items {
+		v, err := versionutil.ParseGeneric(node.Status.NodeInfo.KubeletVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse version for node %s: %w", node.Name, err)
+		}
+		nodeVersions[node.Name] = v
+	}
+
+	return nodeVersions, nil
 }

--- a/src/k8s/pkg/client/kubernetes/node_test.go
+++ b/src/k8s/pkg/client/kubernetes/node_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -51,5 +52,53 @@ func TestDeleteNode(t *testing.T) {
 
 		err := client.DeleteNode(context.Background(), nodeName)
 		g.Expect(err).To(MatchError(fmt.Errorf("failed to delete node: %w", expectedErr)))
+	})
+}
+
+func TestNodeVersions(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("returns versions for all nodes", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(
+			&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{KubeletVersion: "v1.28.1"},
+				},
+			},
+			&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{KubeletVersion: "v1.29.0"},
+				},
+			},
+		)
+
+		client := &Client{Interface: clientset}
+
+		versions, err := client.NodeVersions(context.Background())
+		g.Expect(err).To(Not(HaveOccurred()))
+		g.Expect(versions).To(HaveLen(2))
+
+		v1, _ := versionutil.ParseGeneric("v1.28.1")
+		v2, _ := versionutil.ParseGeneric("v1.29.0")
+
+		g.Expect(versions["node1"].EqualTo(v1)).To(BeTrue())
+		g.Expect(versions["node2"].EqualTo(v2)).To(BeTrue())
+	})
+
+	t.Run("returns error on invalid version", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(
+			&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-bad"},
+				Status: v1.NodeStatus{
+					NodeInfo: v1.NodeSystemInfo{KubeletVersion: "not-a-version"},
+				},
+			},
+		)
+		client := &Client{Interface: clientset}
+
+		_, err := client.NodeVersions(context.Background())
+		g.Expect(err).To(MatchError(ContainSubstring("failed to parse version")))
 	})
 }

--- a/src/k8s/pkg/client/kubernetes/upgrades.go
+++ b/src/k8s/pkg/client/kubernetes/upgrades.go
@@ -1,0 +1,181 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/canonical/k8s/pkg/log"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+)
+
+// TODO: If the upgrade CRD grows, consider using kubebuilder.
+const (
+	UpgradePhaseNodeUpgrade    = "NodeUpgrade"
+	UpgradePhaseFeatureUpgrade = "FeatureUpgrade"
+	UpgradePhaseFailed         = "Failed"
+	UpgradePhaseCompleted      = "Completed"
+)
+
+const (
+	kind            = "Upgrade"
+	group           = "k8sd.io"
+	version         = "v1alpha"
+	apiVersion      = group + "/" + version
+	upgradesAPIPath = "/apis/" + group + "/" + version + "/upgrades"
+)
+
+type UpgradeMetadata struct {
+	Name string `json:"name,omitempty"`
+}
+
+type UpgradeStatus struct {
+	Phase         string   `json:"phase,omitempty"`
+	UpgradedNodes []string `json:"upgradedNodes,omitempty"`
+}
+
+type Upgrade struct {
+	APIVersion string          `json:"apiVersion,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
+	Metadata   UpgradeMetadata `json:"metadata,omitempty"`
+	Status     UpgradeStatus   `json:"status,omitempty"`
+}
+
+func NewUpgrade(name string) Upgrade {
+	return Upgrade{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Metadata:   UpgradeMetadata{Name: name},
+		Status:     UpgradeStatus{Phase: UpgradePhaseNodeUpgrade, UpgradedNodes: []string{}},
+	}
+}
+
+func (c *Client) k8sdIoRestClient() (*rest.RESTClient, error) {
+	k8sdConfig := c.RESTConfig()
+	k8sdConfig.GroupVersion = &schema.GroupVersion{Group: group, Version: version}
+	k8sdConfig.NegotiatedSerializer = serializer.NewCodecFactory(runtime.NewScheme())
+
+	restClient, err := rest.RESTClientFor(k8sdConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
+	}
+	return restClient, nil
+}
+
+// GetInProgressUpgrade returns the upgrade CR that is currently in progress.
+// TODO(ben): Maybe make this more generic, e.g. GetUpgrade(filterFunc func(Upgrade) bool) (*Upgrade, error)
+func (c *Client) GetInProgressUpgrade(ctx context.Context) (*Upgrade, error) {
+	log := log.FromContext(ctx).WithValues("upgrades", "GetInProgressUpgrade")
+
+	restClient, err := c.k8sdIoRestClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
+	}
+
+	upgrades, err := restClient.Get().AbsPath(upgradesAPIPath).DoRaw(ctx)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// No upgrade in progress.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get upgrades: %w", err)
+	}
+
+	var result struct {
+		Items []Upgrade `json:"items"`
+	}
+	if err := json.Unmarshal(upgrades, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal upgrades: %w", err)
+	}
+
+	var matches []Upgrade
+	for _, upgrade := range result.Items {
+		if upgrade.Status.Phase != UpgradePhaseFailed && upgrade.Status.Phase != UpgradePhaseCompleted {
+			matches = append(matches, upgrade)
+		}
+	}
+	lenMatches := len(matches)
+	if lenMatches == 0 {
+		return nil, nil
+	}
+	if lenMatches > 1 {
+		log.Info("Warning: Found multiple in-progress upgrades", "inprogress upgrades", len(matches))
+	}
+	// Sort matches by name
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Metadata.Name < matches[j].Metadata.Name
+	})
+
+	// Return the latest
+	return &matches[lenMatches-1], nil
+}
+
+// CreateUpgrade creates a new upgrade CR.
+func (c *Client) CreateUpgrade(ctx context.Context, upgrade Upgrade) error {
+	log := log.FromContext(ctx).WithValues("upgrades", "createUpgrade")
+	restClient, err := c.k8sdIoRestClient()
+	if err != nil {
+		return fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
+	}
+
+	body, err := json.Marshal(upgrade)
+	if err != nil {
+		return fmt.Errorf("failed to marshal upgrade: %w", err)
+	}
+
+	log.Info("Creating upgrade", "upgrade", upgrade)
+	result := restClient.Post().
+		AbsPath(upgradesAPIPath).
+		Body(body).
+		Do(ctx)
+	if result.Error() != nil {
+		responseBody, _ := result.Raw()
+		log.Error(result.Error(), "failed to create upgrade", "response", string(responseBody))
+		return fmt.Errorf("failed to create upgrade: %w", result.Error())
+	}
+
+	// The status field needs to be patches separatly since it is a subresource.
+	if err := c.PatchUpgradeStatus(ctx, upgrade.Metadata.Name, upgrade.Status); err != nil {
+		return fmt.Errorf("failed to patch upgrade status: %w", err)
+	}
+
+	return nil
+}
+
+// PatchUpgradeStatus patches the status of an upgrade CR.
+func (c *Client) PatchUpgradeStatus(ctx context.Context, upgradeName string, status UpgradeStatus) error {
+	log := log.FromContext(ctx).WithValues("upgrades", "PatchUpgrade", "upgrade", upgradeName, "status", status)
+
+	restClient, err := c.k8sdIoRestClient()
+	if err != nil {
+		return fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
+	}
+
+	// Wrap the status in a struct to match the CRD definition.
+	upgrade := NewUpgrade(upgradeName)
+	upgrade.Status = status
+
+	body, err := json.Marshal(upgrade)
+	if err != nil {
+		return fmt.Errorf("failed to marshal status: %w", err)
+	}
+
+	log.WithValues("upgrade", upgrade).Info("Patching upgrade")
+	result := restClient.Patch(types.MergePatchType).
+		AbsPath(fmt.Sprintf("/apis/%s/%s/upgrades/%s/status", group, version, upgradeName)).
+		Body(body).
+		Do(ctx)
+	if result.Error() != nil {
+		responseBody, _ := result.Raw()
+		log.Error(result.Error(), "failed to update upgrade status", "response", string(responseBody))
+		return fmt.Errorf("failed to update upgrade status: %w", result.Error())
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/client/snapd/snap_info.go
+++ b/src/k8s/pkg/client/snapd/snap_info.go
@@ -9,6 +9,7 @@ import (
 
 type SnapInfoResult struct {
 	InstallDate time.Time `json:"install-date"`
+	Revision    string    `json:"revision"`
 }
 
 type SnapInfoResponse struct {
@@ -16,6 +17,7 @@ type SnapInfoResponse struct {
 	Result     SnapInfoResult `json:"result"`
 }
 
+// GetSnapInfo retrieves information about a snap from the snapd API.
 func (c *Client) GetSnapInfo(snap string) (*SnapInfoResponse, error) {
 	resp, err := c.client.Get(fmt.Sprintf("http://localhost/v2/snaps/%s", snap))
 	if err != nil {
@@ -36,6 +38,8 @@ func (c *Client) GetSnapInfo(snap string) (*SnapInfoResponse, error) {
 	return &snapInfoResponse, nil
 }
 
+// HasInstallDate checks if the InstallDate field is set in the SnapInfoResult.
+// It returns true if the InstallDate is not zero, indicating that the snap is installed.
 func (s SnapInfoResponse) HasInstallDate() bool {
 	return !s.Result.InstallDate.IsZero()
 }

--- a/src/k8s/pkg/client/snapd/snap_info.go
+++ b/src/k8s/pkg/client/snapd/snap_info.go
@@ -10,6 +10,7 @@ import (
 type SnapInfoResult struct {
 	InstallDate time.Time `json:"install-date"`
 	Revision    string    `json:"revision"`
+	Version     string    `json:"version"`
 }
 
 type SnapInfoResponse struct {

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -79,7 +79,6 @@ func (e *Endpoints) postClusterRemove(s state.State, r *http.Request) response.R
 		if err := c.DeleteClusterMember(deleteCtx, req.Name, req.Force); err != nil {
 			return response.InternalError(fmt.Errorf("failed to delete cluster member %s: %w", req.Name, err))
 		}
-
 		return response.SyncResponse(true, &apiv1.RemoveNodeResponse{})
 	}
 

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -269,5 +269,6 @@ func (a *App) markNodeReady(ctx context.Context, s state.State) error {
 
 	log.Info("Marking node as ready")
 	a.readyWg.Done()
+
 	return nil
 }

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/api"
 	"github.com/canonical/k8s/pkg/k8sd/controllers"
 	"github.com/canonical/k8s/pkg/k8sd/controllers/csrsigning"
+	"github.com/canonical/k8s/pkg/k8sd/controllers/upgrade"
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
@@ -43,6 +44,8 @@ type Config struct {
 	DisableFeatureController bool
 	// DisableCSRSigningController is a bool flag to disable csrsigning controller.
 	DisableCSRSigningController bool
+	// DisableUpgradeController is a bool flag to disable upgrade controller.
+	DisableUpgradeController bool
 }
 
 // App is the k8sd microcluster instance.
@@ -61,6 +64,7 @@ type App struct {
 	nodeConfigController         *controllers.NodeConfigurationController
 	controlPlaneConfigController *controllers.ControlPlaneConfigurationController
 	csrsigningController         *csrsigning.Controller
+	upgradeController            *upgrade.Controller
 
 	// updateNodeConfigController
 	triggerUpdateNodeConfigControllerCh chan struct{}
@@ -165,6 +169,28 @@ func New(cfg Config) (*App, error) {
 		})
 	} else {
 		log.L().Info("csrsigning-controller disabled via config")
+	}
+
+	if !cfg.DisableUpgradeController {
+		app.upgradeController = upgrade.NewController(upgrade.ControllerOptions{
+			Snap:                     cfg.Snap,
+			WaitReady:                app.readyWg.Wait,
+			FeatureControllerReadyCh: app.featureController.ReadyCh(),
+			NotifyFeatureController:  app.NotifyFeatureController,
+			FeatureToReconciledCh: map[string]<-chan struct{}{
+				"network":        app.featureController.ReconciledNetworkCh(),
+				"gateway":        app.featureController.ReconciledGatewayCh(),
+				"ingress":        app.featureController.ReconciledIngressCh(),
+				"dns":            app.featureController.ReconciledDNSCh(),
+				"load-balancer":  app.featureController.ReconciledLoadBalancerCh(),
+				"local-storage":  app.featureController.ReconciledLocalStorageCh(),
+				"metrics-server": app.featureController.ReconciledMetricsServerCh(),
+			},
+			FeatureControllerReadyTimeout:     10 * time.Minute,
+			FeatureControllerReconcileTimeout: 10 * time.Minute,
+		})
+	} else {
+		log.L().Info("upgrade-controller disabled via config")
 	}
 
 	return app, nil

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -6,15 +6,18 @@ import (
 	"net"
 	"time"
 
+	"github.com/canonical/k8s/pkg/client/kubernetes"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
 	"github.com/canonical/microcluster/v2/state"
+	versionutil "k8s.io/apimachinery/pkg/util/version"
 )
 
 // onPostJoin is called when a control plane node joins the cluster.
@@ -246,5 +249,156 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to wait for kube-apiserver to become ready: %w", err)
 	}
 
+	log.Info("Create Kubernetes client")
+	k8sClient, err := a.snap.KubernetesClient("")
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes client: %w", err)
+	}
+
+	// This is required for backwards compatibility.
+	log.Info("Applying custom CRDs")
+	if err := k8sClient.ApplyCRDs(ctx, a.snap.K8sCRDDir()); err != nil {
+		log.Error(err, "Failed to apply custom CRDs")
+	}
+
+	if err := handleRollOutUpgrade(ctx, a.snap, s, k8sClient); err != nil {
+		return fmt.Errorf("failed to handle rollout-upgrade: %w", err)
+	}
+
 	return nil
+}
+
+func handleRollOutUpgrade(ctx context.Context, snap snap.Snap, s state.State, k8sClient *kubernetes.Client) error {
+	log := log.FromContext(ctx).WithValues("step", "rollout-upgrade")
+
+	log.Info("Checking if an upgrade is in progress")
+	upgrade, err := k8sClient.GetInProgressUpgrade(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check for in-progress upgrade: %w", err)
+	}
+
+	thisNodeVersion, err := getNodeVersion(ctx, snap)
+	if err != nil {
+		return fmt.Errorf("failed to get node Kubernetes version: %w", err)
+	}
+
+	nodeVersions, err := k8sClient.NodeVersions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes versions of cluster: %w", err)
+	}
+
+	if upgrade == nil {
+		return handleNoUpgradeInProgress(ctx, snap, s, k8sClient, thisNodeVersion, nodeVersions)
+	}
+
+	return handleUpgradeInProgress(ctx, s, k8sClient, upgrade, thisNodeVersion, nodeVersions)
+}
+
+func getNodeVersion(ctx context.Context, snap snap.Snap) (*versionutil.Version, error) {
+	versionStr, err := snap.NodeKubernetesVersion(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node Kubernetes version: %w", err)
+	}
+
+	version, err := versionutil.Parse(versionStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse node Kubernetes version %q: %w", versionStr, err)
+	}
+
+	return version, nil
+}
+
+func handleNoUpgradeInProgress(ctx context.Context, snap snap.Snap, s state.State, k8sClient *kubernetes.Client, thisNodeVersion *versionutil.Version, nodeVersions map[string]*versionutil.Version) error {
+	var clusterK8sVersion *versionutil.Version
+	for node, version := range nodeVersions {
+		if node == s.Name() {
+			continue
+		}
+		if clusterK8sVersion == nil {
+			clusterK8sVersion = version
+		}
+		if !clusterK8sVersion.EqualTo(version) {
+			return fmt.Errorf("the cluster has nodes with different Kubernetes versions %q and %q - upgrade all nodes to the same version before joining a new one", clusterK8sVersion, version)
+		}
+	}
+
+	if clusterK8sVersion == nil {
+		return fmt.Errorf("the cluster has no nodes - cannot determine cluster Kubernetes version")
+	}
+
+	if thisNodeVersion.EqualTo(clusterK8sVersion) {
+		return nil // Normal join
+	}
+
+	if thisNodeVersion.Major() == clusterK8sVersion.Major() && thisNodeVersion.Minor() == clusterK8sVersion.Minor() {
+		return fmt.Errorf("the joining node has a different patch version than cluster nodes")
+	}
+
+	if thisNodeVersion.Major() == clusterK8sVersion.Major() && thisNodeVersion.Minor() != clusterK8sVersion.Minor() {
+		return initiateRollingUpgrade(ctx, snap, s, k8sClient, thisNodeVersion, clusterK8sVersion)
+	}
+
+	return nil
+}
+
+func initiateRollingUpgrade(ctx context.Context, snap snap.Snap, s state.State, k8sClient *kubernetes.Client, thisNodeVersion, clusterK8sVersion *versionutil.Version) error {
+	log := log.FromContext(ctx)
+	log.Info("Minor version mismatch between joining node and cluster")
+
+	rev, err := snap.Revision(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get snap revision: %w", err)
+	}
+
+	var strategy kubernetes.UpgradeStrategy
+	if thisNodeVersion.GreaterThan(clusterK8sVersion) {
+		log.Info("Joining node has a greater version - rolling upgrade")
+		strategy = kubernetes.UpgradeStrategyRollingUpgrade
+	} else {
+		log.Info("Joining node has a lower version - downgrade")
+		strategy = kubernetes.UpgradeStrategyRollingDowngrade
+	}
+
+	newUpgrade := kubernetes.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev), strategy)
+	newUpgrade.Status.UpgradedNodes = []string{s.Name()}
+	return k8sClient.CreateUpgrade(ctx, newUpgrade)
+}
+
+func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kubernetes.Client, upgrade *kubernetes.Upgrade, thisNodeVersion *versionutil.Version, nodeVersions map[string]*versionutil.Version) error {
+	log := log.FromContext(ctx)
+	nodeName := s.Name()
+	lowest, highest := lowestHighestK8sVersions(nodeVersions)
+
+	switch upgrade.Status.Strategy {
+	case kubernetes.UpgradeStrategyRollingUpgrade:
+		log.Info("Rolling upgrade in progress")
+		if !thisNodeVersion.EqualTo(highest) {
+			return fmt.Errorf("joining node version %q needs to match highest version %q", thisNodeVersion, highest)
+		}
+	case kubernetes.UpgradeStrategyRollingDowngrade:
+		log.Info("Rolling downgrade in progress")
+		if !thisNodeVersion.EqualTo(lowest) {
+			return fmt.Errorf("joining node version %q needs to match lowest version %q", thisNodeVersion, lowest)
+		}
+	default:
+		return fmt.Errorf("unknown upgrade strategy in progress: %q", upgrade.Status.Strategy)
+	}
+
+	log.Info("Marking node as upgraded", "node", nodeName)
+	upgradedNodes := upgrade.Status.UpgradedNodes
+	upgradedNodes = append(upgradedNodes, nodeName)
+	return k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{UpgradedNodes: upgradedNodes})
+}
+
+// lowestHighestK8sVersions returns the lowest and highest Kubernetes versions from the given map.
+func lowestHighestK8sVersions(k8sVersionMap map[string]*versionutil.Version) (lowest, highest *versionutil.Version) {
+	for _, version := range k8sVersionMap {
+		if lowest == nil || version.LessThan(lowest) {
+			lowest = version
+		}
+		if highest == nil || version.GreaterThan(highest) {
+			highest = version
+		}
+	}
+	return lowest, highest
 }

--- a/src/k8s/pkg/k8sd/app/hooks_node_ready.go
+++ b/src/k8s/pkg/k8sd/app/hooks_node_ready.go
@@ -22,7 +22,7 @@ func (a *App) onNodeReady(ctx context.Context, s state.State) error {
 	// Apply all custom CRDs on startup
 	log.Info("Applying custom CRDs")
 	if err := a.applyCustomCRDs(ctx); err != nil {
-		return fmt.Errorf("failed to apply custom CRDs: %w", err)
+		log.Error(err, "failed to apply custom CRDs: %w")
 	}
 
 	// Check if a refresh was performed and if so, run the custom post-refresh hook

--- a/src/k8s/pkg/k8sd/app/hooks_node_ready.go
+++ b/src/k8s/pkg/k8sd/app/hooks_node_ready.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/canonical/k8s/pkg/log"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/microcluster/v2/state"
 )
@@ -17,6 +18,12 @@ import (
 // Note that this is not a microcluster hook, but a custom k8sd hook.
 func (a *App) onNodeReady(ctx context.Context, s state.State) error {
 	log := log.FromContext(ctx).WithValues("hook", "onNodeReady")
+
+	// Apply all custom CRDs on startup
+	log.Info("Applying custom CRDs")
+	if err := a.applyCustomCRDs(ctx); err != nil {
+		return fmt.Errorf("failed to apply custom CRDs: %w", err)
+	}
 
 	// Check if a refresh was performed and if so, run the custom post-refresh hook
 	log.Info("Checking if snap is post-refresh")
@@ -36,6 +43,30 @@ func (a *App) onNodeReady(ctx context.Context, s state.State) error {
 		}
 	} else {
 		log.Info("Snap is not post-refresh")
+	}
+
+	return nil
+}
+
+func (a *App) applyCustomCRDs(ctx context.Context) error {
+	log := log.FromContext(ctx).WithValues("startup", "applyCustomCRDs", "dir", a.snap.K8sCRDDir())
+
+	isWorker, err := snaputil.IsWorker(a.snap)
+	if err != nil {
+		return fmt.Errorf("failed to check if node is a worker: %w", err)
+	}
+	if isWorker {
+		log.V(1).Info("Skipping custom CRD application on worker node")
+		return nil
+	}
+
+	k8sClient, err := a.snap.KubernetesClient("")
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	if err := k8sClient.ApplyCRDs(ctx, a.snap.K8sCRDDir()); err != nil {
+		return fmt.Errorf("failed to apply custom CRDs: %w", err)
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -85,7 +85,7 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 		}
 		// TODO(ben): Add more metadata to the upgrade.
 		// e.g. initial revision, target revision, name of the node that started the upgrade, etc.
-		newUpgrade := kubernetes.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev))
+		newUpgrade := kubernetes.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev), kubernetes.UpgradeStrategyInPlace)
 		upgrade = &newUpgrade
 		if err := k8sClient.CreateUpgrade(ctx, *upgrade); err != nil {
 			return fmt.Errorf("failed to create upgrade: %w", err)

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/log"
@@ -46,15 +47,19 @@ func (a *App) postRefreshHook(ctx context.Context, s state.State) error {
 		return fmt.Errorf("failed to get boostrap status: %w", err)
 	}
 
-	// We don't want to run the upgrade if the cluster is not ready.
-	// The post-refresh hook is run after snap refresh AND install, so we need to make sure the cluster is ready.
-	if status.Ready {
-		log.Info("Cluster is ready, running post-upgrade.")
-		if err := a.performPostUpgrade(ctx, s); err != nil {
-			return fmt.Errorf("failed to perform post-upgrade: %w", err)
+	if _, ok := config.Annotations.Get(apiv1_annotations.AnnotationDisableSeparateFeatureUpgrades); !ok {
+		// We don't want to run the upgrade if the cluster is not ready.
+		// The post-refresh hook is run after snap refresh AND install, so we need to make sure the cluster is ready.
+		if status.Ready {
+			log.Info("Cluster is ready, running post-upgrade.")
+			if err := a.performPostUpgrade(ctx, s); err != nil {
+				return fmt.Errorf("failed to perform post-upgrade: %w", err)
+			}
+		} else {
+			log.Info("Node is not yet bootstrapped (was freshly installed), skipping upgrade steps.")
 		}
 	} else {
-		log.Info("Node is not yet bootstrapped (was freshly installed), skipping upgrade steps.")
+		log.Info("Post-upgrade steps skipped due to user annotation override.")
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -95,7 +95,7 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 		}
 
 	} else {
-		log.Info("Upgrade in progress.", "upgrade", upgrade.Metadata.Name, "phase", upgrade.Status.Phase)
+		log.Info("Upgrade in progress.", "upgrade", upgrade.Name, "phase", upgrade.Status.Phase)
 	}
 
 	log.Info("Marking node as upgraded.", "node", s.Name())
@@ -103,7 +103,7 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 	upgradedNodes := upgrade.Status.UpgradedNodes
 	upgradedNodes = append(upgradedNodes, s.Name())
 
-	if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Metadata.Name, kubernetes.UpgradeStatus{UpgradedNodes: upgradedNodes}); err != nil {
+	if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{UpgradedNodes: upgradedNodes}); err != nil {
 		return fmt.Errorf("failed to mark node as upgraded: %w", err)
 	}
 
@@ -114,7 +114,7 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 
 	if clusterUpgradeDone {
 		log.Info("All nodes have been upgraded.")
-		if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Metadata.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseFeatureUpgrade}); err != nil {
+		if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseFeatureUpgrade}); err != nil {
 			return fmt.Errorf("failed to set upgrade phase: %w", err)
 		}
 
@@ -166,7 +166,7 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 
 			log.Info("All feature have reconciled.")
 
-			if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Metadata.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseCompleted}); err != nil {
+			if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseCompleted}); err != nil {
 				log.Error(err, "failed to set upgrade phase after successful feature upgrade")
 				return
 			}

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/client/kubernetes"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/log"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
@@ -39,5 +40,113 @@ func (a *App) postRefreshHook(ctx context.Context, s state.State) error {
 		return fmt.Errorf("failed to set snapd configuration from k8sd: %w", err)
 	}
 
+	status, err := a.MicroCluster().Status(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get boostrap status: %w", err)
+	}
+
+	// We don't want to run the upgrade if the cluster is not ready.
+	// The post-refresh hook is run after snap refresh AND install, so we need to make sure the cluster is ready.
+	if status.Ready {
+		log.Info("Cluster is ready, running post-upgrade.")
+		if err := a.performPostUpgrade(ctx, s); err != nil {
+			return fmt.Errorf("failed to perform post-upgrade: %w", err)
+		}
+	} else {
+		log.Info("Node is not yet bootstrapped (was freshly installed), skipping upgrade steps.")
+	}
+
 	return nil
+}
+
+// performPostUpgrade performs the post-upgrade steps.
+// It marks the node as upgraded and checks if all nodes have been upgraded.
+// If all nodes have been upgraded, it triggers the feature upgrade.
+func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
+	log := log.FromContext(ctx).WithValues("step", "post-upgrade")
+	k8sClient, err := a.snap.KubernetesClient("")
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes client: %w", err)
+	}
+
+	upgrade, err := k8sClient.GetInProgressUpgrade(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get in progress upgrade: %w", err)
+	}
+
+	if upgrade == nil {
+		log.Info("No upgrade is in progress - creating a new one.")
+		rev, err := a.snap.Revision(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get revision: %w", err)
+		}
+		// TODO(ben): Add more metadata to the upgrade.
+		// e.g. initial revision, target revision, name of the node that started the upgrade, etc.
+		newUpgrade := kubernetes.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev))
+		upgrade = &newUpgrade
+		if err := k8sClient.CreateUpgrade(ctx, *upgrade); err != nil {
+			return fmt.Errorf("failed to create upgrade: %w", err)
+		}
+	} else {
+		log.Info("Upgrade in progress.", "upgrade", upgrade.Metadata.Name, "phase", upgrade.Status.Phase)
+	}
+
+	log.Info("Marking node as upgraded.", "node", s.Name())
+
+	upgradedNodes := upgrade.Status.UpgradedNodes
+	upgradedNodes = append(upgradedNodes, s.Name())
+
+	if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Metadata.Name, kubernetes.UpgradeStatus{UpgradedNodes: upgradedNodes}); err != nil {
+		return fmt.Errorf("failed to mark node as upgraded: %w", err)
+	}
+
+	clusterUpgradeDone, err := allNodesUpgraded(ctx, s, upgradedNodes)
+	if err != nil {
+		return fmt.Errorf("failed to check if all nodes have been upgraded: %w", err)
+	}
+
+	if clusterUpgradeDone {
+		log.Info("All nodes have been upgraded.")
+		if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Metadata.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseFeatureUpgrade}); err != nil {
+			return fmt.Errorf("failed to set upgrade phase: %w", err)
+		}
+
+		// TODO: Trigger feature upgrade and unlock feature controllers afterwards.
+	}
+
+	return nil
+}
+
+// allNodesUpgraded checks if all nodes in the cluster have been upgraded.
+func allNodesUpgraded(ctx context.Context, s state.State, upgradedNodes []string) (bool, error) {
+	log := log.FromContext(ctx)
+
+	// Check if all nodes have been upgraded
+	c, err := s.Leader()
+	if err != nil {
+		return false, fmt.Errorf("failed to get leader client: %w", err)
+	}
+
+	clusterMembers, err := c.GetClusterMembers(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get cluster members: %w", err)
+	}
+
+	if len(clusterMembers) != len(upgradedNodes) {
+		log.Info("Not all nodes have been upgraded.", "clusterMembers", len(clusterMembers), "upgradedNodes", len(upgradedNodes))
+		return false, nil
+	}
+
+	clusterMembersMap := make(map[string]struct{})
+	for _, member := range clusterMembers {
+		clusterMembersMap[member.Name] = struct{}{}
+	}
+
+	for _, node := range upgradedNodes {
+		if _, ok := clusterMembersMap[node]; !ok {
+			log.Info("Node has been upgraded but is not part of the cluster.", "node", node)
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
@@ -65,9 +64,7 @@ func (a *App) postRefreshHook(ctx context.Context, s state.State) error {
 	return nil
 }
 
-// performPostUpgrade performs the post-upgrade steps.
-// It marks the node as upgraded and checks if all nodes have been upgraded.
-// If all nodes have been upgraded, it triggers the feature upgrade.
+// performPostUpgrade adds the node name to the list of upgradedNodes in the upgrade custom resource.
 func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 	log := log.FromContext(ctx).WithValues("step", "post-upgrade")
 	k8sClient, err := a.snap.KubernetesClient("")
@@ -107,104 +104,5 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 		return fmt.Errorf("failed to mark node as upgraded: %w", err)
 	}
 
-	clusterUpgradeDone, err := allNodesUpgraded(ctx, s, upgradedNodes)
-	if err != nil {
-		return fmt.Errorf("failed to check if all nodes have been upgraded: %w", err)
-	}
-
-	if clusterUpgradeDone {
-		log.Info("All nodes have been upgraded.")
-		if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseFeatureUpgrade}); err != nil {
-			return fmt.Errorf("failed to set upgrade phase: %w", err)
-		}
-
-		log.Info("Triggering feature upgrades in background")
-
-		// TODO(ben): This is a bit ugly. We cannot wait here for the feature controllers to finish because
-		// the controllers are blocked until the node is marked as ready. For this phase, we can just run a separate
-		// goroutine to trigger the feature controllers and wait for them to finish.
-		// Once we have a separate feature upgrade controller, this should be much cleaner.
-		go func() {
-			log.Info("Triggering feature controllers in separate go routine.")
-			// TODO: Do we need to handle dependencies between features?
-			// If yes, a new features/interface/upgrades should be created that takes all trigger and reconciled channels.
-			// The custom dependencies could then be handled in the flavor feature implementation.
-
-			// Trigger all feature controllers
-			// This intentionally blocks until the feature controllers are available.
-			<-a.featureController.ReadyCh()
-			a.NotifyFeatureController(true, true, true, true, true, true, true)
-
-			log.Info("Waiting for feature controllers to reconcile.")
-			pending := map[string]<-chan struct{}{
-				"Network":       a.featureController.ReconciledNetworkCh(),
-				"Gateway":       a.featureController.ReconciledGatewayCh(),
-				"Ingress":       a.featureController.ReconciledIngressCh(),
-				"DNS":           a.featureController.ReconciledDNSCh(),
-				"LoadBalancer":  a.featureController.ReconciledLoadBalancerCh(),
-				"LocalStorage":  a.featureController.ReconciledLocalStorageCh(),
-				"MetricsServer": a.featureController.ReconciledMetricsServerCh(),
-			}
-
-			for len(pending) > 0 {
-				select {
-				case <-ctx.Done():
-					log.Error(ctx.Err(), "Context canceled while waiting for feature controllers to reconcile.")
-					return
-
-				case <-time.After(100 * time.Millisecond):
-					for name, ch := range pending {
-						select {
-						case <-ch:
-							log.Info(fmt.Sprintf("%s feature controller reconciled.", name))
-							delete(pending, name)
-						default:
-						}
-					}
-				}
-			}
-
-			log.Info("All feature have reconciled.")
-
-			if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseCompleted}); err != nil {
-				log.Error(err, "failed to set upgrade phase after successful feature upgrade")
-				return
-			}
-		}()
-	}
 	return nil
-}
-
-// allNodesUpgraded checks if all nodes in the cluster have been upgraded.
-func allNodesUpgraded(ctx context.Context, s state.State, upgradedNodes []string) (bool, error) {
-	log := log.FromContext(ctx)
-
-	// Check if all nodes have been upgraded
-	c, err := s.Leader()
-	if err != nil {
-		return false, fmt.Errorf("failed to get leader client: %w", err)
-	}
-
-	clusterMembers, err := c.GetClusterMembers(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to get cluster members: %w", err)
-	}
-
-	if len(clusterMembers) != len(upgradedNodes) {
-		log.Info("Not all nodes have been upgraded.", "clusterMembers", len(clusterMembers), "upgradedNodes", len(upgradedNodes))
-		return false, nil
-	}
-
-	clusterMembersMap := make(map[string]struct{})
-	for _, member := range clusterMembers {
-		clusterMembersMap[member.Name] = struct{}{}
-	}
-
-	for _, node := range upgradedNodes {
-		if _, ok := clusterMembersMap[node]; !ok {
-			log.Info("Node has been upgraded but is not part of the cluster.", "node", node)
-			return false, nil
-		}
-	}
-	return true, nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -151,6 +151,7 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 		log.Info("Skipping service stop and certificate cleanup")
 	}
 
+	log.Info("Remove hook completed ")
 	return nil
 }
 

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -101,23 +101,33 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 
 	// start csrsigning controller
 	if a.csrsigningController != nil {
-		go a.csrsigningController.Run(
-			ctx,
-			func(ctx context.Context) (types.ClusterConfig, error) {
-				return databaseutil.GetClusterConfig(ctx, s)
-			},
-		)
+		go func() {
+			if err := a.csrsigningController.Run(
+				ctx,
+				func(ctx context.Context) (types.ClusterConfig, error) {
+					return databaseutil.GetClusterConfig(ctx, s)
+				},
+			); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to start csrsigning controller")
+			}
+			log.FromContext(ctx).Info("csrsigning controller started")
+		}()
 	}
 
 	// start upgrade controller
 	if a.upgradeController != nil {
-		go a.upgradeController.Run(
-			ctx,
-			func(ctx context.Context) (types.ClusterConfig, error) {
-				return databaseutil.GetClusterConfig(ctx, s)
-			},
-			func() state.State { return s },
-		)
+		go func() {
+			if err := a.upgradeController.Run(
+				ctx,
+				func(ctx context.Context) (types.ClusterConfig, error) {
+					return databaseutil.GetClusterConfig(ctx, s)
+				},
+				func() state.State { return s },
+			); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to start upgrade controller")
+			}
+			log.FromContext(ctx).Info("upgrade controller started")
+		}()
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -109,5 +109,16 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 		)
 	}
 
+	// start upgrade controller
+	if a.upgradeController != nil {
+		go a.upgradeController.Run(
+			ctx,
+			func(ctx context.Context) (types.ClusterConfig, error) {
+				return databaseutil.GetClusterConfig(ctx, s)
+			},
+			func() state.State { return s },
+		)
+	}
+
 	return nil
 }

--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -197,7 +197,7 @@ func (c *FeatureController) reconcileLoop(
 	setFeatureStatus func(ctx context.Context, name types.FeatureName, status types.FeatureStatus) error,
 	featureName types.FeatureName,
 	triggerCh chan struct{},
-	reconciledCh chan<- struct{},
+	reconciledCh chan struct{},
 	apply func(cfg types.ClusterConfig) (types.FeatureStatus, error),
 ) {
 	for {

--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -31,6 +31,11 @@ type FeatureController struct {
 	triggerLocalStorageCh  chan struct{}
 	triggerMetricsServerCh chan struct{}
 
+	// TODO(Hue): (KU-3219) Change these with an atomic bool or something similar.
+	// Because we don't close them when the feature is reconciled, we simply
+	// put something into them. And that thing is going to be gone as soon as we
+	// read from these channels. So "checking to see if a feature is reconciled",
+	// will technically cause it to be considered "not-reconciled" immediately.
 	reconciledNetworkCh       chan struct{}
 	reconciledGatewayCh       chan struct{}
 	reconciledIngressCh       chan struct{}
@@ -265,11 +270,11 @@ func (c *FeatureController) isBlocked(ctx context.Context, getClusterConfig func
 		}
 
 		if upgrade.Status.Phase == kubernetes.UpgradePhaseFeatureUpgrade {
-			log.Info("Upgrade in progress - but in feature upgrade phase - applying configuration", "upgrade", upgrade.Metadata.Name, "phase", upgrade.Status.Phase)
+			log.Info("Upgrade in progress - but in feature upgrade phase - applying configuration", "upgrade", upgrade.Name, "phase", upgrade.Status.Phase)
 			return false, nil
 		}
 
-		log.Info("Upgrade in progress - feature controller blocked", "upgrade", upgrade.Metadata.Name, "phase", upgrade.Status.Phase)
+		log.Info("Upgrade in progress - feature controller blocked", "upgrade", upgrade.Name, "phase", upgrade.Status.Phase)
 		return true, nil
 	}
 

--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/canonical/k8s/pkg/client/kubernetes"
 	"github.com/canonical/k8s/pkg/k8sd/features"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
@@ -18,6 +19,8 @@ import (
 type FeatureController struct {
 	snap      snap.Snap
 	waitReady func()
+
+	readyCh chan struct{}
 
 	triggerNetworkCh       chan struct{}
 	triggerGatewayCh       chan struct{}
@@ -34,6 +37,40 @@ type FeatureController struct {
 	reconciledDNSCh           chan struct{}
 	reconciledLocalStorageCh  chan struct{}
 	reconciledMetricsServerCh chan struct{}
+}
+
+// ReadyCh returns a channel that is closed when the controller is ready.
+// This is used to signal to other components that they can start using the controller.
+func (c *FeatureController) ReadyCh() <-chan struct{} {
+	return c.readyCh
+}
+
+func (c *FeatureController) ReconciledNetworkCh() <-chan struct{} {
+	return c.reconciledNetworkCh
+}
+
+func (c *FeatureController) ReconciledGatewayCh() <-chan struct{} {
+	return c.reconciledGatewayCh
+}
+
+func (c *FeatureController) ReconciledIngressCh() <-chan struct{} {
+	return c.reconciledIngressCh
+}
+
+func (c *FeatureController) ReconciledLoadBalancerCh() <-chan struct{} {
+	return c.reconciledLoadBalancerCh
+}
+
+func (c *FeatureController) ReconciledDNSCh() <-chan struct{} {
+	return c.reconciledDNSCh
+}
+
+func (c *FeatureController) ReconciledLocalStorageCh() <-chan struct{} {
+	return c.reconciledLocalStorageCh
+}
+
+func (c *FeatureController) ReconciledMetricsServerCh() <-chan struct{} {
+	return c.reconciledMetricsServerCh
 }
 
 type FeatureControllerOpts struct {
@@ -53,6 +90,7 @@ func NewFeatureController(opts FeatureControllerOpts) *FeatureController {
 	return &FeatureController{
 		snap:                      opts.Snap,
 		waitReady:                 opts.WaitReady,
+		readyCh:                   make(chan struct{}),
 		triggerNetworkCh:          opts.TriggerNetworkCh,
 		triggerGatewayCh:          opts.TriggerGatewayCh,
 		triggerIngressCh:          opts.TriggerIngressCh,
@@ -77,8 +115,10 @@ func (c *FeatureController) Run(
 	notifyDNSChangedIP func(ctx context.Context, dnsIP string) error,
 	setFeatureStatus func(ctx context.Context, name types.FeatureName, featureStatus types.FeatureStatus) error,
 ) {
-	c.waitReady()
 	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "feature"))
+	log := log.FromContext(ctx)
+	log.Info("Starting feature controller")
+	c.waitReady()
 
 	s := getState()
 
@@ -122,6 +162,9 @@ func (c *FeatureController) Run(
 		}
 		return featureStatus, nil
 	})
+
+	close(c.readyCh)
+	log.Info("Feature controller ready")
 }
 
 func (c *FeatureController) reconcile(
@@ -162,10 +205,27 @@ func (c *FeatureController) reconcileLoop(
 		case <-ctx.Done():
 			return
 		case <-triggerCh:
+			log := log.FromContext(ctx).WithValues("feature", featureName)
+
+			// reset "reconciled" state before reconciling
+			utils.MaybeReceive(reconciledCh)
+
+			blocked, err := c.isBlocked(ctx)
+			if err != nil {
+				log.Error(err, "Failed to check if feature controller is blocked")
+				// notify triggerCh after 5 seconds to retry
+				time.AfterFunc(5*time.Second, func() { utils.MaybeNotify(triggerCh) })
+				continue
+			}
+
+			if blocked {
+				continue
+			}
+
 			if err := c.reconcile(ctx, getClusterConfig, apply, func(ctx context.Context, status types.FeatureStatus) error {
 				return setFeatureStatus(ctx, featureName, status)
 			}); err != nil {
-				log.FromContext(ctx).WithValues("feature", featureName).Error(err, "Failed to apply feature configuration")
+				log.Error(err, "Failed to apply feature configuration")
 
 				// notify triggerCh after 5 seconds to retry
 				time.AfterFunc(5*time.Second, func() { utils.MaybeNotify(triggerCh) })
@@ -175,4 +235,31 @@ func (c *FeatureController) reconcileLoop(
 
 		}
 	}
+}
+
+// isBlocked checks if the feature controller is blocked by an in-progress upgrade.
+// If an upgrade is in progress, the feature controller will not apply any configuration changes.
+func (c *FeatureController) isBlocked(ctx context.Context) (bool, error) {
+	log := log.FromContext(ctx)
+	k8sClient, err := c.snap.KubernetesClient("")
+	if err != nil {
+		return false, fmt.Errorf("failed to get Kubernetes client: %w", err)
+	}
+
+	upgrade, err := k8sClient.GetInProgressUpgrade(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to check for in-progress upgrade: %w", err)
+	}
+
+	if upgrade == nil {
+		return false, nil
+	}
+
+	if upgrade.Status.Phase == kubernetes.UpgradePhaseFeatureUpgrade {
+		log.Info("Upgrade in progress - but in feature upgrade phase - applying configuration", "upgrade", upgrade.Metadata.Name, "phase", upgrade.Status.Phase)
+		return false, nil
+	}
+
+	log.Info("Upgrade in progress - feature controller blocked", "upgrade", upgrade.Metadata.Name, "phase", upgrade.Status.Phase)
+	return true, nil
 }

--- a/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
@@ -1,0 +1,156 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
+	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/utils"
+	"github.com/canonical/microcluster/v2/state"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+const (
+	defaultFeatureControllerReadyTimeout     = 30 * time.Second
+	defaultFeatureControllerReconcileTimeout = 30 * time.Second
+)
+
+type Controller struct {
+	snap                              snap.Snap
+	waitReady                         func()
+	featureControllerReadyCh          <-chan struct{}
+	notifyFeatureController           func(network, gateway, ingress, dns, loadBalancer, localStorage, metricsServer bool)
+	featureToReconciledCh             map[string]<-chan struct{}
+	featureControllerReadyTimeout     time.Duration
+	featureControllerReconcileTimeout time.Duration
+
+	getState func() state.State
+	manager  manager.Manager
+	logger   logr.Logger
+}
+
+type ControllerOptions struct {
+	// Snap is the snap instance.
+	Snap snap.Snap
+	// WaitReady is a function that waits for the Microcluster to be ready.
+	WaitReady func()
+	// FeatureControllerReadyCh is a channel that is closed when the feature controller is ready.
+	FeatureControllerReadyCh <-chan struct{}
+	// NotifyFeatureController is a function that notifies the feature controller to reconcile.
+	NotifyFeatureController func(network, gateway, ingress, dns, loadBalancer, localStorage, metricsServer bool)
+	// FeatureToReconciledCh is a map of feature names to channels that are full
+	// when the feature controller has reconciled the feature.
+	FeatureToReconciledCh map[string]<-chan struct{}
+	// FeatureControllerReadyTimeout is the timeout for the feature controller to be ready.
+	FeatureControllerReadyTimeout time.Duration
+	// FeatureControllerReconcileTimeout is the timeout for the feature controller to reconcile.
+	FeatureControllerReconcileTimeout time.Duration
+}
+
+func NewController(opts ControllerOptions) *Controller {
+	return &Controller{
+		snap:                              opts.Snap,
+		waitReady:                         opts.WaitReady,
+		featureControllerReadyCh:          opts.FeatureControllerReadyCh,
+		notifyFeatureController:           opts.NotifyFeatureController,
+		featureToReconciledCh:             opts.FeatureToReconciledCh,
+		featureControllerReadyTimeout:     opts.FeatureControllerReadyTimeout,
+		featureControllerReconcileTimeout: opts.FeatureControllerReconcileTimeout,
+	}
+}
+
+func (c *Controller) Run(
+	ctx context.Context,
+	getClusterConfig func(context.Context) (types.ClusterConfig, error),
+	getState func() state.State,
+) error {
+	logger := log.FromContext(ctx).WithName("upgrade-controller")
+	ctx = log.NewContext(ctx, logger)
+
+	c.waitReady()
+
+	clusterConfig, err := getClusterConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cluster configuration: %w", err)
+	}
+
+	if featureUpgradesDisabled(clusterConfig) {
+		logger.Info("Feature upgrades are disabled. Skipping upgrade controller.")
+		return nil
+	}
+
+	config, err := c.getRESTConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes REST config: %w", err)
+	}
+
+	// TODO(Hue): (KU-3216) use a single manager for upgrade and csrsigning controllers.
+	mgr, err := manager.New(config, manager.Options{
+		Logger:                  logger,
+		LeaderElection:          true,
+		LeaderElectionID:        "a27980c4.k8sd-upgrade-controller",
+		LeaderElectionNamespace: "kube-system",
+		BaseContext:             func() context.Context { return ctx },
+		Cache: cache.Options{
+			SyncPeriod: utils.Pointer(10 * time.Minute),
+		},
+		Metrics: server.Options{
+			BindAddress: "0",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	c.getState = getState
+	c.manager = mgr
+	c.logger = mgr.GetLogger()
+
+	if err := c.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to setup controller with manager: %w", err)
+	}
+
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start manager: %w", err)
+	}
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kubernetes.Upgrade{}).
+		Complete(c)
+}
+
+func (c *Controller) getRESTConfig(ctx context.Context) (*rest.Config, error) {
+	for {
+		client, err := c.snap.KubernetesClient("")
+		if err == nil {
+			return client.RESTConfig(), nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+// featureUpgradesDisabled checks if feature upgrades are disabled in the cluster configuration.
+func featureUpgradesDisabled(clusterConfig types.ClusterConfig) bool {
+	_, ok := clusterConfig.Annotations.Get(apiv1_annotations.AnnotationDisableSeparateFeatureUpgrades)
+	return ok
+}

--- a/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/microcluster/v2/state"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -94,8 +95,14 @@ func (c *Controller) Run(
 		return fmt.Errorf("failed to get Kubernetes REST config: %w", err)
 	}
 
+	scheme := runtime.NewScheme()
+	if err := kubernetes.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add scheme: %w", err)
+	}
+
 	// TODO(Hue): (KU-3216) use a single manager for upgrade and csrsigning controllers.
 	mgr, err := manager.New(config, manager.Options{
+		Scheme:                  scheme,
 		Logger:                  logger,
 		LeaderElection:          true,
 		LeaderElectionID:        "a27980c4.k8sd-upgrade-controller",

--- a/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
@@ -1,0 +1,158 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/log"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// Reconcile implements the Reconciler interface and wraps the reconcile method.
+func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	res, err := c.reconcile(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile: %w", err)
+	}
+
+	bareResult := res == ctrl.Result{}
+	if bareResult {
+		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	}
+
+	return res, nil
+}
+
+// reconcile is the main reconciliation loop for the upgrade controller.
+func (c *Controller) reconcile(ctx context.Context) (ctrl.Result, error) {
+	log := c.logger.WithValues("step", "reconcile")
+
+	// TODO(Hue): (KU-3215) Use mgr.Client when Upgrade CRD is created with kubebuilder.
+	k8sClient, err := c.snap.KubernetesClient("")
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get Kubernetes client: %w", err)
+	}
+
+	upgrade, err := k8sClient.GetInProgressUpgrade(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check for in-progress upgrade: %w", err)
+	}
+
+	if upgrade == nil {
+		log.Info("No in-progress upgrade found, ignoring")
+		return ctrl.Result{}, nil
+	}
+
+	switch {
+	case upgrade.Status.Phase == kubernetes.UpgradePhaseNodeUpgrade:
+		return c.reconcileNodeUpgrade(ctx, k8sClient, upgrade)
+	case upgrade.Status.Phase == kubernetes.UpgradePhaseFeatureUpgrade:
+		return c.reconcileFeatureUpgrade(ctx, k8sClient, upgrade)
+	default:
+		// NOTE(Hue): This should never happen, but even then we don't want to return an error.
+		log.Info("Unknown upgrade phase", "phase", upgrade.Status.Phase)
+		return ctrl.Result{}, nil
+	}
+}
+
+// reconcileNodeUpgrade checks if all nodes have been upgraded.
+// If so, it transitions to the feature upgrade phase and notifies the feature controller.
+func (c *Controller) reconcileNodeUpgrade(ctx context.Context, client *kubernetes.Client, upgrade *kubernetes.Upgrade) (ctrl.Result, error) {
+	log := c.logger.WithValues("upgrade", upgrade.Name, "step", "node-upgrade")
+
+	allNodesUpgraded, err := c.allNodesUpgraded(ctx, upgrade.Status.UpgradedNodes)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check if all nodes have been upgraded: %w", err)
+	} else if !allNodesUpgraded {
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("All nodes have been upgraded.")
+
+	// This will trigger another reconciliation for the upgrade object.
+	if err := client.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseFeatureUpgrade}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set upgrade phase: %w", err)
+	}
+
+	log.Info("Transitioned to feature-upgrade phase.")
+
+	return ctrl.Result{}, nil
+}
+
+// reconcileFeatureUpgrade triggers feature controllers to reconcile
+// and waits for them to finish.
+func (c *Controller) reconcileFeatureUpgrade(ctx context.Context, client *kubernetes.Client, upgrade *kubernetes.Upgrade) (ctrl.Result, error) {
+	log := c.logger.WithValues("upgrade", upgrade.Name, "step", "feature-upgrade")
+	log.Info("Triggering feature controllers")
+
+	select {
+	case <-c.featureControllerReadyCh:
+	case <-time.After(c.featureControllerReadyTimeout):
+		return ctrl.Result{}, fmt.Errorf("timed out waiting for feature controllers to be ready")
+	}
+
+	c.notifyFeatureController(true, true, true, true, true, true, true)
+
+	log.Info("Waiting for feature controllers to reconcile.")
+
+	timeout := time.After(c.featureControllerReconcileTimeout)
+
+	for name, ch := range c.featureToReconciledCh {
+		select {
+		case <-ctx.Done():
+			return ctrl.Result{}, fmt.Errorf("context done while waiting for features to get reconciled: %w", ctx.Err())
+		case <-timeout:
+			// TODO(Hue): (KU-3227) Do something about failed feature reconciliations.
+			return ctrl.Result{}, fmt.Errorf("timed out waiting for feature %q to get reconciled", name)
+		case <-ch:
+			log.Info(fmt.Sprintf("feature %q have reconciled.", name))
+		}
+	}
+
+	log.Info("All feature have reconciled.")
+
+	if err := client.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseCompleted}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set upgrade phase after successful feature upgrade: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// allNodesUpgraded checks if all nodes in the cluster have been upgraded.
+func (c *Controller) allNodesUpgraded(ctx context.Context, upgradedNodes []string) (bool, error) {
+	log := log.FromContext(ctx)
+
+	leader, err := c.getState().Leader()
+	if err != nil {
+		return false, fmt.Errorf("failed to get leader client: %w", err)
+	}
+
+	clusterMembers, err := leader.GetClusterMembers(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get cluster members: %w", err)
+	}
+
+	if len(upgradedNodes) < len(clusterMembers) {
+		log.Info("Not all nodes have been upgraded.", "clusterMembers", len(clusterMembers), "upgradedNodes", len(upgradedNodes))
+		return false, nil
+	}
+
+	upgradedNodesMap := make(map[string]struct{})
+	for _, n := range upgradedNodes {
+		upgradedNodesMap[n] = struct{}{}
+	}
+
+	// NOTE(Hue): We only need to make sure all the nodes that are part of the cluster
+	// are upgraded. Don't care about upgraded nodes that are not part of the cluster.
+	// Maybe they've left, are removed, etc.
+	for _, member := range clusterMembers {
+		if _, ok := upgradedNodesMap[member.Name]; !ok {
+			log.Info(fmt.Sprintf("Cluster member %q is not upgraded", member.Name), "member_name", member.Name)
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -12,8 +12,9 @@ import (
 
 // Snap abstracts file system paths and interacting with the k8s services.
 type Snap interface {
-	Strict() bool                        // Strict returns true if the snap is installed with strict confinement.
-	OnLXD(context.Context) (bool, error) // OnLXD returns true if the host runs on LXD.
+	Revision(ctx context.Context) (string, error) // Revision returns the snap revision.
+	Strict() bool                                 // Strict returns true if the snap is installed with strict confinement.
+	OnLXD(context.Context) (bool, error)          // OnLXD returns true if the host runs on LXD.
 
 	UID() int         // UID is the user ID to set on config files.
 	GID() int         // GID is the group ID to set on config files.

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -50,6 +50,7 @@ type Snap interface {
 	ContainerdSocketPath() string        // classic confinement: /run/containerd/containerd.sock, strict confinement: /var/snap/k8s/common/run/containerd/containerd.sock
 	ContainerdStateDir() string          // classic confinement: /run/containerd, strict confinement: /var/snap/k8s/common/run/containerd
 
+	K8sCRDDir() string            //  /snap/k8s/current/k8s/crds
 	K8sScriptsDir() string        //  /snap/k8s/current/k8s/scripts
 	K8sInspectScriptPath() string //  /snap/k8s/current/k8s/scripts/inspect.sh
 

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -63,7 +63,8 @@ type Snap interface {
 
 	LockFilesDir() string // /var/snap/k8s/common/lock
 
-	NodeTokenFile() string // /var/snap/k8s/common/node-token
+	NodeTokenFile() string                                     // /var/snap/k8s/common/node-token
+	NodeKubernetesVersion(ctx context.Context) (string, error) // The Kubernetes version of the node as set in the snap. Can be queried without running k8s services.
 
 	KubernetesClient(namespace string) (*kubernetes.Client, error)     // admin kubernetes client
 	KubernetesNodeClient(namespace string) (*kubernetes.Client, error) // node kubernetes client

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -47,6 +47,8 @@ type Mock struct {
 	LockFilesDir                string
 	PostRefreshLockPath         string
 	NodeTokenFile               string
+	NodeKubernetesVersion       string
+	NodeKubernetesVersionErr    error
 	KubernetesClient            *kubernetes.Client
 	KubernetesNodeClient        *kubernetes.Client
 	HelmClient                  helm.Client
@@ -257,6 +259,10 @@ func (s *Snap) LockFilesDir() string {
 
 func (s *Snap) NodeTokenFile() string {
 	return s.Mock.NodeTokenFile
+}
+
+func (s *Snap) NodeKubernetesVersion(context.Context) (string, error) {
+	return s.Mock.NodeKubernetesVersion, s.Mock.NodeKubernetesVersionErr
 }
 
 func (s *Snap) KubernetesClient(namespace string) (*kubernetes.Client, error) {

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -35,6 +35,7 @@ type Mock struct {
 	ContainerdSocketDir         string
 	ContainerdSocketPath        string
 	ContainerdStateDir          string
+	K8sCRDDir                   string
 	K8sScriptsDir               string
 	K8sInspectScriptPath        string
 	K8sdStateDir                string
@@ -182,6 +183,10 @@ func (s *Snap) ContainerdExtraConfigDir() string {
 
 func (s *Snap) ContainerdRegistryConfigDir() string {
 	return s.Mock.ContainerdRegistryConfigDir
+}
+
+func (s *Snap) K8sCRDDir() string {
+	return s.Mock.K8sCRDDir
 }
 
 func (s *Snap) K8sScriptsDir() string {

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -13,6 +13,8 @@ import (
 )
 
 type Mock struct {
+	Revision                    string
+	RevisionErr                 error
 	Strict                      bool
 	OnLXD                       bool
 	OnLXDErr                    error
@@ -127,6 +129,10 @@ func (s *Snap) RefreshStatus(ctx context.Context, changeID string) (*types.Refre
 
 func (s *Snap) PostRefreshLockPath() string {
 	return s.Mock.PostRefreshLockPath
+}
+
+func (s *Snap) Revision(ctx context.Context) (string, error) {
+	return s.Mock.Revision, s.Mock.RevisionErr
 }
 
 func (s *Snap) Strict() bool {

--- a/src/k8s/pkg/snap/pebble.go
+++ b/src/k8s/pkg/snap/pebble.go
@@ -111,6 +111,10 @@ func (s *pebble) RefreshStatus(ctx context.Context, changeID string) (*types.Ref
 	}, nil
 }
 
+func (s *pebble) Revision(ctx context.Context) (string, error) {
+	return "", nil
+}
+
 func (s *pebble) Strict() bool {
 	return false
 }

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -305,6 +305,10 @@ func (s *snap) ContainerdRegistryConfigDir() string {
 	return filepath.Join(s.containerdBaseDir, "etc", "containerd", "hosts.d")
 }
 
+func (s *snap) K8sCRDDir() string {
+	return filepath.Join(s.snapDir, "k8s", "crds")
+}
+
 func (s *snap) K8sScriptsDir() string {
 	return filepath.Join(s.snapDir, "k8s", "scripts")
 }

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -372,6 +372,24 @@ func (s *snap) SnapctlSet(ctx context.Context, args ...string) error {
 	return s.runCommand(ctx, append([]string{"snapctl", "set"}, args...))
 }
 
+func (s *snap) Revision(ctx context.Context) (string, error) {
+	client, err := snapd.NewClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to create snapd client: %w", err)
+	}
+
+	snap, err := client.GetSnapInfo(s.snapInstanceName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get snap info: %w", err)
+	}
+
+	if snap.StatusCode != 200 {
+		return "", fmt.Errorf("failed to get snap info: snapd returned with error code %d", snap.StatusCode)
+	}
+
+	return snap.Result.Revision, nil
+}
+
 func (s *snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, serviceConfigs types.K8sServiceConfigs, isControlPlane bool) error {
 	if err := checks.CheckK8sServicePorts(config, serviceConfigs, isControlPlane); err != nil {
 		return fmt.Errorf("Encountered error(s) while verifying port availability for Kubernetes services: %w", err)

--- a/src/k8s/pkg/snap/snap_test.go
+++ b/src/k8s/pkg/snap/snap_test.go
@@ -204,4 +204,65 @@ func TestSnap(t *testing.T) {
 			g.Expect(err).To(HaveOccurred())
 		})
 	})
+
+	t.Run("NodeKubernetesVersion", func(t *testing.T) {
+		t.Run("returns version from bom.json", func(t *testing.T) {
+			g := NewWithT(t)
+
+			tmpDir, err := os.MkdirTemp("", "test-bom-k8s")
+			g.Expect(err).To(Not(HaveOccurred()))
+			defer os.RemoveAll(tmpDir)
+
+			bomContent := `{
+				"components": {
+					"kubernetes": {
+						"version": "v1.32.3"
+					}
+				}
+			}`
+			err = os.WriteFile(filepath.Join(tmpDir, "bom.json"), []byte(bomContent), 0o644)
+			g.Expect(err).To(Not(HaveOccurred()))
+
+			snap := snap.NewSnap(snap.SnapOpts{
+				SnapDir: tmpDir,
+			})
+
+			version, err := snap.NodeKubernetesVersion(context.Background())
+			g.Expect(err).To(Not(HaveOccurred()))
+			g.Expect(version).To(Equal("v1.32.3"))
+		})
+
+		t.Run("fails when bom.json is missing", func(t *testing.T) {
+			g := NewWithT(t)
+
+			tmpDir, err := os.MkdirTemp("", "test-bom-missing")
+			g.Expect(err).To(Not(HaveOccurred()))
+			defer os.RemoveAll(tmpDir)
+
+			snap := snap.NewSnap(snap.SnapOpts{
+				SnapDir: tmpDir,
+			})
+
+			_, err = snap.NodeKubernetesVersion(context.Background())
+			g.Expect(err).To(HaveOccurred())
+		})
+
+		t.Run("fails when bom.json is malformed", func(t *testing.T) {
+			g := NewWithT(t)
+
+			tmpDir, err := os.MkdirTemp("", "test-bom-bad")
+			g.Expect(err).To(Not(HaveOccurred()))
+			defer os.RemoveAll(tmpDir)
+
+			err = os.WriteFile(filepath.Join(tmpDir, "bom.json"), []byte("not-json"), 0o644)
+			g.Expect(err).To(Not(HaveOccurred()))
+
+			snap := snap.NewSnap(snap.SnapOpts{
+				SnapDir: tmpDir,
+			})
+
+			_, err = snap.NodeKubernetesVersion(context.Background())
+			g.Expect(err).To(HaveOccurred())
+		})
+	})
 }

--- a/src/k8s/pkg/utils/chan.go
+++ b/src/k8s/pkg/utils/chan.go
@@ -7,3 +7,11 @@ func MaybeNotify(ch chan<- struct{}) {
 	default:
 	}
 }
+
+// MaybeReceive tries to receive from a channel, but does not block if that fails.
+func MaybeReceive(ch <-chan struct{}) {
+	select {
+	case <-ch:
+	default:
+	}
+}

--- a/src/k8s/pkg/utils/file.go
+++ b/src/k8s/pkg/utils/file.go
@@ -290,3 +290,8 @@ func WriteFile(name string, data []byte, perm fs.FileMode) error {
 
 	return nil
 }
+
+// IsYaml returns true if the file has a yaml or yml extension.
+func IsYaml(file string) bool {
+	return filepath.Ext(strings.ToLower(file)) == ".yaml" || filepath.Ext(strings.ToLower(file)) == ".yml"
+}

--- a/src/k8s/pkg/utils/file_test.go
+++ b/src/k8s/pkg/utils/file_test.go
@@ -272,3 +272,49 @@ func TestWriteFile(t *testing.T) {
 		})
 	}
 }
+
+func TestIsYaml(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{
+			name:     "lowercase yml extension",
+			filename: "my/yaml/file.yml",
+			want:     true,
+		},
+		{
+			name:     "lowercase yaml extension",
+			filename: "my/yaml/file.yaml",
+			want:     true,
+		},
+		{
+			name:     "uppercase YAML extension",
+			filename: "my/yaml/file.YAML",
+			want:     true,
+		},
+		{
+			name:     "uppercase YML extension",
+			filename: "my/yaml/file.YML",
+			want:     true,
+		},
+		{
+			name:     "no extension",
+			filename: "my/yaml/file",
+			want:     false,
+		},
+		{
+			name:     "non-yaml extension",
+			filename: "my/yaml/file.txt",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(utils.IsYaml(tt.filename)).To(Equal(tt.want))
+		})
+	}
+}

--- a/tests/integration/templates/bootstrap-disable-separate-feature-upgrades.yaml
+++ b/tests/integration/templates/bootstrap-disable-separate-feature-upgrades.yaml
@@ -1,0 +1,7 @@
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  annotations:
+    k8sd/v1alpha/lifecycle/disable-separate-feature-upgrades: true

--- a/tests/integration/templates/upgrade.yaml
+++ b/tests/integration/templates/upgrade.yaml
@@ -1,0 +1,4 @@
+apiVersion: k8sd.io/v1alpha
+kind: Upgrade
+metadata:
+  name: cluster-upgrade

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -1,7 +1,9 @@
 #
 # Copyright 2025 Canonical, Ltd.
 #
+import json
 import logging
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -89,3 +91,60 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 1, "worker node should have been removed from the cluster"
     util.check_snap_services_ready(worker, node_type="worker", skip_services=["k8sd"])
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.no_setup()
+@pytest.mark.tags(tags.NIGHTLY)
+def test_disable_separate_feature_upgrades(
+    instances: List[harness.Instance], tmp_path: Path
+):
+    cluster_node = instances[0]
+    joining_cp = instances[1]
+
+    start_branch = util.previous_track(config.SNAP)
+    for instance in instances:
+        instance.exec(f"snap install k8s --classic --channel={start_branch}".split())
+
+    cluster_node.exec(
+        "k8s bootstrap --file -".split(),
+        input=str.encode(
+            (
+                config.MANIFESTS_DIR
+                / "bootstrap-disable-separate-feature-upgrades.yaml"
+            ).read_text()
+        ),
+    )
+
+    join_token = util.get_join_token(cluster_node, joining_cp)
+    util.join_cluster(joining_cp, join_token)
+
+    # Refresh first node, no upgrade CRD should be created.
+    util.setup_k8s_snap(cluster_node, tmp_path, config.SNAP)
+    util.wait_until_k8s_ready(cluster_node, instances)
+
+    upgrades = json.loads(
+        cluster_node.exec(
+            "k8s kubectl get upgrade -o=jsonpath={.items}".split(),
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
+    assert len(upgrades) == 0, "upgrade CRD should not be created"
+
+    # The feature controller should not be blocked.
+    # Disable gateway feature
+    cluster_node.exec("k8s set gateway.enabled=false".split())
+
+    def is_gateway_disabled(process):
+        gateway_status = json.loads(process.stdout)
+        return gateway_status.get("enabled") is False
+
+    # Wait until gateway is disabled
+    util.stubbornly(retries=3, delay_s=5).on(cluster_node).until(
+        is_gateway_disabled
+    ).exec(
+        ["k8s", "get", "gateway", "--output-format=json"],
+        text=True,
+        capture_output=True,
+    )

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -40,32 +40,6 @@ def test_control_plane_nodes(instances: List[harness.Instance]):
     ), f"only {cluster_node.id} should be left in cluster"
 
 
-@pytest.mark.node_count(2)
-@pytest.mark.snap_versions([util.previous_track(config.SNAP), config.SNAP])
-@pytest.mark.tags(tags.NIGHTLY)
-def test_mixed_version_join(instances: List[harness.Instance]):
-    """Test n versioned node joining a n-1 versioned cluster."""
-    cluster_node = instances[0]  # bootstrapped on the previous channel
-    joining_node = instances[1]  # installed with the snap under test
-
-    join_token = util.get_join_token(cluster_node, joining_node)
-    util.join_cluster(joining_node, join_token)
-
-    util.wait_until_k8s_ready(cluster_node, instances)
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 2, "node should have joined cluster"
-
-    assert "control-plane" in util.get_local_node_status(cluster_node)
-    assert "control-plane" in util.get_local_node_status(joining_node)
-
-    cluster_node.exec(["k8s", "remove-node", joining_node.id])
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 1, "node should have been removed from cluster"
-    assert (
-        nodes[0]["metadata"]["name"] == cluster_node.id
-    ), f"only {cluster_node.id} should be left in cluster"
-
-
 @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.PULL_REQUEST)
 def test_worker_nodes(instances: List[harness.Instance]):

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -625,20 +625,11 @@ def previous_track(snap_version: str) -> str:
         return assumed
 
     if snap_version.startswith("/") or _as_int(snap_version) is not None:
-        branch = config.GH_BASE_REF or config.GH_REF or MAIN_BRANCH
-        prev = _previous_track_from_branch(branch)
-        if prev:
-            LOG.info(
-                "Previous track for %s from branch %s is %s", snap_version, branch, prev
-            )
-            return prev
-        else:
-            LOG.info(
-                "Previous track for %s from branch %s is not found -- assume latest",
-                snap_version,
-                branch,
-            )
-            return f"latest/edge/{_get_flavor()}"
+        assumed = "1.32-classic"
+        LOG.info(
+            "Cannot determine previous track for %s -- assume %s", snap_version, assumed
+        )
+        return assumed
 
     if maj_min := major_minor(snap_version):
         maj, min = maj_min

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -616,7 +616,7 @@ def previous_track(snap_version: str) -> str:
     LOG.debug("Determining previous track for %s", snap_version)
 
     if not snap_version:
-        assumed = "1.32-classic"
+        assumed = f"1.32-{_get_flavor()}"
         LOG.info(
             "Cannot determine previous track for undefined snap -- assume %s",
             snap_version,
@@ -625,7 +625,7 @@ def previous_track(snap_version: str) -> str:
         return assumed
 
     if snap_version.startswith("/") or _as_int(snap_version) is not None:
-        assumed = "1.32-classic"
+        assumed = f"1.32-{_get_flavor()}"
         LOG.info(
             "Cannot determine previous track for %s -- assume %s", snap_version, assumed
         )

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -29,7 +29,8 @@ from test_util import config, harness
 
 LOG = logging.getLogger(__name__)
 RISKS = ["stable", "candidate", "beta", "edge"]
-TRACK_RE = re.compile(r"^(\d+)\.(\d+)(\S*)$")
+TRACK_RE = re.compile(r"^v?(\d+)\.(\d+)(.\d+)?(\S*)$")
+MAIN_BRANCH = "main"
 
 # SONOBUOY_VERSION is the version of sonobuoy to use for CNCF conformance tests.
 SONOBUOY_VERSION = os.getenv("TEST_SONOBUOY_VERSION") or "v0.57.3"
@@ -535,9 +536,72 @@ def major_minor(version: str) -> Optional[tuple]:
         a tuple containing the major and minor version or None if the version string is invalid
     """
     if match := TRACK_RE.match(version):
-        maj, min, _ = match.groups()
+        maj, min, _, _ = match.groups()
         return int(maj), int(min)
     return None
+
+
+def _get_flavor() -> str:
+    """Determine the flavor of the snap."""
+    return {"": "classic", "strict": ""}.get(config.FLAVOR, config.FLAVOR)
+
+
+def _major_minor_from_stable_upstream(maj: Optional[int] = None) -> Optional[tuple]:
+    """Determine the major and minor version of the latest stable upstream release.
+
+    Args:
+        maj: the major version to use for the URL
+
+    Returns:
+        a tuple containing the major and minor version or None if the version string is invalid
+    """
+    addr = "https://dl.k8s.io/release/stable{dash_maj}.txt".format(
+        dash_maj=f"-{maj}" if maj else ""
+    )
+    LOG.info("Getting upstream version from %s", addr)
+    with urllib.request.urlopen(addr) as r:
+        stable = r.read().decode().strip()
+        return major_minor(stable)
+
+
+def _previous_track_from_branch(branch: str) -> Optional[str]:
+    """Determine the previous track from the branch.
+
+    Args:
+        branch: the branch to determine the previous track for
+
+    Returns:
+        the previous track or None if fails to determine
+    """
+    if branch == MAIN_BRANCH:
+        # NOTE(Hue): `latest/stable` is not populated at the moment.
+        # When it is, we should return `latest` instead.
+        LOG.info("Getting current version from upstream k8s")
+        # For the main branch, the previous track is the latest release-branch, e.g.
+        # `1.32/stable` for `main` branch which matches the current upstream version.
+        maj_min = _major_minor_from_stable_upstream()
+        if not maj_min:
+            LOG.info("Failed to determine upstream version")
+            return None
+
+    elif branch.startswith("release-"):
+        LOG.info("Getting current version from branch %s", branch)
+        maj_min = major_minor(branch.lstrip("release-"))
+        # Get the previous version from the branch, e.g. for branch `release-1.32` we want `1.31`
+        if maj_min:
+            _maj, _min = maj_min[0], maj_min[1]
+            if _min == 0:
+                maj_min = _major_minor_from_stable_upstream(_maj - 1)
+            else:
+                maj_min = (_maj, _min - 1)
+    else:
+        LOG.info(
+            "Branch is neither `main` nor `release-X.Y`. Can't determine previous track."
+        )
+        return None
+
+    flavor = _get_flavor()
+    return f"{maj_min[0]}.{maj_min[1]}" + (flavor and f"-{flavor}") if maj_min else None
 
 
 def previous_track(snap_version: str) -> str:

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -625,11 +625,20 @@ def previous_track(snap_version: str) -> str:
         return assumed
 
     if snap_version.startswith("/") or _as_int(snap_version) is not None:
-        assumed = "1.32-classic"
-        LOG.info(
-            "Cannot determine previous track for %s -- assume %s", snap_version, assumed
-        )
-        return assumed
+        branch = config.GH_BASE_REF or config.GH_REF or MAIN_BRANCH
+        prev = _previous_track_from_branch(branch)
+        if prev:
+            LOG.info(
+                "Previous track for %s from branch %s is %s", snap_version, branch, prev
+            )
+            return prev
+        else:
+            LOG.info(
+                "Previous track for %s from branch %s is not found -- assume latest",
+                snap_version,
+                branch,
+            )
+            return f"latest/edge/{_get_flavor()}"
 
     if maj_min := major_minor(snap_version):
         maj, min = maj_min

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -143,10 +143,13 @@ def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
         ).stdout
 
         if idx == len(instances) - 1:
-            assert phase in [
-                "FeatureUpgrade",
-                "Completed",
-            ], f"Right after the last upgrade, expected phase to be FeatureUpgrade or Complete but got {phase}"
+            util.stubbornly(retries=15, delay_s=5).on(instance).until(
+                lambda p: p.stdout in ["FeatureUpgrade", "Completed"],
+            ).exec(
+                "k8s kubectl get upgrade -o=jsonpath={.items[0].status.phase}".split(),
+                capture_output=True,
+                text=True,
+            )
 
             # All Feature version should eventually be upgraded.
             LOG.info("Waiting for all helm releases to upgrade")

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -99,8 +99,6 @@ def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
         token = util.get_join_token(main, instance)
         instance.exec(["k8s", "join-cluster", token])
 
-    util.wait_until_k8s_ready(instance, instances)
-
     # Get initial helm releases to track if they are updated correctly.
     initial_releases = {
         release["name"]: release
@@ -126,7 +124,7 @@ def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
     for idx, instance in enumerate(instances):
         util.setup_k8s_snap(instance, tmp_path, config.SNAP)
 
-        # TODO(ben): Check if this wait is really required, if yes - why?
+        # The crd will be created once the node is up and ready, so we might need to wait for it.
         expected_instances = [instance.id for instance in instances[: idx + 1]]
         util.stubbornly(retries=15, delay_s=5).on(instance).until(
             lambda p: _waiting_for_upgraded_nodes(

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -2,6 +2,7 @@
 # Copyright 2025 Canonical, Ltd.
 #
 import logging
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -68,3 +69,24 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
         util.wait_until_k8s_ready(cp, instances)
         current_channel = channel
         LOG.info(f"Upgraded {cp.id} on channel {channel}")
+
+
+@pytest.mark.tags(tags.NIGHTLY)
+def test_feature_upgrades(instances: List[harness.Instance]):
+    """Test the feature upgrades work
+    Note(ben): This test is a work in progress and will
+    be expanded with new tests as the feature upgrades work takes shape.
+    Once this work is complete, this test will likely be merged with the
+    test_version_upgrades test above and create a single test for all upgrades."""
+
+    cp = instances[0]
+
+    # Verify that the UpgradeCRD is known to the cluster
+    cp.exec("k8s kubectl get crd upgrades.k8sd.io".split())
+
+    # Test that the UpgradeCRD can be created.
+    cp.exec(
+        "k8s kubectl apply -f -".split(),
+        input=str.encode(Path(config.MANIFESTS_DIR / "upgrade.yaml").read_text()),
+    )
+    cp.exec("k8s kubectl get upgrade cluster-upgrade".split())

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2025 Canonical, Ltd.
 #
+import json
 import logging
 from pathlib import Path
 from typing import List
@@ -71,22 +72,64 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
         LOG.info(f"Upgraded {cp.id} on channel {channel}")
 
 
+@pytest.mark.node_count(3)
+@pytest.mark.no_setup()
 @pytest.mark.tags(tags.NIGHTLY)
-def test_feature_upgrades(instances: List[harness.Instance]):
+def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
     """Test the feature upgrades work
     Note(ben): This test is a work in progress and will
     be expanded with new tests as the feature upgrades work takes shape.
     Once this work is complete, this test will likely be merged with the
-    test_version_upgrades test above and create a single test for all upgrades."""
+    test_version_upgrades test above and create a single test for all upgrades.
 
-    cp = instances[0]
+    This test creates a cluster, refreshes each node one by one and verifies
+    that the upgrade CR is updated correctly.
+    """
+    assert config.SNAP is not None, "SNAP must be set to run this test"
 
-    # Verify that the UpgradeCRD is known to the cluster
-    cp.exec("k8s kubectl get crd upgrades.k8sd.io".split())
+    start_branch = util.previous_track(config.SNAP)
+    main = instances[0]
 
-    # Test that the UpgradeCRD can be created.
-    cp.exec(
-        "k8s kubectl apply -f -".split(),
-        input=str.encode(Path(config.MANIFESTS_DIR / "upgrade.yaml").read_text()),
-    )
-    cp.exec("k8s kubectl get upgrade cluster-upgrade".split())
+    for instance in instances:
+        instance.exec(f"snap install k8s --classic --channel={start_branch}".split())
+
+    main.exec(["k8s", "bootstrap"])
+    for instance in instances[1:]:
+        token = util.get_join_token(main, instance)
+        instance.exec(["k8s", "join-cluster", token])
+
+    # Refresh each node after each other and verify that the upgrade CR is updated correctly.
+    for idx, instance in enumerate(instances):
+        util.setup_k8s_snap(instance, tmp_path, config.SNAP)
+
+        # TODO(ben): Check if this wait is really required, if yes - why?
+        expected_instances = [instance.id for instance in instances[: idx + 1]]
+        util.stubbornly(retries=15, delay_s=5).on(instance).until(
+            lambda p: _waiting_for_upgraded_nodes(
+                json.loads(p.stdout), expected_instances
+            ),
+        ).exec(
+            "k8s kubectl get upgrade -o=jsonpath={.items[0].status.upgradedNodes}".split(),
+            capture_output=True,
+            text=True,
+        )
+
+        phase = instance.exec(
+            "k8s kubectl get upgrade -o=jsonpath={.items[0].status.phase}".split(),
+            capture_output=True,
+            text=True,
+        ).stdout
+
+        if idx == len(instances) - 1:
+            assert (
+                phase == "FeatureUpgrade"
+            ), f"After the last upgrade, expected phase to be FeatureUpgrade but got {phase}"
+        else:
+            assert (
+                phase == "NodeUpgrade"
+            ), f"While upgrading, expected phase to be NodeUpgrade but got {phase}"
+
+
+def _waiting_for_upgraded_nodes(upgraded_nodes, expected_nodes) -> True:
+    LOG.info("Waiting for upgraded nodes %s to be: %s", upgraded_nodes, expected_nodes)
+    return set(upgraded_nodes) == set(expected_nodes)

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -76,14 +76,15 @@ def test_version_upgrades(instances: List[harness.Instance], tmp_path):
 @pytest.mark.no_setup()
 @pytest.mark.tags(tags.NIGHTLY)
 def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
-    """Test the feature upgrades work
-    Note(ben): This test is a work in progress and will
-    be expanded with new tests as the feature upgrades work takes shape.
-    Once this work is complete, this test will likely be merged with the
-    test_version_upgrades test above and create a single test for all upgrades.
+    """Verify that feature upgrades function correctly.
 
-    This test creates a cluster, refreshes each node one by one and verifies
-    that the upgrade CR is updated correctly.
+    Note: This is an interim test that will be expanded as feature upgrades mature.
+    Eventually, it will merge with test_version_upgrades to create a unified upgrade test.
+
+    This test will spin up a three cp cluster on 1.32-classic/stable, and then upgrade to the snap.
+    The test will then verify that the upgrade CR is updated correctly and that the features are upgraded
+    after the last node is upgraded.
+    The test will also verify that the feature version is not upgraded until all nodes are upgraded.
     """
     assert config.SNAP is not None, "SNAP must be set to run this test"
 
@@ -97,6 +98,29 @@ def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
     for instance in instances[1:]:
         token = util.get_join_token(main, instance)
         instance.exec(["k8s", "join-cluster", token])
+
+    util.wait_until_k8s_ready(instance, instances)
+
+    # Get initial helm releases to track if they are updated correctly.
+    initial_releases = {
+        release["name"]: release
+        for release in json.loads(
+            main.exec(
+                [
+                    "/snap/k8s/current/bin/helm",
+                    "--kubeconfig",
+                    "/etc/kubernetes/admin.conf",
+                    "list",
+                    "-n",
+                    "kube-system",
+                    "-o",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+    }
 
     # Refresh each node after each other and verify that the upgrade CR is updated correctly.
     for idx, instance in enumerate(instances):
@@ -121,13 +145,75 @@ def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
         ).stdout
 
         if idx == len(instances) - 1:
-            assert (
-                phase == "FeatureUpgrade"
-            ), f"After the last upgrade, expected phase to be FeatureUpgrade but got {phase}"
+            assert phase in [
+                "FeatureUpgrade",
+                "Completed",
+            ], f"Right after the last upgrade, expected phase to be FeatureUpgrade or Complete but got {phase}"
+
+            # All Feature version should eventually be upgraded.
+            LOG.info("Waiting for all helm releases to upgrade")
+            util.stubbornly(retries=15, delay_s=5).on(instance).until(
+                lambda p: all(
+                    next(r for r in json.loads(p.stdout) if r["name"] == name)[
+                        "updated"
+                    ]
+                    != initial_releases[name]["updated"]
+                    for name in initial_releases
+                ),
+            ).exec(
+                [
+                    "/snap/k8s/current/bin/helm",
+                    "--kubeconfig",
+                    "/etc/kubernetes/admin.conf",
+                    "list",
+                    "-n",
+                    "kube-system",
+                    "-o",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            LOG.info("All helm releases have upgraded successfully")
+
+            # TODO(ben): Check that new fields are set in the feature config.
+            # TODO(ben): Check that connectivity (e.g. for gateway) is working during the upgrade.
+
+            util.stubbornly(retries=15, delay_s=5).on(instance).until(
+                lambda p: p.stdout == "Completed",
+            ).exec(
+                "k8s kubectl get upgrade -o=jsonpath={.items[0].status.phase}".split(),
+                capture_output=True,
+                text=True,
+            )
         else:
             assert (
                 phase == "NodeUpgrade"
             ), f"While upgrading, expected phase to be NodeUpgrade but got {phase}"
+
+            current_helm_releases = instance.exec(
+                [
+                    "/snap/k8s/current/bin/helm",
+                    "--kubeconfig",
+                    "/etc/kubernetes/admin.conf",
+                    "list",
+                    "-n",
+                    "kube-system",
+                    "-o",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+            ).stdout
+
+            for release in json.loads(current_helm_releases):
+                LOG.info(json.dumps(json.loads(current_helm_releases), indent=2))
+                LOG.info("Checking helm release %s", release["name"])
+                name = release["name"]
+                assert (
+                    release["updated"] == initial_releases[name]["updated"]
+                ), f"{release['name']} was updated while upgrading {instance.id} but should not \
+                    have been ({initial_releases[name]['updated']}, {release['updated']})"
 
 
 def _waiting_for_upgraded_nodes(upgraded_nodes, expected_nodes) -> True:


### PR DESCRIPTION
This PR backports the feature upgrade machinery to 1.32, which consists of:
* #1207
* #1250 
* #1268
* #1274 
* #1286 
* (Hue) Upgrade Controller - #1297
* (Hue) Upgrade controller fix - #1307
* rollout upgrades #1333 
* #1337 

also includes godoc fix to make CI happy https://github.com/canonical/k8s-snap/pull/1088/commits/1152871a85e2adaec5f126d28899c6f3d37fd376