### PR TITLE
docs: Add snap patch notices for 1.32

### DIFF
--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -66,15 +66,22 @@ Kubernetes 1.32, please see the relevant sections of the
 ## Patch notices
 
 Apr 9, 2025
-- Execute post-refresh hook after node is ready[#1287](https://github.com/canonical/k8s-snap/pull/1287)
-- Don't wait for services to terminate on removed node[#1287](https://github.com/canonical/k8s-snap/pull/1287)
+
+- Execute post-refresh hook after node is ready
+[#1287](https://github.com/canonical/k8s-snap/pull/1287)
+- Don't wait for services to terminate on removed node
+[#1287](https://github.com/canonical/k8s-snap/pull/1287)
 - Update cla.yaml to v2 [#1288](https://github.com/canonical/k8s-snap/pull/1288)
 
 Apr 4, 2025
-- Update containerd to v1.6.38 and Kubernetes to v1.32.3 [#1179](https://github.com/canonical/k8s-snap/pull/1179)
+
+- Update containerd to v1.6.38 and Kubernetes to v1.32.3
+[#1179](https://github.com/canonical/k8s-snap/pull/1179)
 
 Apr 3, 2025
-- Pre-install xdelta3 to mitigate LXD rate-limit issues [#1266](https://github.com/canonical/k8s-snap/pull/1266)
+
+- Pre-install xdelta3 to mitigate LXD rate-limit issues
+[#1266](https://github.com/canonical/k8s-snap/pull/1266)
 
 Mar 24, 2025
 - Ensure lock directory exists before creating file [#1220](https://github.com/canonical/k8s-snap/pull/1220)
@@ -83,179 +90,324 @@ Mar 20, 2025
 - Move snapd sync to custom post-refresh hook [#1209](https://github.com/canonical/k8s-snap/pull/1209)
 
 Mar 19, 2025
-- Calculate changed files for markdown lint through git [#1202](https://github.com/canonical/k8s-snap/pull/1202)
+
+- Calculate changed files for markdown lint through git
+[#1202](https://github.com/canonical/k8s-snap/pull/1202)
 
 Mar 18, 2025
+
 - Fix link [#1195](https://github.com/canonical/k8s-snap/pull/1195)
 
 Mar 17, 2025
-- Temporarily disable snap/k8sd config sync during snap upgrade [#1168](https://github.com/canonical/k8s-snap/pull/1168)
-- Adds non-default coredns ServiceAccount [#1109](https://github.com/canonical/k8s-snap/pull/1109)
+
+- Temporarily disable snap/k8sd config sync during snap upgrade
+[#1168](https://github.com/canonical/k8s-snap/pull/1168)
+- Adds non-default coredns ServiceAccount
+[#1109](https://github.com/canonical/k8s-snap/pull/1109)
 
 Mar 14, 2025
-- Remove compromised dependency tj-actions/changed-files [#1190](https://github.com/canonical/k8s-snap/pull/1109)
-- Run all tests on Kubernetes component / feature updates [#1184](https://github.com/canonical/k8s-snap/pull/1184)
+
+- Remove compromised dependency tj-actions/changed-files
+[#1190](https://github.com/canonical/k8s-snap/pull/1109)
+- Run all tests on Kubernetes component / feature updates
+[#1184](https://github.com/canonical/k8s-snap/pull/1184)
 
 Mar 13, 2025
-- Fix test_mixed_versions_join test [#1165](https://github.com/canonical/k8s-snap/pull/1165)
+
+- Fix test_mixed_versions_join test
+[#1165](https://github.com/canonical/k8s-snap/pull/1165)
 
 Mar 6, 2025
-- Add runc 1.2.5 arm patch and switch to noble 24.04 runners [#1133](https://github.com/canonical/k8s-snap/pull/1133)
+
+- Add runc 1.2.5 arm patch and switch to noble 24.04 runners
+[#1133](https://github.com/canonical/k8s-snap/pull/1133)
 
 Mar 5, 2025
-- Use 1.32-classic/edge release in 1.32-release nightly tests [#1157](https://github.com/canonical/k8s-snap/pull/1157)
-- Remove 1.31 release notes [#1145](https://github.com/canonical/k8s-snap/pull/1145)
+
+- Use 1.32-classic/edge release in 1.32-release nightly tests
+[#1157](https://github.com/canonical/k8s-snap/pull/1157)
+- Remove 1.31 release notes
+[#1145](https://github.com/canonical/k8s-snap/pull/1145)
 
 Feb 27, 2025
-- Fix custom registry config name [#1132](https://github.com/canonical/k8s-snap/pull/1132)
-- Fix configuration name [#1130](https://github.com/canonical/k8s-snap/pull/1130)
-- Update containerd and runc versions [#1115](https://github.com/canonical/k8s-snap/pull/1115)
+
+- Fix custom registry config name
+[#1132](https://github.com/canonical/k8s-snap/pull/1132)
+- Fix configuration name
+[#1130](https://github.com/canonical/k8s-snap/pull/1130)
+- Update containerd and runc versions
+[#1115](https://github.com/canonical/k8s-snap/pull/1115)
 
 Feb 14, 2025
-- Add fan-config instructions to Openstack how-to guide [#1073](https://github.com/canonical/k8s-snap/pull/1073)
+
+- Add fan-config instructions to Openstack how-to guide
+[#1073](https://github.com/canonical/k8s-snap/pull/1073)
 
 Feb 13, 2025
-- Update Kubernetes version to 1.32.2 [#1067](https://github.com/canonical/k8s-snap/pull/1067)
+
+- Update Kubernetes version to 1.32.2
+[#1067](https://github.com/canonical/k8s-snap/pull/1067)
 
 Feb 12, 2025
-- Address memory leak update k8s-dqlite version to v1.3.1 [#1063](https://github.com/canonical/k8s-snap/pull/1063)
+
+- Address memory leak update k8s-dqlite version to v1.3.1
+[#1063](https://github.com/canonical/k8s-snap/pull/1063)
 - Fix spell check [#1050](https://github.com/canonical/k8s-snap/pull/1050)
-- Fix pre-release update with same risk-level [#1047](https://github.com/canonical/k8s-snap/pull/1047)
-- Fix custom containerd paths [#1046](https://github.com/canonical/k8s-snap/pull/1046)
-- Add intermediate CA how-to [#1027](https://github.com/canonical/k8s-snap/pull/1027)
-- Switch to cilium native routing mode for IPv6 only setup [#1007](https://github.com/canonical/k8s-snap/pull/1007)
-- Remove obsolete loadbalancer feature check [#1037](https://github.com/canonical/k8s-snap/pull/1037)
-- Use ControlPlaneJoinConfig certificates during Control Plane Join [#1029](https://github.com/canonical/k8s-snap/pull/1029)
-- Collect all inspection reports before cleaning up nodes [#1034](https://github.com/canonical/k8s-snap/pull/1034)
+- Fix pre-release update with same risk-level
+[#1047](https://github.com/canonical/k8s-snap/pull/1047)
+- Fix custom containerd paths
+[#1046](https://github.com/canonical/k8s-snap/pull/1046)
+- Add intermediate CA how-to
+[#1027](https://github.com/canonical/k8s-snap/pull/1027)
+- Switch to cilium native routing mode for IPv6 only setup
+[#1007](https://github.com/canonical/k8s-snap/pull/1007)
+- Remove obsolete loadbalancer feature check
+[#1037](https://github.com/canonical/k8s-snap/pull/1037)
+- Use ControlPlaneJoinConfig certificates during Control Plane Join
+[#1029](https://github.com/canonical/k8s-snap/pull/1029)
+- Collect all inspection reports before cleaning up nodes
+[#1034](https://github.com/canonical/k8s-snap/pull/1034)
 - Remove /src dir [#1018](https://github.com/canonical/k8s-snap/pull/1018)
-- Enrich node configuration controller tests with signed configmaps [#1032](https://github.com/canonical/k8s-snap/pull/1032)
-- Avoid logging an error in inspect.sh if there are no core dumps [#1028](https://github.com/canonical/k8s-snap/pull/1028)
-- Add dqlite configuration to troubleshooting page [#1022](https://github.com/canonical/k8s-snap/pull/1022)
-- Fix typo in setup-image.sh [#1024](https://github.com/canonical/k8s-snap/pull/1024)
-- Split tutorial for CAPI, add capi troubleshooting pages [#1019](https://github.com/canonical/k8s-snap/pull/1019)
-- Log a message if the cluster is unitialized [#1015](https://github.com/canonical/k8s-snap/pull/1015)
-- Add k8s inspect command [#1016](https://github.com/canonical/k8s-snap/pull/1016)
-- Generate and collect core dumps [#1014](https://github.com/canonical/k8s-snap/pull/1014)
-- Add warning for dual stack ingress [#1008](https://github.com/canonical/k8s-snap/pull/1008)
-- Remove two-node HA page [#1006](https://github.com/canonical/k8s-snap/pull/1006)
-- Fix config "show" command [#1012](https://github.com/canonical/k8s-snap/pull/1012)
-- Apply small docs pages fixes [#1011](https://github.com/canonical/k8s-snap/pull/1011)
-- Retry Temporary API Failures in Microcluster [#992](https://github.com/canonical/k8s-snap/pull/992)
-- Update Microcluster version to latest v2 [#1010](https://github.com/canonical/k8s-snap/pull/1010)
-- Bump actions upload-artifact to v4 [#1003](https://github.com/canonical/k8s-snap/pull/1003)
-- Document k8s-snap installation on dev environments [#995](https://github.com/canonical/k8s-snap/pull/995)
-- Fix headers naming style in docs [#1005](https://github.com/canonical/k8s-snap/pull/1005)
-- Enable cluster-config.load-balancer.l2-mode by default [#1001](https://github.com/canonical/k8s-snap/pull/1001)
-- Don't remove Kubernetes certificates and containerd if skipped [#1002](https://github.com/canonical/k8s-snap/pull/1002)
-- Add package management with helm explanation page [#964](https://github.com/canonical/k8s-snap/pull/964)
-- Update outdated links in our docs [#1004](https://github.com/canonical/k8s-snap/pull/1004)
-- Implement timeout in inspect.sh for k8s commands [#990](https://github.com/canonical/k8s-snap/pull/990)
-- Fix token permissions alert [#998](https://github.com/canonical/k8s-snap/pull/998)
-- Fix snap tutorials section [#983](https://github.com/canonical/k8s-snap/pull/983)
-- Adds Prometheus howto guide [#944](https://github.com/canonical/k8s-snap/pull/944)
-- Add missing commands to reference section in docs [#976](https://github.com/canonical/k8s-snap/pull/976)
-- Fix broken links for ingress.md in our docs [#979](https://github.com/canonical/k8s-snap/pull/979)
-- Reorder explanation index, ensure header style consistency in our docs [#978](https://github.com/canonical/k8s-snap/pull/978)
-- Fix snap storage documentation [#985](https://github.com/canonical/k8s-snap/pull/985)
-- Improve security docs [#980](https://github.com/canonical/k8s-snap/pull/980)
-- Add upgrading explanation page [#950](https://github.com/canonical/k8s-snap/pull/950)
-- Update annotations doc page [#974](https://github.com/canonical/k8s-snap/pull/974)
-- Update config file reference page [#977](https://github.com/canonical/k8s-snap/pull/977)
-- Update bootstrap config reference page [#975](https://github.com/canonical/k8s-snap/pull/975)
-- Improve snap install docs [#984](https://github.com/canonical/k8s-snap/pull/984)
-- Fix type on proxy reference page [#981](https://github.com/canonical/k8s-snap/pull/981)
-- Update inspect.sh to collect dmesg logs and configurable number of snap log entries [#982](https://github.com/canonical/k8s-snap/pull/982)
-- Update Microcluster to the latest v2 [#968](https://github.com/canonical/k8s-snap/pull/968)
-- Simplify the docs for installing via terraform [#948](https://github.com/canonical/k8s-snap/pull/948)
-- DISA STIG hardening docs improvements [#967](https://github.com/canonical/k8s-snap/pull/967)
-- Update charm docs [#958](https://github.com/canonical/k8s-snap/pull/958)
-- Allow specifying service env variables [#973](https://github.com/canonical/k8s-snap/pull/973)
-- Add a contributing file [#966](https://github.com/canonical/k8s-snap/pull/966)
-- Update docs home page [#951](https://github.com/canonical/k8s-snap/pull/951)
-- Update networking docs [#963](https://github.com/canonical/k8s-snap/pull/963)
-- Clarify IPv6-only docs interface binding [#972)](https://github.com/canonical/k8s-snap/pull/972)
-- Update Kubernetes version to v1.32.1 [#971](https://github.com/canonical/k8s-snap/pull/971)
-- Add how-to troubleshoot page for charm deployments [#953](https://github.com/canonical/k8s-snap/pull/953)
+- Enrich node configuration controller tests with signed ConfigMaps
+[#1032](https://github.com/canonical/k8s-snap/pull/1032)
+- Avoid logging an error in inspect.sh if there are no core dumps
+[#1028](https://github.com/canonical/k8s-snap/pull/1028)
+- Add Dqlite configuration to troubleshooting page
+[#1022](https://github.com/canonical/k8s-snap/pull/1022)
+- Fix typo in setup-image.sh
+[#1024](https://github.com/canonical/k8s-snap/pull/1024)
+- Split tutorial for CAPI, add capi troubleshooting pages
+[#1019](https://github.com/canonical/k8s-snap/pull/1019)
+- Log a message if the cluster is uninitialized
+[#1015](https://github.com/canonical/k8s-snap/pull/1015)
+- Add k8s inspect command
+[#1016](https://github.com/canonical/k8s-snap/pull/1016)
+- Generate and collect core dumps
+[#1014](https://github.com/canonical/k8s-snap/pull/1014)
+- Add warning for dual stack ingress
+[#1008](https://github.com/canonical/k8s-snap/pull/1008)
+- Remove two-node HA page
+[#1006](https://github.com/canonical/k8s-snap/pull/1006)
+- Fix config "show" command
+[#1012](https://github.com/canonical/k8s-snap/pull/1012)
+- Apply small docs pages fixes
+[#1011](https://github.com/canonical/k8s-snap/pull/1011)
+- Retry Temporary API Failures in Microcluster
+[#992](https://github.com/canonical/k8s-snap/pull/992)
+- Update Microcluster version to latest v2
+[#1010](https://github.com/canonical/k8s-snap/pull/1010)
+- Bump actions upload-artifact to v4
+[#1003](https://github.com/canonical/k8s-snap/pull/1003)
+- Document k8s-snap installation on development environments
+[#995](https://github.com/canonical/k8s-snap/pull/995)
+- Fix headers naming style in docs
+[#1005](https://github.com/canonical/k8s-snap/pull/1005)
+- Enable cluster-config.load-balancer.l2-mode by default
+[#1001](https://github.com/canonical/k8s-snap/pull/1001)
+- Don't remove Kubernetes certificates and containerd if skipped
+[#1002](https://github.com/canonical/k8s-snap/pull/1002)
+- Add package management with helm explanation page
+[#964](https://github.com/canonical/k8s-snap/pull/964)
+- Update outdated links in our docs
+[#1004](https://github.com/canonical/k8s-snap/pull/1004)
+- Implement timeout in inspect.sh for k8s commands
+[#990](https://github.com/canonical/k8s-snap/pull/990)
+- Fix token permissions alert
+[#998](https://github.com/canonical/k8s-snap/pull/998)
+- Fix snap tutorials section
+[#983](https://github.com/canonical/k8s-snap/pull/983)
+- Adds Prometheus how-to guide
+[#944](https://github.com/canonical/k8s-snap/pull/944)
+- Add missing commands to reference section in docs
+[#976](https://github.com/canonical/k8s-snap/pull/976)
+- Fix broken links for ingress.md in our docs
+[#979](https://github.com/canonical/k8s-snap/pull/979)
+- Reorder explanation index, ensure header style consistency in our docs
+[#978](https://github.com/canonical/k8s-snap/pull/978)
+- Fix snap storage documentation
+[#985](https://github.com/canonical/k8s-snap/pull/985)
+- Improve security docs
+[#980](https://github.com/canonical/k8s-snap/pull/980)
+- Add upgrading explanation page
+[#950](https://github.com/canonical/k8s-snap/pull/950)
+- Update annotations doc page
+[#974](https://github.com/canonical/k8s-snap/pull/974)
+- Update config file reference page
+[#977](https://github.com/canonical/k8s-snap/pull/977)
+- Update bootstrap config reference page
+[#975](https://github.com/canonical/k8s-snap/pull/975)
+- Improve snap install docs
+[#984](https://github.com/canonical/k8s-snap/pull/984)
+- Fix type on proxy reference page
+[#981](https://github.com/canonical/k8s-snap/pull/981)
+- Update inspect.sh to collect dmesg logs and configurable number of snap log
+entries [#982](https://github.com/canonical/k8s-snap/pull/982)
+- Update Microcluster to the latest v2
+[#968](https://github.com/canonical/k8s-snap/pull/968)
+- Simplify the docs for installing via terraform
+[#948](https://github.com/canonical/k8s-snap/pull/948)
+- DISA STIG hardening docs improvements
+[#967](https://github.com/canonical/k8s-snap/pull/967)
+- Update charm docs
+[#958](https://github.com/canonical/k8s-snap/pull/958)
+- Allow specifying service env variables
+[#973](https://github.com/canonical/k8s-snap/pull/973)
+- Add a contributing file
+[#966](https://github.com/canonical/k8s-snap/pull/966)
+- Update docs home page
+[#951](https://github.com/canonical/k8s-snap/pull/951)
+- Update networking docs
+[#963](https://github.com/canonical/k8s-snap/pull/963)
+- Clarify IPv6-only docs interface binding
+[#972)](https://github.com/canonical/k8s-snap/pull/972)
+- Update Kubernetes version to v1.32.1
+[#971](https://github.com/canonical/k8s-snap/pull/971)
+- Add how-to troubleshoot page for charm deployments
+[#953](https://github.com/canonical/k8s-snap/pull/953)
 - Update CAPI docs [#957](https://github.com/canonical/k8s-snap/pull/957)
-- Add Load balancer explanation page [#965](https://github.com/canonical/k8s-snap/pull/965)
-- Add Cluster Configuration using Juju page [#960](https://github.com/canonical/k8s-snap/pull/960)
-- Fix service IP poller in test_ingress [#956](https://github.com/canonical/k8s-snap/pull/956)
-- Add image management how-to guide [#954](https://github.com/canonical/k8s-snap/pull/954)
-- Add snap troubleshooting how-to guide [#943](https://github.com/canonical/k8s-snap/pull/943)
-- Move charm install files to charm/howto/install [#955](https://github.com/canonical/k8s-snap/pull/955)
-- Add charm actions reference page [#938](https://github.com/canonical/k8s-snap/pull/938)
-- Change heading title to prerequisites in docs [#959](https://github.com/canonical/k8s-snap/pull/959)
-- Clarify node-labels are additive or destructive in our docs [#949](https://github.com/canonical/k8s-snap/pull/949)
-- Add custom bootstrap configuration documentation [#935](https://github.com/canonical/k8s-snap/pull/935)
-- Add basic operations with the charm tutorial [#947](https://github.com/canonical/k8s-snap/pull/947)
-- Add IPv6 load balancer tests [#926](https://github.com/canonical/k8s-snap/pull/926)
-- Add ports and services reference [#945](https://github.com/canonical/k8s-snap/pull/945)
-- Add ports and services reference page [#946](https://github.com/canonical/k8s-snap/pull/946)
-- Add high availability explanation page [#940](https://github.com/canonical/k8s-snap/pull/940)
-- Add how-to uninstall the snap page [#941](https://github.com/canonical/k8s-snap/pull/941)
-- Clean up k8s-dqlite state dir and stops it on remove hook [#908](https://github.com/canonical/k8s-snap/pull/908)
-- Add reference docs for charm configurations [#939](https://github.com/canonical/k8s-snap/pull/939)
-- Fix snap upgrade how-to guide [#942](https://github.com/canonical/k8s-snap/pull/942)
-- Add choosing an installation method documentation [#933](https://github.com/canonical/k8s-snap/pull/933)
-- Add snap upgrades how-to guide [#934](https://github.com/canonical/k8s-snap/pull/934)
-- Add CAPI bootstrap config docs [#936](https://github.com/canonical/k8s-snap/pull/936)
-- Automatically manage pre-release branches [#916](https://github.com/canonical/k8s-snap/pull/916)
-- Add test for deploying Nvidia gpu-operator through Helm chart [#929](https://github.com/canonical/k8s-snap/pull/929)
-- Add a systemd override to add containerd defaults [#932](https://github.com/canonical/k8s-snap/pull/932)
-- Add charm upgrade documentation [#881](https://github.com/canonical/k8s-snap/pull/881)
-- Add docs for Juju custom configuration [#937](https://github.com/canonical/k8s-snap/pull/937)
-- Add alternative CNI how-to guide [#900](https://github.com/canonical/k8s-snap/pull/900)
-- CI improvements including TICs and Trivy tests[#927](https://github.com/canonical/k8s-snap/pull/927)
-- Include system information in the inspect.sh script [#921](https://github.com/canonical/k8s-snap/pull/921)
+- Add Load balancer explanation page
+[#965](https://github.com/canonical/k8s-snap/pull/965)
+- Add Cluster Configuration using Juju page
+[#960](https://github.com/canonical/k8s-snap/pull/960)
+- Fix service IP poller in test_ingress
+[#956](https://github.com/canonical/k8s-snap/pull/956)
+- Add image management how-to guide
+[#954](https://github.com/canonical/k8s-snap/pull/954)
+- Add snap troubleshooting how-to guide
+[#943](https://github.com/canonical/k8s-snap/pull/943)
+- Move charm install files to charm/howto/install
+[#955](https://github.com/canonical/k8s-snap/pull/955)
+- Add charm actions reference page
+[#938](https://github.com/canonical/k8s-snap/pull/938)
+- Change heading title to prerequisites in docs
+[#959](https://github.com/canonical/k8s-snap/pull/959)
+- Clarify node-labels are additive or destructive in our docs
+[#949](https://github.com/canonical/k8s-snap/pull/949)
+- Add custom bootstrap configuration documentation
+[#935](https://github.com/canonical/k8s-snap/pull/935)
+- Add basic operations with the charm tutorial
+[#947](https://github.com/canonical/k8s-snap/pull/947)
+- Add IPv6 load balancer tests
+[#926](https://github.com/canonical/k8s-snap/pull/926)
+- Add ports and services reference
+[#945](https://github.com/canonical/k8s-snap/pull/945)
+- Add ports and services reference page
+[#946](https://github.com/canonical/k8s-snap/pull/946)
+- Add high availability explanation page
+[#940](https://github.com/canonical/k8s-snap/pull/940)
+- Add how-to uninstall the snap page
+[#941](https://github.com/canonical/k8s-snap/pull/941)
+- Clean up k8s-dqlite state dir and stops it on remove hook
+[#908](https://github.com/canonical/k8s-snap/pull/908)
+- Add reference docs for charm configurations
+[#939](https://github.com/canonical/k8s-snap/pull/939)
+- Fix snap upgrade how-to guide
+[#942](https://github.com/canonical/k8s-snap/pull/942)
+- Add choosing an installation method documentation
+[#933](https://github.com/canonical/k8s-snap/pull/933)
+- Add snap upgrades how-to guide
+[#934](https://github.com/canonical/k8s-snap/pull/934)
+- Add CAPI bootstrap config docs
+[#936](https://github.com/canonical/k8s-snap/pull/936)
+- Automatically manage pre-release branches
+[#916](https://github.com/canonical/k8s-snap/pull/916)
+- Add test for deploying Nvidia gpu-operator through Helm chart
+[#929](https://github.com/canonical/k8s-snap/pull/929)
+- Add a systemd override to add containerd defaults
+[#932](https://github.com/canonical/k8s-snap/pull/932)
+- Add charm upgrade documentation
+[#881](https://github.com/canonical/k8s-snap/pull/881)
+- Add docs for Juju custom configuration
+[#937](https://github.com/canonical/k8s-snap/pull/937)
+- Add alternative CNI how-to guide
+[#900](https://github.com/canonical/k8s-snap/pull/900)
+- CI improvements including TICs and Trivy tests
+[#927](https://github.com/canonical/k8s-snap/pull/927)
+- Include system information in the inspect.sh script
+[#921](https://github.com/canonical/k8s-snap/pull/921)
 - Bump copyright headers [#931](https://github.com/canonical/k8s-snap/pull/931)
-- Ensure LXD is installed before attempting snap refresh [#930](https://github.com/canonical/k8s-snap/pull/930)
-- Retry seed loading in case snap is not ready yet [#925](https://github.com/canonical/k8s-snap/pull/925)
-- Add 1.32 charms release notes [#913](https://github.com/canonical/k8s-snap/pull/913)
-- Fix broken links in our docs [#924](https://github.com/canonical/k8s-snap/pull/924)
-- Bump golang.org/x/net to v0.33.0 [#919](https://github.com/canonical/k8s-snap/pull/919)
-- Fix containerd-related path cleanup on failed bootstrap/join and associated test [#910](https://github.com/canonical/k8s-snap/pull/910)
-- Fix all linter warnings in test harness [#898](https://github.com/canonical/k8s-snap/pull/898)
-- Update etcd how-to guide config option [#918](https://github.com/canonical/k8s-snap/pull/918)
-- Microcluster schema change warning [#922](https://github.com/canonical/k8s-snap/pull/922)
-- Add Terraform documentation for k8s and k8s-worker charms [#920](https://github.com/canonical/k8s-snap/pull/920)
-- Move doc files under /src to fix edit docs button [#917](https://github.com/canonical/k8s-snap/pull/917)
+- Ensure LXD is installed before attempting snap refresh
+[#930](https://github.com/canonical/k8s-snap/pull/930)
+- Retry seed loading in case snap is not ready yet
+[#925](https://github.com/canonical/k8s-snap/pull/925)
+- Add 1.32 charms release notes
+[#913](https://github.com/canonical/k8s-snap/pull/913)
+- Fix broken links in our docs
+[#924](https://github.com/canonical/k8s-snap/pull/924)
+- Bump golang.org/x/net to v0.33.0
+[#919](https://github.com/canonical/k8s-snap/pull/919)
+- Fix containerd-related path cleanup on failed bootstrap/join and associated
+test [#910](https://github.com/canonical/k8s-snap/pull/910)
+- Fix all linter warnings in test harness
+[#898](https://github.com/canonical/k8s-snap/pull/898)
+- Update etcd how-to guide config option
+[#918](https://github.com/canonical/k8s-snap/pull/918)
+- Microcluster schema change warning
+[#922](https://github.com/canonical/k8s-snap/pull/922)
+- Add Terraform documentation for k8s and k8s-worker charms
+[#920](https://github.com/canonical/k8s-snap/pull/920)
+- Move doc files under /src to fix edit docs button
+[#917](https://github.com/canonical/k8s-snap/pull/917)
 - Add 1.32 release docs [#899](https://github.com/canonical/k8s-snap/pull/899)
-- Fix dualstack yaml indentation [#914](https://github.com/canonical/k8s-snap/pull/914)
-- Completely remove LocalHarness [#912](https://github.com/canonical/k8s-snap/pull/912)
-- Deduplicate github actions [#892](https://github.com/canonical/k8s-snap/pull/892)
-- Remove manual provider config for clusterctl in CAPI docs [#911](https://github.com/canonical/k8s-snap/pull/911)
-- Bump golang.org/x/crypto from v0.28.0 to v0.31.0 [#909](https://github.com/canonical/k8s-snap/pull/909)
-- Restructure the CIS and DISA STIG hardening guides [#890](https://github.com/canonical/k8s-snap/pull/890)
-- Add how-to guide on Openstack integration [#855](https://github.com/canonical/k8s-snap/pull/855)
-- Ensure containerd-related directories removed on failed bootstrap/join-cluster [#863](https://github.com/canonical/k8s-snap/pull/863)
-- Update CNI to v1.6.0, Kubernetes to v1.32.0 and Go to 1.23/stable [#896](https://github.com/canonical/k8s-snap/pull/896)
-- Exit early if node name is not provided in CLI [#895](https://github.com/canonical/k8s-snap/pull/895)
-- Remove 1.30 branch from automatic updates [#893](https://github.com/canonical/k8s-snap/pull/893)
-- Add unit test ValidateCAPIAuthTokenAccessHandler [#885](https://github.com/canonical/k8s-snap/pull/885)
-- Add unit test ValidateNodeTokenAccessHandler [#880](https://github.com/canonical/k8s-snap/pull/880)
-- Bump Kubernetes version to v1.32.4 [#887](https://github.com/canonical/k8s-snap/pull/887)
+- Fix dual-stack yaml indentation
+[#914](https://github.com/canonical/k8s-snap/pull/914)
+- Completely remove LocalHarness
+[#912](https://github.com/canonical/k8s-snap/pull/912)
+- Remove duplicate github actions
+[#892](https://github.com/canonical/k8s-snap/pull/892)
+- Remove manual provider config for clusterctl in CAPI docs
+[#911](https://github.com/canonical/k8s-snap/pull/911)
+- Bump golang.org/x/crypto from v0.28.0 to v0.31.0
+[#909](https://github.com/canonical/k8s-snap/pull/909)
+- Restructure the CIS and DISA STIG hardening guides
+[#890](https://github.com/canonical/k8s-snap/pull/890)
+- Add how-to guide on Openstack integration
+[#855](https://github.com/canonical/k8s-snap/pull/855)
+- Ensure containerd-related directories removed on failed bootstrap/join-cluster
+[#863](https://github.com/canonical/k8s-snap/pull/863)
+- Update CNI to v1.6.0, Kubernetes to v1.32.0 and Go to 1.23/stable
+[#896](https://github.com/canonical/k8s-snap/pull/896)
+- Exit early if node name is not provided in CLI
+[#895](https://github.com/canonical/k8s-snap/pull/895)
+- Remove 1.30 branch from automatic updates
+[#893](https://github.com/canonical/k8s-snap/pull/893)
+- Add unit test ValidateCAPIAuthTokenAccessHandler
+[#885](https://github.com/canonical/k8s-snap/pull/885)
+- Add unit test ValidateNodeTokenAccessHandler
+[#880](https://github.com/canonical/k8s-snap/pull/880)
+- Bump Kubernetes version to v1.32.4
+[#887](https://github.com/canonical/k8s-snap/pull/887)
 - Update the DISA doc [#884](https://github.com/canonical/k8s-snap/pull/884)
-- Add 1.32 to supported releases [#883](https://github.com/canonical/k8s-snap/pull/883)
+- Add 1.32 to supported releases
+[#883](https://github.com/canonical/k8s-snap/pull/883)
 
 Jan 23, 2025
-- Bump GitPython to 3.1.41 [#997](https://github.com/canonical/k8s-snap/pull/997)
-- Bump Jinja2 version to 3.1.5 [#1000](https://github.com/canonical/k8s-snap/pull/1000)
+
+- Bump GitPython to 3.1.41
+[#997](https://github.com/canonical/k8s-snap/pull/997)
+- Bump Jinja2 version to 3.1.5
+[#1000](https://github.com/canonical/k8s-snap/pull/1000)
 
 Jan 22, 2025
 
-- Update Microcluster to latest v2 [#987](https://github.com/canonical/k8s-snap/pull/987)
+- Update Microcluster to latest v2
+[#987](https://github.com/canonical/k8s-snap/pull/987)
 
 Jan 16, 2025
 
-- Bump Kubernetes version v1.32.1 [#969](https://github.com/canonical/k8s-snap/pull/969)
+- Bump Kubernetes version v1.32.1
+[#969](https://github.com/canonical/k8s-snap/pull/969)
 
 Jan 14, 2025
 
-- Remove matrix link from docs [#962](https://github.com/canonical/k8s-snap/pull/962)
+- Remove matrix link from docs
+[#962](https://github.com/canonical/k8s-snap/pull/962)
 
 Jan 6, 2025
 
-- Add 1.32 release notes for snap and charm [#913](https://github.com/canonical/k8s-snap/pull/913) and [#928](https://github.com/canonical/k8s-snap/pull/928)
+- Add 1.32 release notes for snap and charm
+[#913](https://github.com/canonical/k8s-snap/pull/913) and
+[#928](https://github.com/canonical/k8s-snap/pull/928)
 
 
 ## Contributors

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -63,6 +63,201 @@ Kubernetes 1.32, please see the relevant sections of the
 - Changed BusyBox image registry in our integration tests to avoid rate limit
  errors ([#845])
 
+## Patch notices
+
+Apr 9, 2025
+- Execute post-refresh hook after node is ready[#1287](https://github.com/canonical/k8s-snap/pull/1287)
+- Don't wait for services to terminate on removed node[#1287](https://github.com/canonical/k8s-snap/pull/1287)
+- Update cla.yaml to v2 [#1288](https://github.com/canonical/k8s-snap/pull/1288)
+
+Apr 4, 2025
+- Update containerd to v1.6.38 and Kubernetes to v1.32.3 [#1179](https://github.com/canonical/k8s-snap/pull/1179)
+
+Apr 3, 2025
+- Pre-install xdelta3 to mitigate LXD rate-limit issues [#1266](https://github.com/canonical/k8s-snap/pull/1266)
+
+Mar 24, 2025
+- Ensure lock directory exists before creating file [#1220](https://github.com/canonical/k8s-snap/pull/1220)
+
+Mar 20, 2025
+- Move snapd sync to custom post-refresh hook [#1209](https://github.com/canonical/k8s-snap/pull/1209)
+
+Mar 19, 2025
+- Calculate changed files for markdown lint through git [#1202](https://github.com/canonical/k8s-snap/pull/1202)
+
+Mar 18, 2025
+- Fix link [#1195](https://github.com/canonical/k8s-snap/pull/1195)
+
+Mar 17, 2025
+- Temporarily disable snap/k8sd config sync during snap upgrade [#1168](https://github.com/canonical/k8s-snap/pull/1168)
+- Adds non-default coredns ServiceAccount [#1109](https://github.com/canonical/k8s-snap/pull/1109)
+
+Mar 14, 2025
+- Remove compromised dependency tj-actions/changed-files [#1190](https://github.com/canonical/k8s-snap/pull/1109)
+- Run all tests on Kubernetes component / feature updates [#1184](https://github.com/canonical/k8s-snap/pull/1184)
+
+Mar 13, 2025
+- Fix test_mixed_versions_join test [#1165](https://github.com/canonical/k8s-snap/pull/1165)
+
+Mar 6, 2025
+- Add runc 1.2.5 arm patch and switch to noble 24.04 runners [#1133](https://github.com/canonical/k8s-snap/pull/1133)
+
+Mar 5, 2025
+- Use 1.32-classic/edge release in 1.32-release nightly tests [#1157](https://github.com/canonical/k8s-snap/pull/1157)
+- Remove 1.31 release notes [#1145](https://github.com/canonical/k8s-snap/pull/1145)
+
+Feb 27, 2025
+- Fix custom registry config name [#1132](https://github.com/canonical/k8s-snap/pull/1132)
+- Fix configuration name [#1130](https://github.com/canonical/k8s-snap/pull/1130)
+- Update containerd and runc versions [#1115](https://github.com/canonical/k8s-snap/pull/1115)
+
+Feb 14, 2025
+- Add fan-config instructions to Openstack how-to guide [#1073](https://github.com/canonical/k8s-snap/pull/1073)
+
+Feb 13, 2025
+- Update Kubernetes version to 1.32.2 [#1067](https://github.com/canonical/k8s-snap/pull/1067)
+
+Feb 12, 2025
+- Address memory leak update k8s-dqlite version to v1.3.1 [#1063](https://github.com/canonical/k8s-snap/pull/1063)
+- Fix spell check [#1050](https://github.com/canonical/k8s-snap/pull/1050)
+- Fix pre-release update with same risk-level [#1047](https://github.com/canonical/k8s-snap/pull/1047)
+- Fix custom containerd paths [#1046](https://github.com/canonical/k8s-snap/pull/1046)
+- Add intermediate CA how-to [#1027](https://github.com/canonical/k8s-snap/pull/1027)
+- Switch to cilium native routing mode for IPv6 only setup [#1007](https://github.com/canonical/k8s-snap/pull/1007)
+- Remove obsolete loadbalancer feature check [#1037](https://github.com/canonical/k8s-snap/pull/1037)
+- Use ControlPlaneJoinConfig certificates during Control Plane Join [#1029](https://github.com/canonical/k8s-snap/pull/1029)
+- Collect all inspection reports before cleaning up nodes [#1034](https://github.com/canonical/k8s-snap/pull/1034)
+- Remove /src dir [#1018](https://github.com/canonical/k8s-snap/pull/1018)
+- Enrich node configuration controller tests with signed configmaps [#1032](https://github.com/canonical/k8s-snap/pull/1032)
+- Avoid logging an error in inspect.sh if there are no core dumps [#1028](https://github.com/canonical/k8s-snap/pull/1028)
+- Add dqlite configuration to troubleshooting page [#1022](https://github.com/canonical/k8s-snap/pull/1022)
+- Fix typo in setup-image.sh [#1024](https://github.com/canonical/k8s-snap/pull/1024)
+- Split tutorial for CAPI, add capi troubleshooting pages [#1019](https://github.com/canonical/k8s-snap/pull/1019)
+- Log a message if the cluster is unitialized [#1015](https://github.com/canonical/k8s-snap/pull/1015)
+- Add k8s inspect command [#1016](https://github.com/canonical/k8s-snap/pull/1016)
+- Generate and collect core dumps [#1014](https://github.com/canonical/k8s-snap/pull/1014)
+- Add warning for dual stack ingress [#1008](https://github.com/canonical/k8s-snap/pull/1008)
+- Remove two-node HA page [#1006](https://github.com/canonical/k8s-snap/pull/1006)
+- Fix config "show" command [#1012](https://github.com/canonical/k8s-snap/pull/1012)
+- Apply small docs pages fixes [#1011](https://github.com/canonical/k8s-snap/pull/1011)
+- Retry Temporary API Failures in Microcluster [#992](https://github.com/canonical/k8s-snap/pull/992)
+- Update Microcluster version to latest v2 [#1010](https://github.com/canonical/k8s-snap/pull/1010)
+- Bump actions upload-artifact to v4 [#1003](https://github.com/canonical/k8s-snap/pull/1003)
+- Document k8s-snap installation on dev environments [#995](https://github.com/canonical/k8s-snap/pull/995)
+- Fix headers naming style in docs [#1005](https://github.com/canonical/k8s-snap/pull/1005)
+- Enable cluster-config.load-balancer.l2-mode by default [#1001](https://github.com/canonical/k8s-snap/pull/1001)
+- Don't remove Kubernetes certificates and containerd if skipped [#1002](https://github.com/canonical/k8s-snap/pull/1002)
+- Add package management with helm explanation page [#964](https://github.com/canonical/k8s-snap/pull/964)
+- Update outdated links in our docs [#1004](https://github.com/canonical/k8s-snap/pull/1004)
+- Implement timeout in inspect.sh for k8s commands [#990](https://github.com/canonical/k8s-snap/pull/990)
+- Fix token permissions alert [#998](https://github.com/canonical/k8s-snap/pull/998)
+- Fix snap tutorials section [#983](https://github.com/canonical/k8s-snap/pull/983)
+- Adds Prometheus howto guide [#944](https://github.com/canonical/k8s-snap/pull/944)
+- Add missing commands to reference section in docs [#976](https://github.com/canonical/k8s-snap/pull/976)
+- Fix broken links for ingress.md in our docs [#979](https://github.com/canonical/k8s-snap/pull/979)
+- Reorder explanation index, ensure header style consistency in our docs [#978](https://github.com/canonical/k8s-snap/pull/978)
+- Fix snap storage documentation [#985](https://github.com/canonical/k8s-snap/pull/985)
+- Improve security docs [#980](https://github.com/canonical/k8s-snap/pull/980)
+- Add upgrading explanation page [#950](https://github.com/canonical/k8s-snap/pull/950)
+- Update annotations doc page [#974](https://github.com/canonical/k8s-snap/pull/974)
+- Update config file reference page [#977](https://github.com/canonical/k8s-snap/pull/977)
+- Update bootstrap config reference page [#975](https://github.com/canonical/k8s-snap/pull/975)
+- Improve snap install docs [#984](https://github.com/canonical/k8s-snap/pull/984)
+- Fix type on proxy reference page [#981](https://github.com/canonical/k8s-snap/pull/981)
+- Update inspect.sh to collect dmesg logs and configurable number of snap log entries [#982](https://github.com/canonical/k8s-snap/pull/982)
+- Update Microcluster to the latest v2 [#968](https://github.com/canonical/k8s-snap/pull/968)
+- Simplify the docs for installing via terraform [#948](https://github.com/canonical/k8s-snap/pull/948)
+- DISA STIG hardening docs improvements [#967](https://github.com/canonical/k8s-snap/pull/967)
+- Update charm docs [#958](https://github.com/canonical/k8s-snap/pull/958)
+- Allow specifying service env variables [#973](https://github.com/canonical/k8s-snap/pull/973)
+- Add a contributing file [#966](https://github.com/canonical/k8s-snap/pull/966)
+- Update docs home page [#951](https://github.com/canonical/k8s-snap/pull/951)
+- Update networking docs [#963](https://github.com/canonical/k8s-snap/pull/963)
+- Clarify IPv6-only docs interface binding [#972)](https://github.com/canonical/k8s-snap/pull/972)
+- Update Kubernetes version to v1.32.1 [#971](https://github.com/canonical/k8s-snap/pull/971)
+- Add how-to troubleshoot page for charm deployments [#953](https://github.com/canonical/k8s-snap/pull/953)
+- Update CAPI docs [#957](https://github.com/canonical/k8s-snap/pull/957)
+- Add Load balancer explanation page [#965](https://github.com/canonical/k8s-snap/pull/965)
+- Add Cluster Configuration using Juju page [#960](https://github.com/canonical/k8s-snap/pull/960)
+- Fix service IP poller in test_ingress [#956](https://github.com/canonical/k8s-snap/pull/956)
+- Add image management how-to guide [#954](https://github.com/canonical/k8s-snap/pull/954)
+- Add snap troubleshooting how-to guide [#943](https://github.com/canonical/k8s-snap/pull/943)
+- Move charm install files to charm/howto/install [#955](https://github.com/canonical/k8s-snap/pull/955)
+- Add charm actions reference page [#938](https://github.com/canonical/k8s-snap/pull/938)
+- Change heading title to prerequisites in docs [#959](https://github.com/canonical/k8s-snap/pull/959)
+- Clarify node-labels are additive or destructive in our docs [#949](https://github.com/canonical/k8s-snap/pull/949)
+- Add custom bootstrap configuration documentation [#935](https://github.com/canonical/k8s-snap/pull/935)
+- Add basic operations with the charm tutorial [#947](https://github.com/canonical/k8s-snap/pull/947)
+- Add IPv6 load balancer tests [#926](https://github.com/canonical/k8s-snap/pull/926)
+- Add ports and services reference [#945](https://github.com/canonical/k8s-snap/pull/945)
+- Add ports and services reference page [#946](https://github.com/canonical/k8s-snap/pull/946)
+- Add high availability explanation page [#940](https://github.com/canonical/k8s-snap/pull/940)
+- Add how-to uninstall the snap page [#941](https://github.com/canonical/k8s-snap/pull/941)
+- Clean up k8s-dqlite state dir and stops it on remove hook [#908](https://github.com/canonical/k8s-snap/pull/908)
+- Add reference docs for charm configurations [#939](https://github.com/canonical/k8s-snap/pull/939)
+- Fix snap upgrade how-to guide [#942](https://github.com/canonical/k8s-snap/pull/942)
+- Add choosing an installation method documentation [#933](https://github.com/canonical/k8s-snap/pull/933)
+- Add snap upgrades how-to guide [#934](https://github.com/canonical/k8s-snap/pull/934)
+- Add CAPI bootstrap config docs [#936](https://github.com/canonical/k8s-snap/pull/936)
+- Automatically manage pre-release branches [#916](https://github.com/canonical/k8s-snap/pull/916)
+- Add test for deploying Nvidia gpu-operator through Helm chart [#929](https://github.com/canonical/k8s-snap/pull/929)
+- Add a systemd override to add containerd defaults [#932](https://github.com/canonical/k8s-snap/pull/932)
+- Add charm upgrade documentation [#881](https://github.com/canonical/k8s-snap/pull/881)
+- Add docs for Juju custom configuration [#937](https://github.com/canonical/k8s-snap/pull/937)
+- Add alternative CNI how-to guide [#900](https://github.com/canonical/k8s-snap/pull/900)
+- CI improvements including TICs and Trivy tests[#927](https://github.com/canonical/k8s-snap/pull/927)
+- Include system information in the inspect.sh script [#921](https://github.com/canonical/k8s-snap/pull/921)
+- Bump copyright headers [#931](https://github.com/canonical/k8s-snap/pull/931)
+- Ensure LXD is installed before attempting snap refresh [#930](https://github.com/canonical/k8s-snap/pull/930)
+- Retry seed loading in case snap is not ready yet [#925](https://github.com/canonical/k8s-snap/pull/925)
+- Add 1.32 charms release notes [#913](https://github.com/canonical/k8s-snap/pull/913)
+- Fix broken links in our docs [#924](https://github.com/canonical/k8s-snap/pull/924)
+- Bump golang.org/x/net to v0.33.0 [#919](https://github.com/canonical/k8s-snap/pull/919)
+- Fix containerd-related path cleanup on failed bootstrap/join and associated test [#910](https://github.com/canonical/k8s-snap/pull/910)
+- Fix all linter warnings in test harness [#898](https://github.com/canonical/k8s-snap/pull/898)
+- Update etcd how-to guide config option [#918](https://github.com/canonical/k8s-snap/pull/918)
+- Microcluster schema change warning [#922](https://github.com/canonical/k8s-snap/pull/922)
+- Add Terraform documentation for k8s and k8s-worker charms [#920](https://github.com/canonical/k8s-snap/pull/920)
+- Move doc files under /src to fix edit docs button [#917](https://github.com/canonical/k8s-snap/pull/917)
+- Add 1.32 release docs [#899](https://github.com/canonical/k8s-snap/pull/899)
+- Fix dualstack yaml indentation [#914](https://github.com/canonical/k8s-snap/pull/914)
+- Completely remove LocalHarness [#912](https://github.com/canonical/k8s-snap/pull/912)
+- Deduplicate github actions [#892](https://github.com/canonical/k8s-snap/pull/892)
+- Remove manual provider config for clusterctl in CAPI docs [#911](https://github.com/canonical/k8s-snap/pull/911)
+- Bump golang.org/x/crypto from v0.28.0 to v0.31.0 [#909](https://github.com/canonical/k8s-snap/pull/909)
+- Restructure the CIS and DISA STIG hardening guides [#890](https://github.com/canonical/k8s-snap/pull/890)
+- Add how-to guide on Openstack integration [#855](https://github.com/canonical/k8s-snap/pull/855)
+- Ensure containerd-related directories removed on failed bootstrap/join-cluster [#863](https://github.com/canonical/k8s-snap/pull/863)
+- Update CNI to v1.6.0, Kubernetes to v1.32.0 and Go to 1.23/stable [#896](https://github.com/canonical/k8s-snap/pull/896)
+- Exit early if node name is not provided in CLI [#895](https://github.com/canonical/k8s-snap/pull/895)
+- Remove 1.30 branch from automatic updates [#893](https://github.com/canonical/k8s-snap/pull/893)
+- Add unit test ValidateCAPIAuthTokenAccessHandler [#885](https://github.com/canonical/k8s-snap/pull/885)
+- Add unit test ValidateNodeTokenAccessHandler [#880](https://github.com/canonical/k8s-snap/pull/880)
+- Bump Kubernetes version to v1.32.4 [#887](https://github.com/canonical/k8s-snap/pull/887)
+- Update the DISA doc [#884](https://github.com/canonical/k8s-snap/pull/884)
+- Add 1.32 to supported releases [#883](https://github.com/canonical/k8s-snap/pull/883)
+
+Jan 23, 2025
+- Bump GitPython to 3.1.41 [#997](https://github.com/canonical/k8s-snap/pull/997)
+- Bump Jinja2 version to 3.1.5 [#1000](https://github.com/canonical/k8s-snap/pull/1000)
+
+Jan 22, 2025
+
+- Update Microcluster to latest v2 [#987](https://github.com/canonical/k8s-snap/pull/987)
+
+Jan 16, 2025
+
+- Bump Kubernetes version v1.32.1 [#969](https://github.com/canonical/k8s-snap/pull/969)
+
+Jan 14, 2025
+
+- Remove matrix link from docs [#962](https://github.com/canonical/k8s-snap/pull/962)
+
+Jan 6, 2025
+
+- Add 1.32 release notes for snap and charm [#913](https://github.com/canonical/k8s-snap/pull/913) and [#928](https://github.com/canonical/k8s-snap/pull/928)
+
+
 ## Contributors
 
 Many thanks to [@neoaggelos], [@bschimke95], [@evilnick],

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -140,11 +140,11 @@ Feb 22, 2025
 - Remove /src dir [#1018](https://github.com/canonical/k8s-snap/pull/1018)
 - Enrich node configuration controller tests with signed ConfigMaps
 [#1032](https://github.com/canonical/k8s-snap/pull/1032)
-- Avoid logging an error in inspect.sh if there are no core dumps
+- Avoid logging an error in `inspect.sh` if there are no core dumps
 [#1028](https://github.com/canonical/k8s-snap/pull/1028)
 - Add Dqlite configuration to troubleshooting page
 [#1022](https://github.com/canonical/k8s-snap/pull/1022)
-- Fix typo in setup-image.sh
+- Fix typo in `setup-image.sh`
 [#1024](https://github.com/canonical/k8s-snap/pull/1024)
 - Split tutorial for CAPI, add capi troubleshooting pages
 [#1019](https://github.com/canonical/k8s-snap/pull/1019)
@@ -180,7 +180,7 @@ Feb 22, 2025
 [#964](https://github.com/canonical/k8s-snap/pull/964)
 - Update outdated links in our docs
 [#1004](https://github.com/canonical/k8s-snap/pull/1004)
-- Implement timeout in inspect.sh for k8s commands
+- Implement timeout in `inspect.sh` for k8s commands
 [#990](https://github.com/canonical/k8s-snap/pull/990)
 - Fix token permissions alert
 [#998](https://github.com/canonical/k8s-snap/pull/998)
@@ -190,7 +190,7 @@ Feb 22, 2025
 [#944](https://github.com/canonical/k8s-snap/pull/944)
 - Add missing commands to reference section in docs
 [#976](https://github.com/canonical/k8s-snap/pull/976)
-- Fix broken links for ingress.md in our docs
+- Fix broken links for `ingress.md` in our docs
 [#979](https://github.com/canonical/k8s-snap/pull/979)
 - Reorder explanation index, ensure header style consistency in our docs
 [#978](https://github.com/canonical/k8s-snap/pull/978)
@@ -210,7 +210,7 @@ Feb 22, 2025
 [#984](https://github.com/canonical/k8s-snap/pull/984)
 - Fix type on proxy reference page
 [#981](https://github.com/canonical/k8s-snap/pull/981)
-- Update inspect.sh to collect dmesg logs and configurable number of snap log
+- Update `inspect.sh` to collect dmesg logs and configurable number of snap log
 entries [#982](https://github.com/canonical/k8s-snap/pull/982)
 - Update Microcluster to the latest v2
 [#968](https://github.com/canonical/k8s-snap/pull/968)
@@ -293,7 +293,7 @@ entries [#982](https://github.com/canonical/k8s-snap/pull/982)
 [#900](https://github.com/canonical/k8s-snap/pull/900)
 - CI improvements including TICs and Trivy tests
 [#927](https://github.com/canonical/k8s-snap/pull/927)
-- Include system information in the inspect.sh script
+- Include system information in the `inspect.sh` script
 [#921](https://github.com/canonical/k8s-snap/pull/921)
 - Bump copyright headers [#931](https://github.com/canonical/k8s-snap/pull/931)
 - Ensure LXD is installed before attempting snap refresh

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -84,10 +84,14 @@ Apr 3, 2025
 [#1266](https://github.com/canonical/k8s-snap/pull/1266)
 
 Mar 24, 2025
-- Ensure lock directory exists before creating file [#1220](https://github.com/canonical/k8s-snap/pull/1220)
+
+- Ensure lock directory exists before creating file
+[#1220](https://github.com/canonical/k8s-snap/pull/1220)
 
 Mar 20, 2025
-- Move snapd sync to custom post-refresh hook [#1209](https://github.com/canonical/k8s-snap/pull/1209)
+
+- Move snapd sync to custom post-refresh hook
+[#1209](https://github.com/canonical/k8s-snap/pull/1209)
 
 Mar 19, 2025
 
@@ -137,9 +141,6 @@ Feb 27, 2025
 [#1130](https://github.com/canonical/k8s-snap/pull/1130)
 - Update containerd and runc versions
 [#1115](https://github.com/canonical/k8s-snap/pull/1115)
-
-Feb 14, 2025
-
 - Add fan-config instructions to Openstack how-to guide
 [#1073](https://github.com/canonical/k8s-snap/pull/1073)
 

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -65,75 +65,47 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
-Apr 9, 2025
+Apr 23, 2025
 
-- Execute post-refresh hook after node is ready
+- Fix node removal waiting for services to terminate
 [#1287](https://github.com/canonical/k8s-snap/pull/1287)
-- Don't wait for services to terminate on removed node
+- Ensure that post-refresh hook is only executed after snap refresh
 [#1287](https://github.com/canonical/k8s-snap/pull/1287)
-- Update cla.yaml to v2 [#1288](https://github.com/canonical/k8s-snap/pull/1288)
-
-Apr 4, 2025
-
 - Update containerd to v1.6.38 and Kubernetes to v1.32.3
 [#1179](https://github.com/canonical/k8s-snap/pull/1179)
-
-Apr 3, 2025
-
 - Pre-install xdelta3 to mitigate LXD rate-limit issues
 [#1266](https://github.com/canonical/k8s-snap/pull/1266)
 
-Mar 24, 2025
+Apr 8, 2025
 
 - Ensure lock directory exists before creating file
 [#1220](https://github.com/canonical/k8s-snap/pull/1220)
-
-Mar 20, 2025
-
 - Move snapd sync to custom post-refresh hook
 [#1209](https://github.com/canonical/k8s-snap/pull/1209)
-
-Mar 19, 2025
-
 - Calculate changed files for markdown lint through git
 [#1202](https://github.com/canonical/k8s-snap/pull/1202)
-
-Mar 18, 2025
-
 - Fix link [#1195](https://github.com/canonical/k8s-snap/pull/1195)
-
-Mar 17, 2025
-
 - Temporarily disable snap/k8sd config sync during snap upgrade
 [#1168](https://github.com/canonical/k8s-snap/pull/1168)
 - Adds non-default coredns ServiceAccount
 [#1109](https://github.com/canonical/k8s-snap/pull/1109)
 
-Mar 14, 2025
+Mar 24, 2025
 
 - Remove compromised dependency tj-actions/changed-files
 [#1190](https://github.com/canonical/k8s-snap/pull/1109)
 - Run all tests on Kubernetes component / feature updates
 [#1184](https://github.com/canonical/k8s-snap/pull/1184)
-
-Mar 13, 2025
-
 - Fix test_mixed_versions_join test
 [#1165](https://github.com/canonical/k8s-snap/pull/1165)
-
-Mar 6, 2025
-
 - Add runc 1.2.5 arm patch and switch to noble 24.04 runners
 [#1133](https://github.com/canonical/k8s-snap/pull/1133)
-
-Mar 5, 2025
-
 - Use 1.32-classic/edge release in 1.32-release nightly tests
 [#1157](https://github.com/canonical/k8s-snap/pull/1157)
 - Remove 1.31 release notes
 [#1145](https://github.com/canonical/k8s-snap/pull/1145)
 
-Feb 27, 2025
+Mar 9th, 2025
 
 - Fix custom registry config name
 [#1132](https://github.com/canonical/k8s-snap/pull/1132)
@@ -144,13 +116,10 @@ Feb 27, 2025
 - Add fan-config instructions to Openstack how-to guide
 [#1073](https://github.com/canonical/k8s-snap/pull/1073)
 
-Feb 13, 2025
+Feb 22, 2025
 
 - Update Kubernetes version to 1.32.2
 [#1067](https://github.com/canonical/k8s-snap/pull/1067)
-
-Feb 12, 2025
-
 - Address memory leak update k8s-dqlite version to v1.3.1
 [#1063](https://github.com/canonical/k8s-snap/pull/1063)
 - Fix spell check [#1050](https://github.com/canonical/k8s-snap/pull/1050)
@@ -381,16 +350,10 @@ test [#910](https://github.com/canonical/k8s-snap/pull/910)
 - Update the DISA doc [#884](https://github.com/canonical/k8s-snap/pull/884)
 - Add 1.32 to supported releases
 [#883](https://github.com/canonical/k8s-snap/pull/883)
-
-Jan 23, 2025
-
 - Bump GitPython to 3.1.41
 [#997](https://github.com/canonical/k8s-snap/pull/997)
 - Bump Jinja2 version to 3.1.5
 [#1000](https://github.com/canonical/k8s-snap/pull/1000)
-
-Jan 22, 2025
-
 - Update Microcluster to latest v2
 [#987](https://github.com/canonical/k8s-snap/pull/987)
 
@@ -398,14 +361,8 @@ Jan 16, 2025
 
 - Bump Kubernetes version v1.32.1
 [#969](https://github.com/canonical/k8s-snap/pull/969)
-
-Jan 14, 2025
-
 - Remove matrix link from docs
 [#962](https://github.com/canonical/k8s-snap/pull/962)
-
-Jan 6, 2025
-
 - Add 1.32 release notes for snap and charm
 [#913](https://github.com/canonical/k8s-snap/pull/913) and
 [#928](https://github.com/canonical/k8s-snap/pull/928)

--- a/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
+++ b/docs/canonicalk8s/styles/config/vocabularies/Canonical/accept.txt
@@ -51,6 +51,7 @@ Terraform
 TLS
 Traefik
 Transport Layer Security
+Trivy
 Ubuntu Core
 Ubuntu Pro
 Ubuntu Server
@@ -127,6 +128,7 @@ Commenter
 config
 configMap
 ConfigMap
+ConfigMaps
 containerd
 CoreDNS
 Corosync
@@ -149,6 +151,7 @@ deallocation
 deployable
 discoverable
 DMA
+dmesg
 dns
 DNS
 DPDK
@@ -160,6 +163,7 @@ EasyRSA
 eBPF
 enp
 enum
+env
 etcd
 eth
 EventRateLimit
@@ -334,6 +338,8 @@ sys
 systemd
 taskset
 Telco
+test_ingress
+test_mixed_versions_join
 throughs
 tickless
 TLB


### PR DESCRIPTION
<I want to make sure the changes are all in stable before we merge this PR >

## Description

Our current release notes do not include any information on back ported PRs. 

## Solution

We have come up with a plan to keep these up to date in the future and the PR will get the doc up to date for now. 

## Backport

1.32

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.