### PR TITLE
[Backport 1.32] fix: Disable markdown lint

### DIFF
--- a/docs/canonicalk8s/.sphinx/.markdownlint.json
+++ b/docs/canonicalk8s/.sphinx/.markdownlint.json
@@ -1,16 +1,3 @@
 {
-    "default": false,
-    "MD003": { "style": "atx" },
-    "MD013": { "code_blocks": false, "tables": false, "stern": true, "line_length": 80},
-    "MD014": true,
-    "MD018": true,
-    "MD022": true,
-    "MD023": true,
-    "MD026": { "punctuation": ".,;。，；"},
-    "MD031": { "list_items": false},
-    "MD032": true,
-    "MD035": true,
-    "MD042": true,
-    "MD045": true,
-    "MD052": true
+    "default": false
 }

--- a/docs/moonray/doc-cheat-sheet-myst.md
+++ b/docs/moonray/doc-cheat-sheet-myst.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable -->
 ---
 orphan: true
 myst:
@@ -260,4 +259,3 @@ A link to a YouTube video:
 ```{youtube} https://www.youtube.com/watch?v=iMLiK1fX4I0
    :title: Demo
 ```
-<!-- markdownlint-restore -->

--- a/docs/moonray/doc-cheat-sheet-myst.md
+++ b/docs/moonray/doc-cheat-sheet-myst.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ---
 orphan: true
 myst:
@@ -259,3 +260,4 @@ A link to a YouTube video:
 ```{youtube} https://www.youtube.com/watch?v=iMLiK1fX4I0
    :title: Demo
 ```
+<!-- markdownlint-restore -->


### PR DESCRIPTION
Backport https://github.com/canonical/k8s-snap/pull/1296/commits/d249120a720f2ea3d66fcb1a7c3cbfba9a522512 and https://github.com/canonical/k8s-snap/pull/1296/commits/e4e628275414c513c6317e99f57d446d08d31885 to `release-1.32`