### PR TITLE
fix: retry the wait command for load balancer

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -412,8 +412,8 @@ def wait_for_network(instance: harness.Instance):
 def wait_for_load_balancer(instance: harness.Instance):
     """Wait for the load balancer to be ready."""
     LOG.info("Waiting for load balancer to be ready")
-    instance.exec(
-        [
+    stubbornly(retries=3, delay_s=1).on(instance).exec(
+            [
             "k8s",
             "kubectl",
             "wait",
@@ -423,7 +423,7 @@ def wait_for_load_balancer(instance: harness.Instance):
             "deployment.apps/metallb-controller",
             "--timeout=20m",
         ]
-    )
+        )
 
 
 def hostname(instance: harness.Instance) -> str:


### PR DESCRIPTION
## Description

In the `_test_loadbalancer` we are waiting for `metallb-controller` deployment to become available immediately after we enable the load-balancer. This results in flakiness since sometimes we run the `kubectl wait` command before the deployment object is created:
```
Error from server (NotFound): deployments.apps "metallb-controller" not found
```
This PR suggests adding a retry logic to account for such scenario

