### PR TITLE
docs: Move from juju/latest to juju/3.6 docs

### DIFF
--- a/docs/canonicalk8s/charm/howto/install/charm.md
+++ b/docs/canonicalk8s/charm/howto/install/charm.md
@@ -90,7 +90,7 @@ Use `juju status` to watch these units approach the active/idle state.
 
 [Installing]:    ./index
 [channels]:      ../../explanation/channels
-[credentials]:   https://documentation.ubuntu.com/juju/latest/reference/credential/
+[credentials]:   https://documentation.ubuntu.com/juju/3.6/reference/credential/
 [juju]:          https://juju.is/docs/juju/install-juju
 [charm]:         https://juju.is/docs/juju/charmed-operator
 [localhost]:     install-lxd

--- a/docs/canonicalk8s/charm/howto/upgrade-minor.md
+++ b/docs/canonicalk8s/charm/howto/upgrade-minor.md
@@ -211,7 +211,7 @@ to ensure that the cluster is fully functional.
 [backup-restore]:      ../../snap/howto/backup-restore
 [charmhub]:            https://charmhub.io/k8s
 [cluster-validation]:  ./validate
-[juju-docs]:           https://documentation.ubuntu.com/juju/latest/howto/manage-models/#manage-models
+[juju-docs]:           https://documentation.ubuntu.com/juju/3.6/howto/manage-models/#manage-models
 [release-notes]:       ../reference/releases
 [upgrade-notes]:       ../reference/upgrade-notes
 [upstream-notes]:      https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation

--- a/docs/canonicalk8s/charm/howto/upgrade-patch.md
+++ b/docs/canonicalk8s/charm/howto/upgrade-patch.md
@@ -202,6 +202,6 @@ to ensure that the cluster is fully functional.
 [backup-restore]:     ../../snap/howto/backup-restore
 [charmhub]:            https://charmhub.io/k8s
 [cluster-validation]: ./validate
-[juju-docs]:          https://documentation.ubuntu.com/juju/latest/howto/manage-models/#how-to-manage-models
+[juju-docs]:          https://documentation.ubuntu.com/juju/3.6/howto/manage-models/#how-to-manage-models
 [release-notes]:      ../reference/releases
 [upstream-notes]:     https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG

--- a/docs/canonicalk8s/charm/reference/az.md
+++ b/docs/canonicalk8s/charm/reference/az.md
@@ -48,7 +48,7 @@ underlying AZ changes from the Juju POV, the operator will not update the
 label to reflect this new AZ.
 
 <!-- LINKS -->
-[zone]: https://documentation.ubuntu.com/juju/latest/reference/zone/
-[placement directive]: https://documentation.ubuntu.com/juju/latest/reference/placement-directive/#zone-zone
-[constraint]: https://documentation.ubuntu.com/juju/latest/reference/constraint/#zones
+[zone]: https://documentation.ubuntu.com/juju/3.6/reference/zone/
+[placement directive]: https://documentation.ubuntu.com/juju/3.6/reference/placement-directive/#zone-zone
+[constraint]: https://documentation.ubuntu.com/juju/3.6/reference/constraint/#zones
 [Kubernetes well-known topology label]: https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone


### PR DESCRIPTION
## Description

Resolve broken links quickly

## Solution

Honestly, it is likely a short term fix
move `juju/latest` -> `juju/3.6`


## Backport

I don't know

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
