### PR TITLE
docs: Clarify creating worker join token

### DIFF
--- a/docs/canonicalk8s/_parts/commands/k8s_get-join-token.md
+++ b/docs/canonicalk8s/_parts/commands/k8s_get-join-token.md
@@ -12,7 +12,7 @@ k8s get-join-token <node-name> [flags]
       --expires-in duration   the time until the token expires (default 24h0m0s)
   -h, --help                  help for get-join-token
       --timeout duration      the max time to wait for the command to execute (default 1m30s)
-      --worker                generate a join token for a worker node
+      --worker                generate a join token for a worker node. Specifying the node name of the worker node is optional
 ```
 
 ### SEE ALSO

--- a/docs/canonicalk8s/snap/howto/install/custom-worker.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-worker.md
@@ -3,7 +3,7 @@
 When creating a {{ product }} cluster you may need to join a worker node with
 a configuration that differs from the default. For example, the worker node
 may need to use alternative certificates for security reasons or the worker
-node may have specific networking requirements that must be configured at node 
+node may have specific networking requirements that must be configured at node
 creation. Passing extra command line arguments or a configuration file
 at cluster join allows you to modify the configuration of your worker node.
 
@@ -13,32 +13,22 @@ This guide assumes the following:
 
 - A working Kubernetes cluster deployed with the `k8s` snap
 
-## Configuration options
+## Command line arguments
 
-### Command line flags
-
-To discover the configuration options available as command line arguments, 
+To discover the configuration options available as command line arguments,
 on the control node run:
 
 ```
 sudo k8s join-cluster --help
 ```
 
-### Configuration file
-
-More configuration options are available when a configuration file is specified.
-Please consult the [reference page] for all of the available configuration
-options and their defaults.
-
-## Command line arguments
-
 In this example, the name of the new worker node joining the cluster is
-specified through command line arguments, rather than defaulting to the 
-hostname of the worker machine.
+specified through command line arguments.
 
-A join token must be generated on the control node of the cluster. Specify
-the join token is for a `--worker` node. The name given for the worker
-node in this example is `custom-worker` which is not the default hostname.
+When creating a worker join token on the control plane node, if we do not
+specify the node name, the worker node will appear in the cluster with
+the default hostname. Specify the join token is for a `--worker` node. Also
+include the name of the worker node, for example `custom-worker`.
 
 ```
 sudo k8s get-join-token custom-worker --worker
@@ -51,16 +41,16 @@ On the new worker machine, install the snap:
 :end-before: <!-- snap end -->
 ```
 
-Join the cluster with the token generated from the output of the 
-`get-join-token` command and specify the `--name` we want the worker node to be
-called. This must match the name used in the `get-join-token` command.
+Join the cluster with the token generated from the output of the
+`get-join-token` command and specify the same `--name` we want the worker node
+to be called. This must match the name used in the `get-join-token` command.
 
 ```
 sudo k8s join-cluster --name custom-worker <JOIN-TOKEN>
 ```
 
 After a few moments, the node should have joined the cluster with a success
-message. Verify the node has joined the cluster with the custom name by 
+message. Verify the node has joined the cluster with the custom name by
 switching to the control node and running:
 
 ```
@@ -71,15 +61,19 @@ The output should list the `custom-worker` node in a `Ready` state.
 
 ## Configuration file
 
-In this example, the configuration file provided at cluster join will set the 
+More configuration options are available when a configuration file is specified.
+Please consult the [reference page] for all of the available configuration
+options and their defaults.
+
+In this example, the configuration file provided at cluster join will set the
 proxy mode of the worker machine to `ipvs`.
 
-A join token must be generated on the control plane node of the cluster. 
-Specify the join token is for a `--worker` node. The name given for the 
-worker node in this example is worker-machine which is the default hostname.
+A join token must be generated on the control plane node of the cluster.
+Specify the join token is for a `--worker` node. We will not specify the
+node name in this example.
 
 ```
-sudo k8s get-join-token worker-machine --worker
+sudo k8s get-join-token --worker
 ```
 
 On the new worker machine, install the snap:
@@ -98,24 +92,24 @@ extra-node-kube-proxy-args:
 EOF
 ```
 
-Join the cluster with the token generated from the output of the 
+Join the cluster with the token generated from the output of the
 `get-join-token` command and the `custom_config.yaml` file.
 
 ```
 sudo k8s join-cluster --file path/to/custom_config.yaml <JOIN-TOKEN>
 ```
 
-After a few moments, the node should have joined the cluster with a success 
-message. Verify the node has joined the cluster by switching to the control 
+After a few moments, the node should have joined the cluster with a success
+message. Verify the node has joined the cluster by switching to the control
 node and running:
 
 ```
 sudo k8s kubectl get nodes
 ```
 
-The output should list the worker-machine node as in a `Ready` state.
+The output should list the worker node as in a `Ready` state.
 
-Also verify the proxy mode configuration has been applied to the worker node 
+Also verify the proxy mode configuration has been applied to the worker node
 by checking the logs of kube-proxy on the worker machine:
 
 ```

--- a/src/k8s/cmd/k8s/k8s_get_join_token.go
+++ b/src/k8s/cmd/k8s/k8s_get_join_token.go
@@ -68,7 +68,7 @@ func newGetJoinTokenCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.worker, "worker", false, "generate a join token for a worker node")
+	cmd.Flags().BoolVar(&opts.worker, "worker", false, "generate a join token for a worker node. Specifying the node name of the worker node is optional")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 90*time.Second, "the max time to wait for the command to execute")
 	// The CLI uses verbose names for flags instead of abbreviations. Internally and for the API, the common TTL (time-to-live) name is used.
 	cmd.Flags().DurationVar(&opts.ttl, "expires-in", 24*time.Hour, "the time until the token expires")


### PR DESCRIPTION
## Description

There has been confusion over providing a node name to the k8s get-join-token command when creating a worker node token. 

For a control plane:
```
k8s get-join-token <NAME_REQUIRED>
```
For a worker node:
```
k8s get-join-token <NAME_OPTIONAL> --worker
```
If the name is left out - the token can be used on multiple workers. If it is included, it can only be used when the names match. 

The way we display the <node_name> in our docs is misleading as it is required for the control plane but not for the worker nodes. Although, I do not have a clear way to fix this. 

```
k8s get-join-token <node-name> [flags]
```

## Solution

I have updated the how to guide on joining a custom worker 
I have also updated the description on the --worker flag. I would appreciate input on this.

## Issue

Raised on Mattermost

## Backport
?

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
