### PR TITLE
docs: document Auto Namespace creation and RBD disable

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -71,7 +71,6 @@ Center
 ceph
 cephcsi
 CephFS
-CephRBD
 cephx
 certfile
 cgroup

--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -71,6 +71,7 @@ Center
 ceph
 cephcsi
 CephFS
+CephRBD
 cephx
 certfile
 cgroup

--- a/docs/canonicalk8s/charm/howto/ceph-csi.md
+++ b/docs/canonicalk8s/charm/howto/ceph-csi.md
@@ -53,7 +53,7 @@ juju integrate ceph-csi k8s:ceph-k8s-info
 juju integrate ceph-csi ceph-mon:client
 ```
 
-CephFS support can be optionally enabled (off by default):
+`ceph-fs` support can be optionally enabled (off by default):
 
 ```
 juju deploy ceph-fs
@@ -61,7 +61,7 @@ juju integrate ceph-fs:ceph-mds ceph-mon:mds
 juju config ceph-csi cephfs-enable=true
 ```
 
-CephRBD support can be optionally disabled (on by default):
+`ceph-rbd` support is enabled by default but can be optionally disabled:
 
 ```
 juju config ceph-csi ceph-rbd-enable=false
@@ -150,8 +150,11 @@ can be deployed again as separate Juju applications with different names.
 Deploy an alternate Ceph cluster containing one monitor and one storage unit
 (OSDs) -- again limiting the resources allocated.
 
+```{note} The alternate ceph drivers will need a new namespace to deploy into.
 ```
-CEPH_NS_ALT=ceph-csi-alt  # kubernetes namespace for the alternate ceph driver
+
+```
+CEPH_NS_ALT=ceph-ns-alt  # kubernetes namespace for the alternate ceph driver
 juju deploy -n 1 ceph-mon-alt ceph-mon \
     --constraints "cores=2 mem=4G root-disk=16G" \
     --config monitor-count=1 \
@@ -193,8 +196,12 @@ Many of the Kubernetes Resources managed by the `ceph-csi` charm have an
 associated namespace. Ensure the configuration for the `ceph-csi-alt`
 application changes so that it doesn't collide with `ceph-csi`.
 
+If both `ceph-csi` and `ceph-csi-alt` were configured with `namespace=default`,
+then one of the charms will be in a blocked state. If it's `ceph-csi-alt`,
+correct by assigning it an alternate namespace.
+
 ```
-CEPH_NS_ALT=ceph-csi-alt  # kubernetes namespace for the alternate ceph driver
+CEPH_NS_ALT=ceph-ns-alt  # kubernetes namespace for the alternate ceph driver
 juju config ceph-csi-alt namespace=${CEPH_NS_ALT} create-namespace=true
 ```
 

--- a/docs/canonicalk8s/charm/howto/ceph-csi.md
+++ b/docs/canonicalk8s/charm/howto/ceph-csi.md
@@ -176,11 +176,13 @@ instances.  A new ceph-cluster via `ceph-mon-alt` and `ceph-osd-alt` and a new
 integration with Kubernetes by `ceph-csi-alt`.
 
 There are some Kubernetes Resources which collide in this deployment style.
-The admin will notice the `ceph-csi-alt` application in the blocked state with
-a status detailing the resource conflicts it detects:
+The `ceph-csi-alt` application may enter a blocked state with a status
+detailing the resource conflicts it detects:
 
 example)
 `10 Kubernetes resource collisions (action: list-resources)`
+
+### Resolving collisions
 
 List the collisions by running an action on the charm:
 
@@ -188,17 +190,15 @@ List the collisions by running an action on the charm:
 juju run ceph-csi-alt/leader list-resources
 ```
 
-### Resolving collisions
-
 #### Namespace collisions
 
 Many of the Kubernetes Resources managed by the `ceph-csi` charm have an
 associated namespace. Ensure the configuration for the `ceph-csi-alt`
-application changes so that it doesn't collide with `ceph-csi`.
+application doesn't collide with `ceph-csi`.
 
 If both `ceph-csi` and `ceph-csi-alt` were configured with `namespace=default`,
-then one of the charms will be in a blocked state. If it's `ceph-csi-alt`,
-correct by assigning it an alternate namespace.
+then one of the charms will be in a blocked state. Assign `ceph-csi-alt` to an
+alternate namespace.
 
 ```
 CEPH_NS_ALT=ceph-ns-alt  # kubernetes namespace for the alternate ceph driver


### PR DESCRIPTION
## Description
Document the usage of two additional features of ceph-csi charm
* the auto-creation of namespaces
* the disabling of the Ceph RBD drivers

## Solution

Integration into the docs how to deploy/reconfigure ceph-csi for the charm proposed features.

## Backport

* 1.33/stable of ceph-csi will support this feature

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

* No tests added as it only concerns documentation
