### PR TITLE
docs: fix typo in discourse link

### DIFF
--- a/docs/canonicalk8s/custom_conf.py
+++ b/docs/canonicalk8s/custom_conf.py
@@ -82,7 +82,7 @@ html_context = {
     # Change to the discourse instance you want to be able to link to
     # using the :discourse: metadata at the top of a file
     # (use an empty value if you don't want to link)
-    'discourse': ' https://discourse.ubuntu.com/c/kubernetes/180',
+    'discourse': 'https://discourse.ubuntu.com/c/kubernetes/180',
 
     # Change to the Mattermost channel you want to link to
     # (use an empty value if you don't want to link)


### PR DESCRIPTION
## Description

There were weird 404 errors on the read the docs site with the discourse link 

## Solution

There was an extra space at the start of the discourse variable link 

## Issue

N/A

## Backport

1.32, 1.33

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
