### PR TITLE
docs: configure with containerd override_path

### DIFF
--- a/docs/canonicalk8s/charm/howto/custom-registry.md
+++ b/docs/canonicalk8s/charm/howto/custom-registry.md
@@ -43,6 +43,50 @@ progress by running:
 juju status --watch 2s
 ```
 
+### Registry mirror
+
+To configure the charm to use a registry mirror, you need to add to the
+`containerd-custom-registries` configuration option.
+
+to add `ghcr.io`:
+
+```
+juju config k8s containerd-custom-registries='[{
+    "url": "http://myregistry.example.com:5000",
+    "host": "myregistry.example.com:5000",
+    "username": "myuser",
+    "password": "mypassword"
+},{
+    "url": "http://myregistry.example.com:5000",
+    "host": "ghcr.io",
+    "username": "myuser",
+    "password": "mypassword"
+}]'
+```
+
+### Nested Path registry mirror
+
+To configure the charm to use a registry mirror where the path to the images is
+nested deeper, you need to add set the `override_path` flag to true
+`containerd-custom-registries` configuration option.
+
+to add `ghcr.io`:
+
+```
+juju config k8s containerd-custom-registries='[{
+    "url": "http://myregistry.example.com:5000",
+    "host": "myregistry.example.com:5000",
+    "username": "myuser",
+    "password": "mypassword"
+},{
+    "url": "http://myregistry.example.com:5000/v2/my/own/ghcr.io",
+    "host": "ghcr.io",
+    "username": "myuser",
+    "password": "mypassword",
+    "override_path": true
+}]'
+```
+
 ## Verify the configuration
 
 Once the charm is configured and active, verify that the custom registry is
@@ -54,14 +98,14 @@ have previously pushed to the `myregistry.example.com:5000` registry, run the
 following command:
 
 ```
-kubectl run nginx --image=myregistry.example.com:5000/nginx:latest
+k8s kubectl run nginx --image=myregistry.example.com:5000/nginx:latest
 ```
 
 To confirm that the image has been pulled from the custom registry and that the
 workload is running, use the following command:
 
 ```
-kubectl get pod nginx -o jsonpath='{.spec.containers[*].image}{"->"}{.status.containerStatuses[*].ready}'
+k8s kubectl get pod nginx -o jsonpath='{.spec.containers[*].image}{"->"}{.status.containerStatuses[*].ready}'
 ```
 
 The output should indicate that the image was pulled from the custom registry

--- a/docs/canonicalk8s/charm/howto/custom-registry.md
+++ b/docs/canonicalk8s/charm/howto/custom-registry.md
@@ -9,10 +9,11 @@ charm to pull images from a custom registry.
 ## Prerequisites
 
 - A running `k8s` charm cluster.
+- A `kubeconfig` to access the charmed cluster.
 - Access to a custom container registry from the cluster (e.g., docker registry
   or Harbor).
 
-## Configure the charm
+## Adding a custom registry
 
 To configure the charm to use a custom registry, you need to set the
 `containerd-custom-registries` configuration option. This options allows
@@ -43,12 +44,12 @@ progress by running:
 juju status --watch 2s
 ```
 
-### Registry mirror
+### Adding a registry mirror
 
 To configure the charm to use a registry mirror, you need to add to the
 `containerd-custom-registries` configuration option.
 
-to add `ghcr.io`:
+To mirror `ghcr.io` with `myregistry.example.com:5000`:
 
 ```
 juju config k8s containerd-custom-registries='[{
@@ -64,13 +65,13 @@ juju config k8s containerd-custom-registries='[{
 }]'
 ```
 
-### Nested Path registry mirror
+### Adding a nested path registry mirror
 
 To configure the charm to use a registry mirror where the path to the images is
 nested deeper, you need to add set the `override_path` flag to true
 `containerd-custom-registries` configuration option.
 
-to add `ghcr.io`:
+To mirror `ghcr.io` with `myregistry.example.com:5000/my/own/ghcr.io`:
 
 ```
 juju config k8s containerd-custom-registries='[{
@@ -98,14 +99,14 @@ have previously pushed to the `myregistry.example.com:5000` registry, run the
 following command:
 
 ```
-k8s kubectl run nginx --image=myregistry.example.com:5000/nginx:latest
+kubectl run nginx --image=myregistry.example.com:5000/nginx:latest
 ```
 
 To confirm that the image has been pulled from the custom registry and that the
 workload is running, use the following command:
 
 ```
-k8s kubectl get pod nginx -o jsonpath='{.spec.containers[*].image}{"->"}{.status.containerStatuses[*].ready}'
+kubectl get pod nginx -o jsonpath='{.spec.containers[*].image}{"->"}{.status.containerStatuses[*].ready}'
 ```
 
 The output should indicate that the image was pulled from the custom registry

--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -286,6 +286,24 @@ capabilities = ["pull", "resolve"]
 ca = "/var/snap/k8s/common/etc/containerd/hosts.d/ghcr.io/ca.crt"
 ```
 
+##### Nested Path registry
+
+If the registry mirrors the images at a nested or namespaced path, configure
+the hosts.toml with an `override_path = true`
+
+```
+# /etc/containerd/hosts.d/ghcr.io/hosts.toml
+server = https://10.10.10.10:5050/v2/my/own/ghcr.io
+
+[host."https://10.10.10.10:5050/v2/my/own/ghcr.io"]
+capabilities = ["pull", "resolve"]
+ca = "/var/snap/k8s/common/etc/containerd/hosts.d/ghcr.io/ca.crt"
+override_path = true
+```
+
+The image `ghcr.io/canonical/coredns:1.12.0-ck1` would be fetched via https
+from `my.mirror.io/my/own/ghcr.io/canonical/coredns:1.12.0-ck1`.
+
 #### Container runtime option C: Side-load images
 
 This is only required if choosing to [side-load images](#side-load). Make sure

--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -288,8 +288,8 @@ ca = "/var/snap/k8s/common/etc/containerd/hosts.d/ghcr.io/ca.crt"
 
 ##### Nested Path registry
 
-If the registry mirrors the images at a nested or namespaced path, configure
-the hosts.toml with an `override_path = true`
+If the registry mirrors the images at a nested path, configure the hosts.toml
+with an `override_path = true`.
 
 ```
 # /etc/containerd/hosts.d/ghcr.io/hosts.toml


### PR DESCRIPTION
Applicable spec: [KU167](https://docs.google.com/document/d/1FLAFY5DgYabJHM-D48qdgLJJy86wYtNa3MSKYC3qq2E/edit?tab=t.0)

### Overview

Addresses documentation gap with respect to `override_path`

### Rationale

Updates both snap and charm documentation