### PR TITLE
docs: add notes for new `refresh-certs` ux

### DIFF
--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -43,6 +43,11 @@ The `--expires-in` flag sets the certificate's validity duration, which can
 be specified in years, months, days, or any other unit accepted by the
 [ParseDuration][] function in Go.
 
+```{note} You can selectively refresh certificates using the
+`--certificates` flag. By default, all are refreshed, but you can target
+specific ones. Run `k8s refresh-certs -h` to see available options.
+```
+
 The cluster will automatically update the certificates in the control plane
 node and restart the necessary services. The new expiration date will be
 displayed in the command output:
@@ -64,6 +69,11 @@ This command refreshes the certificates for the worker node. The `--expires-in`
 flag specifies the certificate's validity period, which can be set using any
 units accepted by the [ParseDuration][] function in Go, such as years, months,
 or days.
+
+```{note} Worker nodes support selective certificate renewal too. Use the
+`--certificates` flag to choose which ones to refresh. For details, see
+`k8s refresh-certs -h`.
+```
 
 2. During the certificate refresh, multiple Certificate Signing Requests (CSRs)
 are created. Follow the instructions in the command output to approve the CSRs

--- a/docs/canonicalk8s/snap/howto/security/refresh-external-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-external-certs.md
@@ -21,6 +21,13 @@ argument with a YAML-formatted file. For a complete list of available
 certificate keys, see the
 [certificates refresh configuration file reference page][reference page].
 
+```{note} If your cluster uses a mixed certificate management approach where
+some certificates are managed externally and others internally, you must
+explicitly specify the internally managed certificates to refresh on worker
+nodes using the `--certificates` flag. Externally managed certificates should
+continue to be provided through the `--external-certificates` argument.
+```
+
 Refer to the {{ product }}
 [cluster certificates and configuration directories][certificates]
 documentation to determine which


### PR DESCRIPTION
## Description

Update the `refresh-certs` docs to reflect the new user experience.
## Solution

This pull request updates the `refresh-certs` docs to provide clearer guidance on selective certificate renewal using the `--certificates` flag. The changes include new notes to help users understand how to target specific certificates during the refresh process.

## Issue

N/A

## Backport

N/A

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 