### PR TITLE
fix: wait longer in the test_gateway

### DIFF
--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -41,9 +41,11 @@ def get_gateway_service_node_port(p):
 
 
 def get_external_service_ip(instance: harness.Instance) -> str:
+    LOG.info("Waiting for gateway IP to be available...")
     try_count = 0
     gateway_ip = None
-    while not gateway_ip and try_count < 5:
+    while not gateway_ip and try_count < 30:
+        LOG.info(f"Attempt {try_count + 1} to get gateway IP...")
         try_count += 1
         try:
             gateway_ip = (


### PR DESCRIPTION
## Description

test_gateway is often failing. 

## Solution

Increased the time we spent in waiting for the GW IP to come up. Was able to reproduce locally. Some times it needed more time. Here are some logs showing this:
```
2025-07-04 13:48:05 [    INFO] Waiting for gateway IP to be available... (test_gateway.py:44)
2025-07-04 13:48:05 [    INFO] Attempt 1 to get gateway IP... (test_gateway.py:48)
2025-07-04 13:48:09 [    INFO] Attempt 2 to get gateway IP... (test_gateway.py:48)
2025-07-04 13:48:13 [    INFO] Attempt 3 to get gateway IP... (test_gateway.py:48)
2025-07-04 13:48:17 [    INFO] Attempt 4 to get gateway IP... (test_gateway.py:48)
2025-07-04 13:48:22 [    INFO] Attempt 5 to get gateway IP... (test_gateway.py:48)
2025-07-04 13:48:26 [    INFO] Attempt 6 to get gateway IP... (test_gateway.py:48)
2025-07-04 13:48:30 [    INFO] Attempt 7 to get gateway IP... (test_gateway.py:48)
2025-07-04 13:48:34 [    INFO] Attempt 8 to get gateway IP... (test_gateway.py:48)
```

## Backport

In 1.33 and 1.32.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
