### PR TITLE
fix: disable feature and update controllers on 1.32

### DIFF
--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -46,8 +46,6 @@ type Config struct {
 	DisableFeatureController bool
 	// DisableCSRSigningController is a bool flag to disable csrsigning controller.
 	DisableCSRSigningController bool
-	// DisableUpgradeController is a bool flag to disable upgrade controller.
-	DisableUpgradeController bool
 }
 
 // App is the k8sd microcluster instance.
@@ -190,7 +188,7 @@ func New(cfg Config) (*App, error) {
 		log.L().Info("csrsigning-controller disabled via config")
 	}
 
-	if !cfg.DisableUpgradeController {
+	if !cfg.DisableFeatureController {
 		app.upgradeController = upgrade.NewController(upgrade.ControllerOptions{
 			Snap:                     cfg.Snap,
 			WaitReady:                app.readyWg.Wait,


### PR DESCRIPTION
## Description

Disabling the feature controller via a k8sd argument causes the daemon to crash.

## Solution

We use the same argument to stop both the feature and update controller.

## Backport

This is a fix only for 1.32. Future branches have this issue addressed.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
