### PR TITLE
feat: bump snap base to core22

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -16,12 +16,12 @@ workloads and {{product}} features.
 ### Download the {{product}} snap
 
 From a machine with access to the internet download the
-`k8s` and `core20` snap with:
+`k8s` and `core22` snap with:
 
 ```{literalinclude} ../../../_parts/install.md
 :start-after: <!-- offline start -->
 :end-before: <!-- offline end -->
-:append: sudo snap download core20 --basename core20
+:append: sudo snap download core22 --basename core22
 ```
 
 Besides the snaps, this will also download the corresponding assert files which
@@ -229,13 +229,13 @@ Transfer the following files to the target node:
 
 - `k8s.snap`
 - `k8s.assert`
-- `core20.snap`
-- `core20.assert`
+- `core22.snap`
+- `core22.assert`
 
 On the target node, run the following command to install the Kubernetes snap:
 
 ```
-sudo snap ack core20.assert && sudo snap install ./core20.snap
+sudo snap ack core22.assert && sudo snap install ./core22.snap
 sudo snap ack k8s.assert && sudo snap install ./k8s.snap --classic
 ```
 
@@ -311,7 +311,6 @@ After a while, confirm that all the cluster nodes show up in the output of the
 
 <!-- LINKS -->
 
-[Core20]: https://canonical.com/blog/ubuntu-core-20-secures-linux-for-iot
 [proxy]: ../networking/proxy.md
 [regsync]: https://github.com/regclient/regclient/blob/main/docs/regsync.md
 [regctl]: https://github.com/regclient/regclient/blob/main/docs/regctl.md

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |-
 license: GPL-3.0
 grade: stable
 confinement: classic
-base: core20
+base: core22
 environment:
   REAL_PATH: $PATH
   REAL_LD_LIBRARY_PATH: $LD_LIBRARY_PATH
@@ -23,7 +23,9 @@ parts:
     plugin: nil
     build-snaps:
       - go/1.24/stable
+    build-attributes: [enable-patchelf]
     build-packages:
+      - sudo
       - autoconf
       - automake
       - autopoint
@@ -50,6 +52,7 @@ parts:
     after: [build-deps]
     plugin: nil
     source: src/k8s/hack
+    build-attributes: [enable-patchelf]
     override-prime: ""
     override-build: |
       DQLITE_STAGING_DIR="${SNAPCRAFT_STAGE}/static-dqlite-deps"
@@ -66,11 +69,13 @@ parts:
     after: [dqlite]
     plugin: nil
     source: build-scripts/components/k8s-dqlite
+    build-attributes: [enable-patchelf]
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh k8s-dqlite
 
   k8s-binaries:
     after: [dqlite]
     source: src/k8s
+    build-attributes: [enable-patchelf]
     plugin: nil
     override-build: |
       INSTALL="${SNAPCRAFT_PART_INSTALL}"
@@ -88,12 +93,14 @@ parts:
     after: [build-deps]
     plugin: nil
     source: build-scripts/components/cni
+    build-attributes: [enable-patchelf]
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh cni
 
   kubernetes:
     after: [build-deps]
     plugin: nil
     source: build-scripts
+    build-attributes: [enable-patchelf]
     override-build: $SNAPCRAFT_PROJECT_DIR/build-scripts/build-component.sh kubernetes
 
   kubernetes-version:
@@ -112,6 +119,7 @@ parts:
     after: [build-deps]
     plugin: autotools
     source: https://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
+    build-attributes: [enable-patchelf]
     prime:
       - -usr/local/include
 
@@ -119,6 +127,7 @@ parts:
     after: [libmnl]
     plugin: autotools
     source: https://www.netfilter.org/projects/libnftnl/files/libnftnl-1.1.8.tar.bz2
+    build-attributes: [enable-patchelf]
     build-environment:
       - LIBMNL_LIBS: $SNAPCRAFT_STAGE/usr/lib
     prime:
@@ -128,6 +137,7 @@ parts:
     after: [libnftnl]
     source: https://www.netfilter.org/projects/iptables/files/iptables-1.8.6.tar.bz2
     plugin: autotools
+    build-attributes: [enable-patchelf]
     build-environment:
       - LIBMNL_LIBS: $SNAPCRAFT_STAGE/usr/lib
       - LIBNFTNL_LIBS: $SNAPCRAFT_STAGE/usr/lib
@@ -157,6 +167,7 @@ parts:
 
   bash-utils:
     plugin: nil
+    build-attributes: [enable-patchelf]
     stage-packages:
       - conntrack
       - coreutils
@@ -196,6 +207,7 @@ parts:
   k8s:
     plugin: nil
     source: k8s
+    build-attributes: [enable-patchelf]
     override-build: |
       rm $SNAPCRAFT_PART_INSTALL/k8s -rf
       cp --archive --link --no-dereference . $SNAPCRAFT_PART_INSTALL/k8s

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -153,7 +153,7 @@ Multipass can also be used to run the tests on Ubuntu Core:
 ```bash
 export TEST_SNAP=$PWD/k8s.snap
 export TEST_SUBSTRATE=multipass
-export TEST_MULTIPASS_IMAGE=core20
+export TEST_MULTIPASS_IMAGE=core22
 
 cd tests/integration && tox -e integration
 ```

--- a/tests/integration/lxd/setup-image.sh
+++ b/tests/integration/lxd/setup-image.sh
@@ -36,7 +36,7 @@ BASE_IMAGE="${BASE_IMAGE:=ubuntu:22.04}"                      # base image
 BASE_DISTRO="${BASE_DISTRO:=ubuntu}"                          # base distro of the image
 
 TEST_SNAP="${TEST_SNAP:=}"                                    # path to './k8s.snap' to test
-BASE_SNAP="${BASE_SNAP:=core20}"                              # base snap to install on the image, e.g. 'core20'
+BASE_SNAP="${BASE_SNAP:=core22}"                              # base snap to install on the image, e.g. 'core22'
 IMAGES=""                                                     # list of images to fetch for side-loading
 
 OUT_IMAGES_DIR="${OUT_IMAGES_DIR:=${DIR}/k8s-e2e-images}"     # directory where OCI images will be fetched

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -152,13 +152,13 @@ STRICT_INTERFACE_CHANNELS = (
     os.environ.get("TEST_STRICT_INTERFACE_CHANNELS", "").strip().split()
 )
 
-# Cache and preload certain snaps such as snapd and core20 to avoid fetching them
-# for every test instance. Note that k8s-snap is currently based on core20.
+# Cache and preload certain snaps such as snapd and core22 to avoid fetching them
+# for every test instance. Note that k8s-snap is currently based on core22.
 PRELOAD_SNAPS = (os.getenv("TEST_PRELOAD_SNAPS") or "1") == "1"
 
 # The following snaps will be downloaded once per test run and preloaded
 # into the harness instances to reduce the number of downloads.
-DEFAULT_PRELOADED_SNAPS = ["snapd", "core20"]
+DEFAULT_PRELOADED_SNAPS = ["snapd", "core22"]
 PRELOADED_SNAPS = (
     os.getenv("TEST_PRELOADED_SNAPS", "").strip().split() or DEFAULT_PRELOADED_SNAPS
 )


### PR DESCRIPTION
## Description

Added `enable-patchelf` to build attributes to preserve old behavior since it is not enabled by default from core22+.
Updated references of core20 to core22.

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
