### PR TITLE
fix: address test_loadbalancer flakiness

### DIFF
--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli = 1
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -141,7 +141,7 @@ def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetTy
         )
     )
     service_ip = p.stdout.decode().replace("'", "")
-    if ':' in service_ip:
+    if ":" in service_ip:
         service_ip = "[" + service_ip + "]"
 
     LOG.info(f"Reaching out to service with service_ip = {service_ip}")

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -408,12 +408,23 @@ def wait_for_network(instance: harness.Instance):
     LOG.info("Waiting for network to be ready")
     instance.exec(["k8s", "x-wait-for", "network", "--timeout", "20m"])
 
+
 def wait_for_load_balancer(instance: harness.Instance):
     """Wait for the load balancer to be ready."""
     LOG.info("Waiting for load balancer to be ready")
-    instance.exec(["k8s", "kubectl", "wait", "--for=condition=available", "-n",
-                   "metallb-system", "deployment.apps/metallb-controller",
-                    "--timeout=20m"])
+    instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=available",
+            "-n",
+            "metallb-system",
+            "deployment.apps/metallb-controller",
+            "--timeout=20m",
+        ]
+    )
+
 
 def hostname(instance: harness.Instance) -> str:
     """Return the hostname for a given instance."""

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -408,6 +408,12 @@ def wait_for_network(instance: harness.Instance):
     LOG.info("Waiting for network to be ready")
     instance.exec(["k8s", "x-wait-for", "network", "--timeout", "20m"])
 
+def wait_for_load_balancer(instance: harness.Instance):
+    """Wait for the load balancer to be ready."""
+    LOG.info("Waiting for load balancer to be ready")
+    instance.exec(["k8s", "kubectl", "wait", "--for=condition=available", "-n",
+                   "metallb-system", "deployment.apps/metallb-controller",
+                    "--timeout=20m"])
 
 def hostname(instance: harness.Instance) -> str:
     """Return the hostname for a given instance."""


### PR DESCRIPTION
## Description

The test_loadbalancer tests are flaky. This PR addresses some of the flakiness issues.

## Solution

The following changes/fixes are introduced:

1. A pytest.ini is introduced so we see the LOG messages in the tests
2. The IP v6 test is set to run as part of this test because we have now transitioned main to Cilium 1.17
3. We enable the network and wait for it to some up before we start the loadbalancer (metallb). We wait for metallb to come up and then we configure it. The way we had it before there was a race condition that resulted in an error like this:
  ```
load-balancer:            Failed to deploy MetalLB, the error was: failed to enable LoadBalancer: failed to apply MetalLB LoadBalancer configuration: failed to upgrade metallb-loadbalancer: failed to create resource: Internal error occurred: failed calling webhook "ipaddresspoolvalidationwebhook.metallb.io": failed to call webhook: Post "https://metallb-webhook-service.metallb-system.svc:443/validate-metallb-io-v1beta1-ipaddresspool?timeout=10s": dial tcp 10.200.73.136:443: connect: connection refused
  ```
This error probably indicates that we were trying to configure the LB before it becomes available.
4. If the IP the LB gives to the service is an IPv6 we need to enclose it in `[]` or else curl gets confused about its format.
5. Increased some of the API query intervals and timeouts.

## Backport

A version of this PR needs to be backported to 1.33 and 1.32 to address flakiness there too.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

