### PR TITLE
docs: Highlight use of Cilium ingress

### DIFF
--- a/docs/canonicalk8s/snap/howto/networking/default-ingress.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-ingress.md
@@ -1,6 +1,6 @@
 # How to use default Ingress
 
-{{product}} enables you to configure Ingress for your cluster. When enabled, it
+{{product}} enables you to configure Ingress for your cluster, which is based on [Cilium ingress]([url](https://docs.cilium.io/en/stable/network/servicemesh/ingress/)). When enabled, it
 directs external HTTP and HTTPS traffic to the appropriate services within the
 cluster.
 


### PR DESCRIPTION
## Description

Canonical Kubernetes uses Cilium ingress by default, this PR highlights that in [here](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/default-ingress/).

## Solution

Based on the question raised in #canonical-slack channel, [see here](https://kubernetes.slack.com/archives/CG1V2CAMB/p1745418049515519?thread_ts=1745413900.657679&cid=CG1V2CAMB).

## Issue

None

## Backport

No

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit
