### PR TITLE
fix: link dqlite against the sqlite we build

### DIFF
--- a/src/k8s/hack/dynamic-dqlite.sh
+++ b/src/k8s/hack/dynamic-dqlite.sh
@@ -100,9 +100,9 @@ if [ ! -f "${BUILD_DIR}/dqlite/libdqlite.la" ]; then
       UV_CFLAGS="-I${BUILD_DIR}/libuv/include" \
       UV_LIBS="-L${BUILD_DIR}/libuv/.libs" \
       SQLITE_CFLAGS="-I${BUILD_DIR}/sqlite" \
+      SQLITE_LIBS="-L${BUILD_DIR}/sqlite/.lib" \
       LZ4_CFLAGS="-I${BUILD_DIR}/lz4/lib" \
       LZ4_LIBS="-L${BUILD_DIR}/lz4/lib" \
-      SQLITE_LIBS="-L${BUILD_DIR}/sqlite/.lib" \
       > /dev/null
 
     make -j > /dev/null

--- a/src/k8s/hack/static-dqlite.sh
+++ b/src/k8s/hack/static-dqlite.sh
@@ -131,9 +131,9 @@ if [ ! -f "${BUILD_DIR}/dqlite/libdqlite.la" ]; then
       UV_CFLAGS="-I${BUILD_DIR}/libuv/include" \
       UV_LIBS="-L${BUILD_DIR}/libuv/.libs" \
       SQLITE_CFLAGS="-I${BUILD_DIR}/sqlite" \
+      SQLITE_LIBS="-L${BUILD_DIR}/sqlite/.lib" \
       LZ4_CFLAGS="-I${BUILD_DIR}/lz4/lib" \
       LZ4_LIBS="-L${BUILD_DIR}/lz4/lib" \
-      SQLITE_LIBS="-L${BUILD_DIR}/sqlite/.lib" \
       > /dev/null
 
     make -j > /dev/null


### PR DESCRIPTION
## Description

Although we are building sqlite we are not linking against it. This came up with the recent dqlite. Before this patch if you tried to build the snap using dqlite from "master" you would fail with the `configure` step of dqlite saying it the sqlite versions do not match. Even though we are building 3.45 sqlite we were linking against the one from the base which was 3.31. Recent dqlite versions from master required sqlite 3.45+ and so this issue was exposed.

## Solution

Tell dqlite's `confgure` where to search for the sqlite libs


- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
