### PR TITLE
[Backport release-1.32] test: Do not expect k8sd to be active after node removal (#1311)

### DIFF
--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -78,9 +78,14 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 2, "cp node should have been removed from the cluster"
     # We cannot determine the node type of the removed node, so we need to set it explicitly here.
-    util.check_snap_services_ready(joining_cp, node_type="control-plane")
+    # NOTE: We're not expecting the k8sd service to be active after the node was removed.
+    # microcluster removes the k8sd state folder, and without the "daemon.yaml" file in it,
+    # k8sd fails to start.
+    util.check_snap_services_ready(
+        joining_cp, node_type="control-plane", skip_services=["k8sd"]
+    )
 
     cluster_node.exec(["k8s", "remove-node", worker.id])
     nodes = util.ready_nodes(cluster_node)
     assert len(nodes) == 1, "worker node should have been removed from the cluster"
-    util.check_snap_services_ready(worker, node_type="worker")
+    util.check_snap_services_ready(worker, node_type="worker", skip_services=["k8sd"])

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -718,7 +718,9 @@ def sonobuoy_tar_gz(architecture: str) -> str:
 
 
 def check_snap_services_ready(
-    instance: harness.Instance, node_type: Optional[str] = None
+    instance: harness.Instance,
+    node_type: Optional[str] = None,
+    skip_services: Optional[List[str]] = None,
 ):
     """Check that the snap services are active on the given harness instance.
 
@@ -731,7 +733,9 @@ def check_snap_services_ready(
             function will determine the node type by checking the local node status.
             This is not always possible (e.g. if a node was already removed from the cluster).
             So, the user can provide the node type explicitly.
+        skip_services: a list of services to ignore when checking for service readiness.
     """
+    skip_services = skip_services or []
 
     expected_worker_services = {
         "containerd",
@@ -770,6 +774,11 @@ def check_snap_services_ready(
         else expected_worker_services
     )
 
+    if skip_services:
+        expected_active_services = [
+            s for s in expected_active_services if s not in skip_services
+        ]
+
     result = instance.exec(["snap", "services", "k8s"], capture_output=True, text=True)
     services_output = result.stdout.split("\n")[1:-1]  # Skip the header line
 
@@ -789,6 +798,8 @@ def check_snap_services_ready(
         ), f"Service {service} should be active, but it is {service_status[service]}"
 
     for service, status in service_status.items():
+        if service in skip_services:
+            continue
         if service not in expected_active_services:
             assert (
                 status == "inactive"


### PR DESCRIPTION
(cherry picked from commit 48917ca2a805abf777d280e14139099b24aa47a8)

## Description

When a node is removed from a cluster, microcluster removes the k8sd state folder, which includes the `daemon.yaml` file required for the service to start. Because of this, the service is in a constant loop of starting and crashing. We cannot expect the service to be running in this case.

## Solution

Skip checking if k8sd is active for the `test_skip_services_stop_on_remove` test.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 
