### PR TITLE
docs: snap patch notice for 1.32.5

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -99,6 +99,7 @@ ClusterRoleBinding
 ClusterRoleBindings
 ClusterRoles
 CMK
+CNCF
 CNI
 CNI's
 CNIs

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -65,6 +65,77 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Jun 5, 2025
+
+- Revert Cilium 1.17 upgrade due to compatibility issues
+([#1360](https://github.com/canonical/k8s-snap/pull/1360)) [#1466](https://github.com/canonical/k8s-snap/pull/1466)
+- Ensure node is removed correctly from the cluster on an internal server error
+[#1377](https://github.com/canonical/k8s-snap/pull/1377)
+- Add logging when rollout upgrade fails
+[#1429](https://github.com/canonical/k8s-snap/pull/1429)
+- Add dqlite deb source lists manually for TICS job stability
+[#1457](https://github.com/canonical/k8s-snap/pull/1457)
+- Fix test to retry snap install of pre-loaded snaps
+[#1464](https://github.com/canonical/k8s-snap/pull/1464)
+- Update Kubernetes version to 1.32.5
+[#1443](https://github.com/canonical/k8s-snap/pull/1443)
+- Fix version upgrade test by setting default FLAVOR to classic
+[#1446](https://github.com/canonical/k8s-snap/pull/1446)
+- Skip feature upgrades tests early if not required
+[#1439](https://github.com/canonical/k8s-snap/pull/1439)
+- Fix inspection report to treat non-bootstrapped node as a control-plane
+[#1419](https://github.com/canonical/k8s-snap/pull/1419)
+- Fix failures in test_cilium_e2e
+[#1417](https://github.com/canonical/k8s-snap/pull/1417)
+- Add quotations to service argument values to care for escape characters
+[#1387](https://github.com/canonical/k8s-snap/pull/1387)
+- Fix indentation of config in our docs [#1412](https://github.com/canonical/k8s-snap/pull/1412)
+- Fix typo in discourse link [#1409](https://github.com/canonical/k8s-snap/pull/1409)
+- Set dqlite failure-domain based on the k8s node AZ label [#1309](https://github.com/canonical/k8s-snap/pull/1309)
+- Address issue with parsing IPv6 endpoints for `k8s-apiserver-proxy.json` [#1396](https://github.com/canonical/k8s-snap/pull/1396)
+- Apply fix that allows BOM generation outside of Snapcraft
+[#1390](https://github.com/canonical/k8s-snap/pull/1390)
+- Add snap patch notices to the release notes [#1392](https://github.com/canonical/k8s-snap/pull/1392)
+- Ensure docs versions are correct [#1383](https://github.com/canonical/k8s-snap/pull/1383)
+- Add support to run test upgrades without needing a local snap
+[#1380](https://github.com/canonical/k8s-snap/pull/1380)
+- Update Kubernetes version to v1.32.4
+[#1335](https://github.com/canonical/k8s-snap/pull/1335)
+- Bump Cilium version to 1.17.1 and gateway API chart to v1.2.0. Also includes
+updates to ensure CNCF conformance
+[#1360](https://github.com/canonical/k8s-snap/pull/1360)
+- Add charm patch notices to the release notes
+[#1348](https://github.com/canonical/k8s-snap/pull/1348)
+- Fix typo in `proxy.md`
+[#1361](https://github.com/canonical/k8s-snap/pull/1361)
+- Bump CoreDNS version to 1.12 and chart to 1.39.2
+[#1356](https://github.com/canonical/k8s-snap/pull/1356)
+- Update CSI image versions
+[#1154](https://github.com/canonical/k8s-snap/pull/1154)
+- Bump CoreDNS chart to 1.36.2 and image to 1.11.4-ck1
+[#1155](https://github.com/canonical/k8s-snap/pull/1155)
+- Update Juju links in our docs from juju/latest to juju/3.6
+[#1338](https://github.com/canonical/k8s-snap/pull/1338)
+- Bump MetalLB chart and images to 0.14.9
+[#1153](https://github.com/canonical/k8s-snap/pull/1153)
+- Add feature upgrades machinery
+[#1296](https://github.com/canonical/k8s-snap/pull/1296)
+- Bump `rawfile-localpv` image to 0.8.2
+[#1329](https://github.com/canonical/k8s-snap/pull/1329)
+- Update tests as we do not expect k8sd to be active after node removal
+[#1319](https://github.com/canonical/k8s-snap/pull/1319)
+- Address error of worker nodes attempting to configure control plane elements
+during snap refreshes
+[#1253](https://github.com/canonical/k8s-snap/pull/1253)
+- Add `tunnel-port` annotation to address possible Cilium conflict with fan
+networking [#1305](https://github.com/canonical/k8s-snap/pull/1305)
+- Disable markdown lint due to false positives
+[#1313](https://github.com/canonical/k8s-snap/pull/1313)
+- Ignore _test packages in `godoc` generator
+[#1308](https://github.com/canonical/k8s-snap/pull/1308)
+- Bump golang.org/x/crypto to v0.35.0
+[#1304](https://github.com/canonical/k8s-snap/pull/1304)
+
 Apr 23, 2025
 
 - Fix node removal waiting for services to terminate


### PR DESCRIPTION
## Description

Updating the patch notices to reflect the latest in stable - v1.32.5

## Solution

These were manually created

## Issue
N/A

## Backport
1.32, 1.33

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
