### PR TITLE
feat: Use controller-runtime client for Upgrade CRD

### DIFF
--- a/src/k8s/pkg/client/kubernetes/client.go
+++ b/src/k8s/pkg/client/kubernetes/client.go
@@ -6,11 +6,13 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Client is a wrapper around the kubernetes.Interface.
 type Client struct {
 	kubernetes.Interface
+	ctrlclient.Client
 	config *rest.Config
 }
 
@@ -23,7 +25,24 @@ func NewClient(restClientGetter genericclioptions.RESTClientGetter) (*Client, er
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Kubernetes clientset: %w", err)
 	}
-	return &Client{Interface: clientset, config: config}, nil
+
+	scheme, err := NewScheme()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scheme: %w", err)
+	}
+
+	ctrlC, err := ctrlclient.New(config, ctrlclient.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create controller-runtime client: %w", err)
+	}
+
+	return &Client{
+		Interface: clientset,
+		Client:    ctrlC,
+		config:    config,
+	}, nil
 }
 
 func (c *Client) RESTConfig() *rest.Config {

--- a/src/k8s/pkg/client/kubernetes/scheme.go
+++ b/src/k8s/pkg/client/kubernetes/scheme.go
@@ -1,0 +1,22 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NewScheme creates a new runtime.Scheme and adds the types defined in this package to it.
+func NewScheme() (*runtime.Scheme, error) {
+	schemeBuilder := runtime.NewSchemeBuilder(
+		addKnownTypes,
+		// NOTE(Hue): Add other types here as needed.
+	)
+	addToScheme := schemeBuilder.AddToScheme
+
+	scheme := runtime.NewScheme()
+	if err := addToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("failed to add types to scheme: %w", err)
+	}
+	return scheme, nil
+}

--- a/src/k8s/pkg/client/kubernetes/upgrades.go
+++ b/src/k8s/pkg/client/kubernetes/upgrades.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -11,9 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TODO: If the upgrade CRD grows, consider using kubebuilder.
@@ -35,18 +32,13 @@ const (
 )
 
 const (
-	kind            = "Upgrade"
-	group           = "k8sd.io"
-	version         = "v1alpha"
-	apiVersion      = group + "/" + version
-	upgradesAPIPath = "/apis/" + group + "/" + version + "/upgrades"
+	kind       = "Upgrade"
+	group      = "k8sd.io"
+	version    = "v1alpha"
+	apiVersion = group + "/" + version
 )
 
-var (
-	schemeGroupVersion = schema.GroupVersion{Group: group, Version: version}
-	schemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme        = schemeBuilder.AddToScheme
-)
+var schemeGroupVersion = schema.GroupVersion{Group: group, Version: version}
 
 type UpgradeStatus struct {
 	Strategy      UpgradeStrategy `json:"strategy,omitempty"`
@@ -62,19 +54,30 @@ type Upgrade struct {
 	Status UpgradeStatus `json:"status,omitempty"`
 }
 
-func (u *Upgrade) DeepCopyObject() runtime.Object {
-	if u == nil {
+func (in *Upgrade) DeepCopyInto(out *Upgrade) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	out.Status.Phase = in.Status.Phase
+	out.Status.Strategy = in.Status.Strategy
+	out.Status.UpgradedNodes = make([]string, len(in.Status.UpgradedNodes))
+	copy(out.Status.UpgradedNodes, in.Status.UpgradedNodes)
+}
+
+func (in *Upgrade) DeepCopy() *Upgrade {
+	if in == nil {
 		return nil
 	}
-	cp := *u
-	cp.ObjectMeta = *u.ObjectMeta.DeepCopy()
-	cp.Status.Phase = u.Status.Phase
-	if u.Status.UpgradedNodes != nil {
-		nodesCopy := make([]string, len(u.Status.UpgradedNodes))
-		copy(nodesCopy, u.Status.UpgradedNodes)
-		cp.Status.UpgradedNodes = nodesCopy
+	out := new(Upgrade)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *Upgrade) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
 	}
-	return &cp
+	return nil
 }
 
 // UpgradeList contains a list of Upgrade resources.
@@ -84,22 +87,33 @@ type UpgradeList struct {
 	Items           []Upgrade `json:"items"`
 }
 
-func (ul *UpgradeList) DeepCopyObject() runtime.Object {
-	if ul == nil {
+func (in *UpgradeList) DeepCopyInto(out *UpgradeList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Upgrade, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *UpgradeList) DeepCopy() *UpgradeList {
+	if in == nil {
 		return nil
 	}
-	cp := *ul
-	cp.ListMeta = *ul.ListMeta.DeepCopy()
-	cp.Items = make([]Upgrade, len(ul.Items))
-	for i, u := range ul.Items {
-		uCp, ok := u.DeepCopyObject().(*Upgrade)
-		if !ok {
-			log.L().Error(fmt.Errorf("type assertion failed for upgrade deepcopy"), "upgrade", u)
-			continue
-		}
-		cp.Items[i] = *uCp
+	out := new(UpgradeList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UpgradeList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
 	}
-	return &cp
+	return nil
 }
 
 // addKnownTypes registers upgrade types into the scheme.
@@ -112,8 +126,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	return nil
 }
 
-func NewUpgrade(name string, strategy UpgradeStrategy) Upgrade {
-	return Upgrade{
+func NewUpgrade(name string, strategy UpgradeStrategy) *Upgrade {
+	return &Upgrade{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: apiVersion,
 			Kind:       kind,
@@ -129,42 +143,18 @@ func NewUpgrade(name string, strategy UpgradeStrategy) Upgrade {
 	}
 }
 
-func (c *Client) k8sdIoRestClient() (*rest.RESTClient, error) {
-	k8sdConfig := c.RESTConfig()
-	k8sdConfig.GroupVersion = &schemeGroupVersion
-	k8sdConfig.NegotiatedSerializer = serializer.NewCodecFactory(runtime.NewScheme())
-
-	restClient, err := rest.RESTClientFor(k8sdConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
-	}
-	return restClient, nil
-}
-
 // GetInProgressUpgrade returns the upgrade CR that is currently in progress.
 // TODO(ben): (KU-3218) Maybe make this more generic, e.g. GetUpgrade(filterFunc func(Upgrade) bool) (*Upgrade, error)
 func (c *Client) GetInProgressUpgrade(ctx context.Context) (*Upgrade, error) {
 	log := log.FromContext(ctx).WithValues("upgrades", "GetInProgressUpgrade")
 
-	restClient, err := c.k8sdIoRestClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
-	}
-
-	upgrades, err := restClient.Get().AbsPath(upgradesAPIPath).DoRaw(ctx)
-	if err != nil {
+	result := &UpgradeList{}
+	if err := c.List(ctx, result); err != nil {
 		if apierrors.IsNotFound(err) {
 			// No upgrade in progress.
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get upgrades: %w", err)
-	}
-
-	var result struct {
-		Items []Upgrade `json:"items"`
-	}
-	if err := json.Unmarshal(upgrades, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal upgrades: %w", err)
 	}
 
 	var matches []Upgrade
@@ -189,65 +179,12 @@ func (c *Client) GetInProgressUpgrade(ctx context.Context) (*Upgrade, error) {
 	return &matches[lenMatches-1], nil
 }
 
-// CreateUpgrade creates a new upgrade CR.
-func (c *Client) CreateUpgrade(ctx context.Context, upgrade Upgrade) error {
-	log := log.FromContext(ctx).WithValues("upgrades", "createUpgrade")
-	restClient, err := c.k8sdIoRestClient()
-	if err != nil {
-		return fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
-	}
-
-	body, err := json.Marshal(upgrade)
-	if err != nil {
-		return fmt.Errorf("failed to marshal upgrade: %w", err)
-	}
-
-	log.Info("Creating upgrade", "upgrade", upgrade)
-	result := restClient.Post().
-		AbsPath(upgradesAPIPath).
-		Body(body).
-		Do(ctx)
-	if result.Error() != nil {
-		responseBody, _ := result.Raw()
-		log.Error(result.Error(), "failed to create upgrade", "response", string(responseBody))
-		return fmt.Errorf("failed to create upgrade: %w", result.Error())
-	}
-
-	// The status field needs to be patches separatly since it is a subresource.
-	if err := c.PatchUpgradeStatus(ctx, upgrade.Name, upgrade.Status); err != nil {
-		return fmt.Errorf("failed to patch upgrade status: %w", err)
-	}
-
-	return nil
-}
-
 // PatchUpgradeStatus patches the status of an upgrade CR.
-func (c *Client) PatchUpgradeStatus(ctx context.Context, upgradeName string, status UpgradeStatus) error {
-	log := log.FromContext(ctx).WithValues("upgrades", "PatchUpgrade", "upgrade", upgradeName, "status", status)
-
-	restClient, err := c.k8sdIoRestClient()
-	if err != nil {
-		return fmt.Errorf("failed to create REST client for k8sd.io group: %w", err)
-	}
-
-	// Wrap the status in a struct to match the CRD definition.
-	upgrade := NewUpgrade(upgradeName, status.Strategy)
-	upgrade.Status = status
-
-	body, err := json.Marshal(upgrade)
-	if err != nil {
-		return fmt.Errorf("failed to marshal status: %w", err)
-	}
-
-	log.WithValues("upgrade", upgrade).Info("Patching upgrade")
-	result := restClient.Patch(types.MergePatchType).
-		AbsPath(fmt.Sprintf("/apis/%s/%s/upgrades/%s/status", group, version, upgradeName)).
-		Body(body).
-		Do(ctx)
-	if result.Error() != nil {
-		responseBody, _ := result.Raw()
-		log.Error(result.Error(), "failed to update upgrade status", "response", string(responseBody))
-		return fmt.Errorf("failed to update upgrade status: %w", result.Error())
+func (c *Client) PatchUpgradeStatus(ctx context.Context, u *Upgrade, status UpgradeStatus) error {
+	p := ctrlclient.MergeFrom(u.DeepCopy())
+	u.Status = status
+	if err := c.Status().Patch(ctx, u, p); err != nil {
+		return fmt.Errorf("failed to patch upgrade status: %w", err)
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -367,8 +367,20 @@ func initiateRollingUpgrade(ctx context.Context, snap snap.Snap, s state.State, 
 	}
 
 	newUpgrade := kubernetes.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev), strategy)
-	newUpgrade.Status.UpgradedNodes = []string{s.Name()}
-	return k8sClient.CreateUpgrade(ctx, newUpgrade)
+	if err := k8sClient.Create(ctx, newUpgrade); err != nil {
+		return fmt.Errorf("failed to create upgrade: %w", err)
+	}
+
+	status := kubernetes.UpgradeStatus{
+		UpgradedNodes: []string{s.Name()},
+		Phase:         kubernetes.UpgradePhaseNodeUpgrade,
+		Strategy:      strategy,
+	}
+	if err := k8sClient.PatchUpgradeStatus(ctx, newUpgrade, status); err != nil {
+		return fmt.Errorf("failed to patch upgrade status: %w", err)
+	}
+
+	return nil
 }
 
 func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kubernetes.Client, upgrade *kubernetes.Upgrade, thisNodeVersion *versionutil.Version, nodeVersions map[string]*versionutil.Version) error {
@@ -387,6 +399,8 @@ func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kube
 		if !thisNodeVersion.EqualTo(lowest) {
 			return fmt.Errorf("joining node version %q needs to match lowest version %q", thisNodeVersion, lowest)
 		}
+	case kubernetes.UpgradeStrategyInPlace:
+		return fmt.Errorf("can not join a new node while an in-place upgrade is in progress")
 	default:
 		return fmt.Errorf("unknown upgrade strategy in progress: %q", upgrade.Status.Strategy)
 	}
@@ -394,7 +408,7 @@ func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kube
 	log.Info("Marking node as upgraded", "node", nodeName)
 	upgradedNodes := upgrade.Status.UpgradedNodes
 	upgradedNodes = append(upgradedNodes, nodeName)
-	return k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{UpgradedNodes: upgradedNodes})
+	return k8sClient.PatchUpgradeStatus(ctx, upgrade, kubernetes.UpgradeStatus{UpgradedNodes: upgradedNodes})
 }
 
 // lowestHighestK8sVersions returns the lowest and highest Kubernetes versions from the given map.

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -85,24 +85,28 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 		}
 		// TODO(ben): Add more metadata to the upgrade.
 		// e.g. initial revision, target revision, name of the node that started the upgrade, etc.
-		newUpgrade := kubernetes.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev), kubernetes.UpgradeStrategyInPlace)
-		upgrade = &newUpgrade
-		if err := k8sClient.CreateUpgrade(ctx, *upgrade); err != nil {
+		upgrade = kubernetes.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev), kubernetes.UpgradeStrategyInPlace)
+		if err := k8sClient.Create(ctx, upgrade); err != nil {
 			return fmt.Errorf("failed to create upgrade: %w", err)
 		}
-
+		log.Info("Created new upgrade CR.", "upgrade", *upgrade)
 	} else {
 		log.Info("Upgrade in progress.", "upgrade", upgrade.Name, "phase", upgrade.Status.Phase)
 	}
 
 	log.Info("Marking node as upgraded.", "node", s.Name())
 
-	upgradedNodes := upgrade.Status.UpgradedNodes
-	upgradedNodes = append(upgradedNodes, s.Name())
+	status := kubernetes.UpgradeStatus{
+		UpgradedNodes: append(upgrade.Status.UpgradedNodes, s.Name()),
+		Phase:         kubernetes.UpgradePhaseNodeUpgrade,
+		Strategy:      kubernetes.UpgradeStrategyInPlace,
+	}
 
-	if err := k8sClient.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{UpgradedNodes: upgradedNodes}); err != nil {
+	if err := k8sClient.PatchUpgradeStatus(ctx, upgrade, status); err != nil {
 		return fmt.Errorf("failed to mark node as upgraded: %w", err)
 	}
+
+	log.Info("Marked node as upgraded.", "status", upgrade.Status)
 
 	return nil
 }

--- a/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
@@ -6,61 +6,61 @@ import (
 	"time"
 
 	"github.com/canonical/k8s/pkg/client/kubernetes"
-	"github.com/canonical/k8s/pkg/log"
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Reconcile implements the Reconciler interface and wraps the reconcile method.
+// Reconcile ensures that the reconciliation is requeued unless the reconciled resource is not found.
 func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	res, err := c.reconcile(ctx)
+	log := c.logger.WithValues("scope", "reconcile wrapper")
+
+	res, err := c.reconcile(ctx, req)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info(fmt.Sprintf("Upgrade %q not found, ignoring.", req.NamespacedName))
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile: %w", err)
 	}
 
 	bareResult := res == ctrl.Result{}
 	if bareResult {
-		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+		res = ctrl.Result{RequeueAfter: 5 * time.Minute}
 	}
 
+	if res.RequeueAfter > 0 {
+		log.Info(fmt.Sprintf("Requeuing after %f seconds.", res.RequeueAfter.Seconds()))
+	} else if res.Requeue {
+		log.Info("Requeuing.")
+	}
 	return res, nil
 }
 
 // reconcile is the main reconciliation loop for the upgrade controller.
-func (c *Controller) reconcile(ctx context.Context) (ctrl.Result, error) {
-	log := c.logger.WithValues("step", "reconcile")
-
-	// TODO(Hue): (KU-3215) Use mgr.Client when Upgrade CRD is created with kubebuilder.
-	k8sClient, err := c.snap.KubernetesClient("")
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get Kubernetes client: %w", err)
-	}
-
-	upgrade, err := k8sClient.GetInProgressUpgrade(ctx)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to check for in-progress upgrade: %w", err)
-	}
-
-	if upgrade == nil {
-		log.Info("No in-progress upgrade found, ignoring")
-		return ctrl.Result{}, nil
+func (c *Controller) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var upgrade kubernetes.Upgrade
+	if err := c.client.Get(ctx, req.NamespacedName, &upgrade); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get upgrade %q: %w", req.NamespacedName, err)
 	}
 
 	switch {
 	case upgrade.Status.Phase == kubernetes.UpgradePhaseNodeUpgrade:
-		return c.reconcileNodeUpgrade(ctx, k8sClient, upgrade)
+		return c.reconcileNodeUpgrade(ctx, &upgrade)
 	case upgrade.Status.Phase == kubernetes.UpgradePhaseFeatureUpgrade:
-		return c.reconcileFeatureUpgrade(ctx, k8sClient, upgrade)
-	default:
-		// NOTE(Hue): This should never happen, but even then we don't want to return an error.
-		log.Info("Unknown upgrade phase", "phase", upgrade.Status.Phase)
-		return ctrl.Result{}, nil
+		return c.reconcileFeatureUpgrade(ctx, &upgrade)
 	}
+
+	return ctrl.Result{}, nil
 }
 
 // reconcileNodeUpgrade checks if all nodes have been upgraded.
 // If so, it transitions to the feature upgrade phase and notifies the feature controller.
-func (c *Controller) reconcileNodeUpgrade(ctx context.Context, client *kubernetes.Client, upgrade *kubernetes.Upgrade) (ctrl.Result, error) {
+func (c *Controller) reconcileNodeUpgrade(ctx context.Context, upgrade *kubernetes.Upgrade) (ctrl.Result, error) {
 	log := c.logger.WithValues("upgrade", upgrade.Name, "step", "node-upgrade")
+	log.Info("Checking if all nodes have been upgraded.")
 
 	allNodesUpgraded, err := c.allNodesUpgraded(ctx, upgrade.Status.UpgradedNodes)
 	if err != nil {
@@ -71,58 +71,46 @@ func (c *Controller) reconcileNodeUpgrade(ctx context.Context, client *kubernete
 
 	log.Info("All nodes have been upgraded.")
 
-	// This will trigger another reconciliation for the upgrade object.
-	if err := client.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseFeatureUpgrade}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set upgrade phase: %w", err)
+	if err := c.transitionTo(ctx, upgrade, kubernetes.UpgradePhaseFeatureUpgrade); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to transition to %q phase: %w", kubernetes.UpgradePhaseFeatureUpgrade, err)
 	}
 
-	log.Info("Transitioned to feature-upgrade phase.")
-
+	log.Info(fmt.Sprintf("Transitioned to %q phase.", kubernetes.UpgradePhaseFeatureUpgrade))
 	return ctrl.Result{}, nil
 }
 
 // reconcileFeatureUpgrade triggers feature controllers to reconcile
 // and waits for them to finish.
-func (c *Controller) reconcileFeatureUpgrade(ctx context.Context, client *kubernetes.Client, upgrade *kubernetes.Upgrade) (ctrl.Result, error) {
+func (c *Controller) reconcileFeatureUpgrade(ctx context.Context, upgrade *kubernetes.Upgrade) (ctrl.Result, error) {
 	log := c.logger.WithValues("upgrade", upgrade.Name, "step", "feature-upgrade")
-	log.Info("Triggering feature controllers")
 
+	log.Info("Waiting for feature controllers to be ready.")
 	select {
 	case <-c.featureControllerReadyCh:
 	case <-time.After(c.featureControllerReadyTimeout):
 		return ctrl.Result{}, fmt.Errorf("timed out waiting for feature controllers to be ready")
 	}
 
+	log.Info("Triggering feature controller.")
 	c.notifyFeatureController(true, true, true, true, true, true, true)
 
 	log.Info("Waiting for feature controllers to reconcile.")
-
-	timeout := time.After(c.featureControllerReconcileTimeout)
-
-	for name, ch := range c.featureToReconciledCh {
-		select {
-		case <-ctx.Done():
-			return ctrl.Result{}, fmt.Errorf("context done while waiting for features to get reconciled: %w", ctx.Err())
-		case <-timeout:
-			// TODO(Hue): (KU-3227) Do something about failed feature reconciliations.
-			return ctrl.Result{}, fmt.Errorf("timed out waiting for feature %q to get reconciled", name)
-		case <-ch:
-			log.Info(fmt.Sprintf("feature %q have reconciled.", name))
-		}
+	if err := c.waitForFeatureReconciliations(ctx, log); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to wait for feature reconciliations: %w", err)
 	}
 
-	log.Info("All feature have reconciled.")
-
-	if err := client.PatchUpgradeStatus(ctx, upgrade.Name, kubernetes.UpgradeStatus{Phase: kubernetes.UpgradePhaseCompleted}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set upgrade phase after successful feature upgrade: %w", err)
+	log.Info("All feature have reconciled. Transitioning to completed phase.")
+	if err := c.transitionTo(ctx, upgrade, kubernetes.UpgradePhaseCompleted); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to transition to %q phase: %w", kubernetes.UpgradePhaseCompleted, err)
 	}
 
+	log.Info(fmt.Sprintf("Transitioned to %q phase.", kubernetes.UpgradePhaseCompleted))
 	return ctrl.Result{}, nil
 }
 
 // allNodesUpgraded checks if all nodes in the cluster have been upgraded.
 func (c *Controller) allNodesUpgraded(ctx context.Context, upgradedNodes []string) (bool, error) {
-	log := log.FromContext(ctx)
+	log := c.logger.WithValues("step", "all-nodes-upgraded")
 
 	leader, err := c.getState().Leader()
 	if err != nil {
@@ -155,4 +143,30 @@ func (c *Controller) allNodesUpgraded(ctx context.Context, upgradedNodes []strin
 	}
 
 	return true, nil
+}
+
+func (c *Controller) waitForFeatureReconciliations(ctx context.Context, log logr.Logger) error {
+	timeout := time.After(c.featureControllerReconcileTimeout)
+	for name, ch := range c.featureToReconciledCh {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeout:
+			// TODO(Hue): (KU-3227) Do something about failed feature reconciliations.
+			return fmt.Errorf("timed out waiting for feature %q to get reconciled", name)
+		case <-ch:
+			log.Info(fmt.Sprintf("feature %q have reconciled.", name))
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) transitionTo(ctx context.Context, upgrade *kubernetes.Upgrade, phase kubernetes.UpgradePhase) error {
+	p := ctrlclient.MergeFrom(upgrade.DeepCopy())
+	upgrade.Status.Phase = phase
+	if err := c.client.Status().Patch(ctx, upgrade, p); err != nil {
+		return fmt.Errorf("failed to patch: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
### Overview

This PR uses the `controller-runtime` client to manage the Upgrade CRD. This is less error prone, and simplifies how we handle this resource significantly.