### PR TITLE
fix: patch k8s to relax the timeouts for populating resource caches

### DIFF
--- a/build-scripts/components/kubernetes/patches/default/0001-Increase-the-timeout-and-interval-for-populating-cac.patch
+++ b/build-scripts/components/kubernetes/patches/default/0001-Increase-the-timeout-and-interval-for-populating-cac.patch
@@ -1,0 +1,25 @@
+From 2f429ac64387401da0e99fde8542db06292c5195 Mon Sep 17 00:00:00 2001
+From: Konstantinos Tsakalozos <konstantinos.tsakalozos@canonical.com>
+Date: Wed, 4 Jun 2025 15:20:11 +0300
+Subject: [PATCH] Increase the timeout and interval for populating caches
+
+---
+ pkg/kubelet/util/manager/watch_based_manager.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkg/kubelet/util/manager/watch_based_manager.go b/pkg/kubelet/util/manager/watch_based_manager.go
+index cbc42fa6bf1..428b3b44176 100644
+--- a/pkg/kubelet/util/manager/watch_based_manager.go
++++ b/pkg/kubelet/util/manager/watch_based_manager.go
+@@ -319,7 +319,7 @@ func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
+ 	if !c.isStopped() {
+ 		item.restartReflectorIfNeeded()
+ 	}
+-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, item.hasSynced); err != nil {
++	if err := wait.PollImmediate(50*time.Millisecond, 5*time.Second, item.hasSynced); err != nil {
+ 		return nil, fmt.Errorf("failed to sync %s cache: %v", c.groupResource.String(), err)
+ 	}
+ 	obj, exists, err := item.store.GetByKey(c.key(namespace, name))
+-- 
+2.43.0
+

--- a/build-scripts/components/kubernetes/patches/v1.32.0/0001-Increase-the-timeout-and-interval-for-populating-cac.patch
+++ b/build-scripts/components/kubernetes/patches/v1.32.0/0001-Increase-the-timeout-and-interval-for-populating-cac.patch
@@ -1,0 +1,25 @@
+From 2f429ac64387401da0e99fde8542db06292c5195 Mon Sep 17 00:00:00 2001
+From: Konstantinos Tsakalozos <konstantinos.tsakalozos@canonical.com>
+Date: Wed, 4 Jun 2025 15:20:11 +0300
+Subject: [PATCH] Increase the timeout and interval for populating caches
+
+---
+ pkg/kubelet/util/manager/watch_based_manager.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkg/kubelet/util/manager/watch_based_manager.go b/pkg/kubelet/util/manager/watch_based_manager.go
+index cbc42fa6bf1..428b3b44176 100644
+--- a/pkg/kubelet/util/manager/watch_based_manager.go
++++ b/pkg/kubelet/util/manager/watch_based_manager.go
+@@ -319,7 +319,7 @@ func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
+ 	if !c.isStopped() {
+ 		item.restartReflectorIfNeeded()
+ 	}
+-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, item.hasSynced); err != nil {
++	if err := wait.PollImmediate(50*time.Millisecond, 5*time.Second, item.hasSynced); err != nil {
+ 		return nil, fmt.Errorf("failed to sync %s cache: %v", c.groupResource.String(), err)
+ 	}
+ 	obj, exists, err := item.store.GetByKey(c.key(namespace, name))
+-- 
+2.43.0
+


### PR DESCRIPTION
## Description

We have seen that often the provisioning of pods is stuck with messages like:
```
Warning  FailedMount  2m50s (x169 over 5h33m)  kubelet  MountVolume.SetUp failed for volume "secret-cinderplugin" : failed to sync secret cache: timed out waiting for the condition
```

This indicates that the secret is not loaded in the cache quick enough.

## Solution

We increase the timeout set for loading a secret.

## Backport

This PR should be ported to 1.33 and main.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
