### PR TITLE
test: Do not expect k8sd to be active after node removal

### DIFF
--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -78,12 +78,17 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 2, "cp node should have been removed from the cluster"
     # We cannot determine the node type of the removed node, so we need to set it explicitly here.
-    util.check_snap_services_ready(joining_cp, node_type="control-plane")
+    # NOTE: We're not expecting the k8sd service to be active after the node was removed.
+    # microcluster removes the k8sd state folder, and without the "daemon.yaml" file in it,
+    # k8sd fails to start.
+    util.check_snap_services_ready(
+        joining_cp, node_type="control-plane", skip_services=["k8sd"]
+    )
 
     cluster_node.exec(["k8s", "remove-node", worker.id])
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 1, "worker node should have been removed from the cluster"
-    util.check_snap_services_ready(worker, node_type="worker")
+    util.check_snap_services_ready(worker, node_type="worker", skip_services=["k8sd"])
 
 
 @pytest.mark.node_count(2)


### PR DESCRIPTION


## Description

When a node is removed from a cluster, microcluster removes the k8sd state folder, which includes the `daemon.yaml` file required for the service to start. Because of this, the service is in a constant loop of starting and crashing. We cannot expect the service to be running in this case.

## Solution

Skip checking if k8sd is active for the `test_skip_services_stop_on_remove` test.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 
