### PR TITLE
[Backport 1.32] Set dqlite failure-domain based on the k8s node AZ label (#989) 

### DIFF
--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -14,6 +14,7 @@ var rootCmdOpts struct {
 	stateDir                            string
 	pprofAddress                        string
 	disableNodeConfigController         bool
+	disableNodeLabelController          bool
 	disableControlPlaneConfigController bool
 	disableFeatureController            bool
 	disableUpdateNodeConfigController   bool
@@ -49,6 +50,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				Snap:                                env.Snap,
 				PprofAddress:                        rootCmdOpts.pprofAddress,
 				DisableNodeConfigController:         rootCmdOpts.disableNodeConfigController,
+				DisableNodeLabelController:          rootCmdOpts.disableNodeLabelController,
 				DisableControlPlaneConfigController: rootCmdOpts.disableControlPlaneConfigController,
 				DisableUpdateNodeConfigController:   rootCmdOpts.disableUpdateNodeConfigController,
 				DisableFeatureController:            rootCmdOpts.disableFeatureController,
@@ -78,6 +80,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.pprofAddress, "pprof-address", "", "Listen address for pprof endpoints, e.g. \"127.0.0.1:4217\"")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeConfigController, "disable-node-config-controller", false, "Disable the Node Config Controller")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeLabelController, "disable-node-label-controller", false, "Disable the Node Label Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableControlPlaneConfigController, "disable-control-plane-config-controller", false, "Disable the Control Plane Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableUpdateNodeConfigController, "disable-update-node-config-controller", false, "Disable the Update Node Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableFeatureController, "disable-feature-controller", false, "Disable the Feature Controller")

--- a/src/k8s/pkg/client/kubernetes/node.go
+++ b/src/k8s/pkg/client/kubernetes/node.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/canonical/k8s/pkg/log"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
@@ -20,6 +22,33 @@ func (c *Client) DeleteNode(ctx context.Context, nodeName string) error {
 		}
 		return nil
 	})
+}
+
+func (c *Client) WatchNode(ctx context.Context, name string, reconcile func(node *v1.Node) error) error {
+	log := log.FromContext(ctx).WithValues("name", name)
+	w, err := c.CoreV1().Nodes().Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{Name: name}))
+	if err != nil {
+		return fmt.Errorf("failed to watch node name=%s: %w", name, err)
+	}
+	defer w.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt, ok := <-w.ResultChan():
+			if !ok {
+				return fmt.Errorf("watch closed")
+			}
+			node, ok := evt.Object.(*v1.Node)
+			if !ok {
+				return fmt.Errorf("expected a Node but received %#v", evt.Object)
+			}
+
+			if err := reconcile(node); err != nil {
+				log.Error(err, "Reconcile Node failed")
+			}
+		}
+	}
 }
 
 // NodeVersions returns a map of node names to their parsed Kubernetes versions.

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -122,6 +122,13 @@ func New(cfg Config) (*App, error) {
 		app.nodeLabelController = controllers.NewNodeLabelController(
 			cfg.Snap,
 			app.readyWg.Wait,
+			func(ctx context.Context) (string, error) {
+				serverStatus, err := cluster.Status(ctx)
+				if err != nil {
+					return "", fmt.Errorf("failed to retrieve microcluster status: %w", err)
+				}
+				return serverStatus.Name, nil
+			},
 		)
 	} else {
 		log.L().Info("node-label-controller disabled via config")

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -36,6 +36,8 @@ type Config struct {
 	PprofAddress string
 	// DisableNodeConfigController is a bool flag to disable node config controller
 	DisableNodeConfigController bool
+	// DisableNodeLabelController is a bool flag to disable node label controller
+	DisableNodeLabelController bool
 	// DisableControlPlaneConfigController is a bool flag to disable control-plane config controller
 	DisableControlPlaneConfigController bool
 	// DisableUpdateNodeConfigController is a bool flag to disable update node config controller
@@ -62,6 +64,7 @@ type App struct {
 	readyWg sync.WaitGroup
 
 	nodeConfigController         *controllers.NodeConfigurationController
+	nodeLabelController          *controllers.NodeLabelController
 	controlPlaneConfigController *controllers.ControlPlaneConfigurationController
 	csrsigningController         *csrsigning.Controller
 	upgradeController            *upgrade.Controller
@@ -113,6 +116,15 @@ func New(cfg Config) (*App, error) {
 		)
 	} else {
 		log.L().Info("node-config-controller disabled via config")
+	}
+
+	if !cfg.DisableNodeLabelController {
+		app.nodeLabelController = controllers.NewNodeLabelController(
+			cfg.Snap,
+			app.readyWg.Wait,
+		)
+	} else {
+		log.L().Info("node-label-controller disabled via config")
 	}
 
 	if !cfg.DisableControlPlaneConfigController {

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -40,6 +40,11 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 		})
 	}
 
+	// start node label controller
+	if a.nodeLabelController != nil {
+		go a.nodeLabelController.Run(ctx)
+	}
+
 	// start control plane config controller
 	if a.controlPlaneConfigController != nil {
 		go a.controlPlaneConfigController.Run(ctx, func(ctx context.Context) (types.ClusterConfig, error) {

--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/canonical/k8s/pkg/client/kubernetes"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
@@ -27,21 +26,6 @@ func NewNodeConfigurationController(snap snap.Snap, waitReady func()) *NodeConfi
 	}
 }
 
-func (c *NodeConfigurationController) retryNewK8sClient(ctx context.Context) (*kubernetes.Client, error) {
-	for {
-		client, err := c.snap.KubernetesNodeClient("kube-system")
-		if err == nil {
-			return client, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(3 * time.Second):
-		}
-	}
-}
-
 func (c *NodeConfigurationController) Run(ctx context.Context, getRSAKey func(context.Context) (*rsa.PublicKey, error)) {
 	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "node-configuration"))
 	log := log.FromContext(ctx)
@@ -53,7 +37,7 @@ func (c *NodeConfigurationController) Run(ctx context.Context, getRSAKey func(co
 	log.Info("Starting node configuration controller")
 
 	for {
-		client, err := c.retryNewK8sClient(ctx)
+		client, err := getNewK8sClientWithRetries(ctx, c.snap, false)
 		if err != nil {
 			log.Error(err, "Failed to create a Kubernetes client")
 		}

--- a/src/k8s/pkg/k8sd/controllers/node_label.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label.go
@@ -56,58 +56,52 @@ func (c *NodeLabelController) Run(ctx context.Context) {
 }
 
 func (c *NodeLabelController) reconcileFailureDomain(ctx context.Context, node *v1.Node) error {
-	log := log.FromContext(ctx)
-
 	azLabel, azFound := node.Labels["topology.kubernetes.io/zone"]
 	var failureDomain uint64
 	if azFound && azLabel != "" {
-		log.Info("Node availability zone found", "label", azLabel)
 		// k8s-dqlite expects the failure domain (availability zone) to be an uint64
 		// value defined in $dbStateDir/failure-domain. Both k8s-snap Dqlite databases
 		// need to be updated (k8sd and k8s-dqlite).
 		failureDomain = snaputil.NodeLabelToDqliteFailureDomain(azLabel)
 	} else {
-		log.Info("The node availability zone label is unset, clearing failure domain")
 		failureDomain = 0
 	}
 
-	log.Info("Setting failure domain", "failure domain", failureDomain, "availability zone", azLabel)
-	if err := c.updateDqliteFailureDomain(ctx, c.snap, failureDomain); err != nil {
+	if err := c.updateDqliteFailureDomain(ctx, failureDomain, azLabel); err != nil {
 		return fmt.Errorf("failed to update failure-domain, error: %w", err)
 	}
 
 	return nil
 }
 
-func (c *NodeLabelController) updateDqliteFailureDomain(ctx context.Context, snap snap.Snap, failureDomain uint64) error {
+func (c *NodeLabelController) updateDqliteFailureDomain(ctx context.Context, failureDomain uint64, availabilityZone string) error {
 	log := log.FromContext(ctx)
 
 	// We need to update both k8s-snap Dqlite databases (k8sd and k8s-dqlite).
-	k8sDqliteStateDir := snap.K8sDqliteStateDir()
-	k8sdDbStateDir := filepath.Join(snap.K8sdStateDir(), "database")
+	k8sDqliteStateDir := c.snap.K8sDqliteStateDir()
+	k8sdDbStateDir := filepath.Join(c.snap.K8sdStateDir(), "database")
 
-	log.Info("Updating k8s-dqlite failure domain", "failure domain", failureDomain)
 	modified, err := snaputil.UpdateDqliteFailureDomain(failureDomain, k8sDqliteStateDir)
 	if err != nil {
 		return err
 	}
-	log.Info("Updated k8s-dqlite failure domain", "restart needed", modified)
 
 	if modified {
+		log.Info("Updated k8s-dqlite failure domain", "failure domain", failureDomain, "availability zone", availabilityZone)
 		if err = c.snap.RestartServices(ctx, []string{"k8s-dqlite"}); err != nil {
 			return fmt.Errorf("failed to restart k8s-dqlite to apply failure domain: %w", err)
 		}
 	}
 
-	log.Info("Updating k8sd failure domain", "failure domain", failureDomain)
 	modified, err = snaputil.UpdateDqliteFailureDomain(failureDomain, k8sdDbStateDir)
 	if err != nil {
 		return err
 	}
-	log.Info("Updated k8sd failure domain", "restart needed", modified)
+
 	// TODO: use Microcluster API once it becomes available. This should
 	// prevent a service restart, at the moment k8sd needs to restart itself.
 	if modified {
+		log.Info("Updated k8sd failure domain", "failure domain", failureDomain, "availability zone", availabilityZone)
 		if err := c.snap.RestartServices(ctx, []string{"k8sd"}); err != nil {
 			return fmt.Errorf("failed to restart k8sd to apply failure domain: %w", err)
 		}
@@ -118,9 +112,6 @@ func (c *NodeLabelController) updateDqliteFailureDomain(ctx context.Context, sna
 }
 
 func (c *NodeLabelController) reconcile(ctx context.Context, node *v1.Node) error {
-	log := log.FromContext(ctx)
-	log.Info("reconciling node labels", "name", node.Name)
-
 	if err := c.reconcileFailureDomain(ctx, node); err != nil {
 		return fmt.Errorf("failed to reconcile failure domain: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/controllers/node_label.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label.go
@@ -1,0 +1,129 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	v1 "k8s.io/api/core/v1"
+)
+
+type NodeLabelController struct {
+	snap      snap.Snap
+	waitReady func()
+}
+
+func NewNodeLabelController(snap snap.Snap, waitReady func()) *NodeLabelController {
+	return &NodeLabelController{
+		snap:      snap,
+		waitReady: waitReady,
+	}
+}
+
+func (c *NodeLabelController) Run(ctx context.Context) {
+	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "node-configuration"))
+	log := log.FromContext(ctx)
+
+	log.Info("Waiting for node to be ready")
+	// wait for microcluster node to be ready
+	c.waitReady()
+
+	hostname := c.snap.Hostname()
+	log.Info("Starting node label controller", "hostname", hostname)
+
+	for {
+		client, err := getNewK8sClientWithRetries(ctx, c.snap, false)
+		if err != nil {
+			log.Error(err, "Failed to create a Kubernetes client")
+		}
+
+		if err := client.WatchNode(
+			ctx, hostname, func(node *v1.Node) error { return c.reconcile(ctx, node) }); err != nil {
+			// The watch may fail during bootstrap or service start-up.
+			log.WithValues("node name", hostname).Error(err, "Failed to watch node")
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+func (c *NodeLabelController) reconcileFailureDomain(ctx context.Context, node *v1.Node) error {
+	log := log.FromContext(ctx)
+
+	azLabel, azFound := node.Labels["topology.kubernetes.io/zone"]
+	var failureDomain uint64
+	if azFound && azLabel != "" {
+		log.Info("Node availability zone found", "label", azLabel)
+		// k8s-dqlite expects the failure domain (availability zone) to be an uint64
+		// value defined in $dbStateDir/failure-domain. Both k8s-snap Dqlite databases
+		// need to be updated (k8sd and k8s-dqlite).
+		failureDomain = snaputil.NodeLabelToDqliteFailureDomain(azLabel)
+	} else {
+		log.Info("The node availability zone label is unset, clearing failure domain")
+		failureDomain = 0
+	}
+
+	log.Info("Setting failure domain", "failure domain", failureDomain, "availability zone", azLabel)
+	if err := c.updateDqliteFailureDomain(ctx, c.snap, failureDomain); err != nil {
+		return fmt.Errorf("failed to update failure-domain, error: %w", err)
+	}
+
+	return nil
+}
+
+func (c *NodeLabelController) updateDqliteFailureDomain(ctx context.Context, snap snap.Snap, failureDomain uint64) error {
+	log := log.FromContext(ctx)
+
+	// We need to update both k8s-snap Dqlite databases (k8sd and k8s-dqlite).
+	k8sDqliteStateDir := snap.K8sDqliteStateDir()
+	k8sdDbStateDir := filepath.Join(snap.K8sdStateDir(), "database")
+
+	log.Info("Updating k8s-dqlite failure domain", "failure domain", failureDomain)
+	modified, err := snaputil.UpdateDqliteFailureDomain(failureDomain, k8sDqliteStateDir)
+	if err != nil {
+		return err
+	}
+	log.Info("Updated k8s-dqlite failure domain", "restart needed", modified)
+
+	if modified {
+		if err = c.snap.RestartServices(ctx, []string{"k8s-dqlite"}); err != nil {
+			return fmt.Errorf("failed to restart k8s-dqlite to apply failure domain: %w", err)
+		}
+	}
+
+	log.Info("Updating k8sd failure domain", "failure domain", failureDomain)
+	modified, err = snaputil.UpdateDqliteFailureDomain(failureDomain, k8sdDbStateDir)
+	if err != nil {
+		return err
+	}
+	log.Info("Updated k8sd failure domain", "restart needed", modified)
+	// TODO: use Microcluster API once it becomes available. This should
+	// prevent a service restart, at the moment k8sd needs to restart itself.
+	if modified {
+		if err := c.snap.RestartServices(ctx, []string{"k8sd"}); err != nil {
+			return fmt.Errorf("failed to restart k8sd to apply failure domain: %w", err)
+		}
+		// We shouldn't actually get here.
+	}
+
+	return nil
+}
+
+func (c *NodeLabelController) reconcile(ctx context.Context, node *v1.Node) error {
+	log := log.FromContext(ctx)
+	log.Info("reconciling node labels", "name", node.Name)
+
+	if err := c.reconcileFailureDomain(ctx, node); err != nil {
+		return fmt.Errorf("failed to reconcile failure domain: %w", err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/k8sd/controllers/node_label_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label_test.go
@@ -106,7 +106,8 @@ func TestAvailabilityZoneLabel(t *testing.T) {
 	g.Expect(os.MkdirAll(k8sDqliteStateDir, 0o700)).To(Succeed())
 	g.Expect(os.MkdirAll(k8sdDbDir, 0o700)).To(Succeed())
 
-	ctrl := controllers.NewNodeLabelController(s, func() {})
+	nodeName := "test-node-name"
+	ctrl := controllers.NewNodeLabelController(s, func() {}, func(context.Context) (string, error) { return nodeName, nil })
 
 	go ctrl.Run(ctx)
 	defer watcher.Stop()
@@ -142,7 +143,7 @@ func TestAvailabilityZoneLabel(t *testing.T) {
 
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: s.Hostname(),
+					Name: nodeName,
 					Labels: map[string]string{
 						"topology.kubernetes.io/zone": tc.availabilityZone,
 					},

--- a/src/k8s/pkg/k8sd/controllers/node_label_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label_test.go
@@ -1,0 +1,172 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/k8sd/setup"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestAvailabilityZoneLabel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g := NewWithT(t)
+
+	tests := []struct {
+		name string
+		// Availability zone label
+		availabilityZone string
+		// The first 8 bytes of the sha-256 hash of the AZ or 0 if unset.
+		expFailureDomain uint64
+		// Does the $stateDir/failure-domain file exist?
+		fileExists bool
+		// The already existing failure domain setting.
+		existingFailureDomain uint64
+		// Do we expect a service restart?
+		expRestart bool
+	}{
+		{
+			name:             "AZ set, file missing",
+			availabilityZone: "testAZ",
+			expFailureDomain: 7130520900010879344,
+			fileExists:       false,
+			expRestart:       true,
+		},
+		{
+			name:                  "No change - file missing",
+			availabilityZone:      "",
+			expFailureDomain:      0,
+			existingFailureDomain: 0,
+			fileExists:            false,
+			expRestart:            false,
+		},
+		{
+			name:                  "No change, AZ unset - file exists",
+			availabilityZone:      "",
+			expFailureDomain:      0,
+			existingFailureDomain: 0,
+			fileExists:            true,
+			expRestart:            false,
+		},
+		{
+			name:                  "No change, AZ set - file exists",
+			availabilityZone:      "testAZ",
+			expFailureDomain:      7130520900010879344,
+			existingFailureDomain: 7130520900010879344,
+			fileExists:            true,
+			expRestart:            false,
+		},
+		{
+			name:                  "AZ changed, file exists",
+			availabilityZone:      "testAZ",
+			expFailureDomain:      7130520900010879344,
+			existingFailureDomain: 101,
+			fileExists:            true,
+			expRestart:            true,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset()
+	watcher := watch.NewFake()
+	clientset.PrependWatchReactor("nodes", k8stesting.DefaultWatchReactor(watcher, nil))
+
+	s := &mock.Snap{
+		Mock: mock.Mock{
+			K8sdStateDir:         filepath.Join(t.TempDir(), "k8sd"),
+			K8sDqliteStateDir:    filepath.Join(t.TempDir(), "k8s-dqlite"),
+			UID:                  os.Getuid(),
+			GID:                  os.Getgid(),
+			KubernetesNodeClient: &kubernetes.Client{Interface: clientset},
+		},
+	}
+
+	g.Expect(setup.EnsureAllDirectories(s)).To(Succeed())
+
+	k8sDqliteStateDir := s.K8sDqliteStateDir()
+	k8sdDbDir := filepath.Join(s.K8sdStateDir(), "database")
+
+	// EnsureAllDirectories doesn't handle the following k8sd dirs, for
+	// now we'll create them here.
+	g.Expect(os.MkdirAll(k8sDqliteStateDir, 0o700)).To(Succeed())
+	g.Expect(os.MkdirAll(k8sdDbDir, 0o700)).To(Succeed())
+
+	ctrl := NewNodeLabelController(s, func() {})
+
+	go ctrl.Run(ctx)
+	defer watcher.Stop()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s.RestartServicesCalledWith = nil
+
+			k8sDqliteFailureDomainFile := snaputil.GetDqliteFailureDomainFile(k8sDqliteStateDir)
+			k8sdFailureDomainFile := snaputil.GetDqliteFailureDomainFile(k8sdDbDir)
+
+			if tc.fileExists {
+				existingFailureDomainStr := fmt.Sprintf("%v", tc.existingFailureDomain)
+				// For simplicity, we'll assume matching dqlite failure domains
+				err := os.WriteFile(k8sDqliteFailureDomainFile, []byte(existingFailureDomainStr), 0o644)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = os.WriteFile(k8sdFailureDomainFile, []byte(existingFailureDomainStr), 0o644)
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				exists, err := utils.FileExists(k8sDqliteFailureDomainFile)
+				g.Expect(err).ToNot(HaveOccurred())
+				if exists {
+					g.Expect(os.Remove(k8sDqliteFailureDomainFile)).To(Succeed())
+				}
+				exists, err = utils.FileExists(k8sdFailureDomainFile)
+				g.Expect(err).ToNot(HaveOccurred())
+				if exists {
+					g.Expect(os.Remove(k8sdFailureDomainFile)).To(Succeed())
+				}
+			}
+
+			g := NewWithT(t)
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: s.Hostname(),
+					Labels: map[string]string{
+						"topology.kubernetes.io/zone": tc.availabilityZone,
+					},
+				},
+			}
+			watcher.Add(node)
+
+			// TODO: this is to ensure that the controller has handled the event. This should ideally
+			// be replaced with something like a "<-sentCh" instead
+			time.Sleep(100 * time.Millisecond)
+
+			k8sdFailureDomain, err := snaputil.GetDqliteFailureDomain(k8sdDbDir)
+			g.Expect(err).ToNot(HaveOccurred())
+			k8sdDqliteFailureDomain, err := snaputil.GetDqliteFailureDomain(k8sDqliteStateDir)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(k8sdFailureDomain).To(Equal(k8sdDqliteFailureDomain))
+			g.Expect(k8sdFailureDomain).To(Equal(tc.expFailureDomain))
+
+			if tc.expRestart {
+				g.Expect(s.RestartServicesCalledWith).To(ContainElement([]string{"k8sd"}))
+				g.Expect(s.RestartServicesCalledWith).To(ContainElement([]string{"k8s-dqlite"}))
+			} else {
+				g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
+			}
+		})
+	}
+}

--- a/src/k8s/pkg/k8sd/controllers/utils.go
+++ b/src/k8s/pkg/k8sd/controllers/utils.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/snap"
+)
+
+func getNewK8sClientWithRetries(ctx context.Context, snapObj snap.Snap, admin bool) (*kubernetes.Client, error) {
+	for {
+		var err error
+		var client *kubernetes.Client
+		if admin {
+			// use admin client
+			client, err = snapObj.KubernetesClient("kube-system")
+		} else {
+			// use node client
+			client, err = snapObj.KubernetesNodeClient("kube-system")
+		}
+
+		if err == nil {
+			return client, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}

--- a/src/k8s/pkg/snap/util/dqlite.go
+++ b/src/k8s/pkg/snap/util/dqlite.go
@@ -1,0 +1,83 @@
+package snaputil
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/utils"
+)
+
+// NodeLabelToDqliteFailureDomain hashes (sha256) node labels to produce
+// uint64 failure domain identifiers.
+func NodeLabelToDqliteFailureDomain(label string) uint64 {
+	sha256Sum := sha256.Sum256([]byte(label))
+	// Select the first 8 bytes of the sha256 hash.
+	return binary.LittleEndian.Uint64(sha256Sum[:])
+}
+
+func GetDqliteFailureDomainFile(dbStateDir string) string {
+	return filepath.Join(dbStateDir, "failure-domain")
+}
+
+func GetDqliteFailureDomain(dbStateDir string) (uint64, error) {
+	failureDomainFile := GetDqliteFailureDomainFile(dbStateDir)
+	fileExists, err := utils.FileExists(failureDomainFile)
+	if err != nil {
+		return 0, fmt.Errorf("unable to check if file exists %s: %w", failureDomainFile, err)
+	}
+	if !fileExists {
+		// Unset, defaults to 0.
+		return 0, nil
+	}
+	contents, err := os.ReadFile(failureDomainFile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read failure-domain file %s: %w", failureDomainFile, err)
+	}
+	failureDomainStr := strings.Split(string(contents), "\n")[0]
+	failureDomain, err := strconv.ParseUint(string(failureDomainStr), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse failure domain %s: %w", failureDomainStr, err)
+	}
+	return failureDomain, nil
+}
+
+// UpdateDqliteFailureDomain updates the failure domain of the dqlite database
+// with the given state directory and returns a (boolean, error) tuple,
+// specifying whether any changes were made. If the failure domain was modified,
+// a service restart is required.
+func UpdateDqliteFailureDomain(failureDomain uint64, dbStateDir string) (bool, error) {
+	failureDomainStr := fmt.Sprintf("%v", failureDomain)
+	failureDomainFile := GetDqliteFailureDomainFile(dbStateDir)
+	fileExists, err := utils.FileExists(failureDomainFile)
+	if err != nil {
+		return false, fmt.Errorf("unable to check if file exists %s: %w", failureDomainFile, err)
+	}
+	if !fileExists {
+		var modified bool = failureDomain != 0
+		err := os.WriteFile(failureDomainFile, []byte(failureDomainStr), 0o644)
+		if err != nil {
+			return false, fmt.Errorf("failed to update failure-domain file %s: %w", failureDomainFile, err)
+		}
+		return modified, nil
+	}
+
+	existingFailureDomain, err := GetDqliteFailureDomain(dbStateDir)
+	if err != nil {
+		return false, err
+	}
+	if existingFailureDomain == failureDomain {
+		// Failure domain already set.
+		return false, nil
+	} else {
+		// Updating failure domain.
+		if err := os.WriteFile(failureDomainFile, []byte(failureDomainStr), 0o644); err != nil {
+			return false, fmt.Errorf("failed to update failure-domain file %s: %w", failureDomainFile, err)
+		}
+		return true, nil
+	}
+}

--- a/tests/integration/tests/test_node_availability_zone.py
+++ b/tests/integration/tests/test_node_availability_zone.py
@@ -1,0 +1,110 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+import hashlib
+import logging
+import struct
+from typing import List
+
+import pytest
+from test_util import harness, tags, util
+
+LOG = logging.getLogger(__name__)
+
+
+def _get_failure_domain(availability_zone: str) -> int:
+    # Generate sha256 hash, select the first 8 bytes and convert it
+    # to a little endian uint64.
+    hash_bytes = hashlib.sha256(bytes(availability_zone, "utf-8")).digest()
+    return struct.unpack("<Q", hash_bytes[:8])[0]
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.parametrize("same_az", (False, True))
+def test_node_availability_zone(
+    instances: List[harness.Instance],
+    same_az: bool,
+):
+    # Steps:
+    # * create a three-node cluster
+    # * set node availability zones
+    #   * use the same AZ if "same_az" is set, unique AZs otherwise
+    # * ensure that the right Dqlite failure domain is set based on the AZ
+    # * ensure that the cluster is still available
+    #   * k8sd and k8s-dqlite services are restarted in order for the failure
+    #     domain changes to be applied. We need to make sure that this doesn't
+    #     lead to a quorum loss.
+    initial_node = instances[0]
+    joining_cplane_node_1 = instances[1]
+    joining_cplane_node_2 = instances[2]
+
+    join_token = util.get_join_token(initial_node, joining_cplane_node_1)
+    join_token_2 = util.get_join_token(initial_node, joining_cplane_node_2)
+    assert join_token != join_token_2
+
+    util.join_cluster(joining_cplane_node_1, join_token)
+    util.join_cluster(joining_cplane_node_2, join_token_2)
+
+    util.wait_until_k8s_ready(initial_node, instances)
+    nodes = util.ready_nodes(initial_node)
+    assert len(nodes) == 3, "all nodes should have joined cluster"
+
+    def _get_az(instance, same_az, suffix):
+        if same_az:
+            return "fake-az"
+        else:
+            return instance.id
+
+    # We're concerned about the risk of quorum loss after dqlite service
+    # restarts. For this reason, we'll have multiple iterations, ensuring
+    # that the cluster remains functional.
+    iterations = 10
+    for iteration in range(iterations):
+        LOG.info("Starting iteration: %s", iteration)
+        az_suffix = f"-{iteration}"
+
+        # Apply the AZ labels.
+        for instance in instances:
+            az = _get_az(instance, same_az, az_suffix)
+            util.stubbornly(retries=5, delay_s=10).on(instance).exec(
+                [
+                    "k8s",
+                    "kubectl",
+                    "label",
+                    "nodes",
+                    instance.id,
+                    f"topology.kubernetes.io/zone={az}",
+                    "--overwrite",
+                ]
+            )
+
+        # Wait for the dqlite failure domain to be applied.
+        for instance in instances:
+            az = _get_az(instance, same_az, az_suffix)
+            failure_domain = _get_failure_domain(az)
+
+            LOG.info(
+                "Node: %s, az: %s, expected failure domain: %s",
+                instance.id,
+                az,
+                failure_domain,
+            )
+            util.stubbornly(retries=5, delay_s=10).on(instance).until(
+                lambda p: str(failure_domain) in p.stdout.decode()
+            ).exec(
+                [
+                    "cat",
+                    "/var/snap/k8s/common/var/lib/k8sd/state/database/failure-domain",
+                ]
+            )
+
+            # Check k8s-dqlite.
+            util.stubbornly(retries=5, delay_s=10).on(instance).until(
+                lambda p: str(failure_domain) in p.stdout.decode()
+            ).exec(["cat", "/var/snap/k8s/common/var/lib/k8s-dqlite/failure-domain"])
+
+        # Make sure that the nodes remain available.
+        util.stubbornly(retries=5, delay_s=10).until(
+            lambda p: util.ready_nodes(initial_node) == 3
+        )


### PR DESCRIPTION
## Description

Backports #989 and #1020 to add AZ support based on kubernetes topology labels.

## Checklist

- [ ] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
