### PR TITLE
chore: Bump rawfile-localpv image

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -123,7 +123,7 @@ ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner:v5.0.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer:v1.11.1
 ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.1
 ghcr.io/canonical/metrics-server:0.7.0-ck2
-ghcr.io/canonical/rawfile-localpv:0.8.1
+ghcr.io/canonical/rawfile-localpv:0.8.2
 ```
 
 A list of images can also be found in the `images.txt` file when the

--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "0.8.1"
+	ImageTag = "0.8.2"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"


### PR DESCRIPTION
## Description

Bump rawfile-localpv image from 0.8.1 -> 0.8.2

## Solution

Component upgrade

## Backport

Should this PR be backported? If so, to which release? Yes

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

