### PR TITLE
docs: Add vxlan port in the list of ports and services

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -530,6 +530,7 @@ ubuntu
 Ubuntu Core
 Ubuntu Pro
 Ubuntu Server
+UDP
 uid
 UIDs
 unix

--- a/docs/canonicalk8s/snap/reference/ports-and-services.md
+++ b/docs/canonicalk8s/snap/reference/ports-and-services.md
@@ -17,6 +17,7 @@ meaning they can only be accessed from within the host.
 | 4240  | TCP      | cilium-agent    | TCP port for cluster-wide network connectivity and Cilium agent health API.                              |
 | 6400  | TCP      | k8sd            | Default REST API port for Canonical Kubernetes daemon.                                                   |
 | 6443  | TCP      | kube-apiserver  | Kubernetes API server. SSL encrypted. Clients must present a valid password from a Static Password File. |
+| 8472  | UDP      | cilium-agent    | Default VXLAN port used by Cilium.                                                                       |
 | 9000  | TCP      | k8s-dqlite      | SSL encrypted connection for k8s-dqlite. Client certificates required.                                   |
 | 9963  | TCP      | cilium-operator | Prometheus metric endpoint for the Cilium operator.                                                      |
 | 10250 | TCP      | kubelet         | Kubelet API. Anonymous authentication is disabled. X509 client certificate required.                     |


### PR DESCRIPTION
## Description

The VXLAN port is not in the list of ports and services

## Solution

Add the VXLAN port in the list

## Backport

1.32 and 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

