### PR TITLE
docs: Update troubleshooting with cilium tunnel port fix 

### DIFF
--- a/docs/canonicalk8s/charm/howto/install/install-terraform.md
+++ b/docs/canonicalk8s/charm/howto/install/install-terraform.md
@@ -21,7 +21,7 @@ controller. Choose one of the options outlined in the
 
 The Terraform deployment is done using a root module that specifies the
 Juju model to deploy the submodules to. The root module also references
-the k8s-bundle module which helps to build the Juju model. 
+the k8s-bundle module which helps to build the Juju model.
 
 ### Root module
 <!-- TODO replace this section once we have a Juju ground up module -->
@@ -44,7 +44,8 @@ module "k8s" {
 }
 ```
 
-Define your `manifest.yaml` based on the requirements for your deployment. 
+Define your `manifest.yaml` based on the requirements for your deployment. We
+ recommend at least 16GB of root-disk storage, 4GB of memory and 2 cores.
 Specific charm configuration options can be found on charmhub.io for charms
 [k8s] and [k8s-worker].
 

--- a/docs/canonicalk8s/charm/reference/troubleshooting.md
+++ b/docs/canonicalk8s/charm/reference/troubleshooting.md
@@ -209,14 +209,14 @@ Set the annotation `tunnel-port` to an appropriate value (the default is 8472).
 sudo k8s set annotation="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
 ```
 
-Since the Cillium pods are in a failing state, the recreation of the VXLAN
+Since the Cilium pods are in a failing state, the recreation of the VXLAN
 interface is automatically triggered. Verify the VXLAN interface has come up:
 
 ```
 ip link list type vxlan
 ```
 
-It should be named `cillium_vxlan` or something similar.
+It should be named `cilium_vxlan` or something similar.
 
 Verify that Cilium is now in a running state:
 

--- a/docs/canonicalk8s/charm/reference/troubleshooting.md
+++ b/docs/canonicalk8s/charm/reference/troubleshooting.md
@@ -201,9 +201,8 @@ juju model-config container-networking-method=local fan-config=
 
 #### Change Cilium tunnel-port
 
-<!-- Do we need to do this on all nodes or just one? -->
-
-Set the annotation `tunnel-port` to an appropriate value (the default is 8472).
+Connect to the node and set the annotation `tunnel-port` to an appropriate value
+(the default is 8472).
 
 ```
 sudo k8s set annotation="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"

--- a/docs/canonicalk8s/charm/reference/troubleshooting.md
+++ b/docs/canonicalk8s/charm/reference/troubleshooting.md
@@ -157,5 +157,35 @@ Verify the Cilium pod has restarted and is now in the running state:
 sudo k8s kubectl get pods -n kube-system
 ```
 
+## Cilium pod fails to start as address is already in use
+
+### Problem 
+
+When deploying {{product}} on a cloud provider such as Openstack, the Cilium pods fail to start and reports the error:
+
+```
+failed to start: daemon creation failed: error while initializing daemon: failed 
+while reinitializing datapath: failed to setup vxlan tunnel device: setting up 
+vxlan device: creating vxlan device: setting up device cilium_vxlan: address 
+already in use
+```
+
+### Explanation 
+
+Fan networking is automatically enabled in some substrates. This causes conflicts with some CNIs such as Cilium. This conflict of `address already in use` causes Cilium to be unable to set up it's VXLAN tunneling network. 
+
+### Solution 
+
+Either disable the fan config and apply the following configuration to the Juju model:
+
+```
+juju model-config container-networking-method=local fan-config=
+```
+
+or change the default port for Cilium by running:
+
+```
+
+```
 <!-- LINKS -->
 [reported here]: https://github.com/cilium/cilium/issues/30889

--- a/docs/canonicalk8s/charm/reference/troubleshooting.md
+++ b/docs/canonicalk8s/charm/reference/troubleshooting.md
@@ -157,7 +157,7 @@ Verify the Cilium pod has restarted and is now in the running state:
 sudo k8s kubectl get pods -n kube-system
 ```
 
-## Cilium pod fails to start as `cilum_vxlan: address is already in use`
+## Cilium pod fails to start as `cilum_vxlan: address already in use`
 
 ### Problem
 
@@ -187,25 +187,21 @@ port.
 
 #### Disable fan networking
 
+```{note}
+Only disable fan networking if it is not in use. Disabling fan networking may
+have implications on your cluster where assets such as LXD VMs, are not
+reachable if they rely on fan networking for communication.
+```
+
 Apply the following configuration to the Juju model:
 
 ```
 juju model-config container-networking-method=local fan-config=
 ```
 
-<!-- Do we need to restart Cilium after this disable? -->
-
-### Change Cilium tunnel-port
+#### Change Cilium tunnel-port
 
 <!-- Do we need to do this on all nodes or just one? -->
-<!-- Get onto node -->
-Identify the interface that was created by Cilium for the VXLAN interface
-
-```
-ip link list type vxlan
-```
-
-It should be named `cillium_vxlan` or something similar.
 
 Set the annotation `tunnel-port` to an appropriate value (the default is 8472).
 
@@ -213,30 +209,20 @@ Set the annotation `tunnel-port` to an appropriate value (the default is 8472).
 sudo k8s set annotation="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
 ```
 
-Now delete the {{product}} Cilium VXLAN interface that we previously identified.
-
-```
-ip link delete cillium_vxlan
-```
-
-To trigger the recreation of the interface, delete the Cilium pod on the node.
-Get the pod ID and delete the pod:
-<!-- Do we need to delete the operator pod too -->
-```
-sudo k8s kubectl get pods -A
-sudo k8s kubectl delete -n kube-system pod/cilium-d7spv
-```
-
-Verify the VXLAN interface has come back up:
+Since the Cillium pods are in a failing state, the recreation of the VXLAN
+interface is automatically triggered. Verify the VXLAN interface has come up:
 
 ```
 ip link list type vxlan
 ```
+
+It should be named `cillium_vxlan` or something similar.
 
 Verify that Cilium is now in a running state:
 
 ```
 sudo k8s kubectl get pods -n kube-system
 ```
+
 <!-- LINKS -->
 [reported here]: https://github.com/cilium/cilium/issues/30889

--- a/docs/canonicalk8s/snap/reference/troubleshooting.md
+++ b/docs/canonicalk8s/snap/reference/troubleshooting.md
@@ -201,9 +201,6 @@ cause the same error.
 
 ### Solution
 
-<!-- Can we disable fan on the snap level? -->
-<!-- Do we need to do this on all nodes or just one? -->
-
 Configure Cilium to use another tunnel port. Set the annotation `tunnel-port`
 to an appropriate value (the default is 8472).
 

--- a/docs/canonicalk8s/snap/reference/troubleshooting.md
+++ b/docs/canonicalk8s/snap/reference/troubleshooting.md
@@ -211,7 +211,7 @@ to an appropriate value (the default is 8472).
 sudo k8s set annotation="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
 ```
 
-Since the Cillium pods are in a failing state, the recreation of the VXLAN
+Since the Cilium pods are in a failing state, the recreation of the VXLAN
 interface is automatically triggered. Verify the VXLAN interface has come
 up:
 
@@ -219,7 +219,7 @@ up:
 ip link list type vxlan
 ```
 
-It should be named `cillium_vxlan` or something similar.
+It should be named `cilium_vxlan` or something similar.
 
 Verify that Cilium is now in a running state:
 

--- a/docs/canonicalk8s/snap/reference/troubleshooting.md
+++ b/docs/canonicalk8s/snap/reference/troubleshooting.md
@@ -177,7 +177,7 @@ conflicts and cause networking issues.
 Adjust the custom defined `ip rule` to have a
 priority value that is greater than `100`.
 
-## Cilium pod fails to start as `cilum_vxlan: address is already in use`
+## Cilium pod fails to start as `cilum_vxlan: address already in use`
 
 ### Problem
 
@@ -201,44 +201,25 @@ cause the same error.
 
 ### Solution
 
-Configure Cilium to use another tunnel port.
-
 <!-- Can we disable fan on the snap level? -->
 <!-- Do we need to do this on all nodes or just one? -->
-<!-- Get onto node -->
-Identify the interface that was created by Cilium for the VXLAN interface
+
+Configure Cilium to use another tunnel port. Set the annotation `tunnel-port`
+to an appropriate value (the default is 8472).
+
+```
+sudo k8s set annotation="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
+```
+
+Since the Cillium pods are in a failing state, the recreation of the VXLAN
+interface is automatically triggered. Verify the VXLAN interface has come
+up:
 
 ```
 ip link list type vxlan
 ```
 
 It should be named `cillium_vxlan` or something similar.
-
-Set the annotation `tunnel-port` to an appropriate value (the default is 8472).
-
-```
-sudo k8s set annotation="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
-```
-
-Now delete the {{product}} Cilium VXLAN interface that we previously identified.
-
-```
-ip link delete cillium_vxlan
-```
-
-To trigger the recreation of the interface, delete the Cilium pod on the node.
-Get the pod ID and delete the pod:
-<!-- Do we need to delete the operator pod too -->
-```
-sudo k8s kubectl get pods -A
-sudo k8s kubectl delete -n kube-system pod/cilium-d7spv
-```
-
-Verify the VXLAN interface has come back up:
-
-```
-ip link list type vxlan
-```
 
 Verify that Cilium is now in a running state:
 

--- a/docs/canonicalk8s/snap/reference/troubleshooting.md
+++ b/docs/canonicalk8s/snap/reference/troubleshooting.md
@@ -123,16 +123,16 @@ memory usage over time. This was particularly evident in smaller clusters.
 
 ### Explanation
 
-This issue was caused due to an inefficient resource configuration of 
-Dqlite for smaller clusters. The threshold and trailing parameters are 
-related to Dqlite transactions and must be adjusted. The threshold is 
-the number of transactions we allow before a snapshot is taken of the 
-leader. The trailing is the number of transactions we allow the follower 
-node to lag behind the leader before it consumes the updated snapshot of the 
+This issue was caused due to an inefficient resource configuration of
+Dqlite for smaller clusters. The threshold and trailing parameters are
+related to Dqlite transactions and must be adjusted. The threshold is
+the number of transactions we allow before a snapshot is taken of the
+leader. The trailing is the number of transactions we allow the follower
+node to lag behind the leader before it consumes the updated snapshot of the
 leader. Currently, the default snapshot configuration is 1024 for the
 threshold and 8192 for trailing which is too large for small clusters. Only
 setting the trailing parameter in a configuration yaml automatically sets the
-threshold to 0. This leads to a snapshot being taken every transaction and 
+threshold to 0. This leads to a snapshot being taken every transaction and
 increased CPU usage.
 
 ### Solution
@@ -176,6 +176,75 @@ conflicts and cause networking issues.
 
 Adjust the custom defined `ip rule` to have a
 priority value that is greater than `100`.
+
+## Cilium pod fails to start as `cilum_vxlan: address is already in use`
+
+### Problem
+
+When deploying {{product}} the Cilium pods fail to start and reports the error:
+
+```
+failed to start: daemon creation failed: error while initializing daemon: failed
+while reinitializing datapath: failed to setup vxlan tunnel device: setting up
+vxlan device: creating vxlan device: setting up device cilium_vxlan: address
+already in use
+```
+
+### Explanation
+
+Fan networking is automatically enabled in some substrates. This causes
+conflicts with some CNIs such as Cilium. This conflict of
+`address already in use` causes Cilium to be unable to set up it's VXLAN
+tunneling network. There may also be other networking components on the system
+attempting to use the default port for their own VXLAN interface that will
+cause the same error.
+
+### Solution
+
+Configure Cilium to use another tunnel port.
+
+<!-- Can we disable fan on the snap level? -->
+<!-- Do we need to do this on all nodes or just one? -->
+<!-- Get onto node -->
+Identify the interface that was created by Cilium for the VXLAN interface
+
+```
+ip link list type vxlan
+```
+
+It should be named `cillium_vxlan` or something similar.
+
+Set the annotation `tunnel-port` to an appropriate value (the default is 8472).
+
+```
+sudo k8s set annotation="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
+```
+
+Now delete the {{product}} Cilium VXLAN interface that we previously identified.
+
+```
+ip link delete cillium_vxlan
+```
+
+To trigger the recreation of the interface, delete the Cilium pod on the node.
+Get the pod ID and delete the pod:
+<!-- Do we need to delete the operator pod too -->
+```
+sudo k8s kubectl get pods -A
+sudo k8s kubectl delete -n kube-system pod/cilium-d7spv
+```
+
+Verify the VXLAN interface has come back up:
+
+```
+ip link list type vxlan
+```
+
+Verify that Cilium is now in a running state:
+
+```
+sudo k8s kubectl get pods -n kube-system
+```
 
 <!-- LINKS -->
 


### PR DESCRIPTION
## Description

Users have faced issues when there are other installations of cilium / other networking services also installed on the hose trying to use the default port for VXLAN encapsulation.

## Solution

Now you can alter the default Cilium tunnel port through annotations but this is not in our docs yet


## Backport

1.32, 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
