### PR TITLE
test: add subunit report files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ k8s_*.txt
 *.assert
 .trivy
 squashfs-root
+
+subunit.html
+subunit.out


### PR DESCRIPTION
We're now generating subunit reports as part of the e2e tests.

Let's add these files to .gitignore to avoid commiting them by mistake.
