### PR TITLE
fix: update etcd keys in configuration file

### DIFF
--- a/docs/canonicalk8s/snap/howto/external-datastore.md
+++ b/docs/canonicalk8s/snap/howto/external-datastore.md
@@ -27,6 +27,9 @@ Create a configuration file and insert the contents below while replacing
 the placeholder values based on the configuration of your etcd cluster.
 
 ```yaml
+cluster-config:
+  network:
+    enabled: true
 datastore-type: external
 datastore-servers: "<etcd-member-addresses>"
 datastore-ca-crt: |


### PR DESCRIPTION
## Description

- The `datastore-url` key in bootstrap configuration file is replaced with `datastore-servers` which is a YAML sequence. This PR suggests a fix to update the key.
- We are suggesting to using a series of YAML key-values as a bootstrap configuration file. This PR suggests providing a valid configuration file that enables the CNI as well. 