### PR TITLE
docs: update version to 1.32 in the docs

### DIFF
--- a/docs/canonicalk8s/capi/explanation/capi-ck8s.md
+++ b/docs/canonicalk8s/capi/explanation/capi-ck8s.md
@@ -22,7 +22,7 @@ distribution that seamlessly integrates with Cluster API.
 With {{product}} CAPI you can:
 
 - provision a cluster with:
-    - Kubernetes version 1.31 onward
+    - Kubernetes version 1.32 onward
     - risk level of the track you want to follow (stable, candidate, beta, edge)
     - deploy behind proxies
 - upgrade clusters with no downtime:

--- a/docs/canonicalk8s/capi/explanation/in-place-upgrades.md
+++ b/docs/canonicalk8s/capi/explanation/in-place-upgrades.md
@@ -1,7 +1,7 @@
 # In-place upgrades
 
-Regularly upgrading the Kubernetes version of the machines in a cluster 
-is important. While rolling upgrades are a popular strategy, certain 
+Regularly upgrading the Kubernetes version of the machines in a cluster
+is important. While rolling upgrades are a popular strategy, certain
 situations will require in-place upgrades:
 
 - Resource constraints (i.e. cost of additional machines).
@@ -9,110 +9,110 @@ situations will require in-place upgrades:
 
 ## Annotations
 
-CAPI machines are considered immutable. Consequently, machines are replaced 
+CAPI machines are considered immutable. Consequently, machines are replaced
 instead of reconfigured.
-While CAPI doesn't support in-place upgrades, {{product}} CAPI does 
+While CAPI doesn't support in-place upgrades, {{product}} CAPI does
 by leveraging annotations for the implementation.
-For a deeper understanding of the CAPI design decisions, consider reading about 
-[machine immutability in CAPI][1], and Kubernetes objects: [`labels`][2], 
+For a deeper understanding of the CAPI design decisions, consider reading about
+[machine immutability in CAPI][1], and Kubernetes objects: [`labels`][2],
 [`spec` and `status`][3].
 
 ## Controllers
 
-In {{product}} CAPI, there are two main types of controllers that handle the 
+In {{product}} CAPI, there are two main types of controllers that handle the
 process of performing in-place upgrades:
 
 - Single Machine In-Place Upgrade Controller
 - Orchestrated In-Place Upgrade Controller
 
-The core component of performing an in-place upgrade is the `Single Machine 
-Upgrader`. The controller watches for annotations on machines and reconciles 
-them to ensure the upgrades happen smoothly. 
+The core component of performing an in-place upgrade is the `Single Machine
+Upgrader`. The controller watches for annotations on machines and reconciles
+them to ensure the upgrades happen smoothly.
 
-The `Orchestrator` watches for certain annotations on 
-machine owners, reconciles them and upgrades groups of owned machines. 
-It’s responsible for ensuring that all the machines owned by the 
+The `Orchestrator` watches for certain annotations on
+machine owners, reconciles them and upgrades groups of owned machines.
+It’s responsible for ensuring that all the machines owned by the
 reconciled object get upgraded successfully.
 
 The main annotations that drive the upgrade process are as follows:
 
-- `v1beta2.k8sd.io/in-place-upgrade-to` --> `upgrade-to` : Instructs 
-the controller to perform an upgrade with the specified option/method. 
-- `v1beta2.k8sd.io/in-place-upgrade-status` --> `status` : As soon as the 
-controller starts the upgrade process, the object will be marked with the 
+- `v1beta2.k8sd.io/in-place-upgrade-to` --> `upgrade-to` : Instructs
+the controller to perform an upgrade with the specified option/method.
+- `v1beta2.k8sd.io/in-place-upgrade-status` --> `status` : As soon as the
+controller starts the upgrade process, the object will be marked with the
 `status` annotation which can either be `in-progress`, `failed` or `done`.
-- `v1beta2.k8sd.io/in-place-upgrade-release` --> `release` : When the 
-upgrade is performed successfully, this annotation will indicate the current 
+- `v1beta2.k8sd.io/in-place-upgrade-release` --> `release` : When the
+upgrade is performed successfully, this annotation will indicate the current
 Kubernetes release/version installed on the machine.
 
-For a complete list of annotations and their values please 
-refer to the [annotations reference page][4]. This explanation proceeds 
+For a complete list of annotations and their values please
+refer to the [annotations reference page][4]. This explanation proceeds
 to use abbreviations of the mentioned labels.
 
 ### Single machine in-place upgrade controller
 
-The Machine objects can be marked with the `upgrade-to` annotation to 
-trigger an in-place upgrade for that machine. While watching for changes 
-on the machines, the single machine upgrade controller notices this annotation  
-and attempts to upgrade the Kubernetes version of that machine to the 
+The Machine objects can be marked with the `upgrade-to` annotation to
+trigger an in-place upgrade for that machine. While watching for changes
+on the machines, the single machine upgrade controller notices this annotation
+and attempts to upgrade the Kubernetes version of that machine to the
 specified version.
 
-Upgrade methods or options can be specified to upgrade to a snap channel, 
-revision, or a local snap file already placed on the 
+Upgrade methods or options can be specified to upgrade to a snap channel,
+revision, or a local snap file already placed on the
 machine in air-gapped environments.
 
 A successfully upgraded machine shows the following annotations:
 
 ```yaml
 annotations:
-  v1beta2.k8sd.io/in-place-upgrade-release: "channel=1.31/stable"
+  v1beta2.k8sd.io/in-place-upgrade-release: "channel=1.32/stable"
   v1beta2.k8sd.io/in-place-upgrade-status: "done"
 ```
 
-If the upgrade fails, the controller will mark the machine and retry 
+If the upgrade fails, the controller will mark the machine and retry
 the upgrade immediately:
 
 ```yaml
 annotations:
   # the `upgrade-to` causes the retry to happen
-  v1beta2.k8sd.io/in-place-upgrade-to: "channel=1.31/stable"
+  v1beta2.k8sd.io/in-place-upgrade-to: "channel=1.32/stable"
   v1beta2.k8sd.io/in-place-upgrade-status: "failed"
 
-  # orchestrator will notice this annotation and knows that the 
+  # orchestrator will notice this annotation and knows that the
   # upgrade for this machine failed
-  v1beta2.k8sd.io/in-place-upgrade-last-failed-attempt-at: "Sat, 7 Nov 
+  v1beta2.k8sd.io/in-place-upgrade-last-failed-attempt-at: "Sat, 7 Nov
   2024 13:30:00 +0400"
 ```
 
-By applying and removing annotations, the single machine 
-upgrader determines the upgrade status of the machine it’s trying to 
-reconcile and takes necessary actions to successfully complete an 
-in-place upgrade. The following diagram shows the flow of the in-place 
+By applying and removing annotations, the single machine
+upgrader determines the upgrade status of the machine it’s trying to
+reconcile and takes necessary actions to successfully complete an
+in-place upgrade. The following diagram shows the flow of the in-place
 upgrade of a single machine:
 
 ![Diagram][img-single-machine]
 
 ### Machine Upgrade Process
 
-The {{product}}'s `k8sd` daemon exposes endpoints that can be used to 
-interact with the cluster. The single machine upgrader calls the  
-`/snap/refresh` endpoint on the machine to trigger the upgrade 
-process while checking `/snap/refresh-status` periodically. 
+The {{product}}'s `k8sd` daemon exposes endpoints that can be used to
+interact with the cluster. The single machine upgrader calls the
+`/snap/refresh` endpoint on the machine to trigger the upgrade
+process while checking `/snap/refresh-status` periodically.
 
 ![Diagram][img-k8sd-call]
 
 ### In-place upgrades on large workload clusters
 
-While the “Single Machine In-Place Upgrade Controller” is responsible 
-for upgrading individual machines, the "Orchestrated In-Place Upgrade 
+While the “Single Machine In-Place Upgrade Controller” is responsible
+for upgrading individual machines, the "Orchestrated In-Place Upgrade
 Controller" ensures that groups of machines will get upgraded.
-By applying the `upgrade-to` annotation on an object that owns machines 
-(e.g. a `MachineDeployment`), this controller will mark the owned machines 
-one by one which will cause the "Single Machine Upgrader" to pickup those 
+By applying the `upgrade-to` annotation on an object that owns machines
+(e.g. a `MachineDeployment`), this controller will mark the owned machines
+one by one which will cause the "Single Machine Upgrader" to pickup those
 annotations and upgrade the machines. To avoid undesirable situations
- like quorum loss or severe downtime, these upgrades happen in sequence. 
+ like quorum loss or severe downtime, these upgrades happen in sequence.
 
-The failures and successes of individual machine upgrades will be reported back 
+The failures and successes of individual machine upgrades will be reported back
 to the orchestrator by the single machine upgrader via annotations.
 
 The illustrated flow of orchestrated in-place upgrades:

--- a/docs/canonicalk8s/capi/howto/custom-ck8s.md
+++ b/docs/canonicalk8s/capi/howto/custom-ck8s.md
@@ -58,14 +58,14 @@ spec:
     files:
     - content: |
         #!/bin/bash -xe
-        snap install k8s --classic --channel=1.31-classic/candidate
+        snap install k8s --classic --channel=1.32-classic/candidate
       owner: root:root
       path: /capi/scripts/install.sh
       permissions: "0500"
 ```
 
 Now the new control plane nodes that are created using this manifest will have
-the `1.31-classic/candidate` {{product}} snap installed on them!
+the `1.32-classic/candidate` {{product}} snap installed on them!
 
 ```{note}
 [Use the configuration specification](#using-config-spec),

--- a/docs/canonicalk8s/charm/howto/validate.md
+++ b/docs/canonicalk8s/charm/howto/validate.md
@@ -30,11 +30,11 @@ version your cluster is set to by running:
 juju status k8s
 ```
 
-The output will be in the form of `version.number/risk`, e.g `1.31/stable`. You should set
+The output will be in the form of `version.number/risk`, e.g `1.32/stable`. You should set
 the `kubernetes-e2e` channel to the same value.
 
 ```
-juju config kubernetes-e2e channel=1.31/stable
+juju config kubernetes-e2e channel=1.32/stable
 ```
 
 Finally we relate the charm to `k8s`:


### PR DESCRIPTION
## Description

Drive by fixes of the versions in our 1.32 branch that were missed

## Solution

Versions updated to 1.32. Automatic md linter also applied to some of the files

## Issue

n/a

## Backport

Main has moved on so merging directly to 1.32

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

