### PR TITLE
docs: Fix indentation in CAPI reference page

### DIFF
--- a/docs/canonicalk8s/capi/reference/configs.md
+++ b/docs/canonicalk8s/capi/reference/configs.md
@@ -111,15 +111,15 @@ spec:
   bootstrapConfig:
     content: |
       cluster-config:
-      network:
-          enabled: true
-      dns:
-          enabled: true
-          cluster-domain: cluster.local
-      ingress:
-          enabled: true
-      load-balancer:
-          enabled: true
+        network:
+            enabled: true
+        dns:
+            enabled: true
+            cluster-domain: cluster.local
+        ingress:
+            enabled: true
+        load-balancer:
+            enabled: true
 ```
 
 - Using `contentFrom`:


### PR DESCRIPTION
## Description

`cluster-config` does not have the correct indentation in the CAPI docs.

## Solution

Indent the `cluster-config`.

## Issue

https://github.com/canonical/k8s-snap/issues/1405

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit
