### PR TITLE
fix: address test_clustering flakiness

### DIFF
--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -22,6 +22,8 @@ def test_control_plane_nodes(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_node = instances[1]
 
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
     join_token = util.get_join_token(cluster_node, joining_node)
     util.join_cluster(joining_node, join_token)
 
@@ -43,6 +45,8 @@ def test_worker_nodes(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_node = instances[1]
     other_joining_node = instances[2]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
 
     join_token = util.get_join_token(cluster_node, joining_node, "--worker")
     join_token_2 = util.get_join_token(cluster_node, other_joining_node, "--worker")
@@ -75,6 +79,8 @@ def test_join_with_custom_token_name(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_cp = instances[1]
     joining_cp_with_hostname = instances[2]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
 
     out = cluster_node.exec(
         ["k8s", "get-join-token", "my-token"],
@@ -131,6 +137,8 @@ extra-sans:
 def test_cert_refresh(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_worker = instances[1]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
 
     join_token_worker = util.get_join_token(cluster_node, joining_worker, "--worker")
     util.join_cluster(joining_worker, join_token_worker)


### PR DESCRIPTION
## Description

Some flakiness may come from trying to join a node to a cluster that is not ready yet.

## Solution

Wait for the cluster to get ready before joining nodes

## Backport

Yes, 1.32 and 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

