### PR TITLE
fix: Don't print k8s binary outputs in CLI

### DIFF
--- a/src/k8s/pkg/snap/snap.go
+++ b/src/k8s/pkg/snap/snap.go
@@ -436,7 +436,7 @@ func (s *snap) PreInitChecks(ctx context.Context, config types.ClusterConfig, se
 	// NOTE(neoaggelos): in some environments the Kubernetes might hang when running for the first time
 	// This works around the issue by running them once during the install hook
 	for _, binary := range []string{"kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy", "kubelet"} {
-		if err := s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", binary), "--version"}); err != nil {
+		if err := s.runCommand(ctx, []string{filepath.Join(s.snapDir, "bin", binary), "--version"}, func(c *exec.Cmd) { c.Stdout = nil; c.Stderr = nil }); err != nil {
 			return fmt.Errorf("%q binary could not run: %w", binary, err)
 		}
 	}


### PR DESCRIPTION
In #1423, a pre-init check was introduced on the client-side. In this check, the k8s binaries are started to ensure they do not hang later. However, the output was printed to stdout causing e.g. the `k8s bootstrap` command to be polluted with debug messages.

This commit pipes the output into the void instead.


