### PR TITLE
test: ensure that the containerd test uses local mirror

### DIFF
--- a/tests/integration/tests/test_cleanup.py
+++ b/tests/integration/tests/test_cleanup.py
@@ -53,7 +53,7 @@ def test_node_cleanup(instances: List[harness.Instance], tmp_path):
 
 @pytest.mark.node_count(2)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.containerd_cfgdir("/home/ubuntu/etc/containerd")
+@pytest.mark.containerd_cfgdir("/home/ubuntu/k8s-containerd/etc/containerd")
 @pytest.mark.tags(tags.NIGHTLY)
 def test_node_cleanup_new_containerd_path(instances: List[harness.Instance]):
     main = instances[0]


### PR DESCRIPTION
One of the tests uses a custom containerd base directory. The problem is that it places the registry configuration at a wrong location that gets ignored.

For this reason, this test will always try to pull the images from the upstream registry, which causes flakiness (timeouts due to the image size and api rate limiting).

We'll solve the issue by using the same directory that is specified in the containerd config file:

```
[plugins."io.containerd.grpc.v1.cri".registry]
  config_path = "/home/ubuntu/k8s-containerd/etc/containerd/hosts.d"
```
