### PR TITLE
test: Fix annotation test

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -112,9 +112,10 @@ jobs:
     with:
       arch: amd64
       os: ubuntu:24.04
-      test-tags: ${{ needs.get-e2e-tags.outputs.test-tags}}
+      test-tags: up_to_weekly
       artifact: k8s.snap
       parallel: true
+      extra-test-args: "-k test_disable_separate_feature_upgrades"
 
   security-scan:
     name: Security scan

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -112,10 +112,9 @@ jobs:
     with:
       arch: amd64
       os: ubuntu:24.04
-      test-tags: up_to_weekly
+      test-tags: ${{ needs.get-e2e-tags.outputs.test-tags }}
       artifact: k8s.snap
       parallel: true
-      extra-test-args: "-k test_disable_separate_feature_upgrades"
 
   security-scan:
     name: Security scan

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -119,8 +119,12 @@ def test_disable_separate_feature_upgrades(
 
     join_token = util.get_join_token(cluster_node, joining_cp)
     util.join_cluster(joining_cp, join_token)
-    cluster_node.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
-    joining_cp.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
+    cluster_node.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    )
+    joining_cp.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    )
     cluster_node.exec("k8s kubectl get nodes -A".split())
     joining_cp.exec("k8s kubectl get nodes -A".split())
 
@@ -129,8 +133,12 @@ def test_disable_separate_feature_upgrades(
     # TODO(ben): Remove me after test
     time.sleep(10)
 
-    cluster_node.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
-    joining_cp.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
+    cluster_node.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    )
+    joining_cp.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    )
     cluster_node.exec("k8s kubectl get nodes -A".split())
     joining_cp.exec("k8s kubectl get nodes -A".split())
 

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -119,28 +119,60 @@ def test_disable_separate_feature_upgrades(
 
     join_token = util.get_join_token(cluster_node, joining_cp)
     util.join_cluster(joining_cp, join_token)
-    cluster_node.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    result = cluster_node.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
+        capture_output=True,
+        text=True,
     )
-    joining_cp.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    LOG.info(result.stdout)
+    result = joining_cp.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
+        capture_output=True,
+        text=True,
     )
-    cluster_node.exec("k8s kubectl get nodes -A".split())
-    joining_cp.exec("k8s kubectl get nodes -A".split())
+    LOG.info(result.stdout)
+    result = cluster_node.exec(
+        "k8s kubectl get nodes -A".split(),
+        capture_output=True,
+        text=True,
+    )
+    LOG.info(result.stdout)
+    result = joining_cp.exec(
+        "k8s kubectl get nodes -A".split(),
+        capture_output=True,
+        text=True,
+    )
+    LOG.info(result.stdout)
 
     util.wait_until_k8s_ready(cluster_node, instances)
 
     # TODO(ben): Remove me after test
     time.sleep(10)
 
-    cluster_node.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    result = cluster_node.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
+        capture_output=True,
+        text=True,
     )
-    joining_cp.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split()
+    LOG.info(result.stdout)
+    result = joining_cp.exec(
+        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
+        capture_output=True,
+        text=True,
     )
-    cluster_node.exec("k8s kubectl get nodes -A".split())
-    joining_cp.exec("k8s kubectl get nodes -A".split())
+    LOG.info(result.stdout)
+    result = cluster_node.exec(
+        "k8s kubectl get nodes -A".split(),
+        capture_output=True,
+        text=True,
+    )
+    LOG.info(result.stdout)
+    result = joining_cp.exec(
+        "k8s kubectl get nodes -A".split(),
+        capture_output=True,
+        text=True,
+    )
+    LOG.info(result.stdout)
 
     # Refresh first node, no upgrade CRD should be created.
     util.setup_k8s_snap(cluster_node, tmp_path, config.SNAP)

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -119,11 +119,20 @@ def test_disable_separate_feature_upgrades(
 
     join_token = util.get_join_token(cluster_node, joining_cp)
     util.join_cluster(joining_cp, join_token)
+    cluster_node.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
+    joining_cp.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
+    cluster_node.exec("k8s kubectl get nodes -A".split())
+    joining_cp.exec("k8s kubectl get nodes -A".split())
 
     util.wait_until_k8s_ready(cluster_node, instances)
 
     # TODO(ben): Remove me after test
     time.sleep(10)
+
+    cluster_node.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
+    joining_cp.exec("cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split())
+    cluster_node.exec("k8s kubectl get nodes -A".split())
+    joining_cp.exec("k8s kubectl get nodes -A".split())
 
     # Refresh first node, no upgrade CRD should be created.
     util.setup_k8s_snap(cluster_node, tmp_path, config.SNAP)

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -3,6 +3,7 @@
 #
 import json
 import logging
+import time
 from pathlib import Path
 from typing import List
 

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -121,6 +121,9 @@ def test_disable_separate_feature_upgrades(
 
     util.wait_until_k8s_ready(cluster_node, instances)
 
+    # TODO(ben): Remove me after test
+    time.sleep(10)
+
     # Refresh first node, no upgrade CRD should be created.
     util.setup_k8s_snap(cluster_node, tmp_path, config.SNAP)
     util.wait_until_k8s_ready(cluster_node, instances)

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -3,7 +3,6 @@
 #
 import json
 import logging
-import time
 from pathlib import Path
 from typing import List
 
@@ -119,60 +118,8 @@ def test_disable_separate_feature_upgrades(
 
     join_token = util.get_join_token(cluster_node, joining_cp)
     util.join_cluster(joining_cp, join_token)
-    result = cluster_node.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
-    result = joining_cp.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
-    result = cluster_node.exec(
-        "k8s kubectl get nodes -A".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
-    result = joining_cp.exec(
-        "k8s kubectl get nodes -A".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
 
-    util.wait_until_k8s_ready(cluster_node, instances)
-
-    # TODO(ben): Remove me after test
-    time.sleep(10)
-
-    result = cluster_node.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
-    result = joining_cp.exec(
-        "cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
-    result = cluster_node.exec(
-        "k8s kubectl get nodes -A".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
-    result = joining_cp.exec(
-        "k8s kubectl get nodes -A".split(),
-        capture_output=True,
-        text=True,
-    )
-    LOG.info(result.stdout)
+    util.wait_until_k8s_ready(joining_cp, instances)
 
     # Refresh first node, no upgrade CRD should be created.
     util.setup_k8s_snap(cluster_node, tmp_path, config.SNAP)


### PR DESCRIPTION
* We join a node to the cluster and immediately trigger a snap refresh.
At this point, the k8sd cluster reflects both nodes, but the k8s-dqlite cluster appears to be out of sync:
* On [node 1](https://github.com/canonical/k8s-snap/actions/runs/15565098315/job/43839259681? pr=1529#step:10:350), the newly joined node doesn't appear yet.
* On [node 2](https://github.com/canonical/k8s-snap/actions/runs/15565098315/job/43839259681?pr=1529#step:10:355), it is already registered.
* Then, k8s-dqlite is stopped due to the snap refresh, and this inconsistency seems to be persisted (visible in the [inspection reports](https://github.com/canonical/k8s-snap/actions/runs/15492797421/artifacts/3294837888) from the failed runs).
* After the refresh, k8s-dqlite restarts but fails to recover correctly, likely due to the inconsistent cluster state.

As an immediate fix, we query the cluster state on the joining node, which ensures that the node is already registered to the cluster (read your own writes). 
I created KU-3664 to work on a long-term k8s-dqlite fix of this consistency issue. 