### PR TITLE
fix: add retry to get_join_token helper

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -475,10 +475,16 @@ def ready_nodes(control_node: harness.Instance) -> List[Any]:
 def get_join_token(
     initial_node: harness.Instance, joining_cplane_node: harness.Instance, *args: str
 ) -> str:
-    out = initial_node.exec(
-        ["k8s", "get-join-token", joining_cplane_node.id, *args],
-        capture_output=True,
+    out = (
+        stubbornly(retries=5, delay_s=3)
+        .on(initial_node)
+        .until(lambda p: len(p.stdout.decode().strip()) > 0)
+        .exec(
+            ["k8s", "get-join-token", joining_cplane_node.id, *args],
+            capture_output=True,
+        )
     )
+
     return out.stdout.decode().strip()
 
 


### PR DESCRIPTION
## Description

Running `k8s get-join-token` right after `k8s bootstrap` may result in error in case microcluster state is not ready. This PR adds a retry logic to the `get_join_token` helper to account for such situations.