### PR TITLE
fix: address flakiness in test_disable_separate_feature_upgrades

### DIFF
--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -114,8 +114,12 @@ def test_disable_separate_feature_upgrades(
         ),
     )
 
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
     join_token = util.get_join_token(cluster_node, joining_cp)
     util.join_cluster(joining_cp, join_token)
+
+    util.wait_until_k8s_ready(cluster_node, instances)
 
     # Refresh first node, no upgrade CRD should be created.
     util.setup_k8s_snap(cluster_node, tmp_path, config.SNAP)


### PR DESCRIPTION
## Description

Some times in test_disable_separate_feature_upgrades we try to join nodes before we have completed the cluster formation or we refresh the charm (restart k8sd) before we complete the joining operation.

## Solution

Wait for the cluster to be ready before we join or refresh the snap.

## Backport

Yes, to 1.32 and 1.33.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

