### PR TITLE
fix: sort --initial-clusters in etcd setup

### DIFF
--- a/src/k8s/pkg/k8sd/setup/etcd.go
+++ b/src/k8s/pkg/k8sd/setup/etcd.go
@@ -2,8 +2,10 @@ package setup
 
 import (
 	"fmt"
+	"maps"
 	"net"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/canonical/k8s/pkg/snap"
@@ -44,8 +46,8 @@ func Etcd(snap snap.Snap, name string, nodeIP net.IP, clientPort, peerPort int, 
 
 	var initialCluster []string
 
-	for memberName, memberURL := range initialClusterMembers {
-		initialCluster = append(initialCluster, fmt.Sprintf("%s=%s", memberName, memberURL))
+	for _, memberName := range slices.Sorted(maps.Keys(initialClusterMembers)) {
+		initialCluster = append(initialCluster, fmt.Sprintf("%s=%s", memberName, initialClusterMembers[memberName]))
 	}
 
 	args := map[string]string{

--- a/src/k8s/pkg/k8sd/setup/etcd_test.go
+++ b/src/k8s/pkg/k8sd/setup/etcd_test.go
@@ -91,7 +91,7 @@ func TestEtcd(t *testing.T) {
 			{key: "--listen-client-urls", expectedVal: "https://10.0.0.3:2379,https://127.0.0.1:2379"},
 			{key: "--advertise-client-urls", expectedVal: "https://10.0.0.3:2379"},
 			{key: "--initial-cluster-state", expectedVal: "existing"},
-			{key: "--initial-cluster", expectedVal: "t2=https://10.0.0.1:2380,t1=https://10.0.0.3:2380"},
+			{key: "--initial-cluster", expectedVal: "t1=https://10.0.0.3:2380,t2=https://10.0.0.1:2380"},
 			{key: "--client-cert-auth", expectedVal: "true"},
 			{key: "--trusted-ca-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "ca.crt")},
 			{key: "--cert-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "server.crt")},


### PR DESCRIPTION
## Description

Map order is not guaranteed in Go, which led to test flakiness, see
```
\=== RUN TestEtcd/JoiningNode/--initial-cluster

etcd\_test.go:109:

Expected

<string>: t1=[https://10.0.0.3:2380,t2=https://10.0.0.1:2380](https://10.0.0.3:2380,t2=https://10.0.0.1:2380)

to equal

<string>: t2=[https://10.0.0.1:2380,t1=https://10.0.0.3:2380](https://10.0.0.1:2380,t1=https://10.0.0.3:2380)
```

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

