### PR TITLE
chore: update token used for approving backports

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -34,7 +34,8 @@ jobs:
 
       - name: Create backport pull requests
         id: create_backports
-        uses: korthout/backport-action@v3
+        # v3.2.0
+        uses: korthout/backport-action@436145e922f9561fc5ea157ff406f21af2d6b363
         with:
           # Set (default) action parameters explicitly.
           branch_name: backport-${pull_number}-to-${target_branch}
@@ -58,7 +59,7 @@ jobs:
 
       - name: Label backports with automerge and approve
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BACKPORT_APPROVAL_TOKEN }}
         run: |
           for pr_number in ${{ steps.create_backports.outputs.created_pull_numbers }}; do
             gh pr edit "$pr_number" --add-label "automerge"


### PR DESCRIPTION
## Description

Update token used for approving backports and pin the backport-action to specific commit hash.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.