### PR TITLE
[Backport 1.32] docs: fix md lint issues

### DIFF
--- a/docs/canonicalk8s/capi/howto/provision.md
+++ b/docs/canonicalk8s/capi/howto/provision.md
@@ -1,4 +1,4 @@
-# Provisioning a {{product}} cluster with CAPI 
+# Provisioning a {{product}} cluster with CAPI
 
 This guide covers how to deploy a {{product}} multi-node cluster
 using Cluster API (CAPI).
@@ -6,6 +6,7 @@ using Cluster API (CAPI).
 ## Prerequisites
 
 This guide assumes the following:
+
 - A CAPI management cluster initialised with the infrastructure, bootstrap and
   control plane providers of your choice. Please refer to the
   [getting-started guide] for instructions.
@@ -38,7 +39,8 @@ clusterctl generate cluster ${CLUSTER_NAME} --from ./templates/<infrastructure-p
 ```
 
 Each provisioned node is associated with a `CK8sConfig`, through which you can
-set the cluster’s properties. Available configuration fields can be listed in detail with:
+set the cluster’s properties. Available configuration fields can be listed in
+detail with:
 
 ```
 sudo k8s kubectl explain CK8sConfig.spec

--- a/docs/canonicalk8s/capi/howto/troubleshooting.md
+++ b/docs/canonicalk8s/capi/howto/troubleshooting.md
@@ -32,7 +32,8 @@ machine.cluster.x-k8s.io/my-cluster-worker-md-0-8zlzv-7vff7   my-cluster   my-cl
 
 ## Check providers status
 
-{{product}} cluster provisioning failures could happen in multiple providers used in CAPI.
+{{product}} cluster provisioning failures could happen in multiple providers
+used in CAPI.
 
 Check the {{product}} bootstrap provider logs:
 
@@ -60,7 +61,8 @@ k8s kubectl logs -n <infrastructure-provider-namespace> <infrastructure-provider
 
 ## Test the API server health
 
-Fetch the kubeconfig file for a {{product}} cluster provisioned through CAPI by running:
+Fetch the kubeconfig file for a {{product}} cluster provisioned through CAPI by
+running:
 
 ```
 clusterctl get kubeconfig ${CLUSTER_NAME} > ./${CLUSTER_NAME}-kubeconfig.yaml
@@ -132,7 +134,8 @@ Services running only on the worker nodes:
 
 * `k8s-apiserver-proxy`
 
-Make the necessary adjustments for SSH access depending on your infrastructure provider and SSH into the unhealthy node with:
+Make the necessary adjustments for SSH access depending on your infrastructure
+provider and SSH into the unhealthy node with:
 
 ```
 ssh <user>@<node>
@@ -191,8 +194,8 @@ information.
 its underlying system. This is an essential tool for bug reports and for
 investigating whether a system is (or isn’t) working.
 
-The inspection script can be executed on a specific node by running the following
-commands:
+The inspection script can be executed on a specific node by running the
+following commands:
 
 ```
 ssh -t <user>@<node> -- sudo k8s inspect /home/<user>/inspection-report.tar.gz

--- a/docs/canonicalk8s/capi/index.md
+++ b/docs/canonicalk8s/capi/index.md
@@ -16,7 +16,12 @@ explanation/index.md
 reference/index.md
 ```
 
-Cluster API (CAPI) is a Kubernetes project focused on providing declarative APIs and tooling to simplify provisioning, upgrading, and operating multiple Kubernetes clusters. The supporting infrastructure, like virtual machines, networks, load balancers, and VPCs, as well as the cluster configuration are all defined in the same way that cluster operators are already familiar with. {{product}} supports deploying and operating Kubernetes through CAPI.
+Cluster API (CAPI) is a Kubernetes project focused on providing declarative
+APIs and tooling to simplify provisioning, upgrading, and operating multiple
+Kubernetes clusters. The supporting infrastructure, like virtual machines,
+networks, load balancers, and VPCs, as well as the cluster configuration are
+all defined in the same way that cluster operators are already familiar with.
+{{product}} supports deploying and operating Kubernetes through CAPI.
 
 ![Illustration depicting working on components and clouds][logo]
 

--- a/docs/canonicalk8s/capi/tutorial/getting-started.md
+++ b/docs/canonicalk8s/capi/tutorial/getting-started.md
@@ -1,6 +1,7 @@
 # Getting started with Cluster API
 
-This guide covers how to deploy a {{product}} management cluster for Cluster API (CAPI).
+This guide covers how to deploy a {{product}} management cluster for Cluster
+API (CAPI).
 
 ## Install `clusterctl`
 
@@ -158,9 +159,12 @@ provision.
 
 ## Next steps
 
-- Learn how to provision a {{product}} cluster with CAPI: [Provision a Canonical Kubernetes cluster]
-- Learn how to upgrade the providers: [Upgrade the providers of a management cluster]
-- Learn how to install a custom {{product}} version: [Install custom Canonical Kubernetes]
+- Learn how to provision a {{product}} cluster with CAPI:
+[Provision a Canonical Kubernetes cluster]
+- Learn how to upgrade the providers:
+[Upgrade the providers of a management cluster]
+- Learn how to install a custom {{product}} version:
+[Install custom Canonical Kubernetes]
 
 <!-- Links -->
 [upstream instructions]: https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl

--- a/docs/canonicalk8s/charm/howto/troubleshooting.md
+++ b/docs/canonicalk8s/charm/howto/troubleshooting.md
@@ -207,8 +207,8 @@ information.
 its underlying system. This is an essential tool for bug reports and for
 investigating whether a system is (or isn’t) working.
 
-The inspection command can be executed on a specific unit by running the following
-commands:
+The inspection command can be executed on a specific unit by running the
+following commands:
 
 ```
 juju exec --unit <k8s/unit#> -- sudo k8s inspect /home/ubuntu/inspection-report.tar.gz

--- a/docs/canonicalk8s/charm/howto/validate.md
+++ b/docs/canonicalk8s/charm/howto/validate.md
@@ -30,8 +30,8 @@ version your cluster is set to by running:
 juju status k8s
 ```
 
-The output will be in the form of `version.number/risk`, e.g `1.31/stable`. You should set
-the `kubernetes-e2e` channel to the same value.
+The output will be in the form of `version.number/risk`, e.g `1.31/stable`. You
+should set the `kubernetes-e2e` channel to the same value.
 
 ```
 juju config kubernetes-e2e channel=1.31/stable
@@ -178,7 +178,8 @@ fill up storage.
 
 ## Upgrade the e2e tests
 
-When an update is available, the `kubernetes-e2e` charm can be upgraded with the command:
+When an update is available, the `kubernetes-e2e` charm can be upgraded with the
+command:
 
 ```bash
 juju refresh kubernetes-e2e --channel=${release}

--- a/docs/canonicalk8s/snap/explanation/channels.md
+++ b/docs/canonicalk8s/snap/explanation/channels.md
@@ -25,8 +25,8 @@ The 'risk level' component of the channel is one of the following:
 Note that for each track, not all risk levels are guaranteed to be available.
 For example, there may be a new upstream version in development which only has
 an `edge` level. For a mature release, there may no longer be any `beta` or
-`candidate`. In these cases, if you specify a risk level which has no releases for
-that track the snap system will choose the closest available release with a
+`candidate`. In these cases, if you specify a risk level which has no releases
+for that track the snap system will choose the closest available release with a
 lower risk level. Whatever risk level specified is the **maximum** risk level
 of the snap that will be installed - if you choose `candidate` you will never
 get `edge` for example.
@@ -43,10 +43,10 @@ More information can be found in the [Snapcraft documentation][]
 ## Updates and switching channels
 
 Updates for upstream patch releases will happen automatically by default. For
-example, if you have selected the channel `1.32-classic/stable`, your snap will refresh
-itself regularly keeping your cluster up-to-date with the latest patches.
-For deployments where this behaviour is undesirable you are given the option to
-postpone, schedule or even block automatic updates.
+example, if you have selected the channel `1.32-classic/stable`, your snap will
+refresh itself regularly keeping your cluster up-to-date with the latest
+patches. For deployments where this behaviour is undesirable you are given the
+option to postpone, schedule or even block automatic updates.
 The [Snap refreshes documentation] page outlines how to configure these options.
 
 To change the channel of an already installed snap, the `refresh` command can

--- a/docs/canonicalk8s/snap/explanation/epa.md
+++ b/docs/canonicalk8s/snap/explanation/epa.md
@@ -9,19 +9,19 @@ capabilities. This document provides a detailed guide of how EPA applies to
 
 -  **HugePage support**: In GA from Kubernetes v1.14, this feature enables the
    discovery, scheduling and allocation of HugePages as a first-class
-   resource.  
+   resource.
 -  **Real-time kernel**: Ensures that high-priority tasks are run within a
    predictable time frame, providing the low latency and high determinism
-   essential for time-sensitive applications.  
+   essential for time-sensitive applications.
 -  **CPU pinning** (CPU Manager for Kubernetes (CMK)): In GA from Kubernetes
    v1.26, provides mechanisms for CPU pinning and isolation of containerised
-   workloads.  
+   workloads.
 -  **NUMA topology awareness**: Ensures that CPU and memory allocation are
    aligned according to the NUMA architecture, reducing memory latency and
-   increasing performance for memory-intensive applications.  
+   increasing performance for memory-intensive applications.
 -  **Single Root I/O Virtualisation (SR-IOV)**: Enhances networking by enabling
    virtualisation of a single physical network device into multiple virtual
-   devices.  
+   devices.
 -  **DPDK (Data Plane Development Kit)**: A set of libraries and drivers for
    fast packet processing, designed to run in user space, optimising network
    performance and reducing latency.
@@ -29,10 +29,10 @@ capabilities. This document provides a detailed guide of how EPA applies to
 This document provides relevant links to detailed instructions for setting up
 and installing these technologies. It is designed for developers and architects
 who wish to integrate these new technologies into their {{product}}-based
-networking solutions. The separate [how to guide][howto-epa] for EPA includes the
-necessary steps to implement these features on {{product}}.
+networking solutions. The separate [how to guide][howto-epa] for EPA includes
+the necessary steps to implement these features on {{product}}.
 
-## HugePages 
+## HugePages
 
 HugePages are a feature in the Linux kernel which enables the allocation of
 larger memory pages. This reduces the overhead of managing large amounts of
@@ -43,21 +43,21 @@ memory access.
 
 -  **Larger memory pages**: HugePages provide larger memory pages (e.g., 2MB or
    1GB) compared to the standard 4KB pages, reducing the number of pages the
-   system must manage.  
+   system must manage.
 -  **Reduced overhead**: By using fewer, larger pages, the system reduces the
    overhead associated with page table entries, leading to improved memory
-   management efficiency.  
+   management efficiency.
 -  **Improved TLB performance**: The Translation Lookaside Buffer (TLB) stores
    recent translations of virtual memory to physical memory addresses. Using
    HugePages increases TLB hit rates, reducing the frequency of memory
-   translation lookups.  
+   translation lookups.
 -  **Enhanced application performance**: Applications that access large amounts
    of memory can benefit from HugePages by experiencing lower latency and
    higher throughput due to reduced page faults and better memory access
-   patterns.  
+   patterns.
 -  **Support for high-performance workloads**: Ideal for high-performance
    computing (HPC) applications, databases and other memory-intensive
-   workloads that demand efficient and fast memory access.  
+   workloads that demand efficient and fast memory access.
 -  **Native Kubernetes integration**: Starting from Kubernetes v1.14, HugePages
    are supported as a native, first-class resource, enabling their
    discovery, scheduling and allocation within Kubernetes environments.
@@ -70,60 +70,60 @@ are the key architectural components and their roles:
 
 -  **Node configuration**: Each Kubernetes node must be configured to reserve
    HugePages. This involves setting the number of HugePages in the node's
-   kernel boot parameters.  
+   kernel boot parameters.
 -  **Kubelet configuration**: The `kubelet` on each node must be configured to
    recognise and manage HugePages. This is typically done through the `kubelet`
-   configuration file, specifying the size and number of HugePages.  
+   configuration file, specifying the size and number of HugePages.
 -  **Pod specification**: HugePages are requested and allocated at the pod
    level through resource requests and limits in the pod specification. Pods
-   can request specific sizes of HugePages (e.g., 2MB or 1GB).  
+   can request specific sizes of HugePages (e.g., 2MB or 1GB).
 -  **Scheduler awareness**: The Kubernetes scheduler is aware of HugePages as a
    resource and schedules pods onto nodes that have sufficient HugePages
    available. This ensures that pods with HugePages requirements are placed
    appropriately. Scheduler configurations and policies can be adjusted to
-   optimise HugePages allocation and utilisation.  
+   optimise HugePages allocation and utilisation.
 -  **Node Feature Discovery (NFD)**: Node Feature Discovery can be used to
    label nodes with their HugePages capabilities. This enables scheduling
-   decisions to be based on the available HugePages resources.  
+   decisions to be based on the available HugePages resources.
 -  **Resource quotas and limits**: Kubernetes enables the definition of resource
    quotas and limits to control the allocation of HugePages across namespaces.
-   This helps in managing and isolating resource usage effectively.  
+   This helps in managing and isolating resource usage effectively.
 -  **Monitoring and metrics**: Kubernetes provides tools and integrations
    (e.g., Prometheus, Grafana) to monitor and visualise HugePages usage across
    the cluster. This helps in tracking resource utilisation and performance.
    Metrics can include HugePages allocation, usage and availability on each
    node, aiding in capacity planning and optimisation.
 
-## Real-time kernel 
+## Real-time kernel
 
 A real-time kernel ensures that high-priority tasks are run within a
 predictable time frame, crucial for applications requiring low latency and high
 determinism. Note that this can also impede applications which were not
-designed with these considerations. 
+designed with these considerations.
 
 ### Key features
 
 -  **Predictable task execution**: A real-time kernel ensures that
    high-priority tasks are run within a predictable and bounded time frame,
-   reducing the variability in task execution time.  
+   reducing the variability in task execution time.
 -  **Low latency**: The kernel is optimised to minimise the time it takes to
    respond to high-priority tasks, which is crucial for applications that
-   require immediate processing.  
+   require immediate processing.
 -  **Priority-based scheduling**: Tasks are scheduled based on their priority
    levels, with real-time tasks being given precedence over other types of
-   tasks to ensure they are processed promptly.  
+   tasks to ensure they are processed promptly.
 -  **Deterministic behaviour**: The kernel guarantees deterministic behaviour,
    meaning the same task will have the same response time every time it is
-   run, essential for time-sensitive applications.  
+   run, essential for time-sensitive applications.
 -  **Preemption:** The real-time kernel supports preemptive multitasking,
    allowing high-priority tasks to interrupt lower-priority tasks to ensure
-   critical tasks are run without delay.  
+   critical tasks are run without delay.
 -  **Resource reservation**: System resources (such as CPU and memory) can be
    reserved by the kernel for real-time tasks, ensuring that these resources
-   are available when needed.  
+   are available when needed.
 -  **Enhanced interrupt handling**: Interrupt handling is optimised to ensure
    minimal latency and jitter, which is critical for maintaining the
-   performance of real-time applications.  
+   performance of real-time applications.
 -  **Real-time scheduling policies**: The kernel includes specific scheduling
    policies (e.g., SCHED\_FIFO, SCHED\_RR) designed to manage real-time tasks
    effectively and ensure they meet their deadlines.
@@ -140,67 +140,67 @@ key architectural components and their roles:
 
 -  **Real-time kernel installation**: Each Kubernetes node must run a real-time
    kernel. This involves installing a real-time kernel package and configuring
-   the system to use it.  
+   the system to use it.
 -  **Kernel boot parameters**: The kernel boot parameters must be configured to
    optimise for real-time performance. This includes isolating CPU cores and
-   configuring other kernel parameters for real-time behaviour.  
+   configuring other kernel parameters for real-time behaviour.
 -  **Kubelet configuration**: The `kubelet` on each node must be configured to
    recognise and manage real-time workloads. This can involve setting specific
-   `kubelet` flags and configurations.  
+   `kubelet` flags and configurations.
 -  **Pod specification**: Real-time workloads are specified at the pod level
    through resource requests and limits. Pods can request dedicated CPU cores
-   and other resources to ensure they meet real-time requirements.  
+   and other resources to ensure they meet real-time requirements.
 -  **CPU Manager**: Kubernetes’ CPU Manager is a critical component for
    real-time workloads. It enables the static allocation of CPUs to
    containers, ensuring that specific CPU cores are dedicated to particular
-   workloads.  
+   workloads.
 -  **Scheduler awareness**: The Kubernetes scheduler must be aware of real-time
    requirements and prioritise scheduling pods onto nodes with available
-   real-time resources.  
+   real-time resources.
 -  **Priority and preemption**: Kubernetes supports priority and preemption to
    ensure that critical real-time pods are scheduled and run as needed. This
    involves defining pod priorities and enabling preemption to ensure
-   high-priority pods can displace lower-priority ones if necessary.  
+   high-priority pods can displace lower-priority ones if necessary.
 -  **Resource quotas and limits**: Kubernetes can define resource quotas
    and limits to control the allocation of resources for real-time workloads
    across namespaces. This helps manage and isolate resource usage effectively.
 -  **Monitoring and metrics**: Monitoring tools such as Prometheus and Grafana
    can be used to track the performance and resource utilisation of real-time
    workloads. Metrics include CPU usage, latency and task scheduling times,
-   which help in optimising and troubleshooting real-time applications.  
+   which help in optimising and troubleshooting real-time applications.
 -  **Security and isolation**: Security contexts and isolation mechanisms
    ensure that real-time workloads are protected and run in a controlled
    environment. This includes setting privileged containers and configuring
    namespaces.
 
-## CPU pinning 
+## CPU pinning
 
 CPU pinning enables specific CPU cores to be dedicated to a particular process
 or container, ensuring that the process runs on the same CPU core(s) every
 time, which reduces context switching and cache invalidation.
 
-### Key features 
+### Key features
 
 -  **Dedicated CPU Cores**: CPU pinning allocates specific CPU cores to a
-   process or container, ensuring consistent and predictable CPU usage.  
+   process or container, ensuring consistent and predictable CPU usage.
 -  **Reduced context switching**: By running a process or container on the same
    CPU core(s), CPU pinning minimises the overhead associated with context
-   switching, leading to better performance.  
+   switching, leading to better performance.
 -  **Improved cache utilisation**: When a process runs on a dedicated CPU core,
    it can take full advantage of the CPU cache, reducing the need to fetch data
-   from main memory and improving overall performance.  
+   from main memory and improving overall performance.
 -  **Enhanced application performance**: Applications that require low latency
    and high performance benefit from CPU pinning as it ensures they have
-   dedicated processing power without interference from other processes.  
+   dedicated processing power without interference from other processes.
 -  **Consistent performance**: CPU pinning ensures that a process or container
    receives consistent CPU performance, which is crucial for real-time and
-   performance-sensitive applications.  
+   performance-sensitive applications.
 -  **Isolation of workloads**: CPU pinning isolates workloads on specific CPU
    cores, preventing them from being affected by other workloads running on
-   different cores. This is especially useful in multi-tenant environments.  
+   different cores. This is especially useful in multi-tenant environments.
 -  **Improved predictability**: By eliminating the variability introduced by
    sharing CPU cores, CPU pinning provides more predictable performance
-   characteristics for critical applications.  
+   characteristics for critical applications.
 -  **Integration with Kubernetes**: Kubernetes supports CPU pinning through the
    CPU Manager (in GA since v1.26), which allows for the static allocation of
    CPUs to containers. This ensures that containers with high CPU demands have
@@ -215,47 +215,47 @@ are the key architectural components and their roles:
 
 -  **Kubelet configuration**: The `kubelet` on each node must be configured to
    enable CPU pinning. This involves setting specific `kubelet` flags to
-   activate the CPU Manager.  
+   activate the CPU Manager.
 -  **CPU manager**: Kubernetes’ CPU Manager is a critical component for CPU
    pinning. It allows for the static allocation of CPUs to containers, ensuring
    that specific CPU cores are dedicated to particular workloads. The CPU
    Manager can be configured to either static or none. Static policy enables
-   exclusive CPU core allocation to Guaranteed QoS (Quality of Service) pods.  
+   exclusive CPU core allocation to Guaranteed QoS (Quality of Service) pods.
 -  **Pod specification**: Pods must be specified to request dedicated CPU
    resources. This is done through resource requests and limits in the pod
-   specification.  
+   specification.
 -  **Scheduler awareness**: The Kubernetes scheduler must be aware of the CPU
    pinning requirements. It schedules pods onto nodes with available CPU
    resources as requested by the pod specification. The scheduler ensures that
    pods with specific CPU pinning requests are placed on nodes with sufficient
-   free dedicated CPUs.  
+   free dedicated CPUs.
 -  **NUMA Topology Awareness**: For optimal performance, CPU pinning should be
    aligned with NUMA (Non-Uniform Memory Access) topology. This ensures that
    memory accesses are local to the CPU, reducing latency. Kubernetes can be
    configured to be NUMA-aware, using the Topology Manager to align CPU
-   and memory allocation with NUMA nodes.  
+   and memory allocation with NUMA nodes.
 -  **Node Feature Discovery (NFD)**: Node Feature Discovery can be used to
    label nodes with their CPU capabilities, including the availability of
-   isolated and reserved CPU cores.  
+   isolated and reserved CPU cores.
 -  **Resource quotas and limits**: Kubernetes can define resource quotas
    and limits to control the allocation of CPU resources across namespaces.
-   This helps in managing and isolating resource usage effectively.  
+   This helps in managing and isolating resource usage effectively.
 -  **Monitoring and metrics**: Monitoring tools such as Prometheus and Grafana
    can be used to track the performance and resource utilisation of CPU-pinned
    workloads. Metrics include CPU usage, core allocation and task scheduling
    times, which help in optimising and troubleshooting performance-sensitive
-   applications.  
+   applications.
 -  **Isolation and security**: Security contexts and isolation mechanisms
    ensure that CPU-pinned workloads are protected and run in a controlled
    environment. This includes setting privileged containers and configuring
-   namespaces to avoid resource contention.  
+   namespaces to avoid resource contention.
 -  **Performance Tuning**: Additional performance tuning can be achieved by
    isolating CPU cores at the OS level and configuring kernel parameters to
    minimise interference from other processes. This includes setting CPU
    isolation and `nohz_full` parameters (reduces the number of scheduling-clock
    interrupts, improving energy efficiency and [reducing OS jitter][no_hz]).
 
-## NUMA topology awareness 
+## NUMA topology awareness
 
 NUMA (Non-Uniform Memory Access) topology awareness ensures that the CPU and
 memory allocation are aligned according to the NUMA architecture, which can
@@ -278,37 +278,37 @@ allocated from a minimum number of NUMA nodes.
 
 -  **Aligned CPU and memory allocation**: NUMA topology awareness ensures that
    CPUs and memory are allocated in alignment with the NUMA architecture,
-   minimising cross-node memory access latency.  
+   minimising cross-node memory access latency.
 -  **Reduced memory latency**: By ensuring that memory is accessed from the
    same NUMA node as the CPU, NUMA topology awareness reduces memory latency,
-   leading to improved performance for memory-intensive applications.  
+   leading to improved performance for memory-intensive applications.
 -  **Increased performance**: Applications benefit from increased performance
    due to optimised memory access patterns, which is especially critical for
-   high-performance computing and data-intensive tasks.  
+   high-performance computing and data-intensive tasks.
 -  **Kubernetes Memory Manager**: The Kubernetes Memory Manager supports
    guaranteed memory allocation for pods in the Guaranteed QoS (Quality of
-   Service) class, ensuring predictable performance.  
+   Service) class, ensuring predictable performance.
 -  **Hint generation protocol**: The Memory Manager uses a hint generation
    protocol to determine the most suitable NUMA affinity for a pod, helping to
-   optimise resource allocation based on NUMA topology.  
+   optimise resource allocation based on NUMA topology.
 -  **Integration with Topology Manager**: The Memory Manager provides NUMA
    affinity hints to the Topology Manager. The Topology Manager then decides
    whether to admit or reject the pod based on these hints and the configured
-   policy.  
+   policy.
 -  **Optimised resource allocation**: The Memory Manager ensures that the
    memory requested by a pod is allocated from the minimum number of NUMA
-   nodes, thereby optimising resource usage and performance.  
+   nodes, thereby optimising resource usage and performance.
 -  **Enhanced scheduling decisions**: The Kubernetes scheduler, in conjunction
    with the Topology Manager, makes informed decisions about pod placement to
-   ensure optimal NUMA alignment, improving overall cluster efficiency.  
+   ensure optimal NUMA alignment, improving overall cluster efficiency.
 -  **Support for HugePages**: The Memory Manager also supports the allocation
    of HugePages, ensuring that large memory pages are allocated in a NUMA-aware
    manner, further enhancing performance for applications that require large
-   memory pages.  
+   memory pages.
 -  **Improved application predictability**: By aligning CPU and memory
    allocation with NUMA topology, applications experience more predictable
    performance characteristics, crucial for real-time and latency-sensitive
-   workloads.  
+   workloads.
 -  **Policy-Based Management**: NUMA topology awareness can be managed through
    policies so that administrators can configure how resources should be
    allocated based on the NUMA architecture, providing flexibility and control.
@@ -323,40 +323,40 @@ architectural components and their roles:
 
 -  **Node configuration**: Each Kubernetes node must have NUMA-aware hardware.
    The system's NUMA topology can be inspected using tools such as `lscpu` or
-   `numactl`.  
+   `numactl`.
 -  **Kubelet configuration**: The `kubelet` on each node must be configured to
    enable NUMA topology awareness. This involves setting specific `kubelet`
-   flags to activate the Topology Manager.  
+   flags to activate the Topology Manager.
 -  **Topology Manager**: The Topology Manager is a critical component that
    coordinates resource allocation based on NUMA topology. It receives NUMA
    affinity hints from other managers (e.g., CPU Manager, Device Manager) and
-   makes informed scheduling decisions.  
+   makes informed scheduling decisions.
 -  **Memory Manager**: The Kubernetes Memory Manager is responsible for
    managing memory allocation, including HugePages, in a NUMA-aware manner. It
    ensures that memory is allocated from the minimum number of NUMA nodes
    required. The Memory Manager uses a hint generation protocol to provide NUMA
-   affinity hints to the Topology Manager.  
+   affinity hints to the Topology Manager.
 -  **Pod specification**: Pods can be specified to request NUMA-aware resource
    allocation through resource requests and limits, ensuring that they get
-   allocated in alignment with the NUMA topology.  
+   allocated in alignment with the NUMA topology.
 -  **Scheduler awareness**: The Kubernetes scheduler works in conjunction with
    the Topology Manager to place pods on nodes that meet their NUMA affinity
    requirements. The scheduler considers NUMA topology during the scheduling
-   process to optimise performance.  
+   process to optimise performance.
 -  **Node Feature Discovery (NFD)**: Node Feature Discovery can be used to
    label nodes with their NUMA capabilities, providing the scheduler with
-   information to make more informed placement decisions.  
+   information to make more informed placement decisions.
 -  **Resource quotas and limits**: Kubernetes allows defining resource quotas
    and limits to control the allocation of NUMA-aware resources across
    namespaces. This helps in managing and isolating resource usage effectively.
 -  **Monitoring and metrics**: Monitoring tools such as Prometheus and Grafana
    can be used to track the performance and resource utilisation of NUMA-aware
    workloads. Metrics include CPU and memory usage per NUMA node, helping in
-   optimising and troubleshooting performance-sensitive applications.  
+   optimising and troubleshooting performance-sensitive applications.
 -  **Isolation and security**: Security contexts and isolation mechanisms
    ensure that NUMA-aware workloads are protected and run in a controlled
    environment. This includes setting privileged containers and configuring
-   namespaces to avoid resource contention.  
+   namespaces to avoid resource contention.
 -  **Performance tuning**: Additional performance tuning can be achieved by
    configuring kernel parameters and using tools like `numactl` to bind
    processes to specific NUMA nodes.
@@ -372,32 +372,32 @@ require direct access to the network hardware.
 -  **Multiple Virtual Functions (VFs)**: SR-IOV enables a single physical
    network device to be partitioned into multiple virtual functions (VFs), each
    of which can be assigned to a virtual machine or container as a separate
-   network interface.  
+   network interface.
 -  **Direct hardware access**: By providing direct access to the physical
    network device, SR-IOV bypasses the software-based network stack, reducing
-   overhead and improving network performance and latency.  
+   overhead and improving network performance and latency.
 -  **Improved network throughput**: Applications can achieve higher network
    throughput as SR-IOV enables high-speed data transfer directly
-   between the network device and the application.  
+   between the network device and the application.
 -  **Reduced CPU utilisation**: Offloading network processing to the hardware
    reduces the CPU load on the host system, freeing up CPU resources for other
-   tasks and improving overall system performance.  
+   tasks and improving overall system performance.
 -  **Isolation and security**: Each virtual function (VF) is isolated from
    others, providing security and stability. This isolation ensures that issues
-   in one VF do not affect other VFs or the physical function (PF).  
+   in one VF do not affect other VFs or the physical function (PF).
 -  **Dynamic resource allocation**: SR-IOV supports dynamic allocation of
    virtual functions, enabling resources to be adjusted based on application
-   demands without requiring changes to the physical hardware setup.  
+   demands without requiring changes to the physical hardware setup.
 -  **Enhanced virtualisation support**: SR-IOV is particularly beneficial in
    virtualised environments, enabling better network performance for virtual
    machines and containers by providing them with dedicated network interfaces.
 -  **Kubernetes integration**: Kubernetes supports SR-IOV through the use of
    network device plugins, enabling the automatic discovery, allocation,
-   and management of virtual functions.  
+   and management of virtual functions.
 -  **Compatibility with Network Functions Virtualisation (NFV)**: SR-IOV is
    widely used in NFV deployments to meet the high-performance networking
    requirements of virtual network functions (VNFs), such as firewalls,
-   routers and load balancers.  
+   routers and load balancers.
 -  **Reduced network latency**: As network packets can bypass the
    hypervisor's virtual switch, SR-IOV significantly reduces network latency,
    making it ideal for latency-sensitive applications.
@@ -413,24 +413,24 @@ Here are the key architectural components and their roles:
 
 -  **Node configuration**: Each Kubernetes node with SR-IOV capable hardware
    must have the SR-IOV drivers and tools installed. This includes the SR-IOV
-   network device plugin and associated drivers.  
+   network device plugin and associated drivers.
 -  **SR-IOV enabled network interface**: The physical network interface card
    (NIC) must be configured to support SR-IOV. This involves enabling SR-IOV in
-   the system BIOS and configuring the NIC to create virtual functions (VFs).  
+   the system BIOS and configuring the NIC to create virtual functions (VFs).
 -  **SR-IOV network device plugin**: The SR-IOV network device plugin is
    deployed as a DaemonSet in Kubernetes. It discovers SR-IOV capable network
-   interfaces and manages the allocation of virtual functions (VFs) to pods.  
+   interfaces and manages the allocation of virtual functions (VFs) to pods.
 -  **Device Plugin Configuration**: The SR-IOV device plugin requires a
    configuration file that specifies the network devices and the number of
-   virtual functions (VFs) to be managed.  
+   virtual functions (VFs) to be managed.
 -  **Pod specification**: Pods can request SR-IOV virtual functions by
    specifying resource requests and limits in the pod specification. The SR-IOV
-   device plugin allocates the requested VFs to the pod.  
+   device plugin allocates the requested VFs to the pod.
 -  **Scheduler awareness**: The Kubernetes scheduler must be aware of the
    SR-IOV resources available on each node. The device plugin advertises the
    available VFs as extended resources, which the scheduler uses to place pods
    accordingly. Scheduler configuration ensures pods with SR-IOV requests are
-   scheduled on nodes with available VFs.  
+   scheduled on nodes with available VFs.
 -  **Resource quotas and limits**: Kubernetes enables the definition of
    resource quotas and limits to control the allocation of SR-IOV resources
    across namespaces. This helps manage and isolate resource usage effectively.
@@ -438,17 +438,17 @@ Here are the key architectural components and their roles:
    can be used to track the performance and resource utilisation of
    SR-IOV-enabled workloads. Metrics include VF allocation, network throughput,
    and latency, helping optimise and troubleshoot performance-sensitive
-   applications.  
+   applications.
 -  **Isolation and security**: SR-IOV provides isolation between VFs, ensuring
    that each VF operates independently and securely. This isolation is critical
    for multi-tenant environments where different workloads share the same
-   physical network device.  
+   physical network device.
 -  **Dynamic resource allocation**: SR-IOV supports dynamic allocation and
    deallocation of VFs, enabling Kubernetes to adjust resources based on
    application demands without requiring changes to the physical hardware
    setup.
 
-## DPDK (Data Plane Development Kit) 
+## DPDK (Data Plane Development Kit)
 
 The Data Plane Development Kit (DPDK) is a set of libraries and drivers for
 fast packet processing. It is designed to run in user space, so that
@@ -461,10 +461,10 @@ virtualisation (NFV).
 ### Key features
 
 -  **High performance**: DPDK can process millions of packets per second per
-   core, using multi-core CPUs to scale performance.  
+   core, using multi-core CPUs to scale performance.
 -  **User-space processing**: By running in user space, DPDK avoids the
    overhead of kernel context switches and uses HugePages for better
-   memory performance.  
+   memory performance.
 -  **Poll Mode Drivers (PMD)**: DPDK uses PMDs that poll for packets instead of
    relying on interrupts, which reduces latency.
 
@@ -473,7 +473,7 @@ virtualisation (NFV).
 The main goal of the DPDK is to provide a simple, complete framework for fast
 packet processing in data plane applications. Anyone can use the code to
 understand some of the techniques employed, to build upon for prototyping or to
-add their own protocol stacks. 
+add their own protocol stacks.
 
 The framework creates a set of libraries for specific environments through the
 creation of an Environment Abstraction Layer (EAL), which may be specific to a
@@ -497,7 +497,7 @@ by passing packets or messages between cores via the rings. This enables work
 to be performed in stages and is a potentially more efficient use of code on
 cores. This is suitable for scenarios where each pipeline must be mapped to a
 specific application thread or when multiple pipelines must be mapped to the
-same thread. 
+same thread.
 
 ### Application to Kubernetes
 
@@ -510,31 +510,31 @@ components and their roles:
 
 -  **Node configuration**: Each Kubernetes node must have the DPDK libraries
    and drivers installed. This includes setting up HugePages and binding
-   network interfaces to DPDK-compatible drivers.  
+   network interfaces to DPDK-compatible drivers.
 -  **HugePages configuration**: DPDK requires HugePages for efficient memory
-   management. Configure the system to reserve HugePages.  
+   management. Configure the system to reserve HugePages.
 -  **Network interface binding**: Network interfaces must be bound to
-   DPDK-compatible drivers (e.g., vfio-pci) to be used by DPDK applications.  
+   DPDK-compatible drivers (e.g., vfio-pci) to be used by DPDK applications.
 -  **DPDK application container**: Create a Docker container image with the
    DPDK application and necessary libraries. Ensure that the container runs
-   with appropriate privileges and mounts HugePages.  
+   with appropriate privileges and mounts HugePages.
 -  **Pod specification**: Deploy the DPDK application in Kubernetes by
    specifying the necessary resources, including CPU pinning and HugePages, in
-   the pod specification.  
+   the pod specification.
 -  **CPU pinning**: For optimal performance, DPDK applications should use
-   dedicated CPU cores. Configure CPU pinning in the pod specification.  
+   dedicated CPU cores. Configure CPU pinning in the pod specification.
 -  **SR-IOV for network interfaces**: Combine DPDK with SR-IOV to provide
    high-performance network interfaces. Allocate SR-IOV virtual functions (VFs)
-   to DPDK pods.  
+   to DPDK pods.
 -  **Scheduler awareness**: The Kubernetes scheduler must be aware of the
    resources required by DPDK applications, including HugePages and CPU
-   pinning, to place pods appropriately on nodes with sufficient resources.  
+   pinning, to place pods appropriately on nodes with sufficient resources.
 -  **Monitoring and metrics**: Use monitoring tools like Prometheus and Grafana
    to track the performance of DPDK applications, including network throughput,
-   latency and CPU usage.  
+   latency and CPU usage.
 -  **Resource quotas and limits**: Define resource quotas and limits to control
    the allocation of resources for DPDK applications across namespaces,
-   ensuring fair resource distribution and preventing resource contention.  
+   ensuring fair resource distribution and preventing resource contention.
 -  **Isolation and security**: Ensure that DPDK applications run in isolated
    and secure environments. Use security contexts to provide the necessary
    privileges while maintaining security best practices.
@@ -544,4 +544,3 @@ components and their roles:
 
 [no_hz]: https://www.kernel.org/doc/Documentation/timers/NO_HZ.txt
 [howto-epa]: ../howto/epa
-

--- a/docs/canonicalk8s/snap/explanation/package-management.md
+++ b/docs/canonicalk8s/snap/explanation/package-management.md
@@ -10,15 +10,15 @@ Please check out the upstream documentation for [installing Helm CLI][].
 
 ## Charts
 
-[Charts][] are the packaging format used by Helm. A chart is a collection of 
-Kubernetes resource manifests related to an application or to a group of 
-applications that can be packaged into versioned archives. 
-Charts utilize templating and template variables called "values" to enable 
+[Charts][] are the packaging format used by Helm. A chart is a collection of
+Kubernetes resource manifests related to an application or to a group of
+applications that can be packaged into versioned archives.
+Charts utilize templating and template variables called "values" to enable
 customization of the resources.
 
 ## Chart repository
 
-The [Chart repository][] is a web server that usually consists of an index and 
+The [Chart repository][] is a web server that usually consists of an index and
 packaged charts. Repositories are the preferred way of distributing charts.
 
 A Helm repository can be added to the local client with:
@@ -26,6 +26,7 @@ A Helm repository can be added to the local client with:
 ```
 helm repo add <repository-name> <repository-url>
 ```
+
 This command fetches the index from the repository and
 stores it in a cache directory.
 This index is used when doing an installation or performing an upgrade.

--- a/docs/canonicalk8s/snap/explanation/upgrade.md
+++ b/docs/canonicalk8s/snap/explanation/upgrade.md
@@ -32,10 +32,10 @@ with a skew of up to three versions is acceptable.
 
 ## Upgrade approach
 
-It is important to upgrade your cluster with the same method that you used to install
-the cluster. If you have deployed {{product}} using Juju, you should upgrade your cluster
-using Juju controller commands. Similarly, with snap and CAPI deployments,
-the original install method should be used.
+It is important to upgrade your cluster with the same method that you used to
+install the cluster. If you have deployed {{product}} using Juju, you should
+upgrade your cluster using Juju controller commands. Similarly, with snap and
+CAPI deployments, the original install method should be used.
 
 
 ## Snap upgrades

--- a/docs/canonicalk8s/snap/howto/install/snap.md
+++ b/docs/canonicalk8s/snap/howto/install/snap.md
@@ -12,8 +12,8 @@ This guide assumes the following:
 - You have root or sudo access to the machine
 - You have an internet connection
 - The target machine has sufficient memory and disk space. To accommodate
-  workloads, we recommend a system with ***at least*** 20G of disk space and 4G of
-  memory.
+  workloads, we recommend a system with ***at least*** 20G of disk space and 4G
+  of memory.
 
 ```{note}
 If you cannot meet these requirements, please see the [Installing][] page for
@@ -59,7 +59,8 @@ step is to `bootstrap` the cluster to activate the services:
 sudo k8s bootstrap
 ```
 
-This command will output a message confirming local cluster services have been started.
+This command will output a message confirming local cluster services have been
+started.
 
 ```{note}
 Additional configuration is possible by passing a YAML file. The various options are described

--- a/docs/canonicalk8s/snap/howto/security/index.md
+++ b/docs/canonicalk8s/snap/howto/security/index.md
@@ -5,8 +5,8 @@
 Hardening <self>
 ```
 
-Administrators are provided with detailed instructions and compliance guidance to
-harden their clusters in accordance with DISA STIG and CIS recommendations.
+Administrators are provided with detailed instructions and compliance guidance
+to harden their clusters in accordance with DISA STIG and CIS recommendations.
 
 ```{toctree}
 :glob:

--- a/docs/moonray/doc-cheat-sheet-myst.md
+++ b/docs/moonray/doc-cheat-sheet-myst.md
@@ -12,6 +12,7 @@ myst:
 <!-- vale off -->
 
 (cheat-sheet-myst)=
+
 # Markdown/MyST cheat sheet
 
 <!-- vale on -->
@@ -19,9 +20,15 @@ myst:
 This file contains the syntax for commonly used Markdown and MyST markup.
 Open it in your text editor to quickly copy and paste the markup you need.
 
-See the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) for detailed information and conventions.
+See the
+[MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/)
+for detailed information and conventions.
 
-Also see the [MyST documentation](https://myst-parser.readthedocs.io/en/latest/index.html) for detailed information on MyST, and the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en) for general style conventions.
+Also see the
+[MyST documentation](https://myst-parser.readthedocs.io/en/latest/index.html)
+for detailed information on MyST, and the
+[Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en) for
+general style conventions.
 
 ## H2 heading
 
@@ -60,6 +67,7 @@ code:
 ```
 
 (a_section_target_myst)=
+
 ## Links
 
 - [Canonical website](https://canonical.com/)
@@ -178,7 +186,8 @@ This might damage your hardware!
 
 ### Keys
 
-Keys can be defined at the top of a file, or in a `myst_substitutions` option in `conf.py`.
+Keys can be defined at the top of a file, or in a `myst_substitutions` option in
+`conf.py`.
 
 {{reuse_key}}
 
@@ -228,7 +237,8 @@ Related links at the top of the page (surrounded by `---`):
     relatedlinks: https://github.com/canonical/lxd-sphinx-extensions, [RTFM](https://www.google.com)
     discourse: 12345
 
-Terms that should not be checked by the spelling checker: {spellexception}`PurposelyWrong`
+Terms that should not be checked by the spelling checker:
+{spellexception}`PurposelyWrong`
 
 A single-line terminal view that separates input from output:
 


### PR DESCRIPTION
## Description

When we changed the way in which the markdown lint action picks up changed files, the linter picked up more issues on already merged docs. We solved this issue on a few PRs, mainly #1215. This was not back ported to 1.32 however. I could not cherry pick this commit as there is changes that we don't want to backport so I am creating a new one.

## Solution

Create a PR to solve the markdown lint issues so other docs backports will not fail on existing docs. 

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
