### PR TITLE
ci: Remove obsolete 1.31 branch from upgrade check

### DIFF
--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -23,7 +23,6 @@ jobs:
           # Supported release branches
           - release-1.33
           - release-1.32
-          - release-1.31
 
     steps:
       - name: Checking out repo


### PR DESCRIPTION
We don't support the 1.31 branch and therefore don't need this check.
