### PR TITLE
test: Sets default FLAVOR to classic

### DIFF
--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -35,7 +35,7 @@ REGISTRY_URL = (
 REGISTRY_VERSION = os.getenv("REGISTRY_VERSION") or "v2.8.3"
 
 # FLAVOR is the flavor of the snap to use.
-FLAVOR = os.getenv("TEST_FLAVOR") or ""
+FLAVOR = os.getenv("TEST_FLAVOR") or "classic"
 
 # SNAP is the absolute path to the snap against which we run the integration tests.
 SNAP = os.getenv("TEST_SNAP")


### PR DESCRIPTION
## Description

Currently, the ``test_version_upgrades`` fails on previous release branches if ``TEST_VERSION_UPGRADE_CHANNELS`` is set to ``"recent N"``. The test is supposed to get a list of snap channels to test the upgrades.

However, by default, ``config.FLAVOR`` (``TEST_FLAVOR`` env var), is ``""``, and that flavor is used by ``snap.get_most_stable_channels`` to filter the snap channels. As it is empty, it creates an invalid regex:

```
(\d+)\.(\d+)-\/(stable|candidate|beta|edge)
```

This regex cannot match the snap channels we'd expect (e.g.: ``1.32-classic/stable``).


## Solution

Sets ``config.FLAVOR`` to classic, as that's the currently supported version.

## Issue

Include a link to the Github issue number if applicable.

## Backport

`release-1.33`, `release-1.32`.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests - N/A
- [x] Covered by integration tests
- [x] Documentation updated - N/A
- [x] CLA signed
- [x] Backport label added if necessary 
