### PR TITLE
docs: canonical-ck8s: cluster-api: add maxSurge documentation

### DIFF
--- a/docs/canonicalk8s/capi/howto/rollout-upgrades.md
+++ b/docs/canonicalk8s/capi/howto/rollout-upgrades.md
@@ -80,6 +80,16 @@ kubectl --kubeconfig c1-kubeconfig.yaml get nodes -o wide
 The machines will be replaced in turn until all machines run on
 the desired version.
 
+## Configure the machine count during the control plane upgrade
+
+When a control plane upgrade is performed, a new CK8sContrplPlane machine is deployed with the new configuration and after that machine is Ready, the old machine is deprovisioned.
+
+This behaviour is controlled by the spec value `spec.strategy.rollingUpdate.maxSurge`, with the default value being set on 1.
+
+If `spec.strategy.rollingUpdate.maxSurge` is set to the value `0`, when a control plane upgrade is performed, the old CK8sContrplPlane machine is deprovisioned first and a new machine is deployed with the new configuration only after the old machine has been removed.
+
+`spec.strategy.rollingUpdate.maxSurge` set to the value `0` is preferable in hardware constrained environments, where an extra machine might not be available.
+
 ## Update the worker nodes
 
 After upgrading the control plane, proceed with upgrading the worker nodes


### PR DESCRIPTION
## Description

Update documentation on the cluster api provider topic: maxSurge.

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit
