### PR TITLE
fix: Properly parse IPv6 endpoints for k8s-apiserver-proxy.json

### DIFF
--- a/src/k8s/pkg/proxy/endpoints.go
+++ b/src/k8s/pkg/proxy/endpoints.go
@@ -3,36 +3,12 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"sort"
 
-	corev1 "k8s.io/api/core/v1"
+	"github.com/canonical/k8s/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-func parseAddresses(endpoint *corev1.Endpoints) []string {
-	if endpoint == nil {
-		return nil
-	}
-	addresses := make([]string, 0, len(endpoint.Subsets))
-	for _, subset := range endpoint.Subsets {
-		portNumber := 6443
-		for _, port := range subset.Ports {
-			if port.Name == "https" {
-				portNumber = int(port.Port)
-				break
-			}
-		}
-
-		for _, addr := range subset.Addresses {
-			addresses = append(addresses, fmt.Sprintf("%s:%d", addr.IP, portNumber))
-		}
-	}
-
-	sort.Strings(addresses)
-	return addresses
-}
 
 func getKubernetesEndpoints(ctx context.Context, kubeconfigFile string) ([]string, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
@@ -44,9 +20,13 @@ func getKubernetesEndpoints(ctx context.Context, kubeconfigFile string) ([]strin
 		return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
 	}
 
-	endpoint, err := clientset.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	endpoints, err := clientset.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve endpoints for kubernetes service: %w", err)
 	}
-	return parseAddresses(endpoint), nil
+	if endpoints == nil {
+		return nil, nil
+	}
+
+	return utils.ParseEndpoints(endpoints), nil
 }

--- a/src/k8s/pkg/utils/endpoints.go
+++ b/src/k8s/pkg/utils/endpoints.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ParseEndpoints processes the given kube-apiserver endpoints and returns a list of
+// IPv4:port or [IPv6]:port strings.
+func ParseEndpoints(endpoints *corev1.Endpoints) []string {
+	addresses := make([]string, 0, len(endpoints.Subsets))
+
+	for _, subset := range endpoints.Subsets {
+		portNumber := 6443
+		for _, port := range subset.Ports {
+			if port.Name == "https" {
+				portNumber = int(port.Port)
+				break
+			}
+		}
+
+		for _, addr := range subset.Addresses {
+			if addr.IP != "" {
+				var address string
+				if IsIPv4(addr.IP) {
+					address = addr.IP
+				} else {
+					address = fmt.Sprintf("[%s]", addr.IP)
+				}
+				addresses = append(addresses, fmt.Sprintf("%s:%d", address, portNumber))
+			}
+		}
+	}
+
+	sort.Strings(addresses)
+	return addresses
+}

--- a/src/k8s/pkg/utils/endpoints_test.go
+++ b/src/k8s/pkg/utils/endpoints_test.go
@@ -1,4 +1,4 @@
-package proxy
+package utils
 
 import (
 	"reflect"
@@ -7,15 +7,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestParseAddresses(t *testing.T) {
+func TestParseEndpoints(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		endpoints *v1.Endpoints
 		addresses []string
 	}{
-		{
-			name: "nil",
-		},
 		{
 			name: "one",
 			endpoints: &v1.Endpoints{
@@ -33,6 +30,15 @@ func TestParseAddresses(t *testing.T) {
 				},
 			},
 			addresses: []string{"1.1.1.1:6443", "2.2.2.2:6443"},
+		},
+		{
+			name: "IPv6",
+			endpoints: &v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{Addresses: []v1.EndpointAddress{{IP: "fe80::e0b9:bfff:fe90:8d37"}}},
+				},
+			},
+			addresses: []string{"[fe80::e0b9:bfff:fe90:8d37]:6443"},
 		},
 		{
 			name: "multiple-subsets",
@@ -66,7 +72,7 @@ func TestParseAddresses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if parsed := parseAddresses(tc.endpoints); !reflect.DeepEqual(parsed, tc.addresses) {
+			if parsed := ParseEndpoints(tc.endpoints); !reflect.DeepEqual(parsed, tc.addresses) {
 				t.Fatalf("expected addresses to be %v but they were %v instead", tc.addresses, parsed)
 			}
 		})


### PR DESCRIPTION
## Description
Currently, in scenarios with clusters with IPv6, we will end up with improper IPv6 addresses in the k8s-apiserver-proxy.json, causing the k8s-apiserver-proxy service to always fail with the following error:

"Failed to start" err="failed to parse endpoint \"fd42:6db9:e49a:486b:216:3eff:fe48:5318:6443\": address fd42:6db9:e49a:486b:216:3eff:fe48:5318:6443: too many colons in address"

According to the documentation [1], the expectation is that the IPv6 address to be enclosed in brackets ([IPv6]:port).

We're writing the k8s-apiserver-proxy.json in 2 cases:
- when joining a worker node.
- when a new control plane node joined the cluster.

In the first scenario, we are properly handling the IPv6 addresses, but not in the second. This PR addresses this issue.

[1] https://pkg.go.dev/net#SplitHostPort

## Solution

The IPv6 addresses are now properly handled.

## Backport

`release-1.33`, `release-1.32`, `release-1.31`.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 