### PR TITLE
feat: Support multiple pre-releases (#29)

### DIFF
--- a/.github/workflows/update-pre-release-branches.yaml
+++ b/.github/workflows/update-pre-release-branches.yaml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "worker@org.com"
       - name: 'Prepare pre-release git branch'
         run: |
-          python3 ./build-scripts/k8s_release.py prepare_prerelease_git_branch
+          python3 ./build-scripts/k8s_release.py prepare_prerelease_git_branches
       - name: Clean obsolete branches
         run: |
           python3 ./build-scripts/k8s_release.py clean_obsolete_git_branches

--- a/build-scripts/k8s_release.py
+++ b/build-scripts/k8s_release.py
@@ -131,7 +131,9 @@ def get_obsolete_prereleases() -> List[str]:
 def _exec(*args, **kwargs) -> tuple[str, str]:
     """Run the specified command and return the stdout/stderr output as a tuple."""
     LOG.debug("Executing: %s, args: %s, kwargs: %s", cmd, args, kwargs)
-    kwargs["text"] = True
+    kwargs.setdefault("text", True)
+    kwargs.setdefault("check", True)
+    kwargs.setdefault("timeout", EXEC_TIMEOUT)
     proc = subprocess.run(*args, **kwargs)
     return proc.stdout, proc.stderr
 

--- a/build-scripts/k8s_release.py
+++ b/build-scripts/k8s_release.py
@@ -77,14 +77,11 @@ def get_latest_releases_by_minor() -> Dict[str, str]:
         latest (pre-)release tag (e.g. 'v1.30.1').
     """
     latest_by_minor: Dict[str, str] = {}
-    version_regex = re.compile(r"^v?(\d+)\.(\d+)\..+")
 
     for tag in get_k8s_tags():
-        match = version_regex.match(tag)
-        if not match:
-            continue
-        major, minor = match.groups()
-        key = f"{major}.{minor}"
+        # Strip leading 'v' if present since Version expects numeric first char
+        version = Version(tag.lstrip("v"))
+        key = f"{version.major}.{version.minor}"
         if key not in latest_by_minor:
             latest_by_minor[key] = tag
 
@@ -133,17 +130,9 @@ def get_obsolete_prereleases() -> List[str]:
 
 def _exec(*args, **kwargs) -> tuple[str, str]:
     """Run the specified command and return the stdout/stderr output as a tuple."""
-    LOG.debug("Executing: %s, cwd: %s.", cmd, cwd)
-    kwargs["text"]=True
+    LOG.debug("Executing: %s, args: %s, kwargs: %s", cmd, args, kwargs)
+    kwargs["text"] = True
     proc = subprocess.run(*args, **kwargs)
-    return proc.stdout, proc.stderr
-        cmd,
-        check=check,
-        timeout=timeout,
-        cwd=cwd,
-        capture_output=capture_output,
-        text=True,
-    )
     return proc.stdout, proc.stderr
 
 

--- a/build-scripts/k8s_release.py
+++ b/build-scripts/k8s_release.py
@@ -131,12 +131,12 @@ def get_obsolete_prereleases() -> List[str]:
     return obsolete
 
 
-def _exec(
-    cmd: List[str], check=True, capture_output=True, timeout=EXEC_TIMEOUT, cwd=None
-):
+def _exec(*args, **kwargs) -> tuple[str, str]:
     """Run the specified command and return the stdout/stderr output as a tuple."""
     LOG.debug("Executing: %s, cwd: %s.", cmd, cwd)
-    proc = subprocess.run(
+    kwargs["text"]=True
+    proc = subprocess.run(*args, **kwargs)
+    return proc.stdout, proc.stderr
         cmd,
         check=check,
         timeout=timeout,

--- a/build-scripts/k8s_release.py
+++ b/build-scripts/k8s_release.py
@@ -239,9 +239,9 @@ def clean_obsolete_git_branches(project_basedir: str, remote="origin"):
     All risk levels will be removed once the latest release is stable.
     """
     obsolete_prereleases = get_obsolete_prereleases()
-    for outstanding_prerelease in obsolete_prereleases:
-        branch = get_prerelease_git_branch(outstanding_prerelease)
-
+    for prerelease in obsolete_prereleases:
+        branch = get_prerelease_git_branch(prerelease)
+        LOG.info("Checking for obsolete pre-release %s branch: %s", prerelease, branch)
         if _branch_exists(
             f"{remote}/{branch}", remote=True, project_basedir=project_basedir
         ):

--- a/build-scripts/k8s_release.py
+++ b/build-scripts/k8s_release.py
@@ -131,11 +131,18 @@ def get_obsolete_prereleases() -> List[str]:
     return obsolete
 
 
-def _exec(cmd: List[str], check=True, timeout=EXEC_TIMEOUT, cwd=None):
+def _exec(
+    cmd: List[str], check=True, capture_output=True, timeout=EXEC_TIMEOUT, cwd=None
+):
     """Run the specified command and return the stdout/stderr output as a tuple."""
     LOG.debug("Executing: %s, cwd: %s.", cmd, cwd)
     proc = subprocess.run(
-        cmd, check=check, timeout=timeout, cwd=cwd, capture_output=True, text=True
+        cmd,
+        check=check,
+        timeout=timeout,
+        cwd=cwd,
+        capture_output=capture_output,
+        text=True,
     )
     return proc.stdout, proc.stderr
 
@@ -182,19 +189,29 @@ def prepare_prerelease_git_branches(project_basedir: str, remote: str = "origin"
     for prerelease in prereleases:
         branch = get_prerelease_git_branch(str(prerelease))
         LOG.info("Preparing pre-release branch: %s", branch)
-        _exec(["git", "checkout", "-B", branch], cwd=project_basedir)
+        _exec(
+            ["git", "checkout", "-B", branch],
+            cwd=project_basedir,
+            capture_output=False,
+        )
 
         _update_prerelease_k8s_component(project_basedir, str(prerelease))
         _exec(
             ["git", "add", "./build-scripts/components/kubernetes/version"],
             cwd=project_basedir,
+            capture_output=False,
         )
         _exec(
             ["git", "commit", "-m", f"Update k8s version to {prerelease}"],
             cwd=project_basedir,
+            capture_output=False,
         )
 
-        _exec(["git", "push", remote, branch, "--force"], cwd=project_basedir)
+        _exec(
+            ["git", "push", remote, branch, "--force"],
+            cwd=project_basedir,
+            capture_output=False,
+        )
 
 
 def clean_obsolete_git_branches(project_basedir: str, remote="origin"):


### PR DESCRIPTION
Right now, only the latest pre-release is supported. However, in transition times there might be multiple non-stable releases (e.g. 1.33.0-rc1 and 1.34.0-alpha) which both need to be supported.

Related PR: https://github.com/canonical/canonical-kubernetes-release-ci/pull/29 (why probably should put those related functions into a util repo or so at some point...)