### PR TITLE
fix: Remove duplicate logic from post-refresh hook, Fix upgrade contr…

### DIFF
--- a/src/k8s/pkg/client/kubernetes/upgrades.go
+++ b/src/k8s/pkg/client/kubernetes/upgrades.go
@@ -32,6 +32,12 @@ const (
 	upgradesAPIPath = "/apis/" + group + "/" + version + "/upgrades"
 )
 
+var (
+	schemeGroupVersion = schema.GroupVersion{Group: group, Version: version}
+	schemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme        = schemeBuilder.AddToScheme
+)
+
 type UpgradeStatus struct {
 	Phase         string   `json:"phase,omitempty"`
 	UpgradedNodes []string `json:"upgradedNodes,omitempty"`
@@ -60,6 +66,36 @@ func (u *Upgrade) DeepCopyObject() runtime.Object {
 	return &cp
 }
 
+// UpgradeList contains a list of Upgrade resources.
+type UpgradeList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Upgrade `json:"items"`
+}
+
+func (ul *UpgradeList) DeepCopyObject() runtime.Object {
+	if ul == nil {
+		return nil
+	}
+	cp := *ul
+	cp.ListMeta = *ul.ListMeta.DeepCopy()
+	cp.Items = make([]Upgrade, len(ul.Items))
+	for i, u := range ul.Items {
+		cp.Items[i] = *u.DeepCopyObject().(*Upgrade)
+	}
+	return &cp
+}
+
+// addKnownTypes registers upgrade types into the scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(schemeGroupVersion,
+		&Upgrade{},
+		&UpgradeList{},
+	)
+	metav1.AddToGroupVersion(scheme, schemeGroupVersion)
+	return nil
+}
+
 func NewUpgrade(name string) Upgrade {
 	return Upgrade{
 		TypeMeta: metav1.TypeMeta{
@@ -75,7 +111,7 @@ func NewUpgrade(name string) Upgrade {
 
 func (c *Client) k8sdIoRestClient() (*rest.RESTClient, error) {
 	k8sdConfig := c.RESTConfig()
-	k8sdConfig.GroupVersion = &schema.GroupVersion{Group: group, Version: version}
+	k8sdConfig.GroupVersion = &schemeGroupVersion
 	k8sdConfig.NegotiatedSerializer = serializer.NewCodecFactory(runtime.NewScheme())
 
 	restClient, err := rest.RESTClientFor(k8sdConfig)

--- a/src/k8s/pkg/client/kubernetes/upgrades.go
+++ b/src/k8s/pkg/client/kubernetes/upgrades.go
@@ -81,7 +81,12 @@ func (ul *UpgradeList) DeepCopyObject() runtime.Object {
 	cp.ListMeta = *ul.ListMeta.DeepCopy()
 	cp.Items = make([]Upgrade, len(ul.Items))
 	for i, u := range ul.Items {
-		cp.Items[i] = *u.DeepCopyObject().(*Upgrade)
+		uCp, ok := u.DeepCopyObject().(*Upgrade)
+		if !ok {
+			log.L().Error(fmt.Errorf("type assertion failed for upgrade deepcopy"), "upgrade", u)
+			continue
+		}
+		cp.Items[i] = *uCp
 	}
 	return &cp
 }

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
@@ -65,9 +64,7 @@ func (a *App) postRefreshHook(ctx context.Context, s state.State) error {
 	return nil
 }
 
-// performPostUpgrade performs the post-upgrade steps.
-// It marks the node as upgraded and checks if all nodes have been upgraded.
-// If all nodes have been upgraded, it triggers the feature upgrade.
+// performPostUpgrade adds the node name to the list of upgradedNodes in the upgrade custom resource.
 func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 	log := log.FromContext(ctx).WithValues("step", "post-upgrade")
 	k8sClient, err := a.snap.KubernetesClient("")
@@ -107,104 +104,5 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 		return fmt.Errorf("failed to mark node as upgraded: %w", err)
 	}
 
-	clusterUpgradeDone, err := allNodesUpgraded(ctx, s, upgradedNodes)
-	if err != nil {
-		return fmt.Errorf("failed to check if all nodes have been upgraded: %w", err)
-	}
-
-	if clusterUpgradeDone {
-		log.Info("All nodes have been upgraded.")
-		if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseFeatureUpgrade}); err != nil {
-			return fmt.Errorf("failed to set upgrade phase: %w", err)
-		}
-
-		log.Info("Triggering feature upgrades in background")
-
-		// TODO(ben): This is a bit ugly. We cannot wait here for the feature controllers to finish because
-		// the controllers are blocked until the node is marked as ready. For this phase, we can just run a separate
-		// goroutine to trigger the feature controllers and wait for them to finish.
-		// Once we have a separate feature upgrade controller, this should be much cleaner.
-		go func() {
-			log.Info("Triggering feature controllers in separate go routine.")
-			// TODO: Do we need to handle dependencies between features?
-			// If yes, a new features/interface/upgrades should be created that takes all trigger and reconciled channels.
-			// The custom dependencies could then be handled in the flavor feature implementation.
-
-			// Trigger all feature controllers
-			// This intentionally blocks until the feature controllers are available.
-			<-a.featureController.ReadyCh()
-			a.NotifyFeatureController(true, true, true, true, true, true, true)
-
-			log.Info("Waiting for feature controllers to reconcile.")
-			pending := map[string]<-chan struct{}{
-				"Network":       a.featureController.ReconciledNetworkCh(),
-				"Gateway":       a.featureController.ReconciledGatewayCh(),
-				"Ingress":       a.featureController.ReconciledIngressCh(),
-				"DNS":           a.featureController.ReconciledDNSCh(),
-				"LoadBalancer":  a.featureController.ReconciledLoadBalancerCh(),
-				"LocalStorage":  a.featureController.ReconciledLocalStorageCh(),
-				"MetricsServer": a.featureController.ReconciledMetricsServerCh(),
-			}
-
-			for len(pending) > 0 {
-				select {
-				case <-ctx.Done():
-					log.Error(ctx.Err(), "Context canceled while waiting for feature controllers to reconcile.")
-					return
-
-				case <-time.After(100 * time.Millisecond):
-					for name, ch := range pending {
-						select {
-						case <-ch:
-							log.Info(fmt.Sprintf("%s feature controller reconciled.", name))
-							delete(pending, name)
-						default:
-						}
-					}
-				}
-			}
-
-			log.Info("All feature have reconciled.")
-
-			if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseCompleted}); err != nil {
-				log.Error(err, "failed to set upgrade phase after successful feature upgrade")
-				return
-			}
-		}()
-	}
 	return nil
-}
-
-// allNodesUpgraded checks if all nodes in the cluster have been upgraded.
-func allNodesUpgraded(ctx context.Context, s state.State, upgradedNodes []string) (bool, error) {
-	log := log.FromContext(ctx)
-
-	// Check if all nodes have been upgraded
-	c, err := s.Leader()
-	if err != nil {
-		return false, fmt.Errorf("failed to get leader client: %w", err)
-	}
-
-	clusterMembers, err := c.GetClusterMembers(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to get cluster members: %w", err)
-	}
-
-	if len(clusterMembers) != len(upgradedNodes) {
-		log.Info("Not all nodes have been upgraded.", "clusterMembers", len(clusterMembers), "upgradedNodes", len(upgradedNodes))
-		return false, nil
-	}
-
-	clusterMembersMap := make(map[string]struct{})
-	for _, member := range clusterMembers {
-		clusterMembersMap[member.Name] = struct{}{}
-	}
-
-	for _, node := range upgradedNodes {
-		if _, ok := clusterMembersMap[node]; !ok {
-			log.Info("Node has been upgraded but is not part of the cluster.", "node", node)
-			return false, nil
-		}
-	}
-	return true, nil
 }

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -106,23 +106,33 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 
 	// start csrsigning controller
 	if a.csrsigningController != nil {
-		go a.csrsigningController.Run(
-			ctx,
-			func(ctx context.Context) (types.ClusterConfig, error) {
-				return databaseutil.GetClusterConfig(ctx, s)
-			},
-		)
+		go func() {
+			if err := a.csrsigningController.Run(
+				ctx,
+				func(ctx context.Context) (types.ClusterConfig, error) {
+					return databaseutil.GetClusterConfig(ctx, s)
+				},
+			); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to start csrsigning controller")
+			}
+			log.FromContext(ctx).Info("csrsigning controller started")
+		}()
 	}
 
 	// start upgrade controller
 	if a.upgradeController != nil {
-		go a.upgradeController.Run(
-			ctx,
-			func(ctx context.Context) (types.ClusterConfig, error) {
-				return databaseutil.GetClusterConfig(ctx, s)
-			},
-			func() state.State { return s },
-		)
+		go func() {
+			if err := a.upgradeController.Run(
+				ctx,
+				func(ctx context.Context) (types.ClusterConfig, error) {
+					return databaseutil.GetClusterConfig(ctx, s)
+				},
+				func() state.State { return s },
+			); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to start upgrade controller")
+			}
+			log.FromContext(ctx).Info("upgrade controller started")
+		}()
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/microcluster/v2/state"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -94,8 +95,14 @@ func (c *Controller) Run(
 		return fmt.Errorf("failed to get Kubernetes REST config: %w", err)
 	}
 
+	scheme := runtime.NewScheme()
+	if err := kubernetes.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add scheme: %w", err)
+	}
+
 	// TODO(Hue): (KU-3216) use a single manager for upgrade and csrsigning controllers.
 	mgr, err := manager.New(config, manager.Options{
+		Scheme:                  scheme,
 		Logger:                  logger,
 		LeaderElection:          true,
 		LeaderElectionID:        "a27980c4.k8sd-upgrade-controller",


### PR DESCRIPTION
### Overview
- Remove duplicate logic from post-refresh hook. Changing upgrade phase to `FeatureUpgrade` and overseeing feature reconciliations is now delegated to the upgrade controller. Based on https://github.com/canonical/k8s-snap/pull/1297.
- Add `UpgradeList` type and necessary scheme for the upgrade controller to operate correctly.