### PR TITLE
chore: [Backport 1.33] Reduce API server calls

### DIFF
--- a/src/k8s/cmd/k8s/k8s_status.go
+++ b/src/k8s/cmd/k8s/k8s_status.go
@@ -37,7 +37,7 @@ func newStatusCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 			ctx, cancel := context.WithTimeout(cmd.Context(), opts.timeout)
 			cobra.OnFinalize(cancel)
 
-			if _, initialized, err := client.NodeStatus(cmd.Context()); err != nil {
+			if _, initialized, err := client.NodeStatus(ctx); err != nil {
 				cmd.PrintErrf("Error: Failed to check the current node status.\n\nThe error was: %v\n", err)
 				env.Exit(1)
 				return

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -22,6 +22,7 @@ var rootCmdOpts struct {
 	disableUpdateNodeConfigController   bool
 	disableCSRSigningController         bool
 	drainConnectionsTimeout             time.Duration
+	featureControllerMaxRetryAttempts   int
 }
 
 func addCommands(root *cobra.Command, group *cobra.Group, commands ...*cobra.Command) {
@@ -59,6 +60,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				DisableFeatureController:            rootCmdOpts.disableFeatureController,
 				DisableCSRSigningController:         rootCmdOpts.disableCSRSigningController,
 				DrainConnectionsTimeout:             rootCmdOpts.drainConnectionsTimeout,
+				FeatureControllerMaxRetryAttempts:   rootCmdOpts.featureControllerMaxRetryAttempts,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd: %v", err)
@@ -93,6 +95,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.Flags().Uint("port", 0, "Default port for the HTTP API")
 	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")
 	cmd.Flags().DurationVar(&rootCmdOpts.drainConnectionsTimeout, "drain-connection-timeout", 10*time.Second, "amount of time to allow for all connections to drain when shutting down")
+	cmd.Flags().IntVar(&rootCmdOpts.featureControllerMaxRetryAttempts, "feature-controller-max-retry-attempts", 15, "Maximum number of retry attempts for the feature controller before giving up. Zero or negative values mean no limit.")
 
 	cmd.AddCommand(newSqlCmd(env))
 

--- a/src/k8s/pkg/client/helm/client.go
+++ b/src/k8s/pkg/client/helm/client.go
@@ -20,7 +20,7 @@ import (
 type client struct {
 	restClientGetter func(string) genericclioptions.RESTClientGetter
 	manifestsBaseDir string
-	//applyTimeout is the timeout for apply operations.
+	// applyTimeout is the timeout for apply operations.
 	applyTimeout time.Duration
 }
 
@@ -109,14 +109,15 @@ func (h *client) Apply(ctx context.Context, c InstallableChart, desired State, v
 
 		sameValues := jsonEqual(oldConfig, values)
 		sameVersions := release.Chart.Metadata.Version == chart.Metadata.Version
-		if sameValues && sameVersions {
+		switch {
+		case sameValues && sameVersions:
 			log.Info("no changes detected, skipping upgrade")
 			return false, nil
-		} else if sameValues {
+		case sameValues && !sameVersions:
 			log.Info("chart version changed, upgrading", "oldVersion", release.Chart.Metadata.Version, "newVersion", chart.Metadata.Version)
-		} else if sameVersions {
+		case sameVersions && !sameValues:
 			log.Info("values changed, upgrading")
-		} else {
+		default:
 			log.Info("both chart version and values changed, upgrading", "oldVersion", release.Chart.Metadata.Version, "newVersion", chart.Metadata.Version)
 		}
 

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -212,7 +212,7 @@ func New(cfg Config) (*App, error) {
 				"metrics-server": app.featureController.ReconciledMetricsServerCh(),
 			},
 			FeatureControllerReadyTimeout:     10 * time.Minute,
-			FeatureControllerReconcileTimeout: 10 * time.Minute,
+			FeatureControllerReconcileTimeout: 2 * time.Minute,
 		})
 	} else {
 		log.L().Info("upgrade-controller disabled via config")

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -48,6 +48,11 @@ type Config struct {
 	DisableCSRSigningController bool
 	// DrainConnectionsTimeout is the amount of time to allow for all connections to drain when shutting down.
 	DrainConnectionsTimeout time.Duration
+	// DisableUpgradeController is a bool flag to disable upgrade controller.
+	DisableUpgradeController bool
+	// FeatureControllerMaxRetryAttempts is the maximum number of retry attempts for the reconcile loop
+	// of the feature controller. Zero or negative values mean no limit.
+	FeatureControllerMaxRetryAttempts int
 }
 
 // App is the k8sd microcluster instance.
@@ -166,15 +171,16 @@ func New(cfg Config) (*App, error) {
 
 	if !cfg.DisableFeatureController {
 		app.featureController = controllers.NewFeatureController(controllers.FeatureControllerOpts{
-			Snap:                   cfg.Snap,
-			WaitReady:              app.readyWg.Wait,
-			TriggerNetworkCh:       app.triggerFeatureControllerNetworkCh,
-			TriggerGatewayCh:       app.triggerFeatureControllerGatewayCh,
-			TriggerIngressCh:       app.triggerFeatureControllerIngressCh,
-			TriggerLoadBalancerCh:  app.triggerFeatureControllerLoadBalancerCh,
-			TriggerDNSCh:           app.triggerFeatureControllerDNSCh,
-			TriggerLocalStorageCh:  app.triggerFeatureControllerLocalStorageCh,
-			TriggerMetricsServerCh: app.triggerFeatureControllerMetricsServerCh,
+			Snap:                          cfg.Snap,
+			WaitReady:                     app.readyWg.Wait,
+			TriggerNetworkCh:              app.triggerFeatureControllerNetworkCh,
+			TriggerGatewayCh:              app.triggerFeatureControllerGatewayCh,
+			TriggerIngressCh:              app.triggerFeatureControllerIngressCh,
+			TriggerLoadBalancerCh:         app.triggerFeatureControllerLoadBalancerCh,
+			TriggerDNSCh:                  app.triggerFeatureControllerDNSCh,
+			TriggerLocalStorageCh:         app.triggerFeatureControllerLocalStorageCh,
+			TriggerMetricsServerCh:        app.triggerFeatureControllerMetricsServerCh,
+			ReconcileLoopMaxRetryAttempts: cfg.FeatureControllerMaxRetryAttempts,
 		})
 	} else {
 		log.L().Info("feature-controller disabled via config")

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -198,10 +198,16 @@ func New(cfg Config) (*App, error) {
 
 	if !cfg.DisableFeatureController {
 		app.upgradeController = upgrade.NewController(upgrade.ControllerOptions{
-			Snap:                     cfg.Snap,
-			WaitReady:                app.readyWg.Wait,
-			FeatureControllerReadyCh: app.featureController.ReadyCh(),
-			NotifyFeatureController:  app.NotifyFeatureController,
+			Snap:                       cfg.Snap,
+			WaitReady:                  app.readyWg.Wait,
+			FeatureControllerReadyCh:   app.featureController.ReadyCh(),
+			NotifyNetworkFeature:       app.NotifyNetwork,
+			NotifyGatewayFeature:       app.NotifyGateway,
+			NotifyIngressFeature:       app.NotifyIngress,
+			NotifyLoadBalancerFeature:  app.NotifyLoadBalancer,
+			NotifyLocalStorageFeature:  app.NotifyLocalStorage,
+			NotifyMetricsServerFeature: app.NotifyMetricsServer,
+			NotifyDNSFeature:           app.NotifyDNS,
 			FeatureToReconciledCh: map[string]<-chan struct{}{
 				"network":        app.featureController.ReconciledNetworkCh(),
 				"gateway":        app.featureController.ReconciledGatewayCh(),

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -409,8 +409,8 @@ func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kube
 
 	log.Info("Marking node as upgraded", "node", nodeName)
 	status := upgrade.Status
-	if !slices.Contains(upgrade.Status.UpgradedNodes, nodeName) {
-		upgrade.Status.UpgradedNodes = append(upgrade.Status.UpgradedNodes, nodeName)
+	if !slices.Contains(status.UpgradedNodes, nodeName) {
+		status.UpgradedNodes = append(status.UpgradedNodes, nodeName)
 	}
 	return k8sClient.PatchUpgradeStatus(ctx, upgrade, status)
 }

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/canonical/k8s/pkg/client/kubernetes"
@@ -408,7 +409,9 @@ func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kube
 
 	log.Info("Marking node as upgraded", "node", nodeName)
 	status := upgrade.Status
-	status.UpgradedNodes = append(status.UpgradedNodes, nodeName)
+	if !slices.Contains(upgrade.Status.UpgradedNodes, nodeName) {
+		upgrade.Status.UpgradedNodes = append(upgrade.Status.UpgradedNodes, nodeName)
+	}
 	return k8sClient.PatchUpgradeStatus(ctx, upgrade, status)
 }
 

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
@@ -96,8 +97,13 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 
 	log.Info("Marking node as upgraded.", "node", s.Name())
 
+	upgradedNodes := upgrade.Status.UpgradedNodes
+	if !slices.Contains(upgradedNodes, s.Name()) {
+		upgradedNodes = append(upgradedNodes, s.Name())
+	}
+
 	status := kubernetes.UpgradeStatus{
-		UpgradedNodes: append(upgrade.Status.UpgradedNodes, s.Name()),
+		UpgradedNodes: upgradedNodes,
 		Phase:         kubernetes.UpgradePhaseNodeUpgrade,
 		Strategy:      kubernetes.UpgradeStrategyInPlace,
 	}

--- a/src/k8s/pkg/k8sd/app/provider.go
+++ b/src/k8s/pkg/k8sd/app/provider.go
@@ -43,5 +43,40 @@ func (a *App) NotifyFeatureController(network, gateway, ingress, loadBalancer, l
 	}
 }
 
+// NotifyNetwork notifies the Network feature to reconcile.
+func (a *App) NotifyNetwork() {
+	utils.MaybeNotify(a.triggerFeatureControllerNetworkCh)
+}
+
+// NotifyGateway notifies the Gateway feature to reconcile.
+func (a *App) NotifyGateway() {
+	utils.MaybeNotify(a.triggerFeatureControllerGatewayCh)
+}
+
+// NotifyIngress notifies the Ingress feature to reconcile.
+func (a *App) NotifyIngress() {
+	utils.MaybeNotify(a.triggerFeatureControllerIngressCh)
+}
+
+// NotifyLoadBalancer notifies the Load Balancer feature to reconcile.
+func (a *App) NotifyLoadBalancer() {
+	utils.MaybeNotify(a.triggerFeatureControllerLoadBalancerCh)
+}
+
+// NotifyLocalStorage notifies the Local Storage feature to reconcile.
+func (a *App) NotifyLocalStorage() {
+	utils.MaybeNotify(a.triggerFeatureControllerLocalStorageCh)
+}
+
+// NotifyMetricsServer notifies the Metrics Server feature to reconcile.
+func (a *App) NotifyMetricsServer() {
+	utils.MaybeNotify(a.triggerFeatureControllerMetricsServerCh)
+}
+
+// NotifyDNS notifies the DNS feature to reconcile.
+func (a *App) NotifyDNS() {
+	utils.MaybeNotify(a.triggerFeatureControllerDNSCh)
+}
+
 // Ensure App implements api.Provider.
 var _ api.Provider = &App{}

--- a/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
@@ -32,7 +32,13 @@ type Controller struct {
 	snap                              snap.Snap
 	waitReady                         func()
 	featureControllerReadyCh          <-chan struct{}
-	notifyFeatureController           func(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool)
+	notifyNetworkFeature              func()
+	notifyGatewayFeature              func()
+	notifyIngressFeature              func()
+	notifyLoadBalancerFeature         func()
+	notifyLocalStorageFeature         func()
+	notifyMetricsServerFeature        func()
+	notifyDNSFeature                  func()
 	featureToReconciledCh             map[string]<-chan struct{}
 	featureControllerReadyTimeout     time.Duration
 	featureControllerReconcileTimeout time.Duration
@@ -50,8 +56,20 @@ type ControllerOptions struct {
 	WaitReady func()
 	// FeatureControllerReadyCh is a channel that is closed when the feature controller is ready.
 	FeatureControllerReadyCh <-chan struct{}
-	// NotifyFeatureController is a function that notifies the feature controller to reconcile.
-	NotifyFeatureController func(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool)
+	// NotifyNetworkFeature is a function that notifies the network feature to reconcile.
+	NotifyNetworkFeature func()
+	// NotifyGatewayFeature is a function that notifies the gateway feature to reconcile.
+	NotifyGatewayFeature func()
+	// NotifyIngressFeature is a function that notifies the ingress feature to reconcile.
+	NotifyIngressFeature func()
+	// NotifyLoadBalancerFeature is a function that notifies the load balancer feature to reconcile.
+	NotifyLoadBalancerFeature func()
+	// NotifyLocalStorageFeature is a function that notifies the local storage feature to reconcile.
+	NotifyLocalStorageFeature func()
+	// NotifyMetricsServerFeature is a function that notifies the metrics server feature to reconcile.
+	NotifyMetricsServerFeature func()
+	// NotifyDNSFeature is a function that notifies the DNS feature to reconcile.
+	NotifyDNSFeature func()
 	// FeatureToReconciledCh is a map of feature names to channels that are full
 	// when the feature controller has reconciled the feature.
 	FeatureToReconciledCh map[string]<-chan struct{}
@@ -66,7 +84,13 @@ func NewController(opts ControllerOptions) *Controller {
 		snap:                              opts.Snap,
 		waitReady:                         opts.WaitReady,
 		featureControllerReadyCh:          opts.FeatureControllerReadyCh,
-		notifyFeatureController:           opts.NotifyFeatureController,
+		notifyNetworkFeature:              opts.NotifyNetworkFeature,
+		notifyGatewayFeature:              opts.NotifyGatewayFeature,
+		notifyIngressFeature:              opts.NotifyIngressFeature,
+		notifyLoadBalancerFeature:         opts.NotifyLoadBalancerFeature,
+		notifyLocalStorageFeature:         opts.NotifyLocalStorageFeature,
+		notifyMetricsServerFeature:        opts.NotifyMetricsServerFeature,
+		notifyDNSFeature:                  opts.NotifyDNSFeature,
 		featureToReconciledCh:             opts.FeatureToReconciledCh,
 		featureControllerReadyTimeout:     opts.FeatureControllerReadyTimeout,
 		featureControllerReconcileTimeout: opts.FeatureControllerReconcileTimeout,
@@ -143,6 +167,8 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kubernetes.Upgrade{}).
 		WithOptions(controller.Options{
+			// NOTE(Hue): We use a custom rate limiter to reduce the load on the API server,
+			// as the default rate limiter is too aggressive for our use case (baseDelay is 5 Milliseconds).
 			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[ctrl.Request](
 				time.Second,
 				5*time.Minute,

--- a/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
@@ -14,9 +14,11 @@ import (
 	"github.com/canonical/microcluster/v2/state"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
@@ -140,6 +142,12 @@ func (c *Controller) Run(
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kubernetes.Upgrade{}).
+		WithOptions(controller.Options{
+			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[ctrl.Request](
+				time.Second,
+				5*time.Minute,
+			),
+		}).
 		Complete(c)
 }
 

--- a/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/controller.go
@@ -32,7 +32,7 @@ type Controller struct {
 	snap                              snap.Snap
 	waitReady                         func()
 	featureControllerReadyCh          <-chan struct{}
-	notifyFeatureController           func(network, gateway, ingress, dns, loadBalancer, localStorage, metricsServer bool)
+	notifyFeatureController           func(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool)
 	featureToReconciledCh             map[string]<-chan struct{}
 	featureControllerReadyTimeout     time.Duration
 	featureControllerReconcileTimeout time.Duration
@@ -51,13 +51,13 @@ type ControllerOptions struct {
 	// FeatureControllerReadyCh is a channel that is closed when the feature controller is ready.
 	FeatureControllerReadyCh <-chan struct{}
 	// NotifyFeatureController is a function that notifies the feature controller to reconcile.
-	NotifyFeatureController func(network, gateway, ingress, dns, loadBalancer, localStorage, metricsServer bool)
+	NotifyFeatureController func(network, gateway, ingress, loadBalancer, localStorage, metricsServer, dns bool)
 	// FeatureToReconciledCh is a map of feature names to channels that are full
 	// when the feature controller has reconciled the feature.
 	FeatureToReconciledCh map[string]<-chan struct{}
 	// FeatureControllerReadyTimeout is the timeout for the feature controller to be ready.
 	FeatureControllerReadyTimeout time.Duration
-	// FeatureControllerReconcileTimeout is the timeout for the feature controller to reconcile.
+	// FeatureControllerReconcileTimeout is the timeout for each feature to get reconciled by the feature controller.
 	FeatureControllerReconcileTimeout time.Duration
 }
 

--- a/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
@@ -46,6 +46,8 @@ func (c *Controller) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("failed to get upgrade %q: %w", req.NamespacedName, err)
 	}
 
+	c.logger.WithValues("upgrade", upgrade.Name, "phase", upgrade.Status.Phase).Info("Reconciling upgrade.")
+
 	switch {
 	case upgrade.Status.Phase == kubernetes.UpgradePhaseNodeUpgrade:
 		return c.reconcileNodeUpgrade(ctx, &upgrade)

--- a/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
@@ -177,27 +177,23 @@ func (c *Controller) transitionTo(ctx context.Context, upgrade *kubernetes.Upgra
 }
 
 func (c *Controller) triggerFeature(name string) error {
-	if c.notifyFeatureController == nil {
-		return fmt.Errorf("notifyFeatureController is not set, cannot trigger feature %q", name)
-	}
-
 	switch name {
 	case string(features.Network):
-		c.notifyFeatureController(true, false, false, false, false, false, false)
+		c.notifyNetworkFeature()
 	case string(features.Gateway):
-		c.notifyFeatureController(false, true, false, false, false, false, false)
+		c.notifyGatewayFeature()
 	case string(features.Ingress):
-		c.notifyFeatureController(false, false, true, false, false, false, false)
+		c.notifyIngressFeature()
 	case string(features.LoadBalancer):
-		c.notifyFeatureController(false, false, false, true, false, false, false)
+		c.notifyLoadBalancerFeature()
 	case string(features.LocalStorage):
-		c.notifyFeatureController(false, false, false, false, true, false, false)
+		c.notifyLocalStorageFeature()
 	case string(features.MetricsServer):
-		c.notifyFeatureController(false, false, false, false, false, true, false)
+		c.notifyMetricsServerFeature()
 	case string(features.DNS):
-		c.notifyFeatureController(false, false, false, false, false, false, true)
+		c.notifyDNSFeature()
 	default:
-		return fmt.Errorf("unknown feature %q", name)
+		return fmt.Errorf("trying to reconcile unknown feature %q", name)
 	}
 
 	return nil

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/canonical/k8s/pkg/client/dqlite"
 	"github.com/canonical/k8s/pkg/client/helm"
@@ -372,6 +373,7 @@ func (s *snap) HelmClient() helm.Client {
 		func(namespace string) genericclioptions.RESTClientGetter {
 			return s.restClientGetter(filepath.Join(s.KubernetesConfigDir(), "admin.conf"), namespace)
 		},
+		1*time.Minute,
 	)
 }
 

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -373,7 +373,7 @@ func (s *snap) HelmClient() helm.Client {
 		func(namespace string) genericclioptions.RESTClientGetter {
 			return s.restClientGetter(filepath.Join(s.KubernetesConfigDir(), "admin.conf"), namespace)
 		},
-		1*time.Minute,
+		5*time.Minute,
 	)
 }
 

--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -374,6 +374,7 @@ func (s *snap) HelmClient() helm.Client {
 			return s.restClientGetter(filepath.Join(s.KubernetesConfigDir(), "admin.conf"), namespace)
 		},
 		5*time.Minute,
+		10,
 	)
 }
 

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli = 1
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -26,10 +26,6 @@ def test_loadbalancer_ipv4(instances: List[harness.Instance]):
     _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv4)
 
 
-@pytest.mark.xfail(
-    run=False,
-    reason="Cilium ipv6 only unsupported: https://github.com/cilium/cilium/issues/15082",
-)
 @pytest.mark.node_count(2)
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.tags(tags.PULL_REQUEST)
@@ -85,6 +81,11 @@ def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetTy
         lb_cidrs.append(get_lb_cidr(ipv6_cidr=True))
     lb_cidr_str = ",".join(lb_cidrs)
 
+    util.wait_for_network(instance)
+    util.wait_for_dns(instance)
+
+    instance.exec(["k8s", "enable", "load-balancer"])
+    util.wait_for_load_balancer(instance)
     instance.exec(
         [
             "k8s",
@@ -93,10 +94,6 @@ def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetTy
             "load-balancer.l2-mode=true",
         ]
     )
-    instance.exec(["k8s", "enable", "load-balancer"])
-
-    util.wait_for_network(instance)
-    util.wait_for_dns(instance)
 
     manifest = MANIFESTS_DIR / "loadbalancer-test.yaml"
     instance.exec(
@@ -110,7 +107,7 @@ def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetTy
     ).exec(["k8s", "kubectl", "get", "pod", "-o", "json"])
     LOG.info("Nginx pod showed up.")
 
-    util.stubbornly(retries=3, delay_s=1).on(instance).exec(
+    util.stubbornly(retries=3, delay_s=5).on(instance).exec(
         [
             "k8s",
             "kubectl",
@@ -124,12 +121,12 @@ def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetTy
         ]
     )
 
-    util.stubbornly(retries=10, delay_s=2).on(instance).until(
+    util.stubbornly(retries=10, delay_s=5).on(instance).until(
         lambda p: "my-nginx" in p.stdout.decode()
     ).exec(["k8s", "kubectl", "get", "service", "-o", "json"])
 
     p = (
-        util.stubbornly(retries=10, delay_s=3)
+        util.stubbornly(retries=10, delay_s=5)
         .on(instance)
         .until(lambda p: len(p.stdout.decode().replace("'", "")) > 0)
         .exec(
@@ -144,7 +141,10 @@ def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetTy
         )
     )
     service_ip = p.stdout.decode().replace("'", "")
+    if ":" in service_ip:
+        service_ip = "[" + service_ip + "]"
 
-    util.stubbornly(retries=20, delay_s=3).on(tester_instance).until(
+    LOG.info(f"Reaching out to service with service_ip = {service_ip}")
+    util.stubbornly(retries=40, delay_s=5).on(tester_instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", service_ip])

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -409,6 +409,23 @@ def wait_for_network(instance: harness.Instance):
     instance.exec(["k8s", "x-wait-for", "network", "--timeout", "20m"])
 
 
+def wait_for_load_balancer(instance: harness.Instance):
+    """Wait for the load balancer to be ready."""
+    LOG.info("Waiting for load balancer to be ready")
+    instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=available",
+            "-n",
+            "metallb-system",
+            "deployment.apps/metallb-controller",
+            "--timeout=20m",
+        ]
+    )
+
+
 def hostname(instance: harness.Instance) -> str:
     """Return the hostname for a given instance."""
     resp = instance.exec(["hostname"], capture_output=True)

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -350,17 +350,18 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
                 "Completed",
             ], f"Right after the last upgrade, expected phase to be FeatureUpgrade or Complete but got {phase}"
 
-            # All Feature version should eventually be upgraded.
-            LOG.info("Waiting for all helm releases to upgrade")
+            # TODO(ben): Check that new fields are set in the feature config.
+            # TODO(ben): Check that connectivity (e.g. for gateway) is working during the upgrade.
+
             util.stubbornly(retries=15, delay_s=5).on(instance).until(
-                lambda p: all(
-                    next(r for r in json.loads(p.stdout) if r["name"] == name)[
-                        "updated"
-                    ]
-                    != initial_releases[name]["updated"]
-                    for name in initial_releases
-                ),
+                lambda p: p.stdout == "Completed",
             ).exec(
+                "k8s kubectl get upgrade -o=jsonpath={.items[0].status.phase}".split(),
+                capture_output=True,
+                text=True,
+            )
+
+            p = instance.exec(
                 [
                     "/snap/k8s/current/bin/helm",
                     "--kubeconfig",
@@ -374,18 +375,22 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
                 capture_output=True,
                 text=True,
             )
-            LOG.info("All helm releases have upgraded successfully")
 
-            # TODO(ben): Check that new fields are set in the feature config.
-            # TODO(ben): Check that connectivity (e.g. for gateway) is working during the upgrade.
+            current_releases = json.loads(p.stdout)
+            for name, initial_rel in initial_releases.items():
+                new_rel = None
+                for r in current_releases:
+                    if r["name"] == name:
+                        new_rel = r
+                        break
+                assert new_rel, f"Release {name} not in helm output"
+                if initial_rel["updated"] == new_rel["updated"]:
+                    LOG.warning(
+                        "Release %s was not updated during upgrade. "
+                        "This might be due to a skipped helm apply due to same values or chart versions",
+                        name,
+                    )
 
-            util.stubbornly(retries=15, delay_s=5).on(instance).until(
-                lambda p: p.stdout == "Completed",
-            ).exec(
-                "k8s kubectl get upgrade -o=jsonpath={.items[0].status.phase}".split(),
-                capture_output=True,
-                text=True,
-            )
         else:
             assert (
                 phase == "NodeUpgrade"


### PR DESCRIPTION
### Overview

This PR aims to reduce the API server calls that are made by k8sd. Each commit corresponds to a specific improvement.

This PR also backports https://github.com/canonical/k8s-snap/pull/1537 which will fix the feature upgrades tests failure.