### PR TITLE
test: Fixes test_cilium_e2e test

### DIFF
--- a/tests/integration/tests/test_cilium_e2e.py
+++ b/tests/integration/tests/test_cilium_e2e.py
@@ -28,14 +28,12 @@ CILIUM_CLI_TAR_GZ = f"https://github.com/cilium/cilium-cli/releases/download/{CI
 def test_cilium_e2e(instances: List[harness.Instance]):
     instance = instances[0]
     instance.exec(["bash", "-c", "mkdir -p ~/.kube"])
-    instance.exec(["bash", "-c", "k8s config > ~/.kube/config"])
+    instance.exec(["k8s config > ~/.kube/config"])
 
     # Download cilium-cli
     instance.exec(["curl", "-L", CILIUM_CLI_TAR_GZ, "-o", "cilium.tar.gz"])
     instance.exec(["tar", "xvzf", "cilium.tar.gz"])
     instance.exec(["./cilium", "version", "--client"])
-
-    instance.exec(["k8s", "status", "--wait-ready"])
 
     util.wait_for_dns(instance)
     util.wait_for_network(instance)


### PR DESCRIPTION
## Description

Currently, there are a few issues preventing the test from passing:

- `instance.exec(["bash", "-c", "k8s config > ~/.kube/config"])` results in k8s' help being saved into `~/.kube/config`, which causes the cilium binary to fail.
- 
- `instance.exec(["k8s", "status", "--wait-ready"])` fails with the error:

```
Error: Failed to retrieve the cluster status.

The error was: context deadline exceeded
```

- The error above is a timeout while waiting for it to become ready. The check is redundant, as we're already waiting for networking and dns to be ready.

## Solution

This PR fixes the issues mentioned.

## Issue

## Backport

`release-1.32`

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests - N/A
- [x] Covered by integration tests
- [x] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 
