### PR TITLE
fix: patch same upgrade status object

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -407,9 +407,8 @@ func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kube
 	}
 
 	log.Info("Marking node as upgraded", "node", nodeName)
-	status := upgradesv1alpha.UpgradeStatus{
-		UpgradedNodes: append(upgrade.Status.UpgradedNodes, nodeName),
-	}
+	status := upgrade.Status
+	status.UpgradedNodes = append(status.UpgradedNodes, nodeName)
 	return k8sClient.PatchUpgradeStatus(ctx, upgrade, status)
 }
 


### PR DESCRIPTION
## Description

When a second upgraded node joins the cluster, the ``Upgrade.k8sd.io`` object is updated. However, the updated ``upgrade.status`` object does not contain the ``strategy`` field, which is required. This leads to errors like this:

```
err="failed to patch upgrade status: Upgrade.k8sd.io \"cluster-upgrade-to-rev-foo\" is invalid: [status.phase: Required value, status.strategy: Required value]"
```

## Solution

Patch existing `upgrade.status`.

## Issue

Include a link to the Github issue number if applicable.

## Backport

`release-1.33`, `release-1.32`

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

