### PR TITLE
docs: improve flow of `refresh-certs` how-to.

### DIFF
--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -25,6 +25,8 @@ steps on each control plane node in your cluster:
 sudo k8s refresh-certs --expires-in 1y --extra-sans mynode.local
 ```
 
+**`--extra-sans`**
+
 This command refreshes the certificates for the control plane node, adding an
 extra [Subject Alternative Name][] (SAN) to the certificate. Check the
 current SANs on your node by running the following command:
@@ -33,22 +35,26 @@ current SANs on your node by running the following command:
 openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -text | grep -A 1 "Subject Alternative Name"
 ```
 
-```{note} If your node setup includes additional SANs, be sure to provide the
+If your node setup includes additional SANs, be sure to provide the
 specific SANs for each node as needed using the `--extra-sans` flag. While this
 is not required, omitting them could impact your node's ability to communicate
 with other components in the cluster.
-```
+
+**`--expires-in`**
 
 The `--expires-in` flag sets the certificate's validity duration, which can
 be specified in years, months, days, or any other unit accepted by the
 [ParseDuration][] function in Go.
 
-```{note} You can selectively refresh certificates using the
-`--certificates` flag. By default, all are refreshed, but you can target
-specific ones. Run `k8s refresh-certs -h` to see available options.
-```
+**`--certificates`**
 
-The cluster will automatically update the certificates in the control plane
+By default, all internal certificates are refreshed on the control plane node
+when you run `refresh-certs`.
+You can however selectively refresh certificates using the `--certificates` flag
+and specify the certificates to be refreshed. Run `k8s refresh-certs -h` to
+see available options.
+
+2. The cluster will automatically update the certificates in the control plane
 node and restart the necessary services. The new expiration date will be
 displayed in the command output:
 
@@ -65,15 +71,18 @@ each worker node in your cluster:
 sudo k8s refresh-certs --expires-in 10y --timeout 10m
 ```
 
+**`--expires-in`**
+
 This command refreshes the certificates for the worker node. The `--expires-in`
 flag specifies the certificate's validity period, which can be set using any
 units accepted by the [ParseDuration][] function in Go, such as years, months,
 or days.
 
-```{note} Worker nodes support selective certificate renewal too. Use the
-`--certificates` flag to choose which ones to refresh. For details, see
+**`--certificates`**
+
+Worker nodes support selective certificate renewal too. Use the
+`--certificates` flag to choose which certificates to refresh. For details, see
 `k8s refresh-certs -h`.
-```
 
 2. During the certificate refresh, multiple Certificate Signing Requests (CSRs)
 are created. Follow the instructions in the command output to approve the CSRs

--- a/docs/canonicalk8s/snap/howto/security/refresh-external-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-external-certs.md
@@ -16,27 +16,25 @@ on a control plane node.
 ### Assemble certificates data
 
 To simplify the process and avoid complex CLI commands, the `refresh-certs`
-command accepts new node certificates via the `--external-certificates`
+command accepts new node external certificates via the `--external-certificates`
 argument with a YAML-formatted file. For a complete list of available
 certificate keys, see the
 [certificates refresh configuration file reference page][reference page].
 
-```{note} If your cluster uses a mixed certificate management approach where
+If your cluster uses a mixed certificate management approach where
 some certificates are managed externally and others internally, you must
 explicitly specify the internally managed certificates to refresh on worker
 nodes using the `--certificates` flag. Externally managed certificates should
 continue to be provided through the `--external-certificates` argument.
-```
 
 Refer to the {{ product }}
 [cluster certificates and configuration directories][certificates]
 documentation to determine which
 certificates are required for each node.
 
-```{note} If you are managing some of the Certificate Authorities (CAs)
+If you are managing some of the Certificate Authorities (CAs)
 externally, provide only the certificates that require updates. Identify the
 externally managed CAs by running `k8s certs-status` on a control plane node.
-```
 
 ### Refresh Control Plane node certificates
 
@@ -47,12 +45,11 @@ node:
 sudo k8s refresh-certs --external-certificates ./certificates.yaml
 ```
 
-```{note} If your node setup includes additional SANs, be sure to include the
+If your node setup includes additional SANs, be sure to include the
 specific SANs for each node when requesting new certificates from your
 certificates authority. Check your provider's documentation for instructions on
 requesting certificates with the required SANs.
 
-```
 
 The node will validate the certificates, update them automatically, and restart
 the necessary services. Upon successful completion, you will see:


### PR DESCRIPTION
## Description

Improve the structure of the `refresh-certs` how-to guides.

## Solution

The current how-to guides use too many notes, making them hard to read and follow. This pull request restructures the guides to improve clarity for both internal and external certificate refresh processes.

## Issue

N/A

## Backport

N/A

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
