### PR TITLE
test: charm-e2e tests collect the juju crashdumps

### DIFF
--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -26,6 +26,8 @@ jobs:
   charm-e2e-tests:
     name: Test ${{ inputs.arch }} ${{ inputs.artifact }}
     runs-on: ${{ inputs.arch == 'arm64' && 'self-hosted-linux-arm64-jammy-large' || 'self-hosted-linux-amd64-jammy-xlarge' }}
+    env:
+      K8S_OPERATOR: k8s-operator
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -48,12 +50,12 @@ jobs:
           mkdir snap_installation
           mv ${{ steps.download-snap.outputs.snap-path }} snap_installation/k8s.snap
           tar cvzf snap_installation.tar.gz -C snap_installation/ .
-      - name: Install charmcraft
-        run: |
-          sudo snap install charmcraft --classic
       - name: Install juju
         run: |
           sudo snap install juju --classic
+      - name: Install juju-crashdump
+        run: |
+          sudo snap install juju-crashdump --classic
       - name: Download charms ${{ inputs.charm-channel }} ${{ inputs.arch }}
         run: |
           # The operator tests expect the charm file name to have the
@@ -81,7 +83,7 @@ jobs:
         with:
           repository: canonical/k8s-operator
           ref: main
-          path: k8s-operator
+          path: ${{ env.K8S_OPERATOR }}
       - name: Disable lxd ipv6
         run: |
           # The charm tests can't handle ipv6 dualstack.
@@ -98,7 +100,8 @@ jobs:
           ls -lh $charmFile
           ls -lh $snapInstallRes
 
-          cd k8s-operator
+          cd ${{ env.K8S_OPERATOR }}
+
           sudo --user "$USER" --preserve-env --preserve-env=PATH \
             -- env -- \
             tox -e integration \
@@ -107,3 +110,20 @@ jobs:
             --charm-file $k8sWorkerChamFile \
             --snap-installation-resource $snapInstallRes \
             'tests/integration/test_k8s.py::test_nodes_ready'
+      - name: Collect Juju Status
+        if: ${{ failure() }}
+        id: collect-juju-status
+        run: |
+          set -x
+          path=${{ env.K8S_OPERATOR }}/tmp
+          mkdir -p $path
+          juju status 2>&1 | tee $path/juju-status.txt
+          juju-crashdump -s -m controller -a debug-layer -a config -o $path/
+          mv ${{ env.K8S_OPERATOR }}/juju-crashdump-* $path/ | true
+          echo "path=${path}/" >> $GITHUB_OUTPUT
+      - name: Upload debug artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-run-artifacts
+          path: ${{ steps.collect-juju-status.outputs.path }}

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -50,11 +50,10 @@ jobs:
           mkdir snap_installation
           mv ${{ steps.download-snap.outputs.snap-path }} snap_installation/k8s.snap
           tar cvzf snap_installation.tar.gz -C snap_installation/ .
-      - name: Install juju
+      - name: Install charmcraft, juju, juju-crashdump
         run: |
+          sudo snap install charmcraft --classic
           sudo snap install juju --classic
-      - name: Install juju-crashdump
-        run: |
           sudo snap install juju-crashdump --classic
       - name: Download charms ${{ inputs.charm-channel }} ${{ inputs.arch }}
         run: |
@@ -111,7 +110,7 @@ jobs:
             --snap-installation-resource $snapInstallRes \
             'tests/integration/test_k8s.py::test_nodes_ready'
       - name: Collect Juju Status
-        if: ${{ failure() }}
+        if: failure()
         id: collect-juju-status
         run: |
           set -x
@@ -119,10 +118,10 @@ jobs:
           mkdir -p $path
           juju status 2>&1 | tee $path/juju-status.txt
           juju-crashdump -s -m controller -a debug-layer -a config -o $path/
-          mv ${{ env.K8S_OPERATOR }}/juju-crashdump-* $path/ | true
+          mv ${{ env.K8S_OPERATOR }}/juju-crashdump-* $path/ || true
           echo "path=${path}/" >> $GITHUB_OUTPUT
       - name: Upload debug artifacts
-        if: ${{ failure() }}
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts


### PR DESCRIPTION
## Description

Adding juju-crashdump the the charm-e2e tests

## Solution

Running `tox -e integration` will create a crashdump of the model under test
Adding `juju-crashdump` for the controller is nice
Finally assemble all the crashdumps into a github artifact of tht ebuild 

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
