### PR TITLE
docs: Fix markdown errors

### DIFF
--- a/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
@@ -386,7 +386,8 @@ The final line of the output will be `PASS`.
 
 ## [V-242391]
 
-**Guideline:** The Kubernetes Kubelet must have anonymous authentication disabled
+**Guideline:** The Kubernetes Kubelet must have anonymous authentication
+disabled
 
 **Severity:** High
 
@@ -3668,7 +3669,8 @@ The final line of the output will be `PASS`.
 
 ## [V-242426]
 
-**Guideline:** Kubernetes etcd must enable client authentication to secure service
+**Guideline:** Kubernetes etcd must enable client authentication to secure
+service
 
 **Severity:** Medium
 
@@ -4465,7 +4467,8 @@ The final line of the output will be `PASS`.
 
 ## [V-242432]
 
-**Guideline:** Kubernetes etcd must have peer-cert-file set for secure communication
+**Guideline:** Kubernetes etcd must have peer-cert-file set for secure
+communication
 
 **Severity:** Medium
 
@@ -4541,7 +4544,8 @@ The final line of the output will be `PASS`.
 
 ## [V-242433]
 
-**Guideline:** Kubernetes etcd must have a peer-key-file set for secure communication
+**Guideline:** Kubernetes etcd must have a peer-key-file set for secure
+communication
 
 **Severity:** Medium
 
@@ -4614,7 +4618,8 @@ The final line of the output will be `PASS`.
 
 ## [V-242438]
 
-**Guideline:** Kubernetes API Server must configure timeouts to limit attack surface
+**Guideline:** Kubernetes API Server must configure timeouts to limit attack
+surface
 
 **Severity:** Medium
 
@@ -5217,7 +5222,8 @@ The final line of the output will be `PASS`.
 
 ## [V-242450]
 
-**Guideline:** The Kubernetes Kubelet certificate authority must be owned by root
+**Guideline:** The Kubernetes Kubelet certificate authority must be owned by
+root
 
 **Severity:** Medium
 

--- a/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
@@ -40,13 +40,16 @@ administrator or a user policy needs to be followed.
 | `Not Applicable` (13) | V-242386, V-242393, V-242394, V-242395, V-242396, V-242398, V-242399, V-242413, V-242437, V-242442, V-242443, V-242454, V-242455 |
 | `Manual` (8) | V-242383, V-242410, V-242411, V-242412, V-242414, V-242415, V-242417, V-254800 |
 
-### [V-242381]: The Kubernetes Controller Manager must create unique service accounts for each work payload
+## [V-242381]
 
-#### Severity: High
+**Guideline:** The Kubernetes Controller Manager must create unique service
+accounts for each work payload
 
-#### Class: Deployment
+**Severity**: High
 
-#### Upstream finding description:
+**Class**: Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes Controller Manager is a background process that embeds core
 > control loops regulating cluster system state through the API Server. Every
@@ -58,7 +61,7 @@ administrator or a user policy needs to be followed.
 > instance.
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Controller Manager in the
 > k8s-snap are defined in the following file:
@@ -67,7 +70,7 @@ administrator or a user policy needs to be followed.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-controller-manager` in order to set the
 argument `--use-service-account-credentials` for service
@@ -83,7 +86,7 @@ Afterwards restart the `kube-controller-manager` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--use-service-account-credentials` for service
 `kube-controller-manager` is set as appropriate in the service's argument file
@@ -101,13 +104,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242383]: User-managed resources must be created in dedicated namespaces
+## [V-242383]
 
-#### Severity: High
+**Guideline:** User-managed resources must be created in dedicated namespaces
 
-#### Class: Manual
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > Creating namespaces for user-managed resources is important when implementing
 > Role-Based Access Controls (RBAC). RBAC allows for the authorization of users
@@ -120,7 +125,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The Kubernetes System Administrators must manually inspect the services in
 > all of the default namespaces to ensure there are no user-created resources
@@ -133,13 +138,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242386]: The Kubernetes API server must have the insecure port flag disabled
+## [V-242386]
 
-#### Severity: High
+**Guideline:** The Kubernetes API server must have the insecure port flag
+disabled
 
-#### Class: Not Applicable
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > By default, the API server will listen on two ports. One port is the secure
 > port and the other port is called the "localhost port". This port is also
@@ -156,7 +164,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--insecure-port` command line argument for the
 > Kubernetes API Server service.
@@ -170,13 +178,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242387]: The Kubernetes Kubelet must have the "readOnlyPort" flag disabled
+## [V-242387]
 
-#### Severity: High
+**Guideline:** The Kubernetes Kubelet must have the "readOnlyPort" flag disabled
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubelet serves a small REST API with read access to port 10255. The read-only
 > port for Kubernetes provides no authentication or authorization security
@@ -188,7 +198,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not pass a `--config` command line argument to the Kubelet
 > service, but does explicitly pass `--read-only-port=0` as a command line
@@ -201,7 +211,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--read-only-port` for service `kubelet` as appropriate.
@@ -216,7 +226,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--read-only-port` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -235,13 +245,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242388]: The Kubernetes API server must have the insecure bind address not set
+## [V-242388]
 
-#### Severity: High
+**Guideline:** The Kubernetes API server must have the insecure bind address
+not set
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > By default, the API server will listen on two ports and addresses. One
 > address is the secure address and the other address is called the "insecure
@@ -259,7 +272,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -268,7 +281,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--insecure-bind-address` for service `kube-apiserver` as appropriate.
@@ -283,7 +296,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--insecure-bind-address` for service `kube-apiserver`
 is set as appropriate in the service's argument file
@@ -303,13 +316,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242390]: The Kubernetes API server must have anonymous authentication disabled
+## [V-242390]
 
-#### Severity: High
+**Guideline:** The Kubernetes API server must have anonymous authentication
+disabled
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes API Server controls Kubernetes via an API interface. A user
 > who has access to the API essentially has root access to the entire
@@ -329,7 +345,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -338,7 +354,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--anonymous-auth` for service `kube-apiserver` as appropriate.
@@ -353,7 +369,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--anonymous-auth` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -368,13 +384,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242391]: The Kubernetes Kubelet must have anonymous authentication disabled
+## [V-242391]
 
-#### Severity: High
+**Guideline:** The Kubernetes Kubelet must have anonymous authentication disabled
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > A user who has access to the Kubelet essentially has root access to the nodes
 > contained within the Kubernetes Control Plane. To control access, users must
@@ -393,7 +411,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not pass a `--config` command line argument to the Kubelet
 > service, but does explicitly pass `--anonymous-auth=0` as a command line
@@ -406,7 +424,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--anonymous-auth` for service `kubelet` as appropriate.
@@ -421,7 +439,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--anonymous-auth` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -438,13 +456,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242392]: The Kubernetes kubelet must enable explicit authorization
+## [V-242392]
 
-#### Severity: High
+**Guideline:** The Kubernetes kubelet must enable explicit authorization
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubelet is the primary agent on each node. The API server communicates with
 > each kubelet to perform tasks such as starting/stopping pods. By default,
@@ -458,7 +478,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not pass a `--config` command line argument to the Kubelet
 > service, but does explicitly pass `--authorization-mode=Webhook` as a command
@@ -471,7 +491,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--authorization-mode` for service `kubelet` as appropriate.
@@ -486,7 +506,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--authorization-mode` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -505,13 +525,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242397]: The Kubernetes kubelet staticPodPath must not enable static pods
+## [V-242397]
 
-#### Severity: High
+**Guideline:** The Kubernetes kubelet staticPodPath must not enable static pods
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Allowing kubelet to set a staticPodPath gives containers with root access
 > permissions to traverse the hosting filesystem. The danger comes when the
@@ -527,7 +549,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The Finding refers to checking the 'staticPodPath' in kubectl's `--config`
 > file is not set.
@@ -542,7 +564,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--pod-manifest-path` for service `kubelet` as appropriate.
@@ -557,7 +579,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--pod-manifest-path` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -576,13 +598,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242415]: Secrets in Kubernetes must not be stored as environment variables
+## [V-242415]
 
-#### Severity: High
+**Guideline:** Secrets in Kubernetes must not be stored as environment variables
 
-#### Class: Manual
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > Secrets, such as passwords, keys, tokens, and certificates should not be
 > stored as environment variables. These environment variables are accessible
@@ -594,7 +618,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The Kubernetes System Administrator must manually inspect the Environment of
 > each user-created Pod to ensure there are no Pods passing information which
@@ -604,13 +628,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242434]: Kubernetes Kubelet must enable kernel protection
+## [V-242434]
 
-#### Severity: High
+**Guideline:** Kubernetes Kubelet must enable kernel protection
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > System kernel is responsible for memory, disk, and task management. The
 > kernel provides a gateway between the system hardware and software.
@@ -620,7 +646,7 @@ The final line of the output will be `PASS`.
 > through Kubernetes components to reduce the attack surface.
 
 
-#### Comments:
+**Comments:**
 
 > The Finding stipulates that `--protect-kernel-defaults` must be set on the
 > Kubelet service.
@@ -635,7 +661,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--protect-kernel-defaults` for service `kubelet` as appropriate.
@@ -650,7 +676,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--protect-kernel-defaults` for service `kubelet` is
 set as appropriate in the service's argument file
@@ -670,13 +696,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242436]: The Kubernetes API server must have the ValidatingAdmissionWebhook enabled
+## [V-242436]
 
-#### Severity: High
+**Guideline:** The Kubernetes API server must have the
+ValidatingAdmissionWebhook enabled
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Enabling the admissions webhook allows for Kubernetes to apply policies
 > against objects that are to be created, read, updated, or deleted. By
@@ -691,7 +720,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding stipulates that the `ValidatingAdmissionWebhook` Admission
 > Plugin should be enabled.
@@ -705,7 +734,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--disable-admission-plugins` for service `kube-apiserver` as appropriate.
@@ -720,7 +749,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--disable-admission-plugins` for service
 `kube-apiserver` is set as appropriate in the service's argument file
@@ -740,13 +769,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242437]: Kubernetes must have a pod security policy set
+## [V-242437]
 
-#### Severity: High
+**Guideline:** Kubernetes must have a pod security policy set
 
-#### Class: Not Applicable
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Enabling the admissions webhook allows for Kubernetes to apply policies
 > against objects that are to be created, read, updated, or deleted. By
@@ -761,7 +792,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding stipulates some checks on the Pod Security Policy object which
 > was deprecated in 1.21 and removed in 1.25, so it is Not Applicable to any
@@ -772,13 +803,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-245542]: Kubernetes API Server must disable basic authentication to protect information in transit
+## [V-245542]
 
-#### Severity: High
+**Guideline:** Kubernetes API Server must disable basic authentication to
+protect information in transit
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes basic authentication sends and receives request containing
 > username, uid, groups, and other fields over a clear text HTTP communication.
@@ -791,7 +825,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -800,7 +834,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--basic-auth-file` for service `kube-apiserver` as appropriate.
@@ -815,7 +849,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--basic-auth-file` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -835,13 +869,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-245543]: Kubernetes API Server must disable token authentication to protect information in transit
+## [V-245543]
 
-#### Severity: High
+**Guideline:** Kubernetes API Server must disable token authentication to
+protect information in transit
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes token authentication uses password known as secrets in a plain
 > text file. This file contains sensitive information such as token, username
@@ -855,7 +892,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -864,7 +901,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--token-auth-file` for service `kube-apiserver` as appropriate.
@@ -881,7 +918,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--token-auth-file` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -901,13 +938,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-245544]: Kubernetes endpoints must use approved organizational certificate and key pair to protect information in transit
+## [V-245544]
 
-#### Severity: High
+**Guideline:** Kubernetes endpoints must use approved organizational certificate
+and key pair to protect information in transit
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes control plane and external communication is managed by API Server.
 > The main implementation of the API Server is to manage hardware resources for
@@ -930,10 +970,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -942,7 +982,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--kubelet-client-certificate` for service `kube-apiserver` as appropriate.
@@ -958,7 +998,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure that the argument `--kubelet-client-certificate` for service
 `kube-apiserver` is set as appropriate in the service's argument file
@@ -978,10 +1018,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -990,7 +1030,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--kubelet-client-key` for service `kube-apiserver` as appropriate.
@@ -1006,7 +1046,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--kubelet-client-key` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -1026,13 +1066,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-254800]: Kubernetes must have a Pod Security Admission control file configured
+## [V-254800]
 
-#### Severity: High
+**Guideline:** Kubernetes must have a Pod Security Admission control file
+configured
 
-#### Class: Manual
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > An admission controller intercepts and processes requests to the Kubernetes
 > API prior to persistence of the object, but after the request is
@@ -1050,7 +1093,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding stipulates the presence of a Pod Security Admission Control File
 > which will need to be manually configured by the Kubernetes System
@@ -1062,13 +1105,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-254801]: Kubernetes must enable PodSecurity admission controller on static pods and Kubelets
+## [V-254801]
 
-#### Severity: High
+**Guideline:** Kubernetes must enable PodSecurity admission controller on static
+pods and Kubelets
 
-#### Class: Deployment
+**Severity:** High
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > PodSecurity admission controller is a component that validates and enforces
 > security policies for pods running within a Kubernetes cluster. It is
@@ -1088,7 +1134,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to setting the `--feature-gates=PodSecurity=true` feature
 > gate for the Kubernetes API Server.
@@ -1102,7 +1148,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--feature-gates` for service `kubelet` as appropriate.
@@ -1117,7 +1163,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--feature-gates` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -1136,13 +1182,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242376]: The Kubernetes Controller Manager must use TLS 1.2, at a minimum, to protect the confidentiality of sensitive data during electronic dissemination
+## [V-242376]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Controller Manager must use TLS 1.2, at a minimum,
+to protect the confidentiality of sensitive data during electronic dissemination
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes Controller Manager will prohibit the use of SSL and
 > unauthorized versions of TLS protocols to properly secure communication.
@@ -1158,7 +1207,7 @@ of
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Controller Manager in the
 > k8s-snap are defined in the following file:
@@ -1167,7 +1216,7 @@ of
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-controller-manager` in order to set the
 argument `--tls-min-version` for service `kube-controller-manager` as
@@ -1183,7 +1232,7 @@ Afterwards restart the `kube-controller-manager` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--tls-min-version` for service
 `kube-controller-manager` is set as appropriate in the service's argument file
@@ -1198,13 +1247,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242377]: The Kubernetes Scheduler must use TLS 1.2, at a minimum, to protect the confidentiality of sensitive data during electronic dissemination
+## [V-242377]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Scheduler must use TLS 1.2, at a minimum, to
+protect the confidentiality of sensitive data during electronic dissemination
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes Scheduler will prohibit the use of SSL and unauthorized
 > versions of TLS protocols to properly secure communication.
@@ -1220,7 +1272,7 @@ of
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Scheduler in the k8s-snap are
 > defined in the following file:
@@ -1229,7 +1281,7 @@ of
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-scheduler` in order to set the argument
 `--tls-min-version` for service `kube-scheduler` as appropriate.
@@ -1244,7 +1296,7 @@ Afterwards restart the `kube-scheduler` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--tls-min-version` for service `kube-scheduler` is
 set as appropriate in the service's argument file
@@ -1259,13 +1311,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242378]: The Kubernetes API Server must use TLS 1.2, at a minimum, to protect the confidentiality of sensitive data during electronic dissemination
+## [V-242378]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server must use TLS 1.2, at a minimum, to
+protect the confidentiality of sensitive data during electronic dissemination
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes API Server will prohibit the use of SSL and unauthorized
 > versions of TLS protocols to properly secure communication.
@@ -1278,7 +1333,7 @@ of
 > API Server, the setting "tls-min-version" must be set.
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Scheduler in the k8s-snap are
 > defined in the following file:
@@ -1287,7 +1342,7 @@ of
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--tls-min-version` for service `kube-apiserver` as appropriate.
@@ -1302,7 +1357,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--tls-min-version` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -1317,13 +1372,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242379]: The Kubernetes etcd must use TLS to protect the confidentiality of sensitive data during electronic dissemination
+## [V-242379]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes etcd must use TLS to protect the confidentiality
+of sensitive data during electronic dissemination
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes etcd will prohibit the use of SSL and unauthorized versions of TLS
 > protocols to properly secure communication.
@@ -1336,10 +1394,10 @@ of
 > API Server, the setting "--auto-tls" must be set.
 
 
-#### Step 1/3
+### Step 1/3
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--auto-tls` command line argument for the etcd
 > service.
@@ -1355,7 +1413,7 @@ of
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -1364,7 +1422,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -1379,15 +1437,15 @@ start with `PASS`.
 
 
 
-#### Step 2/3
+### Step 2/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the permissions on the k8s-dqlite socket.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -1396,7 +1454,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 600 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -1411,17 +1469,17 @@ start with `PASS`.
 
 
 
-#### Step 3/3
+### Step 3/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the `--etcd-servers` argument of the Kube API Server is as
 > expected.
 >
 
 
-#### Remediation for Step 3
+### Remediation for Step 3
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--etcd-servers` for service `kube-apiserver` as appropriate.
@@ -1438,7 +1496,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 3
+### Auditing (as root) for Step 3
 
 Ensure that the argument `--etcd-servers` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -1458,13 +1516,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242380]: The Kubernetes etcd must use TLS to protect the confidentiality of sensitive data during electronic dissemination
+## [V-242380]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes etcd must use TLS to protect the confidentiality
+of sensitive data during electronic dissemination
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes API Server will prohibit the use of SSL and unauthorized
 > versions of TLS protocols to properly secure communication.
@@ -1480,7 +1541,7 @@ of
 
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--peer-auto-tls` command line argument for the
 > etcd service.
@@ -1495,7 +1556,7 @@ of
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/k8s-dqlite` in order to set the argument
 `--enable-tls` for service `k8s-dqlite` as appropriate.
@@ -1510,7 +1571,7 @@ Afterwards restart the `k8s-dqlite` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--enable-tls` for service `k8s-dqlite` is set as
 appropriate in the service's argument file
@@ -1530,13 +1591,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242382]: The Kubernetes API Server must enable Node,RBAC as the authorization mode
+## [V-242382]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server must enable Node,RBAC as the
+authorization mode
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > To mitigate the risk of unauthorized access to sensitive information by
 > entities that have been issued certificates by DOD-approved PKIs, all DOD
@@ -1560,7 +1624,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -1571,7 +1635,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--authorization-mode` for service `kube-apiserver` as appropriate.
@@ -1586,7 +1650,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--authorization-mode` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -1604,13 +1668,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242384]: The Kubernetes Scheduler must have secure binding
+## [V-242384]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Scheduler must have secure binding
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Limiting the number of attack vectors and implementing authentication and
 > encryption on the endpoints available to external sources is paramount when
@@ -1626,7 +1692,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Scheduler in the k8s-snap are
 > defined in the following file:
@@ -1635,7 +1701,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-scheduler` in order to set the argument
 `--bind-address` for service `kube-scheduler` as appropriate.
@@ -1650,7 +1716,7 @@ Afterwards restart the `kube-scheduler` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--bind-address` for service `kube-scheduler` is set
 as appropriate in the service's argument file
@@ -1665,13 +1731,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242385]: The Kubernetes Controller Manager must have secure binding
+## [V-242385]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Controller Manager must have secure binding
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Limiting the number of attack vectors and implementing authentication and
 > encryption on the endpoints available to external sources is paramount when
@@ -1684,7 +1752,7 @@ The final line of the output will be `PASS`.
 > information can access the Control Manager API.
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Controller Manager in the
 > k8s-snap are defined in the following file:
@@ -1693,7 +1761,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-controller-manager` in order to set the
 argument `--bind-address` for service `kube-controller-manager` as appropriate.
@@ -1708,7 +1776,7 @@ Afterwards restart the `kube-controller-manager` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--bind-address` for service `kube-controller-manager`
 is set as appropriate in the service's argument file
@@ -1723,13 +1791,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242389]: The Kubernetes API server must have the secure port set
+## [V-242389]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API server must have the secure port set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > By default, the API server will listen on what is rightfully called the
 > secure port, port 6443. Any requests to this port will perform authentication
@@ -1744,7 +1814,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -1753,7 +1823,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--secure-port` for service `kube-apiserver` as appropriate.
@@ -1768,7 +1838,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--secure-port` for service `kube-apiserver` is set as
 appropriate in the service's argument file
@@ -1788,13 +1858,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242393]: Kubernetes Worker Nodes must not have sshd service running
+## [V-242393]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Worker Nodes must not have sshd service running
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Worker Nodes are maintained and monitored by the Control Plane. Direct access
 > and manipulation of the nodes should not take place by administrators. Worker
@@ -1805,7 +1877,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding aims to completely prohibit the *running* of SSHD on all worker
 > Nodes, and must be assessed by the Kubernetes System Administrator as
@@ -1817,13 +1889,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242394]: Kubernetes Worker Nodes must not have the sshd service enabled
+## [V-242394]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Worker Nodes must not have the sshd service enabled
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Worker Nodes are maintained and monitored by the Control Plane. Direct access
 > and manipulation of the nodes must not take place by administrators. Worker
@@ -1834,7 +1908,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding aims to prohibit the *enabling of the service* for SSHD on all
 > worker Nodes, and must be assessed by the Kubernetes System Administrator as
@@ -1846,13 +1920,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242395]: Kubernetes dashboard must not be enabled
+## [V-242395]
 
-#### Severity: Medium
+**Guideline:** Kubernetes dashboard must not be enabled
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > While the Kubernetes dashboard is not inherently insecure on its own, it is
 > often coupled with a misconfiguration of Role-Based Access control (RBAC)
@@ -1865,7 +1941,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not automatically deploy or configure the Kubernetes
 > Dashboard, so this finding is Not Applicable.
@@ -1878,13 +1954,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242396]: Kubernetes Kubectl cp command must give expected access and results
+## [V-242396]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Kubectl cp command must give expected access and
+results
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > One of the tools heavily used to interact with containers in the Kubernetes
 > cluster is kubectl. The command is the tool System Administrators used to
@@ -1900,7 +1979,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to checking the `kubectl version --client` to avoid a
 > known security issue with `kubectl cp`.
@@ -1913,13 +1992,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242398]: Kubernetes DynamicAuditing must not be enabled
+## [V-242398]
 
-#### Severity: Medium
+**Guideline:** Kubernetes DynamicAuditing must not be enabled
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Protecting the audit data from change or deletion is important when an attack
 > occurs. One way an attacker can cover their tracks is to change or delete
@@ -1937,7 +2018,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This finding relates to the `--feature-gate=DynamicAuditing` feature gate
 > flag.
@@ -1950,13 +2031,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242399]: Kubernetes DynamicKubeletConfig must not be enabled
+## [V-242399]
 
-#### Severity: Medium
+**Guideline:** Kubernetes DynamicKubeletConfig must not be enabled
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Kubernetes allows a user to configure kubelets with dynamic configurations.
 > When dynamic configuration is used, the kubelet will watch for changes to the
@@ -1970,7 +2053,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > Checks related to the `--feature-gate=DynamicKubeletConfig` feature gate
 > flag.
@@ -1983,13 +2066,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242400]: The Kubernetes API server must have Alpha APIs disabled
+## [V-242400]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API server must have Alpha APIs disabled
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes allows alpha API calls within the API server. The alpha features
 > are disabled by default since they are not ready for production and likely to
@@ -2001,13 +2086,13 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not set the `--feature-gate` flag on the `kube-apiserver`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--feature-gate` for service `kube-apiserver` as appropriate.
@@ -2025,7 +2110,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--feature-gate` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -2045,13 +2130,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242402]: The Kubernetes API Server must have an audit log path set
+## [V-242402]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server must have an audit log path set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > When Kubernetes is started, components and user services are started for
 > auditing startup events, and events for components and services, it is
@@ -2063,7 +2150,7 @@ The final line of the output will be `PASS`.
 > audit data is sent to studio.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--audit-log-path` argument of the Kubernetes API
 > Service.
@@ -2082,7 +2169,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--audit-log-path` for service `kube-apiserver` as appropriate.
@@ -2097,7 +2184,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--audit-log-path` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -2112,13 +2199,18 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242403]: Kubernetes API Server must generate audit records that identify what type of event has occurred, identify the source of the event, contain the event results, identify any users, and identify any containers associated with the event
+## [V-242403]
 
-#### Severity: Medium
+**Guideline:** Kubernetes API Server must generate audit records that identify
+what type of event has occurred, identify the source of the event, contain the
+event results, identify any users, and identify any containers associated with
+the event
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Within Kubernetes, audit data for all components is generated by the API
 > server. This audit data is important when there are issues, to include
@@ -2151,7 +2243,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--audit-policy-file` argument of the Kubernetes
 > API Service.
@@ -2163,7 +2255,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--audit-policy-file` for service `kube-apiserver` as appropriate.
@@ -2178,7 +2270,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--audit-policy-file` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -2193,13 +2285,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242404]: Kubernetes Kubelet must deny hostname override
+## [V-242404]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Kubelet must deny hostname override
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes allows for the overriding of hostnames. Allowing this feature to
 > be implemented within the kubelets may break the TLS setup between the
@@ -2212,7 +2306,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of Kubelet in the k8s-snap are defined in the
 > following file:
@@ -2221,7 +2315,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--hostname-override` for service `kubelet` as appropriate.
@@ -2236,7 +2330,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--hostname-override` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -2252,13 +2346,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242405]: The Kubernetes manifests must be owned by root
+## [V-242405]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes manifests must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The manifest files contain the runtime configuration of the API server,
 > proxy, scheduler, controller, and etcd. If an attacker can gain access to
@@ -2269,7 +2365,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The manifest files for the Kubernetes services in the k8s-snap are located in
 > the following directories:
@@ -2279,7 +2375,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -2287,7 +2383,7 @@ Ensure all of the following paths have correct ownership by running:
 
     chown -R 0:0 /etc/containerd /etc/containerd/config.toml
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all files exist and have the correct ownership.
 
@@ -2322,13 +2418,15 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-### [V-242406]: The Kubernetes KubeletConfiguration file must be owned by root
+## [V-242406]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes KubeletConfiguration file must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The kubelet configuration file contains the runtime configuration of the
 > kubelet service. If an attacker can gain access to this file, changes can be
@@ -2338,10 +2436,10 @@ start with `PASS`.
 
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > This Finding relates to the ownership of Kubelet's `--config` file.
 >
@@ -2357,7 +2455,7 @@ start with `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -2366,7 +2464,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/args/kubelet
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -2381,17 +2479,17 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check is defined to ensure that Kubelet is not passed a `--config` file
 > argument in the k8s-snap.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--config` for service `kubelet` as appropriate.
@@ -2407,7 +2505,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--config` for service `kubelet` is set as appropriate
 in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -2428,13 +2526,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242407]: The Kubernetes KubeletConfiguration files must have file permissions set to 644 or more restrictive
+## [V-242407]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes KubeletConfiguration files must have file
+permissions set to 644 or more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The kubelet configuration file contains the runtime configuration of the
 > kubelet service. If an attacker can gain access to this file, changes can be
@@ -2444,10 +2545,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > This Finding relates to the permissions on Kubelet's `--config` file.
 >
@@ -2464,7 +2565,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -2473,7 +2574,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 644 /var/snap/k8s/common/args/kubelet
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -2488,17 +2589,17 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check is defined to ensure that Kubelet is not passed a `--config` file
 > argument in the k8s-snap.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--config` for service `kubelet` as appropriate.
@@ -2514,7 +2615,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--config` for service `kubelet` is set as appropriate
 in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -2535,13 +2636,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242408]: The Kubernetes manifest files must have least privileges
+## [V-242408]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes manifest files must have least privileges
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The manifest files contain the runtime configuration of the API server,
 > scheduler, controller, and etcd. If an attacker can gain access to these
@@ -2555,7 +2658,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The Finding requires checking the permissions of the files within the
 > `/etc/kubernetes/manifests` directory, but the k8s-snap does not use it.
@@ -2566,7 +2669,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -2574,7 +2677,7 @@ Ensure all of the following paths have correct permissions by running:
 
     chmod -R 644 /var/snap/k8s/common/args /var/snap/k8s/common/args/conf.d /var/snap/k8s/common/args/kube-apiserver /var/snap/k8s/common/args/kube-controller-manager /var/snap/k8s/common/args/k8sd /var/snap/k8s/common/args/kube-proxy /var/snap/k8s/common/args/kube-scheduler /var/snap/k8s/common/args/kubelet /var/snap/k8s/common/args/containerd /var/snap/k8s/common/args/k8s-dqlite /var/snap/k8s/common/args/conf.d/auth-token-webhook.conf
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -2597,13 +2700,15 @@ start with `PASS`.
 
 
 
-### [V-242409]: Kubernetes Controller Manager must disable profiling
+## [V-242409]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Controller Manager must disable profiling
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes profiling provides the ability to analyze and troubleshoot
 > Controller Manager events over a web interface on a host port. Enabling this
@@ -2614,7 +2719,7 @@ start with `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Controller Manager in the
 > k8s-snap are defined in the following file:
@@ -2623,7 +2728,7 @@ start with `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-controller-manager` in order to set the
 argument `--profiling` for service `kube-controller-manager` as appropriate.
@@ -2638,7 +2743,7 @@ Afterwards restart the `kube-controller-manager` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--profiling` for service `kube-controller-manager` is
 set as appropriate in the service's argument file
@@ -2656,13 +2761,17 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242410]: The Kubernetes API Server must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL)
+## [V-242410]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server must enforce ports, protocols, and
+services (PPS) that adhere to the Ports, Protocols, and Services Management
+Category Assurance List (PPSM CAL)
 
-#### Class: Manual
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > Kubernetes API Server PPSs must be controlled and conform to the PPSM CAL.
 > Those PPS that fall outside the PPSM CAL must be blocked. Instructions on the
@@ -2672,7 +2781,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This STIG Finding relates to implementing PPSM CAL for kube-apiserver, and
 > must be assessed manually by the Auditor.
@@ -2682,13 +2791,17 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242411]: The Kubernetes Scheduler must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL)
+## [V-242411]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Scheduler must enforce ports, protocols, and
+services (PPS) that adhere to the Ports, Protocols, and Services Management
+Category Assurance List (PPSM CAL)
 
-#### Class: Manual
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > Kubernetes Scheduler PPS must be controlled and conform to the PPSM CAL.
 > Those ports, protocols, and services that fall outside the PPSM CAL must be
@@ -2699,7 +2812,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This STIG Finding relates to implementing PPSM CAL for kube-scheduler, and
 > must be assessed manually by the Auditor.
@@ -2709,13 +2822,17 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242412]: The Kubernetes Controllers must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL)
+## [V-242412]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Controllers must enforce ports, protocols, and
+services (PPS) that adhere to the Ports, Protocols, and Services Management
+Category Assurance List (PPSM CAL)
 
-#### Class: Manual
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > Kubernetes Controller ports, protocols, and services must be controlled and
 > conform to the PPSM CAL. Those PPS that fall outside the PPSM CAL must be
@@ -2726,7 +2843,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This STIG Finding relates to implementing PPSM CAL for
 > kube-controller-manager, and must be assessed manually by the Auditor.
@@ -2736,13 +2853,17 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242413]: The Kubernetes etcd must enforce ports, protocols, and services (PPS) that adhere to the Ports, Protocols, and Services Management Category Assurance List (PPSM CAL)
+## [V-242413]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes etcd must enforce ports, protocols, and services
+(PPS) that adhere to the Ports, Protocols, and Services Management Category
+Assurance List (PPSM CAL)
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Kubernetes etcd PPS must be controlled and conform to the PPSM CAL. Those PPS
 > that fall outside the PPSM CAL must be blocked. Instructions on the PPSM can
@@ -2752,7 +2873,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This STIG Finding relates to implementing PPSM CAL for etcd.
 >
@@ -2765,13 +2886,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242414]: The Kubernetes cluster must use non-privileged host ports for user pods
+## [V-242414]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes cluster must use non-privileged host ports for
+user pods
 
-#### Class: Manual
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > Privileged ports are those ports below 1024 and that require system
 > privileges for their use. If containers can use these ports, the container
@@ -2785,7 +2909,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The Kubernetes System Administrators must manually inspect the Pods in all of
 > the default namespaces to ensure there are no user-created Pods with
@@ -2797,13 +2921,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242417]: Kubernetes must separate user functionality
+## [V-242417]
 
-#### Severity: Medium
+**Guideline:** Kubernetes must separate user functionality
 
-#### Class: Manual
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Manual
+
+**Upstream finding description:**
 
 > Separating user functionality from management functionality is a requirement
 > for all the components within the Kubernetes Control Plane. Without the
@@ -2816,7 +2942,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The Kubernetes System Administrators must manually inspect the Pods in all of
 > the default namespaces to ensure there are no user-created Pods within them,
@@ -2829,13 +2955,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242418]: The Kubernetes API server must use approved cipher suites
+## [V-242418]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API server must use approved cipher suites
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes API server communicates to the kubelet service on the nodes to
 > deploy, update, and delete resources. If an attacker were able to get between
@@ -2848,7 +2976,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -2857,7 +2985,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--tls-cipher-suites` for service `kube-apiserver` as appropriate.
@@ -2875,7 +3003,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--tls-cipher-suites` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -2893,13 +3021,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242419]: Kubernetes API Server must have the SSL Certificate Authority set
+## [V-242419]
 
-#### Severity: Medium
+**Guideline:** Kubernetes API Server must have the SSL Certificate Authority set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes control plane and external communication are managed by API
 > Server. The main implementation of the API Server is to manage hardware
@@ -2921,7 +3051,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -2930,7 +3060,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--client-ca-file` for service `kube-apiserver` as appropriate.
@@ -2945,7 +3075,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--client-ca-file` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -2963,13 +3093,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242420]: Kubernetes Kubelet must have the SSL Certificate Authority set
+## [V-242420]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Kubelet must have the SSL Certificate Authority set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes container and pod configuration are maintained by Kubelet. Kubelet
 > agents register nodes with the API Server, mount volume storage, and perform
@@ -2991,7 +3123,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not pass a `--config` command line argument to the Kubelet
 > service, but does explicitly pass the `--client-ca-file` argument as a
@@ -3004,7 +3136,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--client-ca-file` for service `kubelet` as appropriate.
@@ -3019,7 +3151,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--client-ca-file` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -3036,13 +3168,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242421]: Kubernetes Controller Manager must have the SSL Certificate Authority set
+## [V-242421]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Controller Manager must have the SSL Certificate
+Authority set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes Controller Manager is responsible for creating service
 > accounts and tokens for the API Server, maintaining the correct number of
@@ -3064,7 +3199,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes Controller Manager in the
 > k8s-snap are defined in the following file:
@@ -3073,7 +3208,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-controller-manager` in order to set the
 argument `--root-ca-file` for service `kube-controller-manager` as appropriate.
@@ -3088,7 +3223,7 @@ Afterwards restart the `kube-controller-manager` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--root-ca-file` for service `kube-controller-manager`
 is set as appropriate in the service's argument file
@@ -3106,13 +3241,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242422]: Kubernetes API Server must have a certificate for communication
+## [V-242422]
 
-#### Severity: Medium
+**Guideline:** Kubernetes API Server must have a certificate for communication
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes control plane and external communication is managed by API Server.
 > The main implementation of the API Server is to manage hardware resources for
@@ -3133,10 +3270,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -3145,7 +3282,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--tls-cert-file` for service `kube-apiserver` as appropriate.
@@ -3161,7 +3298,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure that the argument `--tls-cert-file` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -3181,10 +3318,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > The command line arguments of the Kubernetes API Server in the k8s-snap are
 > defined in the following file:
@@ -3193,7 +3330,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--tls-private-key-file` for service `kube-apiserver` as appropriate.
@@ -3209,7 +3346,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--tls-private-key-file` for service `kube-apiserver`
 is set as appropriate in the service's argument file
@@ -3229,13 +3366,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242423]: Kubernetes etcd must enable client authentication to secure service
+## [V-242423]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must enable client authentication to secure
+service
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes container and pod configuration are maintained by Kubelet. Kubelet
 > agents register nodes with the API Server, mount volume storage, and perform
@@ -3256,10 +3396,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/3
+### Step 1/3
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--cert-file` command line argument for the etcd
 > service.
@@ -3275,7 +3415,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -3284,7 +3424,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -3299,15 +3439,15 @@ start with `PASS`.
 
 
 
-#### Step 2/3
+### Step 2/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the permissions on the k8s-dqlite socket.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -3316,7 +3456,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 600 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -3331,17 +3471,17 @@ start with `PASS`.
 
 
 
-#### Step 3/3
+### Step 3/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the `--etcd-servers` argument of the Kube API Server is as
 > expected.
 >
 
 
-#### Remediation for Step 3
+### Remediation for Step 3
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--etcd-servers` for service `kube-apiserver` as appropriate.
@@ -3358,7 +3498,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 3
+### Auditing (as root) for Step 3
 
 Ensure that the argument `--etcd-servers` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -3378,13 +3518,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242424]: Kubernetes Kubelet must enable tlsPrivateKeyFile for client authentication to secure service
+## [V-242424]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Kubelet must enable tlsPrivateKeyFile for client
+authentication to secure service
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes container and pod configuration are maintained by Kubelet. Kubelet
 > agents register nodes with the API Server, mount volume storage, and perform
@@ -3406,7 +3549,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not pass a `--config` command line argument to the Kubelet
 > service, but does explicitly pass
@@ -3420,7 +3563,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--tls-private-key-file` for service `kubelet` as appropriate.
@@ -3435,7 +3578,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--tls-private-key-file` for service `kubelet` is set
 as appropriate in the service's argument file
@@ -3450,13 +3593,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242425]: Kubernetes Kubelet must enable tlsCertFile for client authentication to secure service
+## [V-242425]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Kubelet must enable tlsCertFile for client
+authentication to secure service
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes container and pod configuration are maintained by Kubelet. Kubelet
 > agents register nodes with the API Server, mount volume storage, and perform
@@ -3478,7 +3624,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not pass a `--config` command line argument to the Kubelet
 > service, but does explicitly pass
@@ -3491,7 +3637,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--tls-cert-file` for service `kubelet` as appropriate.
@@ -3506,7 +3652,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--tls-cert-file` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -3520,13 +3666,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242426]: Kubernetes etcd must enable client authentication to secure service
+## [V-242426]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must enable client authentication to secure service
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes container and pod configuration are maintained by Kubelet. Kubelet
 > agents register nodes with the API Server, mount volume storage, and perform
@@ -3551,7 +3699,7 @@ The final line of the output will be `PASS`.
 
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--peer-client-cert-auth` command line argument
 > for the etcd service.
@@ -3566,7 +3714,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/k8s-dqlite` in order to set the argument
 `--enable-tls` for service `k8s-dqlite` as appropriate.
@@ -3581,7 +3729,7 @@ Afterwards restart the `k8s-dqlite` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--enable-tls` for service `k8s-dqlite` is set as
 appropriate in the service's argument file
@@ -3601,13 +3749,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242427]: Kubernetes etcd must have a key file for secure communication
+## [V-242427]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must have a key file for secure communication
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes stores configuration and state information in a distributed
 > key-value store called etcd. Anyone who can write to etcd can effectively
@@ -3628,10 +3778,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/3
+### Step 1/3
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--key-file` command line argument for the etcd
 > service.
@@ -3647,7 +3797,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -3656,7 +3806,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -3668,16 +3818,16 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 2/3
+### Step 2/3
 
 
-#### Comments:
+**Comments:**
 
 
 > This check ensures the permissions on the k8s-dqlite socket.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -3686,7 +3836,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 600 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -3698,17 +3848,17 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 3/3
+### Step 3/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the `--etcd-servers` argument of the Kube API Server is as
 > expected.
 >
 
 
-#### Remediation for Step 3
+### Remediation for Step 3
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--etcd-servers` for service `kube-apiserver` as appropriate.
@@ -3725,7 +3875,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 3
+### Auditing (as root) for Step 3
 
 Ensure that the argument `--etcd-servers` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -3745,13 +3895,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242428]: Kubernetes etcd must have a certificate for communication
+## [V-242428]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must have a certificate for communication
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes stores configuration and state information in a distributed
 > key-value store called etcd. Anyone who can write to etcd can effectively
@@ -3772,10 +3924,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/3
+### Step 1/3
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--cert-file` command line argument for the etcd
 > service.
@@ -3791,7 +3943,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -3800,7 +3952,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -3812,15 +3964,15 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 2/3
+### Step 2/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the permissions on the k8s-dqlite socket.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -3829,7 +3981,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 600 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -3842,17 +3994,17 @@ start with `PASS`.
 
 
 
-#### Step 3/3
+### Step 3/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the `--etcd-servers` argument of the Kube API Server is as
 > expected.
 >
 
 
-#### Remediation for Step 3
+### Remediation for Step 3
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--etcd-servers` for service `kube-apiserver` as appropriate.
@@ -3869,7 +4021,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 3
+### Auditing (as root) for Step 3
 
 Ensure that the argument `--etcd-servers` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -3886,13 +4038,15 @@ start with `PASS`.
 The final line of the output will be `PASS`.
 
 
-### [V-242429]: Kubernetes etcd must have the SSL Certificate Authority set
+## [V-242429]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must have the SSL Certificate Authority set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes stores configuration and state information in a distributed
 > key-value store called etcd. Anyone who can write to etcd can effectively
@@ -3911,10 +4065,10 @@ The final line of the output will be `PASS`.
 > Authority file used to secure etcd communication.
 
 
-#### Step 1/3
+### Step 1/3
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--etcd-cafile` command line argument for the Kube
 > API Service.
@@ -3930,7 +4084,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -3939,7 +4093,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -3951,15 +4105,15 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 2/3
+### Step 2/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the permissions on the k8s-dqlite socket.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -3968,7 +4122,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 600 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -3980,17 +4134,17 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 3/3
+### Step 3/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the `--etcd-servers` argument of the Kube API Server is as
 > expected.
 >
 
 
-#### Remediation for Step 3
+### Remediation for Step 3
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--etcd-servers` for service `kube-apiserver` as appropriate.
@@ -4004,7 +4158,7 @@ Afterwards restart the `kube-apiserver` service with:
 
     sudo systemctl restart snap.k8s.kube-apiserver
 
-#### Auditing (as root) for Step 3
+### Auditing (as root) for Step 3
 
 Ensure that the argument `--etcd-servers` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -4022,13 +4176,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242430]: Kubernetes etcd must have a certificate for communication
+## [V-242430]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must have a certificate for communication
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes stores configuration and state information in a distributed
 > key-value store called etcd. Anyone who can write to etcd can effectively
@@ -4049,10 +4205,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/3
+### Step 1/3
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--etcd-certfile` command line argument for the
 > Kube API Service.
@@ -4068,7 +4224,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -4077,7 +4233,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -4089,15 +4245,15 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 2/3
+### Step 2/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the permissions on the k8s-dqlite socket.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -4106,7 +4262,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 600 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -4119,17 +4275,17 @@ start with `PASS`.
 
 
 
-#### Step 3/3
+### Step 3/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the `--etcd-servers` argument of the Kube API Server is as
 > expected.
 >
 
 
-#### Remediation for Step 3
+### Remediation for Step 3
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--etcd-servers` for service `kube-apiserver` as appropriate.
@@ -4146,7 +4302,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 3
+### Auditing (as root) for Step 3
 
 Ensure that the argument `--etcd-servers` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -4164,13 +4320,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242431]: Kubernetes etcd must have a key file for secure communication
+## [V-242431]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must have a key file for secure communication
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes stores configuration and state information in a distributed
 > key-value store called etcd. Anyone who can write to etcd can effectively
@@ -4191,10 +4349,10 @@ The final line of the output will be `PASS`.
 
 
 
-#### Step 1/3
+### Step 1/3
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--etcd-keyfile` command line argument for the
 > Kube API Service.
@@ -4210,7 +4368,7 @@ The final line of the output will be `PASS`.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -4219,7 +4377,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -4231,14 +4389,14 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 2/3
+### Step 2/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the permissions on the k8s-dqlite socket.
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -4247,7 +4405,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 600 /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -4260,17 +4418,17 @@ start with `PASS`.
 
 
 
-#### Step 3/3
+### Step 3/3
 
 
-#### Comments:
+**Comments:**
 
 > This check ensures the `--etcd-servers` argument of the Kube API Server is as
 > expected.
 >
 
 
-#### Remediation for Step 3
+### Remediation for Step 3
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--etcd-servers` for service `kube-apiserver` as appropriate.
@@ -4287,7 +4445,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root) for Step 3
+### Auditing (as root) for Step 3
 
 Ensure that the argument `--etcd-servers` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -4305,13 +4463,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242432]: Kubernetes etcd must have peer-cert-file set for secure communication
+## [V-242432]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must have peer-cert-file set for secure communication
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes stores configuration and state information in a distributed
 key-value store called etcd. Anyone who can write to etcd can effectively
@@ -4329,7 +4489,7 @@ be set. This parameter gives the location of the SSL certification file used to
 secure etcd communication.
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--peer-cert-file` command line argument for the
 > etcd service.
@@ -4346,7 +4506,7 @@ secure etcd communication.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/k8s-dqlite` in order to set the argument
 `--storage-dir` for service `k8s-dqlite` as appropriate.
@@ -4361,7 +4521,7 @@ Afterwards restart the `k8s-dqlite` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--storage-dir` for service `k8s-dqlite` is set as
 appropriate in the service's argument file
@@ -4379,13 +4539,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242433]: Kubernetes etcd must have a peer-key-file set for secure communication
+## [V-242433]
 
-#### Severity: Medium
+**Guideline:** Kubernetes etcd must have a peer-key-file set for secure communication
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes stores configuration and state information in a distributed
 key-value store called etcd. Anyone who can write to etcd can effectively
@@ -4403,7 +4565,7 @@ be set. This parameter gives the location of the SSL certification file used to
 secure etcd communication.
 
 
-#### Comments:
+**Comments:**
 
 > This finding refers to the `--peer-key-file` command line argument for the
 > etcd service.
@@ -4420,7 +4582,7 @@ secure etcd communication.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/k8s-dqlite` in order to set the argument
 `--storage-dir` for service `k8s-dqlite` as appropriate.
@@ -4432,7 +4594,7 @@ Afterwards restart the `k8s-dqlite` service with:
     sudo systemctl restart snap.k8s.k8s-dqlite
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--storage-dir` for service `k8s-dqlite` is set as
 appropriate in the service's argument file
@@ -4450,13 +4612,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242438]: Kubernetes API Server must configure timeouts to limit attack surface
+## [V-242438]
 
-#### Severity: Medium
+**Guideline:** Kubernetes API Server must configure timeouts to limit attack surface
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes API Server request timeouts sets the duration a request stays open
 before timing out. Since the API Server is the central component in the
@@ -4469,13 +4633,13 @@ set to "0". This disables the request-timeout feature. (By default, the
 "--request-timeout" is set to "1 minute".)
 
 
-#### Comments:
+**Comments:**
 
 > The Finding also allows for setting a timeout larger than 300s.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--request-timeout` for service `kube-apiserver` as appropriate.
@@ -4490,7 +4654,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--request-timeout` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -4505,13 +4669,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242442]: Kubernetes must remove old components after updated versions have been installed
+## [V-242442]
 
-#### Severity: Medium
+**Guideline:** Kubernetes must remove old components after updated versions
+have been installed
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Previous versions of Kubernetes components that are not removed after updates
 have been installed may be exploited by adversaries by allowing the
@@ -4520,7 +4687,7 @@ Kubernetes to remove old pods when newer pods are created using new images to
 always be at the desired security state.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding recommends checking that no residual versions of Kubernetes
 > components are left running following upgrades of the Kubernetes cluster.
@@ -4531,13 +4698,16 @@ always be at the desired security state.
 
 
 
-### [V-242443]: Kubernetes must contain the latest updates as authorized by IAVMs, CTOs, DTMs, and STIGs
+## [V-242443]
 
-#### Severity: Medium
+**Guideline:** Kubernetes must contain the latest updates as authorized by
+IAVMs, CTOs, DTMs, and STIGs
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > Kubernetes software must stay up to date with the latest patches, service
 packs, and hot fixes. Not updating the Kubernetes control plane will expose the
@@ -4570,7 +4740,7 @@ images are current. The specific time period will be defined by an
 authoritative source (e.g., IAVM, CTOs, DTMs, and STIGs).
 
 
-#### Comments:
+**Comments:**
 
 > This Finding recommends checking all Kubernetes component versions are
 > actively supported.
@@ -4583,13 +4753,15 @@ authoritative source (e.g., IAVM, CTOs, DTMs, and STIGs).
 
 
 
-### [V-242444]: The Kubernetes component manifests must be owned by root
+## [V-242444]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes component manifests must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes manifests are those files that contain the arguments and
 settings for the Control Plane services. These services are etcd, the api
@@ -4601,7 +4773,7 @@ settings within the document are implemented through these manifests.
 
 
 
-#### Comments:
+**Comments:**
 
 > The manifest files for the Kubernetes services in the k8s-snap are located in
 > the following directories:
@@ -4610,7 +4782,7 @@ settings within the document are implemented through these manifests.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -4618,7 +4790,7 @@ Ensure all of the following paths have correct ownership by running:
 
     chown -R 0:0 /etc/kubernetes /etc/kubernetes/pki /etc/kubernetes/kubelet.conf /etc/kubernetes/scheduler.conf /etc/kubernetes/proxy.conf /etc/kubernetes/admin.conf /etc/kubernetes/controller.conf /etc/kubernetes/pki/etcd /etc/kubernetes/pki/client-ca.crt /etc/kubernetes/pki/front-proxy-ca.key /etc/kubernetes/pki/apiserver.key /etc/kubernetes/pki/apiserver.crt /etc/kubernetes/pki/apiserver-kubelet-client.key /etc/kubernetes/pki/front-proxy-client.crt /etc/kubernetes/pki/serviceaccount.key /etc/kubernetes/pki/front-proxy-client.key /etc/kubernetes/pki/kubelet.crt /etc/kubernetes/pki/ca.crt /etc/kubernetes/pki/ca.key /etc/kubernetes/pki/apiserver-kubelet-client.crt /etc/kubernetes/pki/front-proxy-ca.crt /etc/kubernetes/pki/kubelet.key
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all files exist and have the correct ownership.
 
@@ -4652,13 +4824,15 @@ start with `PASS`.
 
 
 
-### [V-242445]: The Kubernetes component etcd must be owned by etcd
+## [V-242445]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes component etcd must be owned by etcd
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes etcd key-value store provides a way to store data to the
 Control Plane. If these files can be changed, data to API object and the
@@ -4667,7 +4841,7 @@ immediately. Many of the security settings within the document are implemented
 through this file.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to checking the ownership of all etcd-related files under
 > /var/lib/etcd/*.
@@ -4683,7 +4857,7 @@ through this file.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -4691,7 +4865,7 @@ Ensure all of the following paths have correct ownership by running:
 
     chown 0:0 /var/snap/k8s/common/var/lib/k8s-dqlite /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.yaml /var/snap/k8s/common/var/lib/k8s-dqlite/info.yaml /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all files exist and have the correct ownership.
 
@@ -4709,13 +4883,15 @@ start with `PASS`.
 
 
 
-### [V-242446]: The Kubernetes conf files must be owned by root
+## [V-242446]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes conf files must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes conf files contain the arguments and settings for the Control
 Plane services. These services are controller and scheduler. If these files can
@@ -4723,7 +4899,7 @@ be changed, the scheduler will be implementing the changes immediately. Many of
 the security settings within the document are implemented through this file.
 
 
-#### Comments:
+**Comments:**
 
 > Note that the original Finding references 'controller-manager.conf', but the
 > k8s-snap uses 'controller.conf'.
@@ -4732,7 +4908,7 @@ the security settings within the document are implemented through this file.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -4740,7 +4916,7 @@ Ensure all of the following paths have correct ownership by running:
 
     chown -R 0:0 /etc/kubernetes/admin.conf /etc/kubernetes/scheduler.conf /etc/kubernetes/controller.conf
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all files exist and have the correct ownership.
 
@@ -4754,13 +4930,16 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-### [V-242447]: The Kubernetes Kube Proxy kubeconfig must have file permissions set to 644 or more restrictive
+## [V-242447]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Kube Proxy kubeconfig must have file permissions
+set to 644 or more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes Kube Proxy kubeconfig contain the argument and setting for the
 Control Planes. These settings contain network rules for restricting network
@@ -4771,10 +4950,10 @@ implemented through this file.
 
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > Finding stipulates that permission mask should be at most 644, but they can
 > also be set to be more restrictive.
@@ -4783,7 +4962,7 @@ implemented through this file.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -4792,7 +4971,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 644 /etc/kubernetes/proxy.conf
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -4804,17 +4983,17 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check was added to ensure the Kubernetes Proxy configuration file path
 > is set as expected.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kube-proxy` in order to set the argument
 `--kubeconfig` for service `kube-proxy` as appropriate.
@@ -4830,7 +5009,7 @@ Afterwards restart the `kube-proxy` service with:
 
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--kubeconfig` for service `kube-proxy` is set as
 appropriate in the service's argument file
@@ -4848,13 +5027,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242448]: The Kubernetes Kube Proxy kubeconfig must be owned by root
+## [V-242448]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Kube Proxy kubeconfig must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes Kube Proxy kubeconfig contain the argument and setting for the
 Control Planes. These settings contain network rules for restricting network
@@ -4866,10 +5047,10 @@ implemented through this file.
 
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > Finding stipulates the file should be owned by the root user/group.
 >
@@ -4877,7 +5058,7 @@ implemented through this file.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -4885,7 +5066,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /etc/kubernetes/proxy.conf
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -4898,16 +5079,16 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check was added to ensure the proxy config is as expected.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kube-proxy` in order to set the argument
 `--kubeconfig` for service `kube-proxy` as appropriate.
@@ -4919,7 +5100,7 @@ Afterwards restart the `kube-proxy` service with:
     sudo systemctl restart snap.k8s.kube-proxy
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--kubeconfig` for service `kube-proxy` is set as
 appropriate in the service's argument file
@@ -4937,13 +5118,16 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242449]: The Kubernetes Kubelet certificate authority file must have file permissions set to 644 or more restrictive
+## [V-242449]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Kubelet certificate authority file must have file
+permissions set to 644 or more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes kubelet certificate authority file contains settings for the
 Kubernetes Node TLS certificate authority. Any request presenting a client
@@ -4954,10 +5138,10 @@ compromised. The scheduler will implement the changes immediately. Many of the
 security settings within the document are implemented through this file.
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 >
 > Finding stipulates that permission mask should be at most 644, but they can
 > also be set to be more restrictive.
@@ -4967,7 +5151,7 @@ security settings within the document are implemented through this file.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -4976,7 +5160,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod 644 /etc/kubernetes/pki/client-ca.crt
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -4989,16 +5173,16 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check was added to ensure the `--client-ca-file` is as expected.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--client-ca-file` for service `kubelet` as appropriate.
@@ -5014,7 +5198,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--client-ca-file` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -5031,13 +5215,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242450]: The Kubernetes Kubelet certificate authority must be owned by root
+## [V-242450]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes Kubelet certificate authority must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes kube proxy kubeconfig contain the argument and setting for the
 Control Planes. These settings contain network rules for restricting network
@@ -5047,10 +5233,10 @@ be compromised. Many of the security settings within the document are
 implemented through this file.
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > Finding stipulates the file should be owned by the root user/group.
 >
@@ -5058,7 +5244,7 @@ implemented through this file.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -5067,7 +5253,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /etc/kubernetes/pki/client-ca.crt
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -5080,16 +5266,16 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check was added to ensure the `--client-ca-file` is as expected.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--client-ca-file` for service `kubelet` as appropriate.
@@ -5103,7 +5289,7 @@ Afterwards restart the `kubelet` service with:
     sudo systemctl restart snap.k8s.kubelet
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--client-ca-file` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -5120,13 +5306,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242451]: The Kubernetes component PKI must be owned by root
+## [V-242451]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes component PKI must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes PKI directory contains all certificates (.crt files)
 supporting secure network communications in the Kubernetes Control Plane. If
@@ -5135,7 +5323,7 @@ would become insecure and compromised. Many of the security settings within the
 document are implemented through this file.
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap stores PKI-related files in the following directory:
 >
@@ -5145,7 +5333,7 @@ document are implemented through this file.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -5153,7 +5341,7 @@ Ensure all of the following paths have correct ownership by running:
 
     chown -R 0:0 /etc/kubernetes/pki /etc/kubernetes/pki/etcd /etc/kubernetes/pki/client-ca.crt /etc/kubernetes/pki/front-proxy-ca.key /etc/kubernetes/pki/apiserver.key /etc/kubernetes/pki/apiserver.crt /etc/kubernetes/pki/apiserver-kubelet-client.key /etc/kubernetes/pki/front-proxy-client.crt /etc/kubernetes/pki/serviceaccount.key /etc/kubernetes/pki/front-proxy-client.key /etc/kubernetes/pki/kubelet.crt /etc/kubernetes/pki/ca.crt /etc/kubernetes/pki/ca.key /etc/kubernetes/pki/apiserver-kubelet-client.crt /etc/kubernetes/pki/front-proxy-ca.crt /etc/kubernetes/pki/kubelet.key
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all files exist and have the correct ownership.
 
@@ -5181,13 +5369,16 @@ start with `PASS`.
 
 
 
-### [V-242452]: The Kubernetes kubelet KubeConfig must have file permissions set to 644 or more restrictive
+## [V-242452]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes kubelet KubeConfig must have file permissions set
+to 644 or more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes kubelet agent registers nodes with the API Server, mounts
 volume storage for pods, and performs health checks to containers within pods.
@@ -5196,24 +5387,24 @@ or container degradation. Many of the security settings within the document are
 implemented through this file.
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > Finding stipulates that permission mask should be at most 644, but they can
 > also be set to be more restrictive.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct permissions by running:
 
     chmod -R 644 /etc/kubernetes/kubelet.conf
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -5226,15 +5417,15 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check was added to ensure Kubelet's `--kubeconfig` is as expected.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--kubeconfig` for service `kubelet` as appropriate.
@@ -5248,7 +5439,7 @@ Afterwards restart the `kubelet` service with:
     sudo systemctl restart snap.k8s.kubelet
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--kubeconfig` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -5265,13 +5456,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242453]: The Kubernetes kubelet KubeConfig file must be owned by root
+## [V-242453]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes kubelet KubeConfig file must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes kubelet agent registers nodes with the API server and performs
 health checks to containers within pods. If these files can be modified, the
@@ -5279,15 +5472,15 @@ information system would be unaware of pod or container degradation. Many of
 the security settings within the document are implemented through this file.
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > Finding stipulates the file should be owned by the root user/group.
 >
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct ownership by running:
 
@@ -5296,7 +5489,7 @@ Ensure all of the following paths have correct ownership by running:
     chown -R 0:0 /etc/kubernetes/kubelet.conf
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all files exist and have the correct ownership.
 
@@ -5309,15 +5502,15 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check was added to ensure Kubelet's `--kubeconfig` is as expected.
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--kubeconfig` for service `kubelet` as appropriate.
@@ -5331,7 +5524,7 @@ Afterwards restart the `kubelet` service with:
     sudo systemctl restart snap.k8s.kubelet
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--kubeconfig` for service `kubelet` is set as
 appropriate in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -5348,13 +5541,15 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242454]: The Kubernetes kubeadm.conf must be owned by root
+## [V-242454]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes kubeadm.conf must be owned by root
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > The Kubernetes kubeeadm.conf contains sensitive information regarding the
 cluster nodes configuration. If this file can be modified, the Kubernetes
@@ -5362,7 +5557,7 @@ Platform Plane would be degraded or compromised for malicious intent. Many of
 the security settings within the document are implemented through this file.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding stipulates the file ownership of the kubeadm executable, which
 > does not ship as part of the k8s-snap.
@@ -5376,13 +5571,16 @@ the security settings within the document are implemented through this file.
 
 
 
-### [V-242455]: The Kubernetes kubeadm.conf must have file permissions set to 644 or more restrictive
+## [V-242455]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes kubeadm.conf must have file permissions set to
+644 or more restrictive
 
-#### Class: Not Applicable
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Not Applicable
+
+**Upstream finding description:**
 
 > The Kubernetes kubeadm.conf contains sensitive information regarding the
 cluster nodes configuration. If this file can be modified, the Kubernetes
@@ -5390,7 +5588,7 @@ Platform Plane would be degraded or compromised for malicious intent. Many of
 the security settings within the document are implemented through this file.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding stipulates the file ownership of the kubeadm executable, which
 > does not ship as part of the k8s-snap.
@@ -5404,23 +5602,26 @@ the security settings within the document are implemented through this file.
 
 
 
-### [V-242456]: The Kubernetes kubelet config must have file permissions set to 644 or more restrictive
+## [V-242456]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes kubelet config must have file permissions set to
+644 or more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes kubelet agent registers nodes with the API server and performs
 health checks to containers within pods. If this file can be modified, the
 information system would be unaware of pod or container degradation.
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > This Finding relates to the permissions on the `/var/lib/kubelet/config.yaml`
 > file.
@@ -5438,7 +5639,7 @@ information system would be unaware of pod or container degradation.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -5447,7 +5648,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 644 /var/snap/k8s/common/args/kubelet
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -5462,17 +5663,17 @@ start with `PASS`.
 
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check is defined to ensure that Kubelet is not passed a `--config` file
 > argument in the k8s-snap.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--config` for service `kubelet` as appropriate.
@@ -5488,7 +5689,7 @@ Afterwards restart the `kubelet` service with:
 
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--config` for service `kubelet` is set as appropriate
 in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -5507,23 +5708,25 @@ The final line of the output will be `PASS`.
 
 
 
-### [V-242457]: The Kubernetes kubelet config must be owned by root
+## [V-242457]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes kubelet config must be owned by root
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes kubelet agent registers nodes with the API Server and performs
 health checks to containers within pods. If this file can be modified, the
 information system would be unaware of pod or container degradation.
 
 
-#### Step 1/2
+### Step 1/2
 
 
-#### Comments:
+**Comments:**
 
 > This Finding relates to the permissions on the `/var/lib/kubelet/config.yaml`
 > file in relation to it being used by `kubeadm`.
@@ -5541,7 +5744,7 @@ information system would be unaware of pod or container degradation.
 >
 
 
-#### Remediation for Step 1
+### Remediation for Step 1
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -5549,7 +5752,7 @@ Ensure all of the following paths have correct permissions by running:
     chmod -R 644 /var/snap/k8s/common/args/kubelet
 
 
-#### Auditing (as root) for Step 1
+### Auditing (as root) for Step 1
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -5561,17 +5764,17 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-#### Step 2/2
+### Step 2/2
 
 
-#### Comments:
+**Comments:**
 
 > This check is defined to ensure that Kubelet is not passed a `--config` file
 > argument in the k8s-snap.
 >
 
 
-#### Remediation for Step 2
+### Remediation for Step 2
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--config` for service `kubelet` as appropriate.
@@ -5585,7 +5788,7 @@ Afterwards restart the `kubelet` service with:
     sudo systemctl restart snap.k8s.kubelet
 
 
-#### Auditing (as root) for Step 2
+### Auditing (as root) for Step 2
 
 Ensure that the argument `--config` for service `kubelet` is set as appropriate
 in the service's argument file `/var/snap/k8s/common/args/kubelet`.
@@ -5603,20 +5806,23 @@ start with `UNSET`.
 The final line of the output will be `PASS`.
 
 
-### [V-242459]: The Kubernetes etcd must have file permissions set to 644 or more restrictive
+## [V-242459]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes etcd must have file permissions set to 644 or
+more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes etcd key-value store provides a way to store data to the
 Control Plane. If these files can be changed, data to API object and Control
 Plane would be compromised.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to checking the ownership of all etcd-related files under
 > /var/lib/etcd/*.
@@ -5632,7 +5838,7 @@ Plane would be compromised.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct permissions by running:
 
@@ -5640,7 +5846,7 @@ Ensure all of the following paths have correct permissions by running:
 
     chmod 644 /var/snap/k8s/common/var/lib/k8s-dqlite /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.yaml /var/snap/k8s/common/var/lib/k8s-dqlite/info.yaml /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt /var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -5658,13 +5864,16 @@ start with `PASS`.
 
 
 
-### [V-242460]: The Kubernetes admin kubeconfig must have file permissions set to 644 or more restrictive
+## [V-242460]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes admin kubeconfig must have file permissions set
+to 644 or more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes admin kubeconfig files contain the arguments and settings for
 the Control Plane services. These services are controller and scheduler. If
@@ -5672,7 +5881,7 @@ these files can be changed, the scheduler will be implementing the changes
 immediately.
 
 
-#### Comments:
+**Comments:**
 
 > Note that the original Finding references 'controller-manager.conf', but the
 > k8s-snap uses 'controller.conf'.
@@ -5681,13 +5890,13 @@ immediately.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct permissions by running:
 
     chmod -R 644 /etc/kubernetes/admin.conf /etc/kubernetes/scheduler.conf /etc/kubernetes/controller.conf
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -5701,13 +5910,15 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-### [V-242461]: Kubernetes API Server audit logs must be enabled
+## [V-242461]
 
-#### Severity: Medium
+**Guideline:** Kubernetes API Server audit logs must be enabled
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes API Server validates and configures pods and services for the API
 object. The REST operation provides frontend functionality to the cluster share
@@ -5717,7 +5928,7 @@ in the case the Kubernetes API Server is compromised requiring a cybersecurity
 investigation.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--audit-policy-file` argument of the Kubernetes
 > API Service.
@@ -5729,7 +5940,7 @@ investigation.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--audit-policy-file` for service `kube-apiserver` as appropriate.
@@ -5744,7 +5955,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--audit-policy-file` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -5758,13 +5969,15 @@ test $? -eq 0 && echo PASS || echo FAIL
 The final line of the output will be `PASS`.
 
 
-### [V-242462]: The Kubernetes API Server must be set to audit log max size
+## [V-242462]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server must be set to audit log max size
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes API Server must be set for enough storage to retain log
 information over the period required. When audit logs are large in size, the
@@ -5772,7 +5985,7 @@ monitoring service for events becomes degraded. The function of the maximum log
 file size is to set these limits.
 
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--audit-log-maxsize` argument of the Kubernetes
 > API Service.
@@ -5784,7 +5997,7 @@ file size is to set these limits.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--audit-log-maxsize` for service `kube-apiserver` as appropriate.
@@ -5799,7 +6012,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--audit-log-maxsize` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -5813,19 +6026,21 @@ The output should indicate that `audit-log-maxsize` is set to a value less or
 equal to `100`.
 
 
-### [V-242463]: The Kubernetes API Server must be set to audit log maximum backup
+## [V-242463]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server must be set to audit log maximum backup
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes API Server must set enough storage to retain logs for
 monitoring suspicious activity and system misconfiguration, and provide
 evidence for cybersecurity investigations.
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--audit-log-maxbackup` argument of the Kubernetes
 > API Service.
@@ -5837,7 +6052,7 @@ evidence for cybersecurity investigations.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--audit-log-maxbackup` for service `kube-apiserver` as appropriate.
@@ -5852,7 +6067,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--audit-log-maxbackup` for service `kube-apiserver`
 is set as appropriate in the service's argument file
@@ -5867,19 +6082,21 @@ equal to `10`.
 
 
 
-### [V-242464]: The Kubernetes API Server audit log retention must be set
+## [V-242464]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server audit log retention must be set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes API Server must set enough storage to retain logs for
 monitoring suspicious activity and system misconfiguration, and provide
 evidence for cybersecurity investigations.
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--audit-log-maxage` argument of the Kubernetes
 > API Service.
@@ -5891,7 +6108,7 @@ evidence for cybersecurity investigations.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--audit-log-maxage` for service `kube-apiserver` as appropriate.
@@ -5905,7 +6122,7 @@ Afterwards restart the `kube-apiserver` service with:
 
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--audit-log-maxage` for service `kube-apiserver` is
 set as appropriate in the service's argument file
@@ -5918,13 +6135,15 @@ grep -E '\-\-audit-log-maxage=' '/var/snap/k8s/common/args/kube-apiserver'
 The output should indicate a `audit-log-maxage` value of 30.
 
 
-### [V-242465]: The Kubernetes API Server audit log path must be set
+## [V-242465]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes API Server audit log path must be set
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Kubernetes API Server validates and configures pods and services for the API
 object. The REST operation provides frontend functionality to the cluster share
@@ -5932,7 +6151,7 @@ state. Audit logs are necessary to provide evidence in the case the Kubernetes
 API Server is compromised requiring cybersecurity investigation. To record
 events in the audit log the log path value must be set.
 
-#### Comments:
+**Comments:**
 
 > This Finding refers to the `--audit-log-path` argument of the Kubernetes API
 > Service.
@@ -5946,7 +6165,7 @@ events in the audit log the log path value must be set.
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kube-apiserver` in order to set the argument
 `--audit-log-path` for service `kube-apiserver` as appropriate.
@@ -5958,7 +6177,7 @@ Afterwards restart the `kube-apiserver` service with:
     sudo systemctl restart snap.k8s.kube-apiserver
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--audit-log-path` for service `kube-apiserver` is set
 as appropriate in the service's argument file
@@ -5972,20 +6191,23 @@ test $? -eq 0 && echo PASS || echo FAIL
 The final line of the output will be `PASS`.
 
 
-### [V-242466]: The Kubernetes PKI CRT must have file permissions set to 644 or more restrictive
+## [V-242466]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes PKI CRT must have file permissions set to
+644 or more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes PKI directory contains all certificates (.crt files)
 supporting secure network communications in the Kubernetes Control Plane. If
 these files can be modified, data traversing within the architecture components
 would become insecure and compromised.
 
-#### Comments:
+**Comments:**
 
 > Finding stipulates that permission mask of all the '*.crt' files should be at
 > most 644, but they can also be set to be more restrictive.
@@ -5994,13 +6216,13 @@ would become insecure and compromised.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct permissions by running:
 
     chmod -R 644 /etc/kubernetes/pki/apiserver-kubelet-client.crt /etc/kubernetes/pki/ca.crt /etc/kubernetes/pki/front-proxy-ca.crt /etc/kubernetes/pki/kubelet.crt /etc/kubernetes/pki/apiserver.crt /etc/kubernetes/pki/client-ca.crt /etc/kubernetes/pki/front-proxy-client.crt
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all required files have permissions '644' (or stricter):
 
@@ -6018,20 +6240,23 @@ In the default configuration of the `k8s-snap`, resulting output lines will
 start with `PASS`.
 
 
-### [V-242467]: The Kubernetes PKI keys must have file permissions set to 600 or more restrictive
+## [V-242467]
 
-#### Severity: Medium
+**Guideline:** The Kubernetes PKI keys must have file permissions set to 600 or
+more restrictive
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > The Kubernetes PKI directory contains all certificate key files supporting
 secure network communications in the Kubernetes Control Plane. If these files
 can be modified, data traversing within the architecture components would
 become insecure and compromised.
 
-#### Comments:
+**Comments:**
 
 > Finding stipulates that permission mask of all the '*.key' files should be
 > 600.
@@ -6040,14 +6265,14 @@ become insecure and compromised.
 >
 
 
-#### Remediation
+### Remediation
 
 Ensure all of the following paths have correct permissions by running:
 
 
     chmod -R 600 /etc/kubernetes/pki/apiserver-kubelet-client.key /etc/kubernetes/pki/ca.key /etc/kubernetes/pki/front-proxy-client.key /etc/kubernetes/pki/serviceaccount.key /etc/kubernetes/pki/apiserver.key /etc/kubernetes/pki/front-proxy-ca.key /etc/kubernetes/pki/kubelet.key
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure all required files have permissions '600' (or stricter):
 
@@ -6066,13 +6291,15 @@ start with `PASS`.
 
 
 
-### [V-245541]: Kubernetes Kubelet must not disable timeouts
+## [V-245541]
 
-#### Severity: Medium
+**Guideline:** Kubernetes Kubelet must not disable timeouts
 
-#### Class: Deployment
+**Severity:** Medium
 
-#### Upstream finding description:
+**Class:** Deployment
+
+**Upstream finding description:**
 
 > Idle connections from the Kubelet can be used by unauthorized users to
 perform malicious activity to the nodes, pods, containers, and cluster within
@@ -6082,7 +6309,7 @@ Setting the value to "0" never disconnects any idle sessions. Idle timeouts
 must never be set to "0" and should be defined at "5m" (the default is 4hr).
 
 
-#### Comments:
+**Comments:**
 
 > The k8s-snap does not pass a `--config` command line argument to the Kubelet
 > service, nor does it explicitly pass `--streaming-connection-idle-timeout=5m`
@@ -6095,7 +6322,7 @@ must never be set to "0" and should be defined at "5m" (the default is 4hr).
 >
 
 
-#### Remediation
+### Remediation
 
 Edit `/var/snap/k8s/common/args/kubelet` in order to set the argument
 `--streaming-connection-idle-timeout` for service `kubelet` as appropriate.
@@ -6107,7 +6334,7 @@ Afterwards restart the `kubelet` service with:
     sudo systemctl restart snap.k8s.kubelet
 
 
-#### Auditing (as root)
+### Auditing (as root)
 
 Ensure that the argument `--streaming-connection-idle-timeout` for service
 `kubelet` is set as appropriate in the service's argument file

--- a/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
@@ -40,8 +40,6 @@ administrator or a user policy needs to be followed.
 | `Not Applicable` (13) | V-242386, V-242393, V-242394, V-242395, V-242396, V-242398, V-242399, V-242413, V-242437, V-242442, V-242443, V-242454, V-242455 |
 | `Manual` (8) | V-242383, V-242410, V-242411, V-242412, V-242414, V-242415, V-242417, V-254800 |
 
-<!-- TODO Re-enable once report is formatted >
-<!-- markdownlint-disable MD013 -->
 ### [V-242381]: The Kubernetes Controller Manager must create unique service accounts for each work payload
 
 #### Severity: High
@@ -633,8 +631,7 @@ The final line of the output will be `PASS`.
 > Please review the hardening guide for information on how to properly
 > configure the Node's Operating System for Kubelet.
 >
-> <!-- TODO: link to dedicated K8s hardening doc. -->
-> https://microk8s.io/docs/how-to-cis-harden#check-426
+> https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/security/hardening/
 >
 
 
@@ -1151,7 +1148,8 @@ The final line of the output will be `PASS`.
 > unauthorized versions of TLS protocols to properly secure communication.
 >
 > The use of unsupported protocol exposes vulnerabilities to the Kubernetes by
-> rogue traffic interceptions, person-in-the-middle attacks, and impersonation of
+> rogue traffic interceptions, person-in-the-middle attacks, and impersonation
+of
 > users or services from the container platform runtime, registry, and key
 > store. To enable the minimum version of TLS to be used by the Kubernetes
 > Controller Manager, the setting "tls-min-version" must be set.
@@ -1212,7 +1210,8 @@ The final line of the output will be `PASS`.
 > versions of TLS protocols to properly secure communication.
 >
 > The use of unsupported protocol exposes vulnerabilities to the Kubernetes by
-> rogue traffic interceptions, person-in-the-middle attacks, and impersonation of
+> rogue traffic interceptions, person-in-the-middle attacks, and impersonation
+of
 > users or services from the container platform runtime, registry, and
 > keystore. To enable the minimum version of TLS to be used by the Kubernetes
 > API Server, the setting "tls-min-version" must be set.
@@ -1272,7 +1271,8 @@ The final line of the output will be `PASS`.
 > versions of TLS protocols to properly secure communication.
 >
 > The use of unsupported protocol exposes vulnerabilities to the Kubernetes by
-> rogue traffic interceptions, person-in-the-middle attacks, and impersonation of
+> rogue traffic interceptions, person-in-the-middle attacks, and impersonation
+of
 > users or services from the container platform runtime, registry, and
 > keystore. To enable the minimum version of TLS to be used by the Kubernetes
 > API Server, the setting "tls-min-version" must be set.
@@ -1329,7 +1329,8 @@ The final line of the output will be `PASS`.
 > protocols to properly secure communication.
 >
 > The use of unsupported protocol exposes vulnerabilities to the Kubernetes by
-> rogue traffic interceptions, person-in-the-middle attacks, and impersonation of
+> rogue traffic interceptions, person-in-the-middle attacks, and impersonation
+of
 > users or services from the container platform runtime, registry, and
 > keystore. To enable the minimum version of TLS to be used by the Kubernetes
 > API Server, the setting "--auto-tls" must be set.
@@ -1469,7 +1470,8 @@ The final line of the output will be `PASS`.
 > versions of TLS protocols to properly secure communication.
 >
 > The use of unsupported protocol exposes vulnerabilities to the Kubernetes by
-> rogue traffic interceptions, person-in-the-middle attacks, and impersonation of
+> rogue traffic interceptions, person-in-the-middle attacks, and impersonation
+of
 > users or services from the container platform runtime, registry, and
 > keystore. To enable the minimum version of TLS to be used by the Kubernetes
 > API Server, the setting "--peer-auto-tls" must be set.
@@ -6214,5 +6216,3 @@ The final line of the output will be `PASS`.
 [V-242466]:https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-242466
 [V-242467]:https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-242467
 [V-245541]:https://www.stigviewer.com/stig/kubernetes/2024-06-10/finding/V-245541
-
-<!-- markdownlint-enable MD013 -->

--- a/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
@@ -6353,6 +6353,7 @@ test $? -eq 0 && echo PASS || echo FAIL
 
 The final line of the output will be `PASS`.
 
+
 <!-- Links -->
 [getting started]: ../../tutorial/getting-started
 [post-deployment hardening]: hardening.md


### PR DESCRIPTION
## Description

We had to disable the markdown linter on this file as it was failing. 

## Solution

This PR fixes this issue. It is mainly formatting that I changed so the easiest way to review this I think would be to view the RTD preview in the checks below docs/readthedocs.com:canonical-k8s-snap

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

