### PR TITLE
test: Retry snap install of pre-loaded snaps

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -209,7 +209,7 @@ def preload_snaps(instance: harness.Instance):
             source=f"/tmp/{snap_file}",
             destination=remote_path,
         )
-        instance.exec(["snap", "install", remote_path])
+        util.stubbornly(retries=3, delay_s=5).on(instance).exec(["snap", "install", remote_path])
 
 
 def setup_core_dumps(instance: harness.Instance):


### PR DESCRIPTION
The tests sometimes fails because other setup steps are in progress. See https://github.com/canonical/k8s-snap/actions/runs/15138210397/job/42556216298?pr=1457#step:9:699
