### PR TITLE
fix: Introduce jitter to reconciliation retries

### DIFF
--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"time"
 
 	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
@@ -13,6 +12,7 @@ import (
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
+	timeutils "github.com/canonical/k8s/pkg/utils/time"
 	"github.com/canonical/microcluster/v2/state"
 )
 
@@ -262,8 +262,7 @@ func (c *FeatureController) reconcileLoop(
 
 				log.Info("Retrying feature reconciliation", "attempts", fmt.Sprintf("%d/%s", attempts, maxAttempts))
 				// notify triggerCh after 3-15 seconds to retry
-				retryInterval := time.Duration(3+rand.IntN(13)) * time.Second
-				time.AfterFunc(retryInterval, func() { utils.MaybeNotify(triggerCh) })
+				time.AfterFunc(timeutils.ExponentialBackoff(attempts, 3*time.Second, 5*time.Minute), func() { utils.MaybeNotify(triggerCh) })
 			} else {
 				utils.MaybeNotify(reconciledCh)
 				attempts = 0

--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"time"
 
 	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
@@ -260,8 +261,9 @@ func (c *FeatureController) reconcileLoop(
 				}
 
 				log.Info("Retrying feature reconciliation", "attempts", fmt.Sprintf("%d/%s", attempts, maxAttempts))
-				// notify triggerCh after 5 seconds to retry
-				time.AfterFunc(5*time.Second, func() { utils.MaybeNotify(triggerCh) })
+				// notify triggerCh after 3-15 seconds to retry
+				retryInterval := time.Duration(3+rand.IntN(13)) * time.Second
+				time.AfterFunc(retryInterval, func() { utils.MaybeNotify(triggerCh) })
 			} else {
 				utils.MaybeNotify(reconciledCh)
 				attempts = 0

--- a/src/k8s/pkg/utils/time/backoff.go
+++ b/src/k8s/pkg/utils/time/backoff.go
@@ -1,0 +1,17 @@
+package time
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// ExponentialBackoff returns a duration that grows exponentially with attempt number,
+// capped at maxDelay, and with ±50% jitter.
+func ExponentialBackoff(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
+	exp := min(max(0, attempt), 32) // cap at 32 to avoid overflow
+	// exponential: base * 2^exp
+	d := min(baseDelay<<exp, maxDelay)
+	// add jitter in range [d/2, 3d/2)
+	jitter := time.Duration(rand.Int64N(int64(d))) - d/2
+	return d + jitter
+}


### PR DESCRIPTION
### Overview

Helm `apply` of the feature reconciliations might get into a deadlock since feature controllers run independently.  For features that share the same underlying chart the situation is even more dire since there are `num_cp_nodes * num_sibling_features` goroutines that try to apply the same Helm chart. Applying the same Helm chart concurrently or in parallel might fail with `another operation is in progress`.
This PR introduces a jitter to the reconciliation retries in order to reduce the concurrent/parallel Helm operations.