### PR TITLE
test: Run all tests in parallel on Github runners

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -67,9 +67,14 @@ on:
         default: false
 
 jobs:
-  test-integration:
-    name: Tests
-    runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-noble-large' || 'self-hosted-linux-amd64-noble-large' }}
+  # First job: Prepare the snap and find test files
+  prepare:
+    name: Prepare Environment
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-latest-arm64' || 'ubuntu-latest' }}
+    outputs:
+      snap-path: ${{ steps.download-snap.outputs.snap-path }}
+      test-files: ${{ steps.find-test-files.outputs.test-files }}
+      uuid: ${{ env.UUID }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -80,16 +85,47 @@ jobs:
       - name: Generate job UUID
         # Use this UUID to ensure that the artifact names are unique.
         run: echo UUID=$(uuidgen) >> $GITHUB_ENV
-      - name: Apply patches
-        if: inputs.flavor != ''
-        run: |
-          ./build-scripts/patches/${{ inputs.flavor }}/apply
       - name: Download k8s-snap
         id: download-snap
         uses: ./.github/actions/download-k8s-snap
         with:
           channel: ${{ inputs.channel }}
           artifact: ${{ inputs.artifact }}
+      - name: Install tox
+        run: sudo apt-get install -y tox
+      - name: Find test files using pytest
+        id: find-test-files
+        run: |
+          cd tests/integration
+          TEST_FILES=$(tox -e collect-tests -- --collect-only tests/ --tags "${{ inputs.test-tags }}" \
+            | grep -E "tests/test_.*\.py" \
+            | sed -E 's/.*::([a-zA-Z0-9_]+).*/\1/' \
+            | sort -u)
+          echo "test-files=$TEST_FILES" >> $GITHUB_OUTPUT
+          echo "Found test files: $TEST_FILES"
+
+  # Second job: Run each test in a separate runner
+  run-tests:
+    name: Run ${{ matrix.test-file }} - ${{ inputs.os }}-${{ inputs.arch }}
+    needs: prepare
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-latest-arm64' || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        test-file: ${{ fromJson(needs.prepare.outputs.test-files) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Set UUID from prepare job
+        run: echo UUID=${{ needs.prepare.outputs.uuid }} >> $GITHUB_ENV
+      - name: Apply patches
+        if: inputs.flavor != ''
+        run: |
+          ./build-scripts/patches/${{ inputs.flavor }}/apply
       - name: Install lxd
         uses: ./.github/actions/install-lxd
       - name: Install tox
@@ -97,13 +133,13 @@ jobs:
       - name: Setup tmate session
         uses: canonical/action-tmate@main
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
-      - name: Run e2e tests
+      - name: Run ${{ matrix.test-file }} test
         env:
-          TEST_SNAP: ${{ steps.download-snap.outputs.snap-path }}
+          TEST_SNAP: ${{ needs.prepare.outputs.snap-path }}
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ inputs.os }}
           TEST_FLAVOR: ${{ inputs.flavor }}
-          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports
+          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports/${{ matrix.test-file }}
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6"
           # TODO(etienne): change to "recent" when 1.33 is stable
           TEST_VERSION_DOWNGRADE_CHANNELS: "1.32-classic/stable 1.32-classic/beta 1.31-classic/stable 1.31-classic/beta"
@@ -113,27 +149,27 @@ jobs:
           TEST_GH_REF: ${{ github.ref_name }}
           TEST_GH_BASE_REF: ${{ github.base_ref }}
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- -xvs tests/${{ matrix.test-file }} --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
       - name: Prepare inspection reports
         if: failure()
         run: |
-          tar -czvf inspection-reports.tar.gz -C ${{ github.workspace }} inspection-reports
-          echo "artifact_name=inspection-reports-${{ inputs.os }}-${{ inputs.arch }}" | sed 's/:/-/g' >> $GITHUB_ENV
+          mkdir -p inspection-report-archives
+          tar -czvf inspection-report-archives/${{ matrix.test-file }}.tar.gz -C ${{ github.workspace }} inspection-reports/${{ matrix.test-file }} || true
       - name: Upload inspection report artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.artifact_name }}
-          path: ${{ github.workspace }}/inspection-reports.tar.gz
+          name: inspection-reports-${{ matrix.test-file }}-${{ inputs.os }}-${{ inputs.arch }}
+          path: ${{ github.workspace }}/inspection-report-archives/${{ matrix.test-file }}.tar.gz
       - name: Upload CNCF conformance report artifact
         if: ${{ failure() && contains(inputs.test-tags, 'conformance_tests') }}
         uses: actions/upload-artifact@v4
         with:
-         name: sonobuoy-e2e-${{ env.artifact_name }}
-         path: tests/integration/sonobuoy_e2e.tar.gz
+          name: sonobuoy-e2e-${{ matrix.test-file }}-${{ inputs.os }}-${{ inputs.arch }}
+          path: tests/integration/sonobuoy_e2e.tar.gz
       - name: Upload html test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-         name: subunit-${{ env.UUID }}.html
-         path: tests/integration/subunit.html
+          name: subunit-${{ matrix.test-file }}-${{ env.UUID }}.html
+          path: tests/integration/subunit.html

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-latest-arm64' || 'ubuntu-latest' }}
     outputs:
       snap-path: ${{ steps.download-snap.outputs.snap-path }}
-      test-files: ${{ steps.find-test-files.outputs.test-files }}
+      tests: ${{ steps.find-test-files.outputs.tests }}
       uuid: ${{ env.UUID }}
     steps:
       - name: Check out code
@@ -97,22 +97,33 @@ jobs:
         id: find-test-files
         run: |
           cd tests/integration
-          TEST_FILES=$(tox -e collect-tests -- --collect-only tests/ --tags "${{ inputs.test-tags }}" \
+          # Split the input tags into an array and pass them as individual args
+          IFS=' ' read -ra TAGS <<< "${{ inputs.test-tags }}"
+          TAGS_ARGS=""
+          for tag in "${TAGS[@]}"; do
+            TAGS_ARGS="$TAGS_ARGS --tags $tag"
+          done
+
+          # Collect test names and convert to JSON array for GitHub Actions
+          TEST_FILES=$(tox -e collect-tests -- --collect-only tests/ $TAGS_ARGS \
             | grep -E "tests/test_.*\.py" \
             | sed -E 's/.*::([a-zA-Z0-9_]+).*/\1/' \
             | sort -u)
-          echo "test-files=$TEST_FILES" >> $GITHUB_OUTPUT
+          
+          # Convert to JSON array for GitHub Actions
+          JSON_ARRAY=$(echo "$TEST_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "tests=$JSON_ARRAY" >> $GITHUB_OUTPUT
           echo "Found test files: $TEST_FILES"
 
   # Second job: Run each test in a separate runner
   run-tests:
-    name: Run ${{ matrix.test-file }} - ${{ inputs.os }}-${{ inputs.arch }}
+    name: Run ${{ matrix.test }} - ${{ inputs.os }}-${{ inputs.arch }}
     needs: prepare
     runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-latest-arm64' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        test-file: ${{ fromJson(needs.prepare.outputs.test-files) }}
+        test: ${{ fromJson(needs.prepare.outputs.tests) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -133,13 +144,13 @@ jobs:
       - name: Setup tmate session
         uses: canonical/action-tmate@main
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
-      - name: Run ${{ matrix.test-file }} test
+      - name: Run ${{ matrix.test }} test
         env:
           TEST_SNAP: ${{ needs.prepare.outputs.snap-path }}
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ inputs.os }}
           TEST_FLAVOR: ${{ inputs.flavor }}
-          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports/${{ matrix.test-file }}
+          TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports/${{ matrix.test }}
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6"
           # TODO(etienne): change to "recent" when 1.33 is stable
           TEST_VERSION_DOWNGRADE_CHANNELS: "1.32-classic/stable 1.32-classic/beta 1.31-classic/stable 1.31-classic/beta"
@@ -149,27 +160,27 @@ jobs:
           TEST_GH_REF: ${{ github.ref_name }}
           TEST_GH_BASE_REF: ${{ github.base_ref }}
         run: |
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- -xvs tests/${{ matrix.test-file }} --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- -k ${{ matrix.test }} ${{ inputs.extra-test-args }}
       - name: Prepare inspection reports
         if: failure()
         run: |
           mkdir -p inspection-report-archives
-          tar -czvf inspection-report-archives/${{ matrix.test-file }}.tar.gz -C ${{ github.workspace }} inspection-reports/${{ matrix.test-file }} || true
+          tar -czvf inspection-report-archives/${{ matrix.test }}.tar.gz -C ${{ github.workspace }} inspection-reports/${{ matrix.test }} || true
       - name: Upload inspection report artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: inspection-reports-${{ matrix.test-file }}-${{ inputs.os }}-${{ inputs.arch }}
-          path: ${{ github.workspace }}/inspection-report-archives/${{ matrix.test-file }}.tar.gz
+          name: inspection-reports-${{ matrix.test }}-${{ inputs.os }}-${{ inputs.arch }}
+          path: ${{ github.workspace }}/inspection-report-archives/${{ matrix.test }}.tar.gz
       - name: Upload CNCF conformance report artifact
         if: ${{ failure() && contains(inputs.test-tags, 'conformance_tests') }}
         uses: actions/upload-artifact@v4
         with:
-          name: sonobuoy-e2e-${{ matrix.test-file }}-${{ inputs.os }}-${{ inputs.arch }}
+          name: sonobuoy-e2e-${{ matrix.test }}-${{ inputs.os }}-${{ inputs.arch }}
           path: tests/integration/sonobuoy_e2e.tar.gz
       - name: Upload html test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: subunit-${{ matrix.test-file }}-${{ env.UUID }}.html
+          name: subunit-${{ matrix.test }}-${{ env.UUID }}.html
           path: tests/integration/subunit.html

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -72,9 +72,7 @@ jobs:
     name: Prepare Environment
     runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-latest-arm64' || 'ubuntu-latest' }}
     outputs:
-      snap-path: ${{ steps.download-snap.outputs.snap-path }}
-      tests: ${{ steps.find-test-files.outputs.tests }}
-      uuid: ${{ env.UUID }}
+      tests: ${{ steps.collect-tests.outputs.tests }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -82,19 +80,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Generate job UUID
-        # Use this UUID to ensure that the artifact names are unique.
-        run: echo UUID=$(uuidgen) >> $GITHUB_ENV
-      - name: Download k8s-snap
-        id: download-snap
-        uses: ./.github/actions/download-k8s-snap
-        with:
-          channel: ${{ inputs.channel }}
-          artifact: ${{ inputs.artifact }}
       - name: Install tox
         run: sudo apt-get install -y tox
-      - name: Find test files using pytest
-        id: find-test-files
+      - name: Collect tests
+        id: collect-tests
         run: |
           cd tests/integration
           # Split the input tags into an array and pass them as individual args
@@ -109,7 +98,7 @@ jobs:
             | grep -E "tests/test_.*\.py" \
             | sed -E 's/.*::([a-zA-Z0-9_]+).*/\1/' \
             | sort -u)
-          
+
           # Convert to JSON array for GitHub Actions
           JSON_ARRAY=$(echo "$TEST_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "tests=$JSON_ARRAY" >> $GITHUB_OUTPUT
@@ -131,12 +120,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Set UUID from prepare job
-        run: echo UUID=${{ needs.prepare.outputs.uuid }} >> $GITHUB_ENV
-      - name: Apply patches
-        if: inputs.flavor != ''
-        run: |
-          ./build-scripts/patches/${{ inputs.flavor }}/apply
+      - name: Generate job UUID
+        # Use this UUID to ensure that the artifact names are unique.
+        run: echo UUID=$(uuidgen) >> $GITHUB_ENV
+      - name: Download k8s-snap
+        id: download-snap
+        uses: ./.github/actions/download-k8s-snap
+        with:
+          channel: ${{ inputs.channel }}
+          artifact: ${{ inputs.artifact }}
       - name: Install lxd
         uses: ./.github/actions/install-lxd
       - name: Install tox
@@ -146,7 +138,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
       - name: Run ${{ matrix.test }} test
         env:
-          TEST_SNAP: ${{ needs.prepare.outputs.snap-path }}
+          TEST_SNAP: ${{ download-snap.outputs.snap-path }}
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ inputs.os }}
           TEST_FLAVOR: ${{ inputs.flavor }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
   # First job: Prepare the snap and find test files
   prepare:
     name: Prepare Environment
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-latest-arm64' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm64' || 'ubuntu-24.04' }}
     outputs:
       tests: ${{ steps.collect-tests.outputs.tests }}
     steps:
@@ -108,7 +108,7 @@ jobs:
   run-tests:
     name: Run ${{ matrix.test }} - ${{ inputs.os }}-${{ inputs.arch }}
     needs: prepare
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-latest-arm64' || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm64' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -171,7 +171,7 @@ jobs:
           name: sonobuoy-e2e-${{ matrix.test }}-${{ inputs.os }}-${{ inputs.arch }}
           path: tests/integration/sonobuoy_e2e.tar.gz
       - name: Upload html test report
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: subunit-${{ matrix.test }}-${{ env.UUID }}.html

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
   # First job: Prepare the snap and find test files
   prepare:
     name: Prepare Environment
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm64' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     outputs:
       tests: ${{ steps.collect-tests.outputs.tests }}
     steps:
@@ -108,7 +108,7 @@ jobs:
   run-tests:
     name: Run ${{ matrix.test }} - ${{ inputs.os }}-${{ inputs.arch }}
     needs: prepare
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm64' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -67,7 +67,6 @@ on:
         default: false
 
 jobs:
-  # First job: Prepare the snap and find test files
   prepare:
     name: Prepare Environment
     runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
@@ -106,7 +105,6 @@ jobs:
           echo "tests=$JSON_ARRAY" >> $GITHUB_OUTPUT
           echo "Found test files: $TEST_FILES"
 
-  # Second job: Run each test in a separate runner
   run-tests:
     name: Run ${{ matrix.test }} - ${{ inputs.os }}-${{ inputs.arch }}
     needs: prepare

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -94,9 +94,11 @@ jobs:
           done
 
           # Collect test names and convert to JSON array for GitHub Actions
-          TEST_FILES=$(tox -e collect-tests -- --collect-only tests/ $TAGS_ARGS \
-            | grep -E "tests/test_.*\.py" \
-            | sed -E 's/.*::([a-zA-Z0-9_]+).*/\1/' \
+          # There is no easy way to get the test names from pytest, so we use the --collect-only flag
+          # and parse the output to extract the test names.
+          TEST_FILES=$(tox -e integration -- --collect-only tests/ $TAGS_ARGS --quiet --no-header \
+            | grep -E "<Function test_[a-zA-Z0-9_]+>" \
+            | sed -E 's/<Function (test_[a-zA-Z0-9_]+)>.*/\1/' \
             | sort -u)
 
           # Convert to JSON array for GitHub Actions

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -138,7 +138,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
       - name: Run ${{ matrix.test }} test
         env:
-          TEST_SNAP: ${{ download-snap.outputs.snap-path }}
+          TEST_SNAP: ${{ steps.download-snap.outputs.snap-path }}
           TEST_SUBSTRATE: lxd
           TEST_LXD_IMAGE: ${{ inputs.os }}
           TEST_FLAVOR: ${{ inputs.flavor }}

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -26,7 +26,7 @@ jobs:
       arch: ${{ matrix.arch }}
       os: ${{ matrix.os }}
       channel: ${{ matrix.channel }}
-      test-tags: 'up_to_nightly conformance_tests'
+      test-tags: 'up_to_nightly'
 
   Trivy:
     permissions:

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-env_list = format, lint, integration
+env_list = format, lint, integration, collect-tests
 
 [testenv]
 set_env =
@@ -45,6 +45,15 @@ commands =
 commands_post =
     subunit2html "{toxinidir}/subunit.out" "{toxinidir}/subunit.html"
 
+passenv =
+    TEST_*
+
+[testenv:collect-tests]
+description = "Collect test files using pytest's --collect-only flag"
+deps =
+    -r {toxinidir}/requirements-test.txt
+commands =
+    pytest --collect-only {toxinidir}/tests {posargs} --quiet --no-header --disable-warnings
 passenv =
     TEST_*
 

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -48,15 +48,6 @@ commands_post =
 passenv =
     TEST_*
 
-[testenv:collect-tests]
-description = "Collect test files using pytest's --collect-only flag"
-deps =
-    -r {toxinidir}/requirements-test.txt
-commands =
-    pytest --collect-only {toxinidir}/tests {posargs} --quiet --no-header --disable-warnings
-passenv =
-    TEST_*
-
 [flake8]
 max-line-length = 120
 select = E,W,F,C,N


### PR DESCRIPTION
This PR does two things:
1. Spin up a job for each test which massively reduces our CI/PR testing time
2. Move to official Github runners instead of self-hosted runners

Notes:
* For normal PRs, we don't run the nightly tests so we *only* spin up ~15 jobs
* We could think about not doing this for our nightly runs since iteration speed is not critical in this scenario. 