### PR TITLE
fix: Implement Revision for pebble

### DIFF
--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -414,6 +414,10 @@ func (s *snap) Revision(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to get snap info: snapd returned with error code %d", snap.StatusCode)
 	}
 
+	if snap.Result.Revision == "" {
+		return "", fmt.Errorf("failed to get snap revision: got empty string")
+	}
+
 	return snap.Result.Revision, nil
 }
 


### PR DESCRIPTION
## Description

The `Upgrade.k8sd.io` CRD has the following regex for its name:

```
[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
```

However, if `snap.Revision()` would return an empty string, we'd create an resource with the name `cluster-upgrade-to-rev-`, which is invalid.

For pebble, we are returning `""`, and pebble is being used in `cluster-api-k8s`, which results in the following error:

```
[k8sd] E0507 145 app/hooks_join.go:273] "Failed to handle rollout-upgrade" err="failed to create upgrade: Upgrade.k8sd.io \"cluster-upgrade-to-rev-\" is invalid: metadata.name: Invalid value: \"cluster-upgrade-to-rev-\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')" logger="k8sd" hook="postJoin"
```

What issue is this PR trying to solve?

## Solution

For Pebble, we're now returning the k8s revision instead.

## Issue

Include a link to the Github issue number if applicable.

## Backport

`release-1.33`

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
