### PR TITLE
test: Remove mixed-version join test

### DIFF
--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -37,30 +37,6 @@ def test_control_plane_nodes(instances: List[harness.Instance]):
     ), f"only {cluster_node.id} should be left in cluster"
 
 
-@pytest.mark.node_count(2)
-@pytest.mark.snap_versions([util.previous_track(config.SNAP), config.SNAP])
-@pytest.mark.tags(tags.NIGHTLY)
-def test_mixed_version_join(instances: List[harness.Instance]):
-    """Test n versioned node joining a n-1 versioned cluster."""
-    cluster_node = instances[0]  # bootstrapped on the previous channel
-    joining_node = instances[1]  # installed with the snap under test
-
-    join_token = util.get_join_token(cluster_node, joining_node)
-    util.join_cluster(joining_node, join_token)
-
-    util.wait_until_k8s_ready(cluster_node, instances)
-
-    assert "control-plane" in util.get_local_node_status(cluster_node)
-    assert "control-plane" in util.get_local_node_status(joining_node)
-
-    cluster_node.exec(["k8s", "remove-node", joining_node.id])
-    nodes = util.ready_nodes(cluster_node)
-    assert len(nodes) == 1, "node should have been removed from cluster"
-    assert (
-        nodes[0]["metadata"]["name"] == cluster_node.id
-    ), f"only {cluster_node.id} should be left in cluster"
-
-
 @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.PULL_REQUEST)
 def test_worker_nodes(instances: List[harness.Instance]):


### PR DESCRIPTION
This test was originally introduced to validate that minor version upgrades work by allowing nodes with different versions to join the same cluster. However, we now have dedicated version upgrade tests that more accurately cover this scenario.

With the introduction of the rollout upgrade feature, this test has started to fail—nodes attempting to join a cluster with a different patch version are now rejected, as expected. The correct process is to upgrade the cluster first, then join the node.

Since the test no longer reflects a valid upgrade path and has become obsolete, it is being removed.