### PR TITLE
docs: Update CAPI explanation page

### DIFF
--- a/docs/canonicalk8s/capi/explanation/capi-ck8s.md
+++ b/docs/canonicalk8s/capi/explanation/capi-ck8s.md
@@ -1,4 +1,6 @@
-# Cluster API - {{product}}
+# Cluster API and {{product}}
+
+## Cluster API
 
 ClusterAPI (CAPI) is an open-source Kubernetes project that provides a
 declarative API for cluster creation, configuration, and management. It is
@@ -19,31 +21,47 @@ allowing for a variety of Kubernetes distributions to be delivered in all of
 the supported infrastructure providers. {{product}} is one such Kubernetes
 distribution that seamlessly integrates with Cluster API.
 
+## {{product}} and CAPI
+
 With {{product}} CAPI you can:
 
-- provision a cluster with:
-    - Kubernetes version 1.31 onward
-    - risk level of the track you want to follow (stable, candidate, beta, edge)
-    - deploy behind proxies
-- upgrade clusters with no downtime:
-    - rolling upgrades for HA clusters and worker nodes
-    - in-place upgrades for non-HA control planes and worker nodes
+- Provision a cluster that meets your needs
+  - Choose Kubernetes version 1.31 onwards
+  - Choose the risk level of the track (Kubernetes version) you want to follow -
+  stable, candidate, beta or edge
+  - Deploy behind proxies
+- Upgrade clusters with no downtime
+    - Carry out rolling upgrades for High Availability (HA) clusters and worker
+    nodes
+    - Carry out in-place upgrades for non-HA control planes and worker nodes
 
-Please refer to the [tutorial section] for concrete examples on CAPI
-deployments.
+Please refer to the [getting started tutorial] for a concrete example of a CAPI
+deployment.
 
 ## CAPI architecture
 
 Being a cloud-native framework, CAPI implements all its components as
-controllers that run within a Kubernetes cluster. There is a separate
-controller, called a ‘provider’, for each supported infrastructure substrate.
-The infrastructure providers are responsible for provisioning physical or
-virtual nodes and setting up networking elements such as load balancers and
-virtual networks. In a similar way, each Kubernetes distribution that
-integrates with ClusterAPI is managed by two providers: the control plane
-provider and the bootstrap provider. The bootstrap provider is responsible for
-delivering and managing Kubernetes on the nodes, while the control plane
-provider handles the control plane’s specific lifecycle.
+controllers that run within a Kubernetes cluster. There is a separate controller
+, called a ‘provider’, for each supported
+infrastructure substrate.
+
+### Infrastructure provider
+
+The infrastructure providers are responsible for
+provisioning physical or virtual nodes and setting up networking elements such
+as load balancers and
+virtual networks.
+
+### Kubernetes distributions
+
+In a similar way, each Kubernetes distribution that
+integrates with ClusterAPI is managed by two providers:
+
+- **Control plane provider**: handles the control plane’s specific lifecycle.
+- **Bootstrap provider**: responsible for
+delivering and managing Kubernetes on the nodes.
+
+### Management cluster
 
 The CAPI providers operate within a Kubernetes cluster known as the management
 cluster. The administrator is responsible for selecting the desired combination
@@ -61,27 +79,35 @@ clusters. While CAPI providers mostly live on the management cluster, it's
 also possible to maintain the them in the workload cluster.
 Read more about this in the [upstream docs around pivoting].
 
+## {{product}} providers
+
 The {{product}} team maintains the two providers required for integrating
 with CAPI:
 
-- The Cluster API Bootstrap Provider {{product}} (**CABPCK**) responsible for
-  provisioning the nodes in the cluster and preparing them to be joined to the
-  Kubernetes control plane. When you use the CABPCK you define a Kubernetes
-  `Cluster` object that describes the desired state of the new cluster and
-  includes the number and type of nodes in the cluster, as well as any
-  additional configuration settings. The Bootstrap Provider then creates the
-  necessary resources in the Kubernetes API server to bring the cluster up to
-  the desired state. Under the hood, the Bootstrap Provider uses cloud-init to
-  configure the nodes in the cluster. This includes setting up SSH keys,
-  configuring the network, and installing necessary software packages.
+### CABPCK
 
-- The Cluster API Control Plane Provider {{product}} (**CACPCK**) enables the
-  creation and management of Kubernetes control planes using {{product}} as the
-  underlying Kubernetes distribution. Its main tasks are to update the machine
-  state and to generate the kubeconfig file used for accessing the cluster. The
-  kubeconfig file is stored as a secret which the user can then retrieve using
-  the `clusterctl` command. This component also handles the upgrade process for
-  the control plane nodes.
+The Cluster API Bootstrap Provider {{product}} (**CABPCK**) is responsible for
+provisioning the nodes in the cluster and preparing them to be joined to the
+Kubernetes control plane. When you use the CABPCK, you define a Kubernetes
+`Cluster` object that describes the desired state of the new cluster. This
+includes the number and type of nodes in the cluster, as well as any
+additional configuration settings. The Bootstrap Provider then creates the
+necessary resources in the Kubernetes API server to bring the cluster up to
+the desired state. Under the hood, the Bootstrap Provider uses cloud-init to
+configure the nodes in the cluster. This includes setting up SSH keys,
+configuring the network, and installing necessary software packages.
+
+### CACPCK
+
+The Cluster API Control Plane Provider {{product}} (**CACPCK**) enables the
+creation and management of Kubernetes control planes using {{product}} as the
+underlying Kubernetes distribution. Its main tasks are to update the machine
+state and to generate the kubeconfig file used for accessing the cluster. The
+kubeconfig file is stored as a secret which the user can then retrieve using
+the `clusterctl` command. This component also handles the upgrade process for
+the control plane nodes.
+
+## {{product}} CAPI architecture diagram
 
 ```{figure} ../../assets/capi-ck8s.svg
    :width: 100%
@@ -91,5 +117,5 @@ with CAPI:
 ```
 
 <!-- LINKS -->
-[tutorial section]: ../tutorial/index
+[getting started tutorial]: /capi/tutorial/getting-started.md
 [upstream docs around pivoting]: https://cluster-api.sigs.k8s.io/clusterctl/commands/move#pivot

--- a/docs/canonicalk8s/capi/explanation/capi-ck8s.md
+++ b/docs/canonicalk8s/capi/explanation/capi-ck8s.md
@@ -26,7 +26,7 @@ distribution that seamlessly integrates with Cluster API.
 With {{product}} CAPI you can:
 
 - Provision a cluster that meets your needs
-  - Choose Kubernetes version 1.31 onwards
+  - Choose a {{product}} version
   - Choose the risk level of the track (Kubernetes version) you want to follow -
   stable, candidate, beta or edge
   - Deploy behind proxies
@@ -41,13 +41,12 @@ deployment.
 ## CAPI architecture
 
 Being a cloud-native framework, CAPI implements all its components as
-controllers that run within a Kubernetes cluster. There is a separate controller
-, called a ‘provider’, for each supported
-infrastructure substrate.
+controllers that run within a Kubernetes cluster.
 
 ### Infrastructure provider
 
-The infrastructure providers are responsible for
+There is a separate controller, called a ‘provider’, for each supported
+infrastructure substrate. The infrastructure providers are responsible for
 provisioning physical or virtual nodes and setting up networking elements such
 as load balancers and
 virtual networks.
@@ -55,11 +54,12 @@ virtual networks.
 ### Kubernetes distributions
 
 In a similar way, each Kubernetes distribution that
-integrates with ClusterAPI is managed by two providers:
+integrates with ClusterAPI is managed by either the control plane provider,
+the bootstrap provider, or both.
 
 - **Control plane provider**: handles the control plane’s specific lifecycle.
-- **Bootstrap provider**: responsible for
-delivering and managing Kubernetes on the nodes.
+- **Bootstrap provider**: responsible for delivering and managing Kubernetes on
+the nodes.
 
 ### Management cluster
 
@@ -84,7 +84,7 @@ Read more about this in the [upstream docs around pivoting].
 The {{product}} team maintains the two providers required for integrating
 with CAPI:
 
-### CABPCK
+### Cluster API Bootstrap Provider {{product}}
 
 The Cluster API Bootstrap Provider {{product}} (**CABPCK**) is responsible for
 provisioning the nodes in the cluster and preparing them to be joined to the
@@ -97,7 +97,7 @@ the desired state. Under the hood, the Bootstrap Provider uses cloud-init to
 configure the nodes in the cluster. This includes setting up SSH keys,
 configuring the network, and installing necessary software packages.
 
-### CACPCK
+### Cluster API Control Plane Provider {{product}}
 
 The Cluster API Control Plane Provider {{product}} (**CACPCK**) enables the
 creation and management of Kubernetes control planes using {{product}} as the

--- a/docs/canonicalk8s/capi/explanation/index.md
+++ b/docs/canonicalk8s/capi/explanation/index.md
@@ -17,8 +17,8 @@ method that best suits your orchestration needs.
 ```{toctree}
 :titlesonly:
 about
-installation-methods.md
 capi-ck8s.md
+installation-methods.md
 ```
 
 ## Networking


### PR DESCRIPTION
## Description

It was highlighted that this page was quite dense with information. 

## Solution

This rework is to try make the info more manageable

## Backport

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
