### PR TITLE
WIP: tests: Add dqlite deb source lists manually for TICS job

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -43,6 +43,7 @@ jobs:
           - { branch: release-1.30, channel: 1.30-classic/edge }
           - { branch: release-1.31, channel: 1.31-classic/edge }
           - { branch: release-1.32, channel: 1.32-classic/edge }
+          - { branch: release-1.33, channel: 1.33-classic/edge }
     uses: ./.github/workflows/security-scan.yaml
     with:
       channel: ${{ matrix.channel }}

--- a/tests/tics-scan.sh
+++ b/tests/tics-scan.sh
@@ -37,7 +37,15 @@ go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
 # We need to have our project built
 # We load the dqlite libs here instead of doing through make because TICS
 # will try to build parts of the project itself
-sudo add-apt-repository -y ppa:dqlite/dev
+#
+# NOTE: Running add-apt-repository -y ppa:dqlite/dev may flake with a 504 Gateway Time-out from Launchpad.
+# Avoid this by adding the apt source lists manually.
+# GPG signing key from: https://launchpad.net/~dqlite/+archive/ubuntu/dev
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x392A47B5A84EACA9B2C43CDA06CD096F50FB3D04" | sudo tee /etc/apt/trusted.gpg.d/dqlite-dev.asc
+echo "deb-src https://ppa.launchpadcontent.net/dqlite/dev/ubuntu noble main" | sudo tee /etc/apt/sources.list.d/dqlite-dev.list
+echo "deb https://ppa.launchpadcontent.net/dqlite/dev/ubuntu noble main" | sudo tee /etc/apt/sources.list.d/dqlite-dev.list
+apt-get update
+
 sudo apt-get install -y dqlite-tools-v2 libdqlite1.17-dev
 sudo make clean
 go build -a ./...


### PR DESCRIPTION
## Description

Running `add-apt-repository -y ppa:dqlite/dev` may flake with a `504 Gateway Time-out` from Launchpad.

## Solution

We may avoid this by adding the apt source lists manually.

## Issue

Include a link to the Github issue number if applicable.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit
