### PR TITLE
test: Add performance tests machinery

### DIFF
--- a/.github/workflows/create-perf-baselines.yaml
+++ b/.github/workflows/create-perf-baselines.yaml
@@ -1,0 +1,64 @@
+name: Create Performance Baselines
+description: |
+  This workflow creates performance baselines on the specified runner tags
+  and creates a baseline for future comparisons. It uses pytest-benchmark to run the tests
+  and save the results.
+  It also creates a pull request with the results
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/create-perf-baselines.yaml
+      - tests/integration/tests/performance/*.py
+
+jobs:
+  baselines:
+    name: Create Baselines for ${{ matrix.os }}-${{ matrix.arch }}
+    strategy:
+      matrix:
+        os: ["ubuntu:22.04", "ubuntu:24.04"]
+        arch: ["amd64", "arm64"]
+    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-noble-medium' || 'self-hosted-linux-amd64-noble-medium' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Create performance baselines
+        run: |
+          tox -e integration -- --tags performance \
+            --benchmark-storage baselines \
+            --benchmark-name ${ matrix.os }-${{ matrix.arch }}
+      - name: Prepare baseline results
+        run: |
+          echo "artifact_name=${{ inputs.os }}-${{ inputs.arch }}.json" | sed 's/:/-/g' >> $GITHUB_ENV
+      - name: Upload baseline results
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.artifact_name }}
+          path: baselines/**/*.json
+
+  create_pr:
+    name: Create PR with baseline results
+    runs-on: ubuntu-latest
+    needs: baselines
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: tests/integration/tests/performance/baselines
+      - name: Commit and create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "test: Update performance baseline results"
+          title: "test: Automatic Performance Baselines update"
+          body: "Update performance baselines because of changed performance tests"
+          branch: performance/baseline-updates
+          base: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -13,78 +13,30 @@ permissions:
   contents: read
 
 jobs:
-  test-integration:
-    name: Integration
+  test-performance:
+    name: Run performance tests for ${{ matrix.os }}-${{ matrix.arch }}
     strategy:
       matrix:
         os: ["ubuntu:22.04", "ubuntu:24.04"]
         arch: ["amd64", "arm64"]
-        channel: ["latest/edge"]
-      fail-fast: false # TODO: remove once we no longer have flaky tests.
-    uses: ./.github/workflows/e2e-tests.yaml
-    with:
-      arch: ${{ matrix.arch }}
-      os: ${{ matrix.os }}
-      channel: ${{ matrix.channel }}
-      test-tags: 'up_to_nightly conformance_tests'
-
-  Trivy:
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-    strategy:
-      matrix:
-        include:
-          # Latest branches
-          - { branch: main, channel: latest/edge }
-          # Stable branches
-          # Add branches to test here
-          # TODO: automatically retrieve the list of channels.
-          - { branch: release-1.30, channel: 1.30-classic/edge }
-          - { branch: release-1.31, channel: 1.31-classic/edge }
-          - { branch: release-1.32, channel: 1.32-classic/edge }
-    uses: ./.github/workflows/security-scan.yaml
-    with:
-      channel: ${{ matrix.channel }}
-      checkout-ref: ${{ matrix.branch }}
-      upload-reports-to-jira: true
-    secrets: inherit
-
-  TICS:
-    if: ${{ always() && github.event_name == 'schedule' }}
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - { branch: main }
+    runs-on: ${{ matrix.arch == 'arm64' && 'self-hosted-linux-arm64-noble-medium' || 'self-hosted-linux-amd64-noble-medium' }}
     steps:
-      - name: Checking out repo
+      - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Save tics-scan.sh script
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run Performance Tests
+        env:
+          TEST_SUBSTRATE: lxd
+          TEST_LXD_IMAGE: ${{ matrix.os }}
         run: |
-          # We'll need to scan other branches, let's create a copy of
-          # the TICS scan script.
-          cp tests/tics-scan.sh /tmp/tics-scan.sh
-      - name: Checking out tested repo branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{matrix.branch}}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: './src/k8s/go.mod'
-      - name: go mod download
-        working-directory: src/k8s
-        run: go mod download
-      - name: TICS scan
-        run: |
-          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
-          /tmp/tics-scan.sh `pwd`
+          tox -e integration -- --tags performance \
+            --benchmark-storage tests/integration/tests/performance/baselines \
+            --benchmark-compare ${ matrix.os }-${{ matrix.arch }}.json
+            --benchmark-compare-fail mean:10%
+
 
   Mattermost:
     name: Notify Mattermost

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ squashfs-root
 
 subunit.html
 subunit.out
+
+.benchmark

--- a/tests/integration/requirements-test.txt
+++ b/tests/integration/requirements-test.txt
@@ -1,6 +1,7 @@
 coverage[toml]==7.2.5
 pytest==7.3.1
-pytest_tagging==1.5.3
+pytest_tagging==1.6.0
+pytest-benchmark==5.0.0
 PyYAML==6.0.1
 tenacity==8.2.3
 pylint==3.2.5

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -14,7 +14,7 @@ from test_util.registry import Registry
 
 LOG = logging.getLogger(__name__)
 
-pytest_plugins = ("pytest_tagging",)
+pytest_plugins = ("pytest_tagging", "pytest_benchmark")
 
 
 def pytest_itemcollected(item):
@@ -23,12 +23,10 @@ def pytest_itemcollected(item):
     """
     # Check for tags in the pytest.mark attributes
     marked_tags = [mark for mark in item.iter_markers(name="tags")]
-    if not marked_tags or not any(
-        tag.args[0] in tags.TEST_LEVELS for tag in marked_tags
-    ):
+    if not marked_tags or not any(tag.args[0] in tags.TEST_TAGS for tag in marked_tags):
         pytest.fail(
             f"The test {item.nodeid} does not have one of the test level tags."
-            f"Please add at least one test-level tag using @pytest.mark.tags ({tags.TEST_LEVELS})."
+            f"Please add at least one test tag using @pytest.mark.tags ({tags.TEST_TAGS})."
         )
 
 

--- a/tests/integration/tests/performance/test_perf_clustering.py
+++ b/tests/integration/tests/performance/test_perf_clustering.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+from typing import List
+
+import pytest
+from test_util import config, harness, tags, util
+
+
+@pytest.mark.node_count(1)
+@pytest.mark.no_setup()
+@pytest.mark.tags(tags.PERFORMANCE)
+def test_perf_clustering_bootstrap_cli(
+    instances: List[harness.Instance], tmp_path: str, benchmark
+):
+    node = instances[0]
+
+    def setup():
+        # TODO(ben): benchmark `teardown` function is implemented but not yet released
+        # in 5.1.0. Once released, we can move this teardown logic in a separate function.
+        # See https://github.com/ionelmc/pytest-benchmark/issues/270
+        node.exec(["snap", "remove", "k8s", "--purge"])
+        util.setup_k8s_snap(node, tmp_path)
+
+    def run():
+        node.exec(["k8s", "bootstrap"])
+
+    benchmark.pedantic(run, setup=setup, rounds=config.PERF_DEFAULT_ROUNDS)

--- a/tests/integration/tests/performance/test_perf_status.py
+++ b/tests/integration/tests/performance/test_perf_status.py
@@ -1,0 +1,20 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+from typing import List
+
+import pytest
+from test_util import harness, tags
+
+
+@pytest.mark.node_count(1)
+@pytest.mark.tags(tags.PULL_REQUEST, tags.PERFORMANCE)
+def test_perf_status_single_node_cli(
+    instances: List[harness.Instance], tmp_path: str, benchmark
+):
+    node = instances[0]
+
+    def run():
+        node.exec(["k8s", "status"])
+
+    benchmark.pedantic(run, rounds=20)

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -188,3 +188,6 @@ GH_BASE_REF = os.getenv("TEST_GH_BASE_REF")
 
 # SONOBUOY_VERSION is the version of sonobuoy to use for CNCF conformance tests.
 SONOBUOY_VERSION = os.getenv("TEST_SONOBUOY_VERSION") or "v0.57.3"
+
+# PERF_DEFAULT_ROUNDS is the number of rounds to run for performance tests.
+PERF_DEFAULT_ROUNDS = int(os.getenv("TEST_PERF_DEFAULT_ROUNDS") or 5)

--- a/tests/integration/tests/test_util/tags.py
+++ b/tests/integration/tests/test_util/tags.py
@@ -8,8 +8,11 @@ NIGHTLY = "nightly"
 WEEKLY = "weekly"
 GPU = "gpu"
 CONFORMANCE = "conformance_tests"
+PERFORMANCE = "performance"
 
-TEST_LEVELS = [PULL_REQUEST, NIGHTLY, WEEKLY, CONFORMANCE]
+# Each test needs to be tagged with at least one of the following tags.
+# This is enforced by conftest.
+TEST_TAGS = [PULL_REQUEST, NIGHTLY, WEEKLY, CONFORMANCE, PERFORMANCE, GPU]
 
 # Those tags can be used for a convenient way to run multiple test levels.
 combine_tags("up_to_nightly", PULL_REQUEST, NIGHTLY)


### PR DESCRIPTION
This PR introduces machinery to create performance tests and
measure them agains a historic baseline.

* Create test structures including tags and `pytest-benchmark` to create
  performance tests
* Introduce structure to store and compare performance against a
  historic baseline that runs on specified hardware (GH runners)
* Create a workflow that creates new performance baselines when requirements
  or performance tests change
* Extend the nightly test with performance tests that validates current
  latests edge with the current baseline and fails if performance
significantly deteriorated

See KU-152 for more details