### PR TITLE
fix: retry the query of the upstream versions

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -638,9 +638,20 @@ def _major_minor_from_stable_upstream(maj: Optional[int] = None) -> Optional[tup
         dash_maj=f"-{maj}" if maj else ""
     )
     LOG.info("Getting upstream version from %s", addr)
-    with urllib.request.urlopen(addr) as r:
-        stable = r.read().decode().strip()
-        return major_minor(stable)
+    for attempt in range(1, 11):
+        try:
+            with urllib.request.urlopen(addr) as r:
+                stable = r.read().decode().strip()
+                return major_minor(stable)
+        except urllib.error.HTTPError as e:
+            LOG.warning(
+                "Attempt %d: Failed to get upstream version from %s. Retrying...",
+                attempt, addr
+            )
+            if attempt == 10:
+                LOG.error("Failed to get upstream version after 10 attempts")
+                raise
+        time.sleep(6)
 
 
 def _previous_track_from_branch(branch: str) -> Optional[str]:


### PR DESCRIPTION
## Description

Several nightly tests failed because we could not get the stable k8s version, eg https://github.com/canonical/k8s-snap/actions/runs/16012802976/job/45173875685


## Solution

Retry the HTTP GET calls :)

## Backport

1.32 and 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

