### PR TITLE
fix: strict patch

### DIFF
--- a/build-scripts/patches/strict/0001-Strict-patch.patch
+++ b/build-scripts/patches/strict/0001-Strict-patch.patch
@@ -47,7 +47,7 @@ index 9d21e55..26f49ad 100644
  grade: stable
 -confinement: classic
 +confinement: strict
- base: core20
+ base: core22
  environment:
    REAL_PATH: $PATH
 @@ -217,6 +217,20 @@ parts:


### PR DESCRIPTION
The autoupdate workflow failed because of the base mismatch

See e.g. https://github.com/canonical/k8s-snap/actions/runs/15611270727/job/43972522328