### PR TITLE
test: Avoid decoding strings

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -77,9 +77,16 @@ class Retriable:
         try:
             resp = self._run(command_args, **command_kwds)
         except subprocess.CalledProcessError as e:
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+            if not command_kwds.get("text"):
+                # The output will be in bytes if text is not set / is False.
+                stdout = e.stdout.decode() if e.stdout else ""
+                stderr = e.stderr.decode() if e.stderr else ""
+
             LOG.warning(f"  rc={e.returncode}")
-            LOG.warning(f"  stdout={e.stdout.decode()}")
-            LOG.warning(f"  stderr={e.stderr.decode()}")
+            LOG.warning(f"  stdout={stdout}")
+            LOG.warning(f"  stderr={stderr}")
             raise
         if self._condition:
             assert self._condition(resp), "Failed to meet condition"


### PR DESCRIPTION
## Description

Currently, we're assuming that a process' ``stdout`` and ``stderr`` are bytes, but that's not always the case. First of all, if the output is not captured, they are None, and if ``text=True``, then the output will be strings.

## Solution

Decode only if the output is in bytes.

## Issue

## Backport


## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 

