### PR TITLE
fix: Do not remove cilium_vxlan interface. Ask the user instead

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -37,6 +37,11 @@ func checkAndSanitizeCiliumVXLAN(port int) error {
 	}
 
 	for _, vxlanDevice := range vxlanDevices {
+		// Note(Reza): Currently Cilium tries to bring up the vxlan interface before applying
+		// any configuration changes. If the Cilium vxlan interface has any conflicts with other
+		// interfaces that makes it unable to brought up, Cilium fails to apply configuration
+		// changes. We can remove this block when the following issue gets settled:
+		// https://github.com/cilium/cilium/issues/38581
 		if vxlanDevice.Port == port && vxlanDevice.Name != ciliumVXLANDeviceName {
 			return fmt.Errorf("interface %s uses the same destination port as cilium. Please consider changing the Cilium tunnel port", vxlanDevice.Name)
 		}


### PR DESCRIPTION
### Overview
This PR suggests a fix for the `cilium_vxlan` interface getting removed.

Fixes #1495 
Fixes #1585 