### PR TITLE
fix: Adds logging when rollout upgrade fails

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -270,6 +270,7 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 	}
 
 	if err := handleRollOutUpgrade(ctx, a.snap, s, k8sClient); err != nil {
+		log.Error(err, "Failed to handle rollout-upgrade")
 		return fmt.Errorf("failed to handle rollout-upgrade: %w", err)
 	}
 


### PR DESCRIPTION
## Description

Currently, when a control plane joins, and ``handleRollOutUpgrade`` returns an error, the node is then removed from the cluster. The reason for this failure is not logged, which makes it harder to debug.

## Solution

Adds a log line for this scenario.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests - N/A
- [x] Covered by integration tests - N/A
- [x] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary 

