### PR TITLE
test: Run test upgrades without needing a local snap

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -80,6 +80,13 @@ def _generate_inspection_report(h: harness.Harness, instance_id: str):
         LOG.warning("Failed to pull inspection report: %s", e)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def validate_test_config():
+    """Validate the configuration before running tests."""
+    if config.SNAP:
+        assert Path(config.SNAP).exists(), f"Snap path {config.SNAP} does not exist."
+
+
 @pytest.fixture(scope="session")
 def h() -> harness.Harness:
     LOG.debug("Create harness for %s", config.SUBSTRATE)

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -234,7 +234,10 @@ def setup_k8s_snap(
     which_snap = snap or config.SNAP
 
     if not which_snap:
-        pytest.fail("Set TEST_SNAP to the channel, revision, or path to the snap")
+        pytest.fail(
+            "Cannot install without either a channel, revision, or path to the snap "
+            + f"argument {snap=} and {config.SNAP=}"
+        )
 
     if isinstance(which_snap, str) and which_snap.startswith("/"):
         LOG.info("Install k8s snap by path")

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -48,7 +48,7 @@ def test_version_upgrades(
         )
         current_channel = channels[0]
 
-    if config.SNAP is not None:
+    if config.SNAP:
         # Copy the current snap into the instances.
         snap_path = (tmp_path / "k8s.snap").as_posix()
         for instance in instances:

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -284,7 +284,8 @@ def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
     after the last node is upgraded.
     The test will also verify that the feature version is not upgraded until all nodes are upgraded.
     """
-    assert config.SNAP is not None, "SNAP must be set to run this test"
+    if not config.SNAP:
+        pytest.skip("Feature upgrades currently require a local snap file")
 
     start_branch = util.previous_track(config.SNAP)
     main = instances[0]

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -285,6 +285,7 @@ def test_feature_upgrades(instances: List[harness.Instance], tmp_path: Path):
     The test will also verify that the feature version is not upgraded until all nodes are upgraded.
     """
     if not config.SNAP:
+        # TODO(Adam): use TEST_VERSION_UPGRADE_CHANNELS if not set
         pytest.skip("Feature upgrades currently require a local snap file")
 
     start_branch = util.previous_track(config.SNAP)

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -48,30 +48,31 @@ def test_version_upgrades(
         )
         current_channel = channels[0]
 
-    # Copy the current snap into the instances.
-    snap_path = (tmp_path / "k8s.snap").as_posix()
-    for instance in instances:
-        instance.send_file(config.SNAP, snap_path)
+    if config.SNAP is not None:
+        # Copy the current snap into the instances.
+        snap_path = (tmp_path / "k8s.snap").as_posix()
+        for instance in instances:
+            instance.send_file(config.SNAP, snap_path)
 
-    # Figure out where to add the current snap into the channels array.
-    # Upgrades should be in order.
-    out = cp.exec(["snap", "info", snap_path], capture_output=True)
-    info = yaml.safe_load(out.stdout)
+        # Figure out where to add the current snap into the channels array.
+        # Upgrades should be in order.
+        out = cp.exec(["snap", "info", snap_path], capture_output=True)
+        info = yaml.safe_load(out.stdout)
 
-    # expected: "v1.32.2 classic"
-    ver = info["version"].lstrip("v").split()[0].split(".")
-    added = False
-    for i in range(len(channels)):
-        # e.g.: 1.32-classic/stable
-        chan_ver = channels[i].split("-")[0].split(".")
-        if len(chan_ver) > 1 and (ver[0], ver[1]) < (chan_ver[0], chan_ver[1]):
-            channels.insert(i, snap_path)
-            added = True
-            break
+        # expected: "v1.32.2 classic"
+        ver = info["version"].lstrip("v").split()[0].split(".")
+        added = False
+        for i in range(len(channels)):
+            # e.g.: 1.32-classic/stable
+            chan_ver = channels[i].split("-")[0].split(".")
+            if len(chan_ver) > 1 and (ver[0], ver[1]) < (chan_ver[0], chan_ver[1]):
+                channels.insert(i, snap_path)
+                added = True
+                break
 
-    if not added:
-        # if not added yet, config.SNAP should be at the end.
-        channels.append(snap_path)
+        if not added:
+            # if not added yet, config.SNAP should be at the end.
+            channels.append(snap_path)
 
     if len(channels) < 2:
         pytest.fail(


### PR DESCRIPTION
### Overview

Support running test_version_upgrades without a local snapfile

### Details
* pairs nicely with https://github.com/canonical/canonical-kubernetes-release-ci/pull/28 to run the promote automation