### PR TITLE
docs: Add charm patch notices for 1.32

### DIFF
--- a/docs/canonicalk8s/charm/howto/upgrade-minor.md
+++ b/docs/canonicalk8s/charm/howto/upgrade-minor.md
@@ -211,7 +211,7 @@ to ensure that the cluster is fully functional.
 [backup-restore]:      ../../snap/howto/backup-restore
 [charmhub]:            https://charmhub.io/k8s
 [cluster-validation]:  ./validate
-[juju-docs]:           https://documentation.ubuntu.com/juju/3.6/howto/manage-models/#manage-models
+[juju-docs]:           https://documentation.ubuntu.com/juju/3.6/howto/manage-models/
 [release-notes]:       ../reference/releases
 [upgrade-notes]:       ../reference/upgrade-notes
 [upstream-notes]:      https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation

--- a/docs/canonicalk8s/charm/howto/upgrade-patch.md
+++ b/docs/canonicalk8s/charm/howto/upgrade-patch.md
@@ -202,6 +202,6 @@ to ensure that the cluster is fully functional.
 [backup-restore]:     ../../snap/howto/backup-restore
 [charmhub]:            https://charmhub.io/k8s
 [cluster-validation]: ./validate
-[juju-docs]:          https://documentation.ubuntu.com/juju/3.6/howto/manage-models/#how-to-manage-models
+[juju-docs]:          https://documentation.ubuntu.com/juju/3.6/howto/manage-models/
 [release-notes]:      ../reference/releases
 [upstream-notes]:     https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG

--- a/docs/canonicalk8s/charm/reference/versions/1.32.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.32.md
@@ -7,7 +7,6 @@ for {{product}}! These release notes cover the highlights of this release.
 
 ## What’s new
 
-<!-- add in some text on what is new in a bold -->
 - **Kubernetes 1.32** - read more about the upstream release
 [here][upstream release].
 - **{{product}} Snap 1.32** - read more about the snap release
@@ -55,31 +54,20 @@ relevant sections of the [upstream release notes][upstream-changelog-1.32].
 
 ## Patch notices
 
-Apr 9, 2025
-
-- Update k8s snap revisions ["amd64-2907","arm64-2908"]
-[#431](https://github.com/canonical/k8s-operator/pull/431)
-
 Mar 25, 2025
 
-- Bypass operator-workflows promote task which is limited to charmcraft 2 base
+- Bypass operator-workflows promote task which is limited to Charmcraft 2 base
 notation [#414](https://github.com/canonical/k8s-operator/pull/414)
-
-Mar 21, 2025
-
-- Update k8s snap revisions ["amd64-2717","arm64-2723"]
+- Update k8s snap revisions amd64-2717 and arm64-2723
 [#407](https://github.com/canonical/k8s-operator/pull/407)
 -  Bump node-base to apply AZ node labels
 [#400](https://github.com/canonical/k8s-operator/pull/400)
-
-Feb 26, 2025
-
 - Update canonical/operator-workflows digest to e848763
 [#376](https://github.com/canonical/k8s-operator/pull/376)
 
 Feb 19, 2025
 
-- Cherry-pick bugfixes to 1.32
+- Cherry-pick bug fixes to 1.32
 [#327](https://github.com/canonical/k8s-operator/pull/327) including:
 
     - Improve external load balancer endpoint testing
@@ -87,28 +75,16 @@ Feb 19, 2025
     - Test custom-registry config is applied with or without the containerd
     relation
     - Address httpx.ConnectError as a cluster-inspect error
-    - Use uv as the build system
+    - Use UV as the build system
     - Update integrating testing
-
-Feb 18, 2025
-
 - Update k8s snap 1.32 revision to 2502 on arm64
 [#335](https://github.com/canonical/k8s-operator/pull/335)
 - Update k8s snap 1.32 revision to 2500 on amd64
 [#334](https://github.com/canonical/k8s-operator/pull/334)
-
-Feb 15, 2025
-
 - Pin kube-control dependency to 0.2.0
 [#332](https://github.com/canonical/k8s-operator/pull/332)
-
-Feb 7, 2025
-
 - Fix containerd base dir issue
 [#311](https://github.com/canonical/k8s-operator/pull/311)
-
-Feb 6, 2025
-
 - Manually set k8s snap 1.32-classic/stable revision
 [#306](https://github.com/canonical/k8s-operator/pull/306)
 
@@ -134,11 +110,11 @@ Feb 5, 2025
 [#270](https://github.com/canonical/k8s-operator/pull/270)
 - Upgrade to Charmcraft 3.x
 [#265](https://github.com/canonical/k8s-operator/pull/265)
-- Update dependency pydantic to v1.10.21
+- Update dependency Pydantic to v1.10.21
 [#236](https://github.com/canonical/k8s-operator/pull/236)
 - Update dependency cosl to v0.0.51
 [#227](https://github.com/canonical/k8s-operator/pull/227)
-- Update dependency lightkube to v0.17.1
+- Update dependency LightKube to v0.17.1
 [#228](https://github.com/canonical/k8s-operator/pull/228)
 - Update docs link to cluster annotations
 [#254](https://github.com/canonical/k8s-operator/pull/254)
@@ -154,7 +130,7 @@ Feb 5, 2025
 [#253](https://github.com/canonical/k8s-operator/pull/253)
 - Test with UV on various python versions
 [#247](https://github.com/canonical/k8s-operator/pull/247)
-- Require tf users to specify a charm channel
+- Require Terraform users to specify a charm channel
 [#242](https://github.com/canonical/k8s-operator/pull/242)
 - Add Tiobe TICS cron job to CI
 [#249](https://github.com/canonical/k8s-operator/pull/249)
@@ -170,28 +146,16 @@ Feb 5, 2025
 [#222](https://github.com/canonical/k8s-operator/pull/222)
 - Pick up changes applied to 1.32-release branch
 [#225](https://github.com/canonical/k8s-operator/pull/225) including:
-    - Pin snap_installations to 1.32-classic stable
+    - Pin snap installations to 1.32-classic stable
     - Revert changes to continue having the snap override available from edge
     channels
     - Begin testing upgrades from 1.32/beta channels
-
-Jan 17, 2025
-
 - Manually upgrade the snap revision to 1958
 [#256](https://github.com/canonical/k8s-operator/pull/256)
-
-Jan 16, 2025
-
 - Allow charms to remove node labels via config
 [#244](https://github.com/canonical/k8s-operator/pull/244)
-
-Jan 14, 2025
-
 - Fix reporting of the default image registry
 [#243](https://github.com/canonical/k8s-operator/pull/243)
-
-Jan 13, 2025
-
 - Change year to 2025 in licenses
 [#245](https://github.com/canonical/k8s-operator/pull/245)
 

--- a/docs/canonicalk8s/charm/reference/versions/1.32.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.32.md
@@ -56,86 +56,144 @@ relevant sections of the [upstream release notes][upstream-changelog-1.32].
 ## Patch notices
 
 Apr 9, 2025
-- Update k8s snap revisions ["amd64-2907","arm64-2908"] [#431](https://github.com/canonical/k8s-operator/pull/431)
+
+- Update k8s snap revisions ["amd64-2907","arm64-2908"]
+[#431](https://github.com/canonical/k8s-operator/pull/431)
 
 Mar 25, 2025
-- Bypass operator-workflows promote task which is limited to charmcraft 2 base notation [#414](https://github.com/canonical/k8s-operator/pull/414)
+
+- Bypass operator-workflows promote task which is limited to charmcraft 2 base
+notation [#414](https://github.com/canonical/k8s-operator/pull/414)
 
 Mar 21, 2025
-- Update k8s snap revisions ["amd64-2717","arm64-2723"] [#407](https://github.com/canonical/k8s-operator/pull/407)
--  Bump node-base to apply AZ node labels [#400](https://github.com/canonical/k8s-operator/pull/400)
+
+- Update k8s snap revisions ["amd64-2717","arm64-2723"]
+[#407](https://github.com/canonical/k8s-operator/pull/407)
+-  Bump node-base to apply AZ node labels
+[#400](https://github.com/canonical/k8s-operator/pull/400)
 
 Feb 26, 2025
-- Update canonical/operator-workflows digest to e848763 [#376](https://github.com/canonical/k8s-operator/pull/376)
+
+- Update canonical/operator-workflows digest to e848763
+[#376](https://github.com/canonical/k8s-operator/pull/376)
 
 Feb 19, 2025
 
-- Cherry-pick bugfixes to 1.32 [#327](https://github.com/canonical/k8s-operator/pull/327) including:
+- Cherry-pick bugfixes to 1.32
+[#327](https://github.com/canonical/k8s-operator/pull/327) including:
 
     - Improve external load balancer endpoint testing
     - Add external load balancer relation
-    - Test custom-registry config is applied with or without the containerd relation
+    - Test custom-registry config is applied with or without the containerd
+    relation
     - Address httpx.ConnectError as a cluster-inspect error
     - Use uv as the build system
     - Update integrating testing
 
 Feb 18, 2025
-- Update k8s snap 1.32 revision to 2502 on arm64 [#335](https://github.com/canonical/k8s-operator/pull/335)
-- Update k8s snap 1.32 revision to 2500 on amd64 [#334](https://github.com/canonical/k8s-operator/pull/334)
+
+- Update k8s snap 1.32 revision to 2502 on arm64
+[#335](https://github.com/canonical/k8s-operator/pull/335)
+- Update k8s snap 1.32 revision to 2500 on amd64
+[#334](https://github.com/canonical/k8s-operator/pull/334)
 
 Feb 15, 2025
-- Pin kube-control dependency to 0.2.0 [#332](https://github.com/canonical/k8s-operator/pull/332)
+
+- Pin kube-control dependency to 0.2.0
+[#332](https://github.com/canonical/k8s-operator/pull/332)
 
 Feb 7, 2025
-- Fix containerd base dir issue [#311](https://github.com/canonical/k8s-operator/pull/311)
+
+- Fix containerd base dir issue
+[#311](https://github.com/canonical/k8s-operator/pull/311)
 
 Feb 6, 2025
-- Manually set k8s snap 1.32-classic/stable revision [#306](https://github.com/canonical/k8s-operator/pull/306)
+
+- Manually set k8s snap 1.32-classic/stable revision
+[#306](https://github.com/canonical/k8s-operator/pull/306)
 
 Feb 5, 2025
-- Streamline storage tests by using k8s python client [#285](https://github.com/canonical/k8s-operator/pull/285)
-- Update dependency cosl to v0.0.54 [#276](https://github.com/canonical/k8s-operator/pull/276)
-- Update charm libraries [#248](https://github.com/canonical/k8s-operator/pull/248)
-- Update dependency ops to v2.18.0 [#269](https://github.com/canonical/k8s-operator/pull/269)
-- Don't allow bootstrap with containerd_base [#272](https://github.com/canonical/k8s-operator/pull/272)
-- Address markdown-lint errors [#275](https://github.com/canonical/k8s-operator/pull/275)
-- Update canonical/operator-workflows digest to 1c44a58 [#273](https://github.com/canonical/k8s-operator/pull/273)
-- Expose k8s application config via Terraform [#268](https://github.com/canonical/k8s-operator/pull/268)
-- Pin operator-workflows version [#270](https://github.com/canonical/k8s-operator/pull/270)
-- Upgrade to Charmcraft 3.x [#265](https://github.com/canonical/k8s-operator/pull/265)
-- Update dependency pydantic to v1.10.21 [#236](https://github.com/canonical/k8s-operator/pull/236)
-- Update dependency cosl to v0.0.51 [#227](https://github.com/canonical/k8s-operator/pull/227)
-- Update dependency lightkube to v0.17.1 [#228](https://github.com/canonical/k8s-operator/pull/228)
-- Update docs link to cluster annotations [#254](https://github.com/canonical/k8s-operator/pull/254)
-- Reduce requirements for the model/bundle for tests specifically on OpenStack [#259](https://github.com/canonical/k8s-operator/pull/259)
-- Map containerd to systemd file rather than /etc/environment [#258](https://github.com/canonical/k8s-operator/pull/258)
-- Allows for `clouds(...)` marker and `--no-deploy` handling in integration test [#237](https://github.com/canonical/k8s-operator/pull/237)
-- Upgrade tests must continue when k8s leader is ready for worker upgrades [#255](https://github.com/canonical/k8s-operator/pull/255)
-- Fix CI issue and add missing dependencies for TICS job [#253](https://github.com/canonical/k8s-operator/pull/253)
-- Test with UV on various python versions [#247](https://github.com/canonical/k8s-operator/pull/247)
-- Require tf users to specify a charm channel [#242](https://github.com/canonical/k8s-operator/pull/242)
-- Add Tiobe TICS cron job to CI [#249](https://github.com/canonical/k8s-operator/pull/249)
-- Allow bootstrap and join cluster with a fixed containerd-base-dir [#239](https://github.com/canonical/k8s-operator/pull/239)
-- Provide tag-prefix when promoting charms [#226](https://github.com/canonical/k8s-operator/pull/226)
-- Update charm libraries [#218](https://github.com/canonical/k8s-operator/pull/218)
-- Update dependency lightkube to v0.16.0 [#220](https://github.com/canonical/k8s-operator/pull/220)
-- Update dependency cosl to v0.0.48 [#222](https://github.com/canonical/k8s-operator/pull/222)
-- Pick up changes applied to 1.32-release branch [#225](https://github.com/canonical/k8s-operator/pull/225) including:
+
+- Streamline storage tests by using k8s python client
+[#285](https://github.com/canonical/k8s-operator/pull/285)
+- Update dependency cosl to v0.0.54
+[#276](https://github.com/canonical/k8s-operator/pull/276)
+- Update charm libraries
+[#248](https://github.com/canonical/k8s-operator/pull/248)
+- Update dependency ops to v2.18.0
+[#269](https://github.com/canonical/k8s-operator/pull/269)
+- Don't allow bootstrap with containerd_base
+[#272](https://github.com/canonical/k8s-operator/pull/272)
+- Address markdown-lint errors
+[#275](https://github.com/canonical/k8s-operator/pull/275)
+- Update canonical/operator-workflows digest to 1c44a58
+[#273](https://github.com/canonical/k8s-operator/pull/273)
+- Expose k8s application config via Terraform
+[#268](https://github.com/canonical/k8s-operator/pull/268)
+- Pin operator-workflows version
+[#270](https://github.com/canonical/k8s-operator/pull/270)
+- Upgrade to Charmcraft 3.x
+[#265](https://github.com/canonical/k8s-operator/pull/265)
+- Update dependency pydantic to v1.10.21
+[#236](https://github.com/canonical/k8s-operator/pull/236)
+- Update dependency cosl to v0.0.51
+[#227](https://github.com/canonical/k8s-operator/pull/227)
+- Update dependency lightkube to v0.17.1
+[#228](https://github.com/canonical/k8s-operator/pull/228)
+- Update docs link to cluster annotations
+[#254](https://github.com/canonical/k8s-operator/pull/254)
+- Reduce requirements for the model/bundle for tests specifically on OpenStack
+[#259](https://github.com/canonical/k8s-operator/pull/259)
+- Map containerd to systemd file rather than /etc/environment
+[#258](https://github.com/canonical/k8s-operator/pull/258)
+- Allows for `clouds(...)` marker and `--no-deploy` handling in integration test
+[#237](https://github.com/canonical/k8s-operator/pull/237)
+- Upgrade tests must continue when k8s leader is ready for worker upgrades
+[#255](https://github.com/canonical/k8s-operator/pull/255)
+- Fix CI issue and add missing dependencies for TICS job
+[#253](https://github.com/canonical/k8s-operator/pull/253)
+- Test with UV on various python versions
+[#247](https://github.com/canonical/k8s-operator/pull/247)
+- Require tf users to specify a charm channel
+[#242](https://github.com/canonical/k8s-operator/pull/242)
+- Add Tiobe TICS cron job to CI
+[#249](https://github.com/canonical/k8s-operator/pull/249)
+- Allow bootstrap and join cluster with a fixed containerd-base-dir
+[#239](https://github.com/canonical/k8s-operator/pull/239)
+- Provide tag-prefix when promoting charms
+[#226](https://github.com/canonical/k8s-operator/pull/226)
+- Update charm libraries
+[#218](https://github.com/canonical/k8s-operator/pull/218)
+- Update dependency lightkube to v0.16.0
+[#220](https://github.com/canonical/k8s-operator/pull/220)
+- Update dependency cosl to v0.0.48
+[#222](https://github.com/canonical/k8s-operator/pull/222)
+- Pick up changes applied to 1.32-release branch
+[#225](https://github.com/canonical/k8s-operator/pull/225) including:
     - Pin snap_installations to 1.32-classic stable
-    - Revert changes to continue having the snap override available from edge channels
+    - Revert changes to continue having the snap override available from edge
+    channels
     - Begin testing upgrades from 1.32/beta channels
 
 Jan 17, 2025
-- Manually upgrade the snap revision to 1958 [#256](https://github.com/canonical/k8s-operator/pull/256)
+
+- Manually upgrade the snap revision to 1958
+[#256](https://github.com/canonical/k8s-operator/pull/256)
 
 Jan 16, 2025
-- Allow charms to remove node labels via config[#244](https://github.com/canonical/k8s-operator/pull/244)
+
+- Allow charms to remove node labels via config
+[#244](https://github.com/canonical/k8s-operator/pull/244)
 
 Jan 14, 2025
-- Fix reporting of the default image registry [#243](https://github.com/canonical/k8s-operator/pull/243)
+
+- Fix reporting of the default image registry
+[#243](https://github.com/canonical/k8s-operator/pull/243)
 
 Jan 13, 2025
-- Change year to 2025 in licences [#245](https://github.com/canonical/k8s-operator/pull/245)
+
+- Change year to 2025 in licenses
+[#245](https://github.com/canonical/k8s-operator/pull/245)
 
 ## Contributors
 

--- a/docs/canonicalk8s/charm/reference/versions/1.32.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.32.md
@@ -53,6 +53,90 @@ relevant sections of the [upstream release notes][upstream-changelog-1.32].
 - Add worker `bootstrap-node-taints` setting [#215]
 - Enhance status visibility during cluster upgrades [#216]
 
+## Patch notices
+
+Apr 9, 2025
+- Update k8s snap revisions ["amd64-2907","arm64-2908"] [#431](https://github.com/canonical/k8s-operator/pull/431)
+
+Mar 25, 2025
+- Bypass operator-workflows promote task which is limited to charmcraft 2 base notation [#414](https://github.com/canonical/k8s-operator/pull/414)
+
+Mar 21, 2025
+- Update k8s snap revisions ["amd64-2717","arm64-2723"] [#407](https://github.com/canonical/k8s-operator/pull/407)
+-  Bump node-base to apply AZ node labels [#400](https://github.com/canonical/k8s-operator/pull/400)
+
+Feb 26, 2025
+- Update canonical/operator-workflows digest to e848763 [#376](https://github.com/canonical/k8s-operator/pull/376)
+
+Feb 19, 2025
+
+- Cherry-pick bugfixes to 1.32 [#327](https://github.com/canonical/k8s-operator/pull/327) including:
+
+    - Improve external load balancer endpoint testing
+    - Add external load balancer relation
+    - Test custom-registry config is applied with or without the containerd relation
+    - Address httpx.ConnectError as a cluster-inspect error
+    - Use uv as the build system
+    - Update integrating testing
+
+Feb 18, 2025
+- Update k8s snap 1.32 revision to 2502 on arm64 [#335](https://github.com/canonical/k8s-operator/pull/335)
+- Update k8s snap 1.32 revision to 2500 on amd64 [#334](https://github.com/canonical/k8s-operator/pull/334)
+
+Feb 15, 2025
+- Pin kube-control dependency to 0.2.0 [#332](https://github.com/canonical/k8s-operator/pull/332)
+
+Feb 7, 2025
+- Fix containerd base dir issue [#311](https://github.com/canonical/k8s-operator/pull/311)
+
+Feb 6, 2025
+- Manually set k8s snap 1.32-classic/stable revision [#306](https://github.com/canonical/k8s-operator/pull/306)
+
+Feb 5, 2025
+- Streamline storage tests by using k8s python client [#285](https://github.com/canonical/k8s-operator/pull/285)
+- Update dependency cosl to v0.0.54 [#276](https://github.com/canonical/k8s-operator/pull/276)
+- Update charm libraries [#248](https://github.com/canonical/k8s-operator/pull/248)
+- Update dependency ops to v2.18.0 [#269](https://github.com/canonical/k8s-operator/pull/269)
+- Don't allow bootstrap with containerd_base [#272](https://github.com/canonical/k8s-operator/pull/272)
+- Address markdown-lint errors [#275](https://github.com/canonical/k8s-operator/pull/275)
+- Update canonical/operator-workflows digest to 1c44a58 [#273](https://github.com/canonical/k8s-operator/pull/273)
+- Expose k8s application config via Terraform [#268](https://github.com/canonical/k8s-operator/pull/268)
+- Pin operator-workflows version [#270](https://github.com/canonical/k8s-operator/pull/270)
+- Upgrade to Charmcraft 3.x [#265](https://github.com/canonical/k8s-operator/pull/265)
+- Update dependency pydantic to v1.10.21 [#236](https://github.com/canonical/k8s-operator/pull/236)
+- Update dependency cosl to v0.0.51 [#227](https://github.com/canonical/k8s-operator/pull/227)
+- Update dependency lightkube to v0.17.1 [#228](https://github.com/canonical/k8s-operator/pull/228)
+- Update docs link to cluster annotations [#254](https://github.com/canonical/k8s-operator/pull/254)
+- Reduce requirements for the model/bundle for tests specifically on OpenStack [#259](https://github.com/canonical/k8s-operator/pull/259)
+- Map containerd to systemd file rather than /etc/environment [#258](https://github.com/canonical/k8s-operator/pull/258)
+- Allows for `clouds(...)` marker and `--no-deploy` handling in integration test [#237](https://github.com/canonical/k8s-operator/pull/237)
+- Upgrade tests must continue when k8s leader is ready for worker upgrades [#255](https://github.com/canonical/k8s-operator/pull/255)
+- Fix CI issue and add missing dependencies for TICS job [#253](https://github.com/canonical/k8s-operator/pull/253)
+- Test with UV on various python versions [#247](https://github.com/canonical/k8s-operator/pull/247)
+- Require tf users to specify a charm channel [#242](https://github.com/canonical/k8s-operator/pull/242)
+- Add Tiobe TICS cron job to CI [#249](https://github.com/canonical/k8s-operator/pull/249)
+- Allow bootstrap and join cluster with a fixed containerd-base-dir [#239](https://github.com/canonical/k8s-operator/pull/239)
+- Provide tag-prefix when promoting charms [#226](https://github.com/canonical/k8s-operator/pull/226)
+- Update charm libraries [#218](https://github.com/canonical/k8s-operator/pull/218)
+- Update dependency lightkube to v0.16.0 [#220](https://github.com/canonical/k8s-operator/pull/220)
+- Update dependency cosl to v0.0.48 [#222](https://github.com/canonical/k8s-operator/pull/222)
+- Pick up changes applied to 1.32-release branch [#225](https://github.com/canonical/k8s-operator/pull/225) including:
+    - Pin snap_installations to 1.32-classic stable
+    - Revert changes to continue having the snap override available from edge channels
+    - Begin testing upgrades from 1.32/beta channels
+
+Jan 17, 2025
+- Manually upgrade the snap revision to 1958 [#256](https://github.com/canonical/k8s-operator/pull/256)
+
+Jan 16, 2025
+- Allow charms to remove node labels via config[#244](https://github.com/canonical/k8s-operator/pull/244)
+
+Jan 14, 2025
+- Fix reporting of the default image registry [#243](https://github.com/canonical/k8s-operator/pull/243)
+
+Jan 13, 2025
+- Change year to 2025 in licences [#245](https://github.com/canonical/k8s-operator/pull/245)
+
 ## Contributors
 
 Many thanks to [@addyess], [@mateoflorido], [@bschimke95], [@louiseschmidtgen],

--- a/docs/canonicalk8s/custom_conf.py
+++ b/docs/canonicalk8s/custom_conf.py
@@ -259,5 +259,6 @@ custom_linkcheck_anchors_ignore_for_url = [
     'https://canonical.com/multipass/docs/tutorial',
     'https://microk8s.io/docs/how-to-cis-harden',
     'https://registry.terraform.io/providers/juju/juju/latest/docs',
-    'https://snapcraft.io/docs/managing-updates'
+    'https://snapcraft.io/docs/managing-updates',
+    'https://documentation.ubuntu.com/juju/latest/reference/constraint/'
 ]

--- a/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
+++ b/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
@@ -7,9 +7,11 @@ Anbox Cloud
 Canonical Observability Stack
 Ceph
 COS
+Charmcraft
 Charmed
 Charmed Kubeflow
 Charmhub
+cosl
 CRDs
 Data Integrator
 Grafana
@@ -128,10 +130,12 @@ config
 configMap
 ConfigMap
 containerd
+containerd_base
 CoreDNS
 Corosync
 CPUs
 cpuset
+cron
 crt
 csi
 CSI
@@ -223,6 +227,7 @@ libcontainer
 lifecycle
 linux
 Lite's
+LightKube
 LoadBalancer
 localhost
 logfile
@@ -290,6 +295,7 @@ provisioner
 Pre
 PRs
 PV
+Pydantic
 qdisc
 qlen
 QoS
@@ -336,6 +342,7 @@ taskset
 Telco
 throughs
 tickless
+Tiobe
 TLB
 tls
 TLS
@@ -349,6 +356,7 @@ unix
 unschedulable
 unsquashed
 uuid
+UV
 Velero
 vf
 VF


### PR DESCRIPTION
<I want to make sure the changes are all in stable before we merge this PR >

## Description

Our current release notes do not include any information on back ported PRs. 

## Solution

We have come up with a plan to keep these up to date in the future and the PR will get the doc up to date for now. 

## Backport

1.32

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.