### PR TITLE
fix: remove gateway class auto created by cilium

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/gateway.go
+++ b/src/k8s/pkg/k8sd/features/cilium/gateway.go
@@ -52,7 +52,18 @@ func enableGateway(ctx context.Context, snap snap.Snap) (types.FeatureStatus, er
 		}, err
 	}
 
-	changed, err := m.Apply(ctx, ChartCilium, helm.StateUpgradeOnly, map[string]any{"gatewayAPI": map[string]any{"enabled": true}})
+	values := map[string]any{
+		"gatewayAPI": map[string]any{
+			"enabled": true,
+			"gatewayClass": map[string]any{
+				// This needs to be string, not bool, as the helm chart uses a string
+				// Due to the values of 'auto', 'true' and 'false'
+				"create": "false",
+			},
+		},
+	}
+
+	changed, err := m.Apply(ctx, ChartCilium, helm.StateUpgradeOnly, values)
 	if err != nil {
 		err = fmt.Errorf("failed to upgrade Gateway API cilium configuration: %w", err)
 		return types.FeatureStatus{


### PR DESCRIPTION
## Description

Cilium automatically creates a gateway class which is not intended since k8s-snap already creates the `ck-gateway` class. 

## Issue

Fixes #1331

## Backport

We should probably avoid backporting this change since some users might depend on the removed class.

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
