### PR TITLE
feat: update cilium rock version

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,13 +39,13 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.1-ck0"
+	CiliumAgentImageTag = "1.17.1-ck2"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.1-ck0"
+	ciliumOperatorImageTag = "1.17.1-ck2"
 
 	ciliumDefaultVXLANPort = 8472
 


### PR DESCRIPTION
## Description

We have recently reduced the image size of the cilium rock from 1.47 GB to 811 MB. This should reduce the amount of time spent by the Kubernetes nodes to become Ready as well.

Related: https://github.com/canonical/cilium-rocks/pull/21

## Solution

Updated the rock versions to the latest ones built.

## Issue


## Backport

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests - N/A
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - N/A

If any item on the checklist is not complete, please provide justification why.

The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit
