### PR TITLE
test: [Backport 1.32] Run test upgrades without needing a local snap

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -84,6 +84,13 @@ def _generate_inspection_report(h: harness.Harness, instance_id: str):
         LOG.warning("Failed to pull inspection report: %s", e)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def validate_test_config():
+    """Validate the configuration before running tests."""
+    if config.SNAP:
+        assert Path(config.SNAP).exists(), f"Snap path {config.SNAP} does not exist."
+
+
 @pytest.fixture(scope="session")
 def h() -> harness.Harness:
     LOG.debug("Create harness for %s", config.SUBSTRATE)

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -196,7 +196,10 @@ def setup_k8s_snap(
     which_snap = snap or config.SNAP
 
     if not which_snap:
-        pytest.fail("Set TEST_SNAP to the channel, revision, or path to the snap")
+        pytest.fail(
+            "Cannot install without either a channel, revision, or path to the snap "
+            + f"argument {snap=} and {config.SNAP=}"
+        )
 
     if isinstance(which_snap, str) and which_snap.startswith("/"):
         LOG.info("Install k8s snap by path")


### PR DESCRIPTION
Backports  #1314 to the 1.32 release branch