### PR TITLE
chore: update docs to address disk pressure troubleshooting

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -572,3 +572,5 @@ YAMLs
 YanisaHS
 ZooKeeper
 zsh
+tmpfs 
+ErrImagePull 

--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -572,5 +572,5 @@ YAMLs
 YanisaHS
 ZooKeeper
 zsh
-tmpfs 
-ErrImagePull 
+tmpfs
+ErrImagePull

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -6,7 +6,9 @@ virtual machine.
 You **can** install {{product}} directly on your development machine. But if
 you choose to do so, please take note of the following considerations.
 
-## Containerd conflicts
+## Containerd 
+
+### Conflicts
 
 {{product}} runs its own containerd service, which will use the standard
 containerd-related paths by default (`/run/containerd`, `/var/lib/containerd`,
@@ -38,7 +40,7 @@ Any non-temporary directory can be chosen for `containerd-base-dir`
 containerd-related files (e.g.: `/ck8s/etc/containerd`,
 `/ck8s/var/run/containerd/containerd.sock`, etc.).
 
-## Containerd State Directory on tmpfs — Disk Pressure & ErrImagePull
+### State Directory on tmpfs — Disk Pressure & ErrImagePull
 
 When using a custom containerd, if it is configured to use a state directory on
 `tmpfs` (e.g., `/run/containerd`), ensure that the `tmpfs` mount has sufficient 

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -39,17 +39,23 @@ containerd-related files (e.g.: `/ck8s/etc/containerd`,
 `/ck8s/var/run/containerd/containerd.sock`, etc.).
 
 ## Containerd State Directory on tmpfs — Disk Pressure & ErrImagePull
-When using a custom containerd, if it is configured to use a state directory on `tmpfs` (e.g., `/run/containerd`), ensure that the `tmpfs` mount has sufficient space for operations like image layer unpacking. Insufficient space can cause:
+
+When using a custom containerd, if it is configured to use a state directory on
+`tmpfs` (e.g., `/run/containerd`), ensure that the `tmpfs` mount has sufficient 
+space for operations like image layer unpacking. Insufficient space can cause:
 
 - Pod failures with `ErrImagePull`
 - Node taints such as `node.kubernetes.io/disk-pressure`
 
 To check the available space on the tmpfs:
+
 ```bash
 df -h /run
 ```
 
-If the space is low and you're experiencing these issues, you can temporarily increase the size of the tmpfs mount to see if it resolves the problem:
+If the space is low and you're experiencing these issues, you can temporarily 
+increase the size of the tmpfs mount to see if it resolves the problem:
+
 ```bash
 sudo mount -o remount,size=10G /run
 ```

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -38,6 +38,26 @@ Any non-temporary directory can be chosen for `containerd-base-dir`
 containerd-related files (e.g.: `/ck8s/etc/containerd`,
 `/ck8s/var/run/containerd/containerd.sock`, etc.).
 
+## Containerd State Directory on tmpfs — Disk Pressure & ErrImagePull
+When using a custom containerd, if it is configured to use a state directory on `tmpfs` (e.g., `/run/containerd`), ensure that the `tmpfs` mount has sufficient space for operations like image layer unpacking. Insufficient space can cause:
+
+- Pod failures with `ErrImagePull`
+- Node taints such as `node.kubernetes.io/disk-pressure`
+
+To check the available space on the tmpfs:
+```bash
+df -h /run
+```
+
+If the space is low and you're experiencing these issues, you can temporarily increase the size of the tmpfs mount to see if it resolves the problem:
+```bash
+sudo mount -o remount,size=10G /run
+```
+
+```{note}
+This change is not persistent and will reset on reboot.
+```
+
 ## Changing IP addresses
 
 The local IP addresses of your development machine are likely to change,


### PR DESCRIPTION
## Description

This PR adds a section to provide a troubleshooting steps when encountered with disk pressure error caused by insufficient space in custom containerd's state dir. This is a possible solution for #1456.