### PR TITLE
docs: remove duplicate section in reference landing page

### DIFF
--- a/docs/canonicalk8s/capi/reference/index.md
+++ b/docs/canonicalk8s/capi/reference/index.md
@@ -47,16 +47,6 @@ Ports and services <ports-and-services>
 
 ```
 
-## Providers configurations
-
-{{product}} bootstrap and control plane providers can be configured to reach
-the desired state for the workload cluster.
-
-```{toctree}
-:titlesonly:
-configs
-```
-
 ## Contributing
 
 ```{toctree}


### PR DESCRIPTION
## Description

I just noticed that there is duplication of the Providers configurations section in the capi reference section.

## Solution

Removed duplicate

## Issue

N/A

## Backport

The landing page rework was not back ported so no need to update 1.32. Need to update 1.33.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
