### PR TITLE
test: Disable moonray testing for 1.33+

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -23,7 +23,8 @@ jobs:
     uses: ./.github/workflows/build-snap.yaml
     strategy:
       matrix:
-        patch: ["", "moonray"]
+        # e.g. moonray, strict - right now we only support the classic flavor
+        patch: [""]
     with:
       flavor: ${{ matrix.patch }}
 

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -117,23 +117,6 @@ jobs:
       test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
       artifact: k8s.snap
 
-  test-integration-informing:
-    name: Informing
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu:24.04"]
-        patch: ["moonray"]
-    needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
-    if: success() && github.event_name == 'pull_request'
-    uses: ./.github/workflows/e2e-tests.yaml
-    with:
-      arch: amd64
-      os: ${{ matrix.os }}
-      test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
-      artifact: k8s-${{ matrix.patch }}.snap
-      flavor: ${{ matrix.patch }}
-
   security-scan:
     name: Security scan
     needs: build-snap


### PR DESCRIPTION
For 1.33 and beyond, we don't want to support moonray anymore and disable testing for this flavor. 