### PR TITLE
[Backport 1.32] test: Sonobuoy Nightly Tests (#1125)

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -82,3 +82,9 @@ jobs:
         with:
           name: ${{ env.artifact_name }}
           path: ${{ github.workspace }}/inspection-reports.tar.gz
+      - name: Upload CNCF conformance report artifact
+        if: ${{ failure() && contains(inputs.test-tags, 'conformance_tests') }}
+        uses: actions/upload-artifact@v4
+        with:
+         name: sonobuoy-e2e-${{ env.artifact_name }}
+         path: tests/integration/sonobuoy_e2e.tar.gz

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -26,7 +26,7 @@ jobs:
       arch: ${{ matrix.arch }}
       os: ${{ matrix.os }}
       channel: ${{ matrix.channel }}
-      test-tags: 'up_to_nightly'
+      test-tags: 'up_to_nightly conformance_tests'
 
   Trivy:
     permissions:

--- a/tests/integration/tests/test_cncf_conformace.py
+++ b/tests/integration/tests/test_cncf_conformace.py
@@ -1,0 +1,69 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+import logging
+import re
+from typing import List
+
+import pytest
+from test_util import harness, tags, util
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.CONFORMANCE)
+def test_cncf_conformance(instances: List[harness.Instance]):
+    cluster_node = cluster_setup(instances)
+    install_sonobuoy(cluster_node)
+
+    cluster_node.exec(
+        ["./sonobuoy", "run", "--plugin", "e2e", "--wait"],
+    )
+    cluster_node.exec(
+        ["./sonobuoy", "retrieve", "-f", "sonobuoy_e2e.tar.gz"],
+    )
+    cluster_node.exec(
+        ["tar", "-xf", "sonobuoy_e2e.tar.gz", "--one-top-level"],
+    )
+    resp = cluster_node.exec(
+        ["./sonobuoy", "results", "sonobuoy_e2e.tar.gz"],
+        capture_output=True,
+    )
+
+    cluster_node.pull_file("/root/sonobuoy_e2e.tar.gz", "sonobuoy_e2e.tar.gz")
+
+    output = resp.stdout.decode()
+    LOG.info(output)
+    failed_tests = int(re.search("Failed: (\\d+)", output).group(1))
+    assert failed_tests == 0, f"{failed_tests} tests failed"
+
+
+def cluster_setup(instances: List[harness.Instance]) -> harness.Instance:
+    cluster_node = instances[0]
+    joining_nodes = instances[1:]
+
+    for joining_node in joining_nodes:
+        join_token = util.get_join_token(cluster_node, joining_node)
+        util.join_cluster(joining_node, join_token)
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 3, "node should have joined cluster"
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_nodes[0])
+    assert "control-plane" in util.get_local_node_status(joining_nodes[1])
+
+    config = cluster_node.exec(["k8s", "config"], capture_output=True)
+    cluster_node.exec(["dd", "of=/root/.kube/config"], input=config.stdout)
+
+    return cluster_node
+
+
+def install_sonobuoy(instance: harness.Instance):
+    instance.exec(
+        ["curl", "-L", util.sonobuoy_tar_gz(instance.arch), "-o", "sonobuoy.tar.gz"]
+    )
+    instance.exec(["tar", "xvzf", "sonobuoy.tar.gz"])
+    instance.exec(["./sonobuoy", "version"])

--- a/tests/integration/tests/test_util/tags.py
+++ b/tests/integration/tests/test_util/tags.py
@@ -7,8 +7,9 @@ PULL_REQUEST = "pull_request"
 NIGHTLY = "nightly"
 WEEKLY = "weekly"
 GPU = "gpu"
+CONFORMANCE = "conformance_tests"
 
-TEST_LEVELS = [PULL_REQUEST, NIGHTLY, WEEKLY]
+TEST_LEVELS = [PULL_REQUEST, NIGHTLY, WEEKLY, CONFORMANCE]
 
 # Those tags can be used for a convenient way to run multiple test levels.
 combine_tags("up_to_nightly", PULL_REQUEST, NIGHTLY)

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -35,6 +35,9 @@ MAIN_BRANCH = "main"
 # SONOBUOY_VERSION is the version of sonobuoy to use for CNCF conformance tests.
 SONOBUOY_VERSION = os.getenv("TEST_SONOBUOY_VERSION") or "v0.57.3"
 
+# SONOBUOY_VERSION is the version of sonobuoy to use for CNCF conformance tests.
+SONOBUOY_VERSION = os.getenv("TEST_SONOBUOY_VERSION") or "v0.57.3"
+
 
 def run(command: list, **kwargs) -> subprocess.CompletedProcess:
     """Log and run command."""


### PR DESCRIPTION
Adds the ``test_cncf_conformance`` test. It has the ``conformance_tests`` tag, preventing it from being run, unless specifically included through the tag. This test is only meant to be run on the Nightly job.

