### PR TITLE
fix: move cleanup code to go and handle custom containerd path

### DIFF
--- a/k8s/profiles/containerd
+++ b/k8s/profiles/containerd
@@ -37,5 +37,7 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
 
   signal (receive) peer=snap.k8s.containerd,
   signal (receive) peer=snap.k8s.kubelet,
+  signal (receive) peer=snap.k8s.k8sd,
+  signal (receive) peer=snap.k8s.k8s,
   signal (receive) peer=snap.k8s.hook.remove,
 }

--- a/src/k8s/cmd/k8s/k8s_x_cleanup.go
+++ b/src/k8s/cmd/k8s/k8s_x_cleanup.go
@@ -6,6 +6,7 @@ import (
 
 	cmdutil "github.com/canonical/k8s/cmd/util"
 	"github.com/canonical/k8s/pkg/k8sd/features"
+	"github.com/canonical/k8s/pkg/snap/util/cleanup"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,8 @@ func newXCleanupCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
 			defer cancel()
 
+			cleanup.RemoveKubeProxyRules(ctx, env.Snap)
+
 			if err := features.Cleanup.CleanupNetwork(ctx, env.Snap); err != nil {
 				cmd.PrintErrf("Error: failed to cleanup network: %v\n", err)
 				env.Exit(1)
@@ -30,6 +33,32 @@ func newXCleanupCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	}
 	cleanupNetworkCmd.Flags().DurationVar(&opts.timeout, "timeout", 5*time.Minute, "the max time to wait for the command to execute")
 
+	cleanupContainersCmd := &cobra.Command{
+		Use:   "containers",
+		Short: "Cleanup left-over containers",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			defer cancel()
+
+			cleanup.TryCleanupContainers(ctx, env.Snap)
+		},
+	}
+	cleanupContainersCmd.Flags().DurationVar(&opts.timeout, "timeout", 5*time.Minute, "the max time to wait for the command to execute")
+
+	cleanupContainerdCmd := &cobra.Command{
+		Use:   "containerd",
+		Short: "Cleanup containerd left-over resources",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
+			defer cancel()
+
+			cleanup.TryCleanupContainerdPaths(ctx, env.Snap)
+		},
+	}
+	cleanupContainerdCmd.Flags().DurationVar(&opts.timeout, "timeout", 5*time.Minute, "the max time to wait for the command to execute")
+
 	cmd := &cobra.Command{
 		Use:    "x-cleanup",
 		Short:  "Cleanup left-over resources from the cluster's features",
@@ -37,6 +66,8 @@ func newXCleanupCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	}
 
 	cmd.AddCommand(cleanupNetworkCmd)
+	cmd.AddCommand(cleanupContainersCmd)
+	cmd.AddCommand(cleanupContainerdCmd)
 
 	return cmd
 }

--- a/src/k8s/pkg/k8sd/app/hooks_remove.go
+++ b/src/k8s/pkg/k8sd/app/hooks_remove.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net"
 	"os"
 
@@ -14,8 +13,8 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/pki"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
 	"github.com/canonical/k8s/pkg/log"
-	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/snap/util/cleanup"
 	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/microcluster/v2/cluster"
 	"github.com/canonical/microcluster/v2/state"
@@ -145,72 +144,15 @@ func (a *App) onPreRemove(ctx context.Context, s state.State, force bool) (rerr 
 			log.Error(err, "failed to stop k8s services")
 		}
 
+		log.Info("Cleaning up containers")
+		cleanup.TryCleanupContainers(ctx, snap)
+
 		log.Info("Cleaning up containerd paths")
-		tryCleanupContainerdPaths(log, snap)
+		cleanup.TryCleanupContainerdPaths(ctx, snap)
 	} else {
 		log.Info("Skipping service stop and certificate cleanup")
 	}
 
 	log.Info("Remove hook completed ")
 	return nil
-}
-
-// tryCleanupContainerdPaths attempts to clean up all containerd directories which were
-// created by the k8s-snap based on the existence of their respective lockfiles
-// located in the directory returned by `s.LockFilesDir()`.
-func tryCleanupContainerdPaths(log log.Logger, s snap.Snap) {
-	for lockpath, dirpath := range setup.ContainerdLockPathsForSnap(s) {
-		// Ensure lockfile exists:
-		log.Info("Cleaning up containerd data directory", "directory", dirpath)
-		if _, err := os.Stat(lockpath); os.IsNotExist(err) {
-			log.Info("WARN: failed to find containerd lockfile, no cleanup will be perfomed", "lockfile", lockpath, "directory", dirpath)
-			continue
-		}
-
-		// Ensure lockfile's contents is the one we expect:
-		lockfile_contents := ""
-		if contents, err := os.ReadFile(lockpath); err != nil {
-			log.Info("WARN: failed to read contents of lockfile", "lockfile", lockpath, "error", err)
-			continue
-		} else {
-			lockfile_contents = string(contents)
-		}
-
-		if lockfile_contents != dirpath {
-			log.Info("WARN: lockfile points to different path than expected", "lockfile", lockpath, "expected", dirpath, "actual", lockfile_contents)
-			continue
-		}
-
-		// Check directory exists before attempting to remove:
-		if stat, err := os.Stat(dirpath); os.IsNotExist(err) {
-			log.Info("Containerd directory doesn't exist; skipping cleanup", "directory", dirpath)
-		} else {
-			realPath := dirpath
-			if stat.Mode()&fs.ModeSymlink != 0 {
-				// NOTE(aznashwan): because of the convoluted interfaces-based way the snap
-				// composes and creates the original lockfiles (see k8sd/setup/containerd.go)
-				// this check is meant to defend against accidental code/configuration errors which
-				// might lead to the root FS being deleted:
-				realPath, err = os.Readlink(dirpath)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Failed to os.Readlink the directory path for lockfile %q pointing to %q. Skipping cleanup", lockpath, dirpath))
-					continue
-				}
-			}
-
-			if realPath == "/" {
-				log.Error(fmt.Errorf("There is some configuration/logic error in the current versions of the k8s-snap related to lockfile %q (meant to lock %q, which points to %q) which could lead to accidental wiping of the root file system.", lockpath, dirpath, realPath), "Please report this issue upstream immediately.")
-				continue
-			}
-
-			if err := os.RemoveAll(dirpath); err != nil {
-				log.Info("WARN: failed to remove containerd data directory", "directory", dirpath, "error", err, "realPath", realPath)
-				continue // Avoid removing the lockfile path.
-			}
-		}
-
-		if err := os.Remove(lockpath); err != nil {
-			log.Info("WARN: Failed to remove containerd lockfile", "lockfile", lockpath)
-		}
-	}
 }

--- a/src/k8s/pkg/k8sd/setup/containerd.go
+++ b/src/k8s/pkg/k8sd/setup/containerd.go
@@ -181,35 +181,9 @@ func Containerd(snap snap.Snap, extraContainerdConfig map[string]any, extraArgs 
 	return nil
 }
 
-// ContainerdLockPathsForSnap returns a mapping between the absolute paths of
-// the lockfiles within the k8s snap and the absolute paths of the containerd
-// directory they lock.
-//
-// WARN: these lockfiles are meant to be used in later cleanup stages.
-// DO NOT include any system paths which are not managed by the k8s-snap!
-//
-// It intentionally does NOT include the containerd base dir lockfile
-// (which most of the rest of the paths are based on), as it is meant
-// to indicate the root of the containerd install ('/' or '/var/snap/k8s/*').
-func ContainerdLockPathsForSnap(s snap.Snap) map[string]string {
-	m := map[string]string{
-		"containerd-socket-path": s.ContainerdSocketDir(),
-		"containerd-config-dir":  s.ContainerdConfigDir(),
-		"containerd-root-dir":    s.ContainerdRootDir(),
-		"containerd-cni-bin-dir": s.CNIBinDir(),
-	}
-
-	prefixed := map[string]string{}
-	for k, v := range m {
-		prefixed[filepath.Join(s.LockFilesDir(), k)] = v
-	}
-
-	return prefixed
-}
-
 // saveSnapContainerdPaths creates the lock files for the containerd directory paths to be used for later cleanup.
 func saveSnapContainerdPaths(s snap.Snap) error {
-	for lockpath, dirpath := range ContainerdLockPathsForSnap(s) {
+	for lockpath, dirpath := range snaputil.ContainerdLockPathsForSnap(s) {
 		if err := utils.WriteFile(lockpath, []byte(dirpath), 0o600); err != nil {
 			return fmt.Errorf("failed to write %s: %w", lockpath, err)
 		}

--- a/src/k8s/pkg/snap/interface.go
+++ b/src/k8s/pkg/snap/interface.go
@@ -53,6 +53,7 @@ type Snap interface {
 
 	K8sCRDDir() string            //  /snap/k8s/current/k8s/crds
 	K8sScriptsDir() string        //  /snap/k8s/current/k8s/scripts
+	K8sBinDir() string            //  /snap/k8s/current/bin
 	K8sInspectScriptPath() string //  /snap/k8s/current/k8s/scripts/inspect.sh
 
 	K8sdStateDir() string      // /var/snap/k8s/common/var/lib/k8sd/state

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -39,6 +39,7 @@ type Mock struct {
 	ContainerdStateDir          string
 	K8sCRDDir                   string
 	K8sScriptsDir               string
+	K8sBinDir                   string
 	K8sInspectScriptPath        string
 	K8sdStateDir                string
 	K8sDqliteStateDir           string
@@ -199,6 +200,10 @@ func (s *Snap) K8sCRDDir() string {
 
 func (s *Snap) K8sScriptsDir() string {
 	return s.Mock.K8sScriptsDir
+}
+
+func (s *Snap) K8sBinDir() string {
+	return s.Mock.K8sBinDir
 }
 
 func (s *Snap) K8sInspectScriptPath() string {

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -340,6 +340,10 @@ func (s *snap) K8sScriptsDir() string {
 	return filepath.Join(s.snapDir, "k8s", "scripts")
 }
 
+func (s *snap) K8sBinDir() string {
+	return filepath.Join(s.snapDir, "bin")
+}
+
 func (s *snap) K8sInspectScriptPath() string {
 	return filepath.Join(s.K8sScriptsDir(), "inspect.sh")
 }

--- a/src/k8s/pkg/snap/util/cleanup/cleanup.go
+++ b/src/k8s/pkg/snap/util/cleanup/cleanup.go
@@ -1,0 +1,36 @@
+package cleanup
+
+import (
+	"context"
+
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/canonical/k8s/pkg/snap/util/cleanup/internal"
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+	netnsutils "github.com/canonical/k8s/pkg/utils/netns"
+)
+
+// [DANGER] Cleanup containers and runtime state. Note that the order of operations below is crucial.
+// Cleanup is done on a best-effort basis, and errors are logged but not returned.
+func TryCleanupContainers(ctx context.Context, s snap.Snap) {
+	mountHelper := mountutils.NewUnixMountHelper()
+	netnsHelper := netnsutils.NewUnixNetworkNSHelper()
+
+	internal.RemoveContainers(ctx)
+	internal.RemoveNetworkNamespaces(ctx, netnsHelper)
+	internal.RemoveVolumeMountsGracefully(ctx, s, mountHelper)
+	internal.RemoveVolumeMountsForce(ctx, s, mountHelper)
+	internal.RemovePluginSockets(ctx)
+	internal.RemoveLoopDevices(ctx, mountHelper)
+}
+
+// TryCleanupContainerdPaths attempts to clean up all containerd directories which were
+// created by the k8s-snap based on the existence of their respective lockfiles
+// located in the directory returned by `s.LockFilesDir()`.
+func TryCleanupContainerdPaths(ctx context.Context, s snap.Snap) {
+	internal.TryCleanupContainerdPaths(ctx, s)
+}
+
+// RemoveKubeProxyRules removes routing rules, such as iptables rules, that were created by kube-proxy.
+func RemoveKubeProxyRules(ctx context.Context, s snap.Snap) {
+	internal.RemoveKubeProxyRules(ctx, s)
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/containerd_paths.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/containerd_paths.go
@@ -1,0 +1,59 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+)
+
+// TryCleanupContainerdPaths attempts to clean up all containerd directories which were
+// created by the k8s-snap based on the existence of their respective lockfiles
+// located in the directory returned by `s.LockFilesDir()`.
+func TryCleanupContainerdPaths(ctx context.Context, s snap.Snap) {
+	log := log.FromContext(ctx)
+
+	snaputil.ForEachContainerdPath(ctx, s, func(lockpath string, dirpath string) error {
+		log.Info("Cleaning up containerd data directory", "directory", dirpath)
+
+		// Check directory exists before attempting to remove:
+		stat, err := os.Stat(dirpath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("containerd data directory %q does not exist", dirpath)
+			}
+			return fmt.Errorf("failed to stat containerd data directory %q: %w", dirpath, err)
+		}
+
+		realPath := dirpath
+		if stat.Mode()&fs.ModeSymlink != 0 {
+			// NOTE(aznashwan): because of the convoluted interfaces-based way the snap
+			// composes and creates the original lockfiles (see k8sd/setup/containerd.go)
+			// this check is meant to defend against accidental code/configuration errors which
+			// might lead to the root FS being deleted:
+			realPath, err = os.Readlink(dirpath)
+			if err != nil {
+				return fmt.Errorf("failed to read link for directory %q: %w", dirpath, err)
+			}
+		}
+
+		if realPath == "/" {
+			return fmt.Errorf("there is some configuration/logic error in the current versions of the k8s-snap related to lockfile %q (meant to lock %q, which points to %q) which could lead to accidental wiping of the root file system", lockpath, dirpath, realPath)
+		}
+
+		if err := os.RemoveAll(dirpath); err != nil {
+			// Avoid removing the lockfile path.
+			return fmt.Errorf("failed to remove containerd data directory %q: %w", dirpath, err)
+		}
+
+		if err := os.Remove(lockpath); err != nil {
+			return fmt.Errorf("failed to remove containerd lockfile %q: %w", lockpath, err)
+		}
+
+		return nil
+	})
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/containerd_paths_test.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/containerd_paths_test.go
@@ -1,0 +1,101 @@
+package internal_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/k8s/pkg/snap/util/cleanup/internal"
+	. "github.com/onsi/gomega"
+)
+
+func TestTryCleanupContainerdPaths_RemovesDirAndLockfile(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	lockFilesDir := filepath.Join(t.TempDir(), "lockfiles")
+	err := os.MkdirAll(lockFilesDir, 0o755)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	t.Run("Removes all data directories and lock files", func(t *testing.T) {
+		// Use t.TempDir() for all containerd-related directories to ensure test isolation
+		containerdRootDir := filepath.Join(t.TempDir(), "containerd")
+		containerdSocketDir := filepath.Join(t.TempDir(), "containerd_socket")
+		containerdConfigDir := filepath.Join(t.TempDir(), "containerd_config")
+		cniBinDir := filepath.Join(t.TempDir(), "cni_bin")
+
+		// Mock snap with a lock files directory
+		s := &mock.Snap{
+			Mock: mock.Mock{
+				LockFilesDir:        lockFilesDir,
+				ContainerdRootDir:   containerdRootDir,
+				ContainerdSocketDir: containerdSocketDir,
+				ContainerdConfigDir: containerdConfigDir,
+				CNIBinDir:           cniBinDir,
+			},
+		}
+
+		// Create lock files for each path in the map
+		m := map[string]string{
+			"containerd-socket-path": s.ContainerdSocketDir(),
+			"containerd-config-dir":  s.ContainerdConfigDir(),
+			"containerd-root-dir":    s.ContainerdRootDir(),
+			"containerd-cni-bin-dir": s.CNIBinDir(),
+		}
+		for name, dir := range m {
+			lockFile := filepath.Join(lockFilesDir, name)
+			f, err := os.Create(lockFile)
+			g.Expect(err).To(Not(HaveOccurred()))
+			_, err = f.WriteString(dir)
+			g.Expect(err).To(Not(HaveOccurred()))
+			f.Close()
+			// Create the directory to simulate the data dir
+			dataDir := dir
+			err = os.MkdirAll(dataDir, 0o755)
+			g.Expect(err).To(Not(HaveOccurred()))
+		}
+
+		internal.TryCleanupContainerdPaths(ctx, s)
+
+		// All data dirs should be removed
+		for _, dir := range m {
+			_, err := os.Stat(dir)
+			g.Expect(os.IsNotExist(err)).To(BeTrue())
+		}
+		// All lock files should be removed
+		for name := range m {
+			lockFile := filepath.Join(lockFilesDir, name)
+			_, err := os.Stat(lockFile)
+			g.Expect(os.IsNotExist(err)).To(BeTrue())
+		}
+	})
+
+	// This is a dangerous test that ensures the cleanup function does not remove the root directory
+	t.Run("Does not remove root directory", func(t *testing.T) {
+		// Simulate a lockfile that (incorrectly) points to "/"
+		lockFile := filepath.Join(lockFilesDir, "containerd-root-dir")
+		err = os.WriteFile(lockFile, []byte("/"), 0o644)
+		g.Expect(err).To(Not(HaveOccurred()))
+
+		// Create a mock snap that returns "/" as the containerd root dir
+		s := &mock.Snap{
+			Mock: mock.Mock{
+				LockFilesDir:      lockFilesDir,
+				ContainerdRootDir: "/",
+			},
+		}
+
+		// Call the cleanup function
+		internal.TryCleanupContainerdPaths(ctx, s)
+
+		// The lockfile should still exist, since the root dir must not be deleted
+		_, err = os.Stat(lockFile)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// The root directory should still exist
+		_, err = os.Stat("/")
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/containers.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/containers.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/utils/shims"
+)
+
+func RemoveContainers(ctx context.Context) {
+	log := log.FromContext(ctx)
+	pids, err := shims.RunningContainerdShimPIDs(ctx)
+	if err != nil {
+		log.Error(err, "failed to get containerd shim PIDs")
+		return
+	}
+
+	for _, pid := range pids {
+		intPid, err := strconv.Atoi(pid)
+		if err != nil {
+			log.Error(err, "failed to convert PID to integer", "pid", pid)
+			continue
+		}
+
+		process, err := os.FindProcess(intPid)
+		if err != nil {
+			log.Error(err, "failed to find containerd shim PID", "pid", intPid)
+			continue
+		}
+
+		if err := process.Kill(); err != nil {
+			log.Error(err, "failed to kill containerd shim PID", "pid", intPid)
+			continue
+		}
+	}
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/kube_proxy.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/kube_proxy.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+)
+
+func RemoveKubeProxyRules(ctx context.Context, s snap.Snap) {
+	log := log.FromContext(ctx)
+
+	// Remove kube-proxy rules
+	cmd := exec.CommandContext(ctx, filepath.Join(s.K8sBinDir(), "kube-proxy"), "--cleanup")
+
+	if err := cmd.Run(); err != nil {
+		log.Error(err, "failed to run kube-proxy cleanup")
+	}
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/loop_devices.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/loop_devices.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"context"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/log"
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+)
+
+func RemoveLoopDevices(ctx context.Context, mountHelper mountutils.MountManager) {
+	log := log.FromContext(ctx)
+
+	err := mountHelper.ForEachMount(ctx, func(ctx context.Context, device string, mountPoint string, fsType string, flags string) error {
+		if strings.HasPrefix(mountPoint, "/var/lib/kubelet/pods") && strings.HasPrefix(device, "/dev/loop") {
+			// Gather loop devices for detachment
+			return mountHelper.DetachLoopDevice(ctx, device)
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Error(err, "failed to iterate mounts for loop devices")
+	}
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/loop_devices_test.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/loop_devices_test.go
@@ -1,0 +1,41 @@
+package internal_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap/util/cleanup/internal"
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+	. "github.com/onsi/gomega"
+)
+
+func TestRemoveLoopDevices(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	// Create a temp file to simulate /proc/mounts with loop device entries
+	procMountsFile := filepath.Join(t.TempDir(), "mounts")
+	mountsContent := `
+/dev/loop123 /var/lib/kubelet/pods/abc ext4 rw,relatime 0 0
+/dev/loop124 /not/kubelet/pods ext4 rw,relatime 0 0
+/dev/sda1 /var/lib/kubelet/pods/def ext4 rw,relatime 0 0
+`
+	err := os.WriteFile(procMountsFile, []byte(mountsContent), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	// Create a mock MountHelper
+	mockHelper := mountutils.NewMockMountHelper(procMountsFile)
+
+	internal.RemoveLoopDevices(ctx, mockHelper)
+
+	// Read the file again to check that loop device entries are removed
+	updatedContent, err := os.ReadFile(procMountsFile)
+	g.Expect(err).To(Not(HaveOccurred()))
+	g.Expect(string(updatedContent)).ToNot(ContainSubstring("/dev/loop123"))
+	// Ensure that the loop device that was not in kubelet pods is still present
+	g.Expect(string(updatedContent)).To(ContainSubstring("/dev/loop124"))
+	// Non-loop device entries should remain
+	g.Expect(string(updatedContent)).To(ContainSubstring("/dev/sda1"))
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/network_namespaces.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/network_namespaces.go
@@ -1,0 +1,23 @@
+package internal
+
+import (
+	"context"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/log"
+	netnsutils "github.com/canonical/k8s/pkg/utils/netns"
+)
+
+func RemoveNetworkNamespaces(ctx context.Context, netnsHelper netnsutils.NetworkNamespaceManager) {
+	log := log.FromContext(ctx)
+
+	err := netnsHelper.ForEachNetworkNamespace(ctx, func(ctx context.Context, namespace string) error {
+		if strings.HasPrefix(namespace, "cni-") {
+			return netnsHelper.DeleteNetworkNamespace(ctx, namespace)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Error(err, "failed to iterate and delete network namespaces")
+	}
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/network_namespaces_test.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/network_namespaces_test.go
@@ -1,0 +1,36 @@
+package internal_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap/util/cleanup/internal"
+	netnsutils "github.com/canonical/k8s/pkg/utils/netns"
+	. "github.com/onsi/gomega"
+)
+
+func TestRemoveNetworkNamespaces(t *testing.T) {
+	ctx := context.Background()
+	netnsDir := t.TempDir()
+	g := NewWithT(t)
+
+	helper := netnsutils.NewMockNetworkNSHelper(netnsDir)
+
+	// Create namespaces: one cni- and one non-cni-
+	cniNS := "cni-test-ns"
+	otherNS := "other-ns"
+	cniPath := filepath.Join(netnsDir, cniNS)
+	otherPath := filepath.Join(netnsDir, otherNS)
+	g.Expect(os.Mkdir(cniPath, 0o755)).To(Succeed())
+	g.Expect(os.Mkdir(otherPath, 0o755)).To(Succeed())
+	g.Expect(cniPath).To(BeAnExistingFile())
+	g.Expect(otherPath).To(BeAnExistingFile())
+
+	internal.RemoveNetworkNamespaces(ctx, helper)
+
+	// cni- namespace should be deleted, other should remain
+	g.Expect(cniPath).ToNot(BeAnExistingFile())
+	g.Expect(otherPath).To(BeAnExistingFile())
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/plugins.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/plugins.go
@@ -1,0 +1,44 @@
+package internal
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/log"
+)
+
+var PluginDirs = []string{"/var/lib/kubelet/plugins/", "/var/lib/kubelet/plugins_registry/"}
+
+func RemovePluginSockets(ctx context.Context) {
+	for _, pluginDir := range PluginDirs {
+		removeSockets(ctx, pluginDir)
+	}
+}
+
+func removeSockets(ctx context.Context, dir string) {
+	log := log.FromContext(ctx)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		log.Error(err, "failed to list files under directory", "dir", dir)
+		return
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+
+		if entry.IsDir() {
+			removeSockets(ctx, path)
+			continue
+		}
+
+		if strings.HasSuffix(entry.Name(), ".sock") {
+			if err := os.RemoveAll(path); err != nil {
+				log.Error(err, "failed to remove socket", "path", path)
+				continue
+			}
+		}
+	}
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/plugins_test.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/plugins_test.go
@@ -1,0 +1,87 @@
+package internal_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap/util/cleanup/internal"
+	. "github.com/onsi/gomega"
+)
+
+func TestRemovePluginSockets(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	// Create temporary plugin directories
+	tmpDir := t.TempDir()
+	pluginDir1 := filepath.Join(tmpDir, "plugins")
+	pluginDir2 := filepath.Join(tmpDir, "plugins_registry")
+	err := os.MkdirAll(pluginDir1, 0o755)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.MkdirAll(pluginDir2, 0o755)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	// Create subdirectories
+	subDir1 := filepath.Join(pluginDir1, "subdir1")
+	subDir2 := filepath.Join(pluginDir2, "subdir2")
+	err = os.MkdirAll(subDir1, 0o755)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.MkdirAll(subDir2, 0o755)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	// Patch the global pluginDirs variable for test isolation
+	origPluginDirs := internal.PluginDirs
+	internal.PluginDirs = []string{pluginDir1, pluginDir2}
+	defer func() { internal.PluginDirs = origPluginDirs }()
+
+	// Create some .sock files and some non-sock files
+	sock1 := filepath.Join(pluginDir1, "test1.sock")
+	sock2 := filepath.Join(pluginDir2, "test2.sock")
+	sock3 := filepath.Join(subDir1, "nested1.sock")
+	sock4 := filepath.Join(subDir2, "nested2.sock")
+	other1 := filepath.Join(pluginDir1, "notasocket.txt")
+	other2 := filepath.Join(pluginDir2, "anotherfile.conf")
+	other3 := filepath.Join(subDir1, "notasocket3.txt")
+	other4 := filepath.Join(subDir2, "notasocket4.conf")
+	err = os.WriteFile(sock1, []byte("socket1"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.WriteFile(sock2, []byte("socket2"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.WriteFile(sock3, []byte("socket3"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.WriteFile(sock4, []byte("socket4"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.WriteFile(other1, []byte("notasocket"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.WriteFile(other2, []byte("notasocket2"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.WriteFile(other3, []byte("notasocket3"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+	err = os.WriteFile(other4, []byte("notasocket4"), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	// Call the function under test
+	internal.RemovePluginSockets(ctx)
+
+	// .sock files should be removed (including in subdirectories)
+	_, err = os.Stat(sock1)
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+	_, err = os.Stat(sock2)
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+	_, err = os.Stat(sock3)
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+	_, err = os.Stat(sock4)
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+
+	// Other files should remain
+	_, err = os.Stat(other1)
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = os.Stat(other2)
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = os.Stat(other3)
+	g.Expect(err).ToNot(HaveOccurred())
+	_, err = os.Stat(other4)
+	g.Expect(err).ToNot(HaveOccurred())
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/volume_mounts.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/volume_mounts.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+	"golang.org/x/sys/unix"
+)
+
+func containerdMountPrefixes(ctx context.Context, s snap.Snap) []string {
+	paths := []string{}
+
+	// Get the containerd root directory
+	// e.g. /var/lib/containerd
+	containerdRootDir := s.ContainerdRootDir()
+	if snaputil.IsContainerdPathManaged(ctx, s, containerdRootDir) {
+		paths = append(paths, containerdRootDir)
+	}
+
+	// e.g. /run/containerd/io.containerd.
+	containerdSocketDir := s.ContainerdSocketDir()
+	if snaputil.IsContainerdPathManaged(ctx, s, containerdSocketDir) {
+		paths = append(paths, filepath.Join(containerdSocketDir, "io.containerd."))
+	}
+
+	return paths
+}
+
+func RemoveVolumeMountsGracefully(ctx context.Context, s snap.Snap, mountHelper mountutils.MountManager) {
+	log := log.FromContext(ctx)
+
+	prefixes := []string{"/var/lib/kubelet/pods"}
+	containerdPaths := containerdMountPrefixes(ctx, s)
+	prefixes = append(prefixes, containerdPaths...)
+	log.Info("Removing volume mounts", "prefixes", prefixes)
+
+	err := mountHelper.ForEachMount(ctx, func(ctx context.Context, device string, mountPoint string, fsType string, flags string) error {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(mountPoint, prefix) && !strings.Contains(fsType, "nfs") {
+				// unmount Pod NFS volumes only forcefully, as unmounting them normally may hang otherwise.
+				// unmount remaining Pod volumes gracefully.
+				return mountHelper.Unmount(ctx, mountPoint, unix.MNT_DETACH)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Error(err, "failed to iterate mounts for removing volume mounts")
+	}
+}
+
+func RemoveVolumeMountsForce(ctx context.Context, s snap.Snap, mountHelper mountutils.MountManager) {
+	log := log.FromContext(ctx)
+
+	prefixes := []string{"/var/lib/kubelet/pods", "/var/lib/kubelet/plugins"}
+	containerdPaths := containerdMountPrefixes(ctx, s)
+	prefixes = append(prefixes, containerdPaths...)
+	log.Info("Removing volume mounts", "prefixes", prefixes)
+
+	err := mountHelper.ForEachMount(ctx, func(ctx context.Context, device string, mountPoint string, fsType string, flags string) error {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(mountPoint, prefix) {
+				// unmount lingering Pod volumes by force, to prevent potential volume leaks.
+				return mountHelper.Unmount(ctx, mountPoint, unix.MNT_FORCE)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Error(err, "failed to iterate mounts for forcefully removing volume mounts")
+	}
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/volume_mounts_test.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/volume_mounts_test.go
@@ -1,0 +1,145 @@
+package internal_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/k8s/pkg/snap/util/cleanup/internal"
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+	. "github.com/onsi/gomega"
+)
+
+func TestRemoveVolumeMountsGracefully(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	lockFilesDir := filepath.Join(t.TempDir(), "lockfiles")
+	err := os.MkdirAll(lockFilesDir, 0o755)
+	g.Expect(err).To(Not(HaveOccurred()))
+	// Mock snap with a lock files directory
+
+	s := &mock.Snap{
+		Mock: mock.Mock{
+			LockFilesDir:        lockFilesDir,
+			ContainerdRootDir:   "/var/lib/containerd",
+			ContainerdSocketDir: "/run/containerd",
+			ContainerdConfigDir: "/etc/containerd",
+			CNIBinDir:           "/opt/cni/bin",
+		},
+	}
+
+	// Create lock files for each path in the map
+	m := map[string]string{
+		"containerd-socket-path": s.ContainerdSocketDir(),
+		"containerd-config-dir":  s.ContainerdConfigDir(),
+		"containerd-root-dir":    s.ContainerdRootDir(),
+		"containerd-cni-bin-dir": s.CNIBinDir(),
+	}
+	for name, dir := range m {
+		lockFile := filepath.Join(lockFilesDir, name)
+		f, err := os.Create(lockFile)
+		g.Expect(err).To(Not(HaveOccurred()))
+		_, err = f.WriteString(dir)
+		g.Expect(err).To(Not(HaveOccurred()))
+		f.Close()
+	}
+
+	// Prepare a temp file to simulate /proc/mounts
+	procMountsFile := filepath.Join(t.TempDir(), "mounts")
+	mountsContent := `
+/dev/sda1 /var/lib/kubelet/pods/abc ext4 rw,relatime 0 0
+/dev/sda2 /var/lib/kubelet/pods/def nfs rw,relatime 0 0
+/dev/sda3 /run/containerd/io.containerd.xzy ext4 rw,relatime 0 0
+/dev/sda4 /var/lib/containerd/vol1 ext4 rw,relatime 0 0
+/dev/sda5 /not/affected/path ext4 rw,relatime 0 0
+`
+	err = os.WriteFile(procMountsFile, []byte(mountsContent), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	// Create a mock MountHelper that records unmounts
+	mockHelper := mountutils.NewMockMountHelper(procMountsFile)
+
+	internal.RemoveVolumeMountsGracefully(ctx, s, mockHelper)
+	// Read the file again to check that the correct mount points are removed
+	updatedContent, err := os.ReadFile(procMountsFile)
+	g.Expect(err).To(Not(HaveOccurred()))
+	contentStr := string(updatedContent)
+
+	// Should remove all except the NFS and unrelated mount
+	g.Expect(contentStr).ToNot(ContainSubstring("/var/lib/kubelet/pods/abc"))
+	g.Expect(contentStr).ToNot(ContainSubstring("/run/containerd/io.containerd.xzy"))
+	g.Expect(contentStr).ToNot(ContainSubstring("/var/lib/containerd/vol1"))
+	// NFS mount should remain
+	g.Expect(contentStr).To(ContainSubstring("/var/lib/kubelet/pods/def"))
+	// Unrelated mount should remain
+	g.Expect(contentStr).To(ContainSubstring("/not/affected/path"))
+}
+
+func TestRemoveVolumeMountsForce(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	lockFilesDir := filepath.Join(t.TempDir(), "lockfiles")
+	err := os.MkdirAll(lockFilesDir, 0o755)
+	g.Expect(err).To(Not(HaveOccurred()))
+	// Mock snap with a lock files directory
+
+	s := &mock.Snap{
+		Mock: mock.Mock{
+			LockFilesDir:        lockFilesDir,
+			ContainerdRootDir:   "/var/lib/containerd",
+			ContainerdSocketDir: "/run/containerd",
+			ContainerdConfigDir: "/etc/containerd",
+			CNIBinDir:           "/opt/cni/bin",
+		},
+	}
+
+	// Create lock files for each path in the map
+	m := map[string]string{
+		"containerd-socket-path": s.ContainerdSocketDir(),
+		"containerd-config-dir":  s.ContainerdConfigDir(),
+		"containerd-root-dir":    s.ContainerdRootDir(),
+		"containerd-cni-bin-dir": s.CNIBinDir(),
+	}
+	for name, dir := range m {
+		lockFile := filepath.Join(lockFilesDir, name)
+		f, err := os.Create(lockFile)
+		g.Expect(err).To(Not(HaveOccurred()))
+		_, err = f.WriteString(dir)
+		g.Expect(err).To(Not(HaveOccurred()))
+		f.Close()
+	}
+
+	// Prepare a temp file to simulate /proc/mounts
+	procMountsFile := filepath.Join(t.TempDir(), "mounts")
+	mountsContent := `
+/dev/sda1 /var/lib/kubelet/pods/abc ext4 rw,relatime 0 0
+/dev/sda2 /run/containerd/io.containerd.xzy ext4 rw,relatime 0 0
+/dev/sda3 /var/lib/kubelet/plugins/vol1 ext4 rw,relatime 0 0
+/dev/sda4 /var/lib/containerd/vol2 ext4 rw,relatime 0 0
+/dev/sda5 /not/affected/path ext4 rw,relatime 0 0
+`
+	err = os.WriteFile(procMountsFile, []byte(mountsContent), 0o644)
+	g.Expect(err).To(Not(HaveOccurred()))
+
+	// Create a mock MountHelper that records unmounts
+	mockHelper := mountutils.NewMockMountHelper(procMountsFile)
+
+	internal.RemoveVolumeMountsForce(ctx, s, mockHelper)
+
+	// Read the file again to check that the correct mount points are removed
+	updatedContent, err := os.ReadFile(procMountsFile)
+	g.Expect(err).To(Not(HaveOccurred()))
+	contentStr := string(updatedContent)
+
+	// Should remove all matching the prefixes
+	g.Expect(contentStr).ToNot(ContainSubstring("/var/lib/kubelet/pods/abc"))
+	g.Expect(contentStr).ToNot(ContainSubstring("/run/containerd/io.containerd.xzy"))
+	g.Expect(contentStr).ToNot(ContainSubstring("/var/lib/kubelet/plugins/vol1"))
+	g.Expect(contentStr).ToNot(ContainSubstring("/var/lib/containerd/vol2"))
+	// Unrelated mount should remain
+	g.Expect(contentStr).To(ContainSubstring("/not/affected/path"))
+}

--- a/src/k8s/pkg/snap/util/containerd.go
+++ b/src/k8s/pkg/snap/util/containerd.go
@@ -1,0 +1,86 @@
+package snaputil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+)
+
+// ContainerdLockPathsForSnap returns a mapping between the absolute paths of
+// the lockfiles within the k8s snap and the absolute paths of the containerd
+// directory they lock.
+//
+// WARN: these lockfiles are meant to be used in later cleanup stages.
+// DO NOT include any system paths which are not managed by the k8s-snap!
+//
+// It intentionally does NOT include the containerd base dir lockfile
+// (which most of the rest of the paths are based on), as it is meant
+// to indicate the root of the containerd install ('/' or '/var/snap/k8s/*').
+func ContainerdLockPathsForSnap(s snap.Snap) map[string]string {
+	m := map[string]string{
+		"containerd-socket-path": s.ContainerdSocketDir(),
+		"containerd-config-dir":  s.ContainerdConfigDir(),
+		"containerd-root-dir":    s.ContainerdRootDir(),
+		"containerd-cni-bin-dir": s.CNIBinDir(),
+	}
+
+	prefixed := map[string]string{}
+	for k, v := range m {
+		prefixed[filepath.Join(s.LockFilesDir(), k)] = v
+	}
+
+	return prefixed
+}
+
+func ForEachContainerdPath(ctx context.Context, s snap.Snap, callback func(lockPath string, dirPath string) error) {
+	log := log.FromContext(ctx)
+
+	for lockpath, dirpath := range ContainerdLockPathsForSnap(s) {
+		// Ensure the directory exists
+		if err := func() error {
+			// Ensure lockfile exists:
+			if _, err := os.Stat(lockpath); os.IsNotExist(err) {
+				return fmt.Errorf("failed to find containerd lockfile %q for directory %q", lockpath, dirpath)
+			}
+
+			// Ensure lockfile's contents is the one we expect:
+			lockfile_contents := ""
+			if contents, err := os.ReadFile(lockpath); err != nil {
+				return fmt.Errorf("failed to read contents of lockfile %q: %w", lockpath, err)
+			} else {
+				lockfile_contents = string(contents)
+			}
+
+			if lockfile_contents != dirpath {
+				return fmt.Errorf("lockfile %q points to different path than expected: %q != %q", lockpath, dirpath, lockfile_contents)
+			}
+
+			return nil
+		}(); err != nil {
+			log.Info("WARN: skipping containerd path due to error", "lockpath", lockpath, "dirpath", dirpath, "error", err)
+			continue
+		}
+
+		if err := callback(lockpath, dirpath); err != nil {
+			log.Error(err, "callback failed for containerd lock path and directory", "lockpath", lockpath, "dirpath", dirpath)
+		}
+	}
+}
+
+func IsContainerdPathManaged(ctx context.Context, s snap.Snap, hee string) bool {
+	isManaged := false
+
+	ForEachContainerdPath(ctx, s, func(lockpath string, dirpath string) error {
+		// Check if the directory matches the given path
+		if dirpath == hee {
+			isManaged = true
+		}
+		return nil
+	})
+
+	return isManaged
+}

--- a/src/k8s/pkg/utils/mount/mock.go
+++ b/src/k8s/pkg/utils/mount/mock.go
@@ -1,0 +1,73 @@
+package mountutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/log"
+)
+
+type MockMountManager struct {
+	mountsPath string
+}
+
+func (h MockMountManager) ForEachMount(ctx context.Context, callback func(ctx context.Context, device string, mountPoint string, fsType string, flags string) error) error {
+	return forEachMount(ctx, h.mountsPath, callback)
+}
+
+func (h MockMountManager) Unmount(ctx context.Context, mountPoint string, flags int) error {
+	log := log.FromContext(ctx)
+	log.Info("Mock unmount called", "mountPoint", mountPoint, "flags", flags)
+
+	err := h.removeLineFromMounts(mountPoint)
+	if err != nil {
+		return fmt.Errorf("failed to remove mount point %s from mounts: %w", mountPoint, err)
+	}
+
+	return nil
+}
+
+func (h MockMountManager) DetachLoopDevice(ctx context.Context, device string) error {
+	log := log.FromContext(ctx)
+	log.Info("Mock detach loop device called", "device", device)
+
+	err := h.removeLineFromMounts(device)
+	if err != nil {
+		return fmt.Errorf("failed to remove loop device %s from mounts: %w", device, err)
+	}
+
+	// Simulate successful detachment without actual operation
+	return nil
+}
+
+func NewMockMountHelper(mountsPath string) MountManager {
+	return &MockMountManager{
+		mountsPath: mountsPath,
+	}
+}
+
+func (h MockMountManager) removeLineFromMounts(removed string) error {
+	if h.mountsPath == "" {
+		// If mountsPath is not set, we ignore the operation
+		return nil
+	}
+	data, err := os.ReadFile(h.mountsPath)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	var newLines []string
+	for _, line := range lines {
+		if !strings.Contains(line, removed) {
+			newLines = append(newLines, line)
+		}
+	}
+	err = os.WriteFile(h.mountsPath, []byte(strings.Join(newLines, "\n")), 0o644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/utils/mount/mount.go
+++ b/src/k8s/pkg/utils/mount/mount.go
@@ -1,0 +1,49 @@
+package mountutils
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/canonical/k8s/pkg/log"
+)
+
+type MountManager interface {
+	ForEachMount(ctx context.Context, callback func(ctx context.Context, device string, mountPoint string, fsType string, flags string) error) error
+	Unmount(ctx context.Context, mountPoint string, flags int) error
+	DetachLoopDevice(ctx context.Context, loopDevice string) error
+}
+
+func forEachMount(ctx context.Context, mountsPath string, callback func(ctx context.Context, device string, mountPoint string, fsType string, flags string) error) error {
+	log := log.FromContext(ctx)
+
+	file, err := os.Open(mountsPath)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", mountsPath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+
+		if len(fields) < 4 {
+			log.Error(fmt.Errorf("less than 4 fields in mount entry: %s", line), "skipping invalid mount entry")
+			continue
+		}
+
+		if err := callback(ctx, fields[0], fields[1], fields[2], fields[3]); err != nil {
+			log.Error(err, "callback failed for mount entry", "device", fields[0], "mountPoint", fields[1], "fsType", fields[2], "flags", fields[3])
+			continue
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read %s: %w", mountsPath, err)
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/utils/mount/unix.go
+++ b/src/k8s/pkg/utils/mount/unix.go
@@ -1,0 +1,34 @@
+package mountutils
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+type UnixMountManager struct{}
+
+func (h UnixMountManager) ForEachMount(ctx context.Context, callback func(ctx context.Context, device string, mountPoint string, fsType string, flags string) error) error {
+	return forEachMount(ctx, "/proc/mounts", callback)
+}
+
+func (h UnixMountManager) Unmount(ctx context.Context, mountPoint string, flags int) error {
+	if err := unix.Unmount(mountPoint, flags); err != nil {
+		return fmt.Errorf("failed to unmount %s: %w", mountPoint, err)
+	}
+	return nil
+}
+
+func (h UnixMountManager) DetachLoopDevice(ctx context.Context, device string) error {
+	cmd := exec.CommandContext(ctx, "losetup", "-d", device)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to detach loop device using losetup %s: %w", device, err)
+	}
+	return nil
+}
+
+func NewUnixMountHelper() MountManager {
+	return &UnixMountManager{}
+}

--- a/src/k8s/pkg/utils/netns/mock.go
+++ b/src/k8s/pkg/utils/netns/mock.go
@@ -1,0 +1,26 @@
+package netnsutils
+
+import (
+	"context"
+
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+)
+
+type MockNetworkNamespaceManager struct {
+	netnsDir string
+}
+
+func (h MockNetworkNamespaceManager) ForEachNetworkNamespace(ctx context.Context, callback func(ctx context.Context, namespace string) error) error {
+	return forEachNetworkNamespace(ctx, h.netnsDir, callback)
+}
+
+func (h MockNetworkNamespaceManager) DeleteNetworkNamespace(ctx context.Context, namespace string) error {
+	mountHelper := mountutils.MockMountManager{}
+	return deleteNetworkNamespace(ctx, mountHelper, h.netnsDir, namespace)
+}
+
+func NewMockNetworkNSHelper(netnsDir string) NetworkNamespaceManager {
+	return &MockNetworkNamespaceManager{
+		netnsDir: netnsDir,
+	}
+}

--- a/src/k8s/pkg/utils/netns/netns.go
+++ b/src/k8s/pkg/utils/netns/netns.go
@@ -1,0 +1,48 @@
+package netnsutils
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/canonical/k8s/pkg/log"
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+	"golang.org/x/sys/unix"
+)
+
+type NetworkNamespaceManager interface {
+	ForEachNetworkNamespace(ctx context.Context, callback func(ctx context.Context, namespace string) error) error
+	DeleteNetworkNamespace(ctx context.Context, namespace string) error
+}
+
+func deleteNetworkNamespace(ctx context.Context, mountHelper mountutils.MountManager, netnsDir string, namespace string) error {
+	nsPath := filepath.Join(netnsDir, namespace)
+
+	if err := mountHelper.Unmount(ctx, nsPath, unix.MNT_DETACH); err != nil {
+		return fmt.Errorf("failed to unmount network namespace %s: %w", namespace, err)
+	}
+
+	if err := os.Remove(nsPath); err != nil {
+		return fmt.Errorf("failed to remove network namespace %s: %w", namespace, err)
+	}
+
+	return nil
+}
+
+func forEachNetworkNamespace(ctx context.Context, netnsDir string, callback func(ctx context.Context, namespace string) error) error {
+	log := log.FromContext(ctx)
+
+	entries, err := os.ReadDir(netnsDir)
+	if err != nil {
+		return fmt.Errorf("failed to list files under network namespace directory %w", err)
+	}
+
+	for _, entry := range entries {
+		if err := callback(ctx, entry.Name()); err != nil {
+			log.Error(err, "callback failed for network namespace entry", "namespace", entry.Name())
+		}
+	}
+
+	return nil
+}

--- a/src/k8s/pkg/utils/netns/unix.go
+++ b/src/k8s/pkg/utils/netns/unix.go
@@ -1,0 +1,22 @@
+package netnsutils
+
+import (
+	"context"
+
+	mountutils "github.com/canonical/k8s/pkg/utils/mount"
+)
+
+type UnixNetworkNamespaceManager struct{}
+
+func (h UnixNetworkNamespaceManager) ForEachNetworkNamespace(ctx context.Context, callback func(ctx context.Context, namespace string) error) error {
+	return forEachNetworkNamespace(ctx, "/run/netns", callback)
+}
+
+func (h UnixNetworkNamespaceManager) DeleteNetworkNamespace(ctx context.Context, namespace string) error {
+	mountHelper := mountutils.NewUnixMountHelper()
+	return deleteNetworkNamespace(ctx, mountHelper, "/run/netns", namespace)
+}
+
+func NewUnixNetworkNSHelper() NetworkNamespaceManager {
+	return &UnixNetworkNamespaceManager{}
+}


### PR DESCRIPTION
## Description

* moves cleanup logic from bash to go so it can be used both in snap hooks and k8sd hooks.
* adds the container cleanup step to remove hook before containerd paths are cleaned up

## Solution

A clear and concise description of how your changes address the above issue.

## Issue

Fixes #1326 
## Backport

`release-1.32`
`release-1.33`

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
