### PR TITLE
fix: update vxlan port check to ignore 0 unset or missing port number

### DIFF
--- a/src/k8s/pkg/utils/netlink.go
+++ b/src/k8s/pkg/utils/netlink.go
@@ -9,14 +9,14 @@ import (
 
 type VXLANInterface struct {
 	net.Interface
-	Port int
+	Port *int
 }
 
 var ipLinks []struct {
 	IfName   string `json:"ifname"`
 	LinkInfo struct {
 		InfoData struct {
-			Port int `json:"port"`
+			Port *int `json:"port"`
 		} `json:"info_data"`
 	} `json:"linkinfo"`
 }


### PR DESCRIPTION
Fix for #1586 