### PR TITLE
fix: bump systemd limits on snap install

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -55,7 +55,7 @@ k8s::common::on_fips_host() {
 }
 
 # Cleanup systemd overrides
-k8s::common::cleanup_systemd_overrides() {
+k8s::remove::cleanup_systemd_overrides() {
   if ! k8s::common::is_strict; then
     # remove custom sysctl parameters
     rm -f /etc/sysctl.d/10-k8s.conf
@@ -299,6 +299,8 @@ k8s::containerd::ensure_systemd_defaults() {
 }
 
 k8s::k8d_dqlite::ensure_systemd_defaults() {
+  k8s::common::setup_env
+  
   k8s::util::increase_sysctl_parameter "fs.inotify.max_user_instances" "1024"
   k8s::util::increase_sysctl_parameter "fs.inotify.max_user_watches" "1048576"
 }

--- a/k8s/systemd/containerd-defaults.conf
+++ b/k8s/systemd/containerd-defaults.conf
@@ -5,6 +5,7 @@ Delegate=yes
 LimitNPROC=infinity
 LimitCORE=infinity
 LimitNOFILE=infinity
+LimitMEMLOCK=infinity
 # Comment TasksMax if your systemd version does not supports it.
 # Only systemd 226 and above support this version.
 TasksMax=infinity

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -12,3 +12,6 @@ k8s::cmd::k8s x-snapd-config disable || true
 # In order to interact with the REST API the k8sd service
 # needs to be started and configured in the installation step.
 k8s::init::k8sd || true
+
+# Ensure systemd limits are sufficient
+k8s::k8d_dqlite::ensure_systemd_defaults

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -9,3 +9,5 @@ k8s::remove::containers
 k8s::remove::network
 
 k8s::remove::containerd
+
+k8s::remove::cleanup_systemd_overrides


### PR DESCRIPTION
## Description

An issue came up during in an internal Kubernetes environment showing errors in kube-apiserver-proxy related to reaching max_user_watches.

## Solution

We should bump the systemd limits on the snap install to allow for a seamless experience for our k8s.
When the snap is removed we should revert any of those adjustments made. I am choosing the same limits that worked for microk8s.

In addition, this PR appends the `LimitMEMLOCK=infinity` to containerd defaults.

## Issue

N/A internal.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
