### PR TITLE
fix: Set git credentials for CLA check

### DIFF
--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "[${{ matrix.branch }}] Update component versions"
-          title: "[${{ matrix.branch }}] Update component versions"
+          title: "[${{ matrix.branch }}] Update component versions -test"
           body: "[${{ matrix.branch }}] Update component versions"
           branch: "autoupdate/sync/${{ matrix.branch }}"
           labels: |

--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
-          ssh-key: ${{ secrets.BOT_SSH_KEY }}
+          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -41,12 +41,6 @@ jobs:
         run: |
           pip3 install -r ./build-scripts/hack/requirements.txt
 
-      - name: Define git credentials
-        run: |
-          # Needed to create commits.
-          git config --global user.name "CDK bot"
-          git config --global user.email "cdkbot@canonical.com"
-
       - name: Check for new component versions
         run: |
           ./build-scripts/hack/update-component-versions.py
@@ -63,3 +57,5 @@ jobs:
           delete-branch: true
           base: ${{ matrix.branch }}
           token: ${{ secrets.BOT_TOKEN }}
+          author: CDK bot <cdkbot@canonical.com>
+          committer: CDK bot <cdkbot@canonical.com>

--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -2,6 +2,7 @@ name: Check for component upgrades
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: "0 10 * * *"
 
@@ -39,6 +40,12 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install -r ./build-scripts/hack/requirements.txt
+
+      - name: Define git credentials
+        run: |
+          # Needed to create commits.
+          git config --global user.name "CDK bot"
+          git config --global user.email "cdkbot@canonical.com"
 
       - name: Check for new component versions
         run: |


### PR DESCRIPTION
## Description

The update-components job fails because the ssh key does not contain the proper E-mail for Canonical to pass the CLA check.
