### PR TITLE
docs: fix fmt annotations page

### DIFF
--- a/docs/canonicalk8s/snap/reference/annotations.md
+++ b/docs/canonicalk8s/snap/reference/annotations.md
@@ -3,7 +3,7 @@
 This page outlines the annotations that can be configured during cluster
 [bootstrap] or when setting cluster configuration later on.
 
-To specify annotations during the bootstrap process, set the 
+To specify annotations during the bootstrap process, set the
 `cluster-config.annotations` parameter in the bootstrap configuration:
 
 ```yaml
@@ -14,13 +14,12 @@ cluster-config:
         k8sd/v1alpha/lifecycle/skip-stop-services-on-remove: true
 ```
 
-You can also set annotations after the bootstrap. For example to change 
+You can also set annotations after the bootstrap. For example to change
 Cilium's VXLAN port you can run the following command:
 
 ```bash
 sudo k8s set annotations="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
 ```
-
 
 ```{note}
 v1alpha annotations are experimental and subject to change or removal in future {{product}} releases
@@ -94,9 +93,7 @@ v1alpha annotations are experimental and subject to change or removal in future 
 |   |   |
 |---|---|
 |**Values**| integer value port number|
-|**Description**|The port number cilium will for its VXLAN encapsulation protocol 
-destination port.|
-
+|**Description**|The port number cilium will for its VXLAN encapsulation protocol destination port.|
 
 ## `k8sd/v1alpha1/metrics-server/image-repo`
 
@@ -122,5 +119,4 @@ for(var i=0;i<el.length;i++){
 
 <!-- Links -->
 
-[Kubernetes website]:https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 [bootstrap]: /snap/reference/config-files/bootstrap-config.md


### PR DESCRIPTION
## Description

Fixes formatting of the annotations page.

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
