### PR TITLE
test: Skip CNCF Disruptive tests

### DIFF
--- a/tests/integration/tests/test_cncf_conformace.py
+++ b/tests/integration/tests/test_cncf_conformace.py
@@ -20,7 +20,8 @@ def test_cncf_conformance(instances: List[harness.Instance]):
     # TODO: Remove the test skip once the following issue has been resolved,
     # and if sonobuoy version has been updated if the test was changed:
     # https://github.com/kubernetes/kubernetes/issues/131150
-    skipped = "validates resource limits of pods that are allowed to run"
+    # We're also adding the default --e2e-skip value.
+    skipped = "validates resource limits of pods that are allowed to run|\\[Disruptive\\]|NoExecuteTaintManager"
     cluster_node.exec(
         ["./sonobuoy", "run", "--plugin", "e2e", "--e2e-skip", skipped, "--wait"],
     )


### PR DESCRIPTION
## Description

The default value for `--e2e-skip` is `"\[Disruptive\]|NoExecuteTaintManager"`, which we've overridden when we started skipping a particular test.

## Solution

Added the tests to ``--e2e-skip`` parameter.

## Issue


## Backport

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests - N/A
- [x] Covered by integration tests
- [x] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary - N/A
