### PR TITLE
docs: Update custom worker join how to guide

### DIFF
--- a/docs/canonicalk8s/conf.py
+++ b/docs/canonicalk8s/conf.py
@@ -217,6 +217,7 @@ linkcheck_ignore = [
     r'https://www\.stigviewer\.com/.*',
     'https://www.squid-cache.org/',
     'https://www.esd.whs.mil/portals/54/documents/dd/issuances/dodi/855101p.pdf',
+    r'https://stigviewer.com/stigs/kubernetes/2024-06-10/finding/V-24',
     ]
 
 

--- a/docs/canonicalk8s/snap/howto/install/custom-worker.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-worker.md
@@ -13,27 +13,17 @@ This guide assumes the following:
 
 - A working Kubernetes cluster deployed with the `k8s` snap
 
-## Command line arguments
+## Generate worker join token
 
-To discover the configuration options available as command line arguments,
-on the control node run:
-
-```
-sudo k8s join-cluster --help
-```
-
-In this example, the name of the new worker node joining the cluster is
-specified through command line arguments.
-
-If we do not specify the node name upon creating a worker join token on 
-the control plane node the worker node will appear in the cluster with
-the default hostname. In this example, we
-include the name of the worker node: `custom-worker`. To generate the 
-join token for a worker add the `--worker` option.
+When generating a join token for a worker node, pass the `--worker`
+parameter to the `get-join-token` command. Adding the
+hostname when creating a worker join token is optional and is not included here.
 
 ```
-sudo k8s get-join-token custom-worker --worker
+sudo k8s get-join-token --worker
 ```
+
+## Install the snap
 
 On the new worker machine, install the snap:
 
@@ -42,25 +32,34 @@ On the new worker machine, install the snap:
 :end-before: <!-- snap end -->
 ```
 
-Join the cluster with the token generated from the output of the
-`get-join-token` command and specify the same `--name` we want the worker node
-to be called. This must match the name used in the `get-join-token` command.
+## Join the cluster
+
+### Default configuration
+
+To join the cluster with the default configuration, on the worker node use the
+token generated from the output of the `get-join-token` command and run:
 
 ```
-sudo k8s join-cluster --name custom-worker <JOIN-TOKEN>
+sudo k8s join-cluster <JOIN-TOKEN>
 ```
 
-After a few moments, the node should have joined the cluster with a success
-message. Verify the node has joined the cluster with the custom name by
-switching to the control node and running:
+### Command line arguments
+
+To discover the configuration options available as command line arguments when
+joining the cluster, on the control node run:
 
 ```
-sudo k8s kubectl get nodes
+sudo k8s join-cluster --help
 ```
 
-The output should list the `custom-worker` node in a `Ready` state.
+You can then run the join the cluster with the token generated from the output
+of the `get-join-token` command and any arguments you may need. For example, to set the output formatting to JSON run:
 
-## Configuration file
+```
+sudo k8s join-cluster --output-format=json <JOIN-TOKEN>
+```
+
+### Configuration file
 
 More configuration options are available when a configuration file is specified.
 Please consult the [reference page] for all of the available configuration
@@ -68,21 +67,6 @@ options and their defaults.
 
 In this example, the configuration file provided at cluster join will set the
 proxy mode of the worker machine to `ipvs`.
-
-A join token must be generated on the control plane node of the cluster.
-To generate the join token for a worker the `--worker` option is added. 
-We will not specify the node name in this example.
-
-```
-sudo k8s get-join-token --worker
-```
-
-On the new worker machine, install the snap:
-
-```{literalinclude} ../../../_parts/install.md
-:start-after: <!-- snap start -->
-:end-before: <!-- snap end -->
-```
 
 Create a `custom_config.yaml` file that sets the intended custom configurations.
 
@@ -93,12 +77,14 @@ extra-node-kube-proxy-args:
 EOF
 ```
 
-Join the cluster with the token generated from the output of the
-`get-join-token` command and the `custom_config.yaml` file.
+On the worker node, join the cluster with the token generated from the output of
+the `get-join-token` command and the `custom_config.yaml` file.
 
 ```
 sudo k8s join-cluster --file path/to/custom_config.yaml <JOIN-TOKEN>
 ```
+
+## Verify worker join
 
 After a few moments, the node should have joined the cluster with a success
 message. Verify the node has joined the cluster by switching to the control
@@ -108,16 +94,9 @@ node and running:
 sudo k8s kubectl get nodes
 ```
 
-The output should list the worker node as in a `Ready` state.
+The output should list the worker node in a `Ready` state.
 
-Also verify the proxy mode configuration has been applied to the worker node
-by checking the logs of kube-proxy on the worker machine:
-
-```
-sudo journalctl -u snap.k8s.kube-proxy | grep ipvs
-```
-
-The output should show the proxy-mode is `ipvs`.
+Also verify if any custom configuration has been applied to the worker.
 
 <!-- LINKS -->
 

--- a/docs/canonicalk8s/snap/howto/install/custom-worker.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-worker.md
@@ -53,7 +53,8 @@ sudo k8s join-cluster --help
 ```
 
 You can then run the join the cluster with the token generated from the output
-of the `get-join-token` command and any arguments you may need. For example, to set the output formatting to JSON run:
+of the `get-join-token` command and any arguments you may need. For example, to
+set the output formatting to JSON run:
 
 ```
 sudo k8s join-cluster --output-format=json <JOIN-TOKEN>


### PR DESCRIPTION
## Description

The previous example where the --name is set should only be used when the hostname cannot be resolved. It is not the default or recommended behaviour.

## Solution

Replacing that example and reformatting the page.

Drive by fix : There is a huge amount of links in the DISA STIG how to guide for the same website (stigviewer) that often flake and give a false positive in our tests. By only checking 3 of the links (ones starting with V-25*) we should still be altered to broken links but not have the same stability issues

## Issue

N/A

## Backport

1.32,1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.