### PR TITLE
feat(upgrade): Wait for worker nodes to get upgraded as well

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -15,9 +15,11 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
+	upgradepkg "github.com/canonical/k8s/pkg/upgrade"
 	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
+	"github.com/canonical/k8s/pkg/version"
 	"github.com/canonical/microcluster/v2/state"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 )
@@ -422,7 +424,8 @@ func initiateRollingUpgrade(ctx context.Context, snap snap.Snap, s state.State, 
 		strategy = upgradesv1alpha.UpgradeStrategyRollingDowngrade
 	}
 
-	newUpgrade := upgradesv1alpha.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev))
+	versionData := version.Info{Revision: rev}
+	newUpgrade := upgradesv1alpha.NewUpgrade(upgradepkg.GetName(versionData))
 	if err := k8sClient.Create(ctx, newUpgrade); err != nil {
 		return fmt.Errorf("failed to create upgrade: %w", err)
 	}

--- a/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
+++ b/src/k8s/pkg/k8sd/app/hooks_post_refresh.go
@@ -10,7 +10,9 @@ import (
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/log"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	upgradepkg "github.com/canonical/k8s/pkg/upgrade"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
+	"github.com/canonical/k8s/pkg/version"
 	"github.com/canonical/microcluster/v2/state"
 )
 
@@ -86,7 +88,8 @@ func (a *App) performPostUpgrade(ctx context.Context, s state.State) error {
 		}
 		// TODO(ben): Add more metadata to the upgrade.
 		// e.g. initial revision, target revision, name of the node that started the upgrade, etc.
-		upgrade = upgradesv1alpha.NewUpgrade(fmt.Sprintf("cluster-upgrade-to-rev-%s", rev))
+		versionData := version.Info{Revision: rev}
+		upgrade = upgradesv1alpha.NewUpgrade(upgradepkg.GetName(versionData))
 		if err := k8sClient.Create(ctx, upgrade); err != nil {
 			return fmt.Errorf("failed to create upgrade: %w", err)
 		}

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -130,7 +130,6 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 			func(ctx context.Context) (types.ClusterConfig, error) {
 				return databaseutil.GetClusterConfig(ctx, s)
 			},
-			func() state.State { return s },
 		); err != nil {
 			log.FromContext(ctx).Error(err, "Failed to start controller coordinator")
 		}

--- a/src/k8s/pkg/k8sd/controllers/coordinator.go
+++ b/src/k8s/pkg/k8sd/controllers/coordinator.go
@@ -13,7 +13,6 @@ import (
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
 	"github.com/canonical/k8s/pkg/utils"
-	"github.com/canonical/microcluster/v2/state"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -55,7 +54,6 @@ func NewCoordinator(
 func (c *Coordinator) Run(
 	ctx context.Context,
 	getClusterConfig func(context.Context) (types.ClusterConfig, error),
-	getState func() state.State,
 ) error {
 	logger := log.FromContext(ctx).WithName("controller-coordinator")
 	ctrllog.SetLogger(logger)
@@ -100,7 +98,7 @@ func (c *Coordinator) Run(
 		return fmt.Errorf("failed to create manager: %w", err)
 	}
 
-	if err := c.setupControllers(ctx, getClusterConfig, getState, mgr); err != nil {
+	if err := c.setupControllers(ctx, getClusterConfig, mgr); err != nil {
 		return fmt.Errorf("failed to setup controllers: %w", err)
 	}
 
@@ -114,10 +112,9 @@ func (c *Coordinator) Run(
 func (c *Coordinator) setupControllers(
 	ctx context.Context,
 	getClusterConfig func(context.Context) (types.ClusterConfig, error),
-	getState func() state.State,
 	mgr manager.Manager,
 ) error {
-	if err := c.setupUpgradeController(ctx, getClusterConfig, getState, mgr); err != nil {
+	if err := c.setupUpgradeController(ctx, getClusterConfig, mgr); err != nil {
 		return fmt.Errorf("failed to setup upgrade controller: %w", err)
 	}
 
@@ -131,7 +128,6 @@ func (c *Coordinator) setupControllers(
 func (c *Coordinator) setupUpgradeController(
 	ctx context.Context,
 	getClusterConfig func(context.Context) (types.ClusterConfig, error),
-	getState func() state.State,
 	mgr manager.Manager,
 ) error {
 	logger := mgr.GetLogger()
@@ -152,7 +148,6 @@ func (c *Coordinator) setupUpgradeController(
 	}
 
 	upgradeController := upgrade.NewController(
-		getState,
 		logger,
 		mgr.GetClient(),
 		c.upgradeControllerOpts,

--- a/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/upgrade/reconcile.go
@@ -3,28 +3,27 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	upgradesv1alpha "github.com/canonical/k8s/pkg/k8sd/crds/upgrades/v1alpha"
 	"github.com/canonical/k8s/pkg/k8sd/features"
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	upgradepkg "github.com/canonical/k8s/pkg/upgrade"
+	"github.com/canonical/k8s/pkg/version"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Reconcile implements the Reconciler interface and wraps the reconcile method.
-// Reconcile ensures that the reconciliation is requeued unless the reconciled resource is not found.
+// Reconcile ensures that the reconciliation is requeued.
 func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := c.logger.WithValues("scope", "reconcile wrapper")
-
 	res, err := c.reconcile(ctx, req)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info(fmt.Sprintf("Upgrade %q not found, ignoring.", req.NamespacedName))
-			return ctrl.Result{}, nil
-		}
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile: %w", err)
 	}
 
@@ -38,26 +37,93 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 // reconcile is the main reconciliation loop for the upgrade controller.
 func (c *Controller) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	errs := []error{}
 	var upgrade upgradesv1alpha.Upgrade
-	if err := c.client.Get(ctx, req.NamespacedName, &upgrade); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get upgrade %q: %w", req.NamespacedName, err)
+	if err := c.client.Get(ctx, req.NamespacedName, &upgrade); err == nil {
+		res, err := c.reconcileUpgrade(ctx, &upgrade)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile upgrade %q: %w", req.NamespacedName, err)
+		}
+		return res, nil
+	} else if !apierrors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("failed to get upgrade %q: %w", req.NamespacedName, err))
 	}
 
+	var node corev1.Node
+	if err := c.client.Get(ctx, req.NamespacedName, &node); err == nil {
+		res, err := c.reconcileNode(ctx, &node)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile node %q: %w", req.NamespacedName, err)
+		}
+		return res, nil
+	} else if !apierrors.IsNotFound(err) {
+		errs = append(errs, fmt.Errorf("failed to get node %q: %w", req.NamespacedName, err))
+	}
+
+	if len(errs) == 0 {
+		errs = append(errs, fmt.Errorf("no upgrade or node found for %q", req.NamespacedName))
+	}
+
+	return ctrl.Result{}, errors.NewAggregate(errs)
+}
+
+// reconcileNode handles the reconciliation of a node resource.
+func (c *Controller) reconcileNode(ctx context.Context, node *corev1.Node) (ctrl.Result, error) {
+	vStr, ok := node.Annotations[version.NodeAnnotationKey]
+	if !ok {
+		c.logger.WithValues("node", node.Name).Info("Node does not have a version annotation, skipping reconciliation.")
+		return ctrl.Result{}, nil
+	}
+
+	var versionData version.Info
+	if err := versionData.Decode([]byte(vStr)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to decode version info for node %q: %w", node.Name, err)
+	}
+
+	c.logger.WithValues("node", node.Name, "version", versionData.Revision).Info("Reconciling node version.")
+
+	var upgrade upgradesv1alpha.Upgrade
+	if err := c.client.Get(ctx, ctrlclient.ObjectKey{
+		Name: upgradepkg.GetName(versionData),
+	}, &upgrade); err != nil && apierrors.IsNotFound(err) {
+		c.logger.WithValues("node", node.Name, "revision", versionData.Revision).Info("No upgrade found for revision, skipping reconciliation.")
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get upgrade for revision %q: %w", versionData.Revision, err)
+	}
+
+	if err := c.addToUpgradedNodes(ctx, &upgrade, node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to add node %q to upgraded nodes: %w", node.Name, err)
+	}
+
+	c.logger.WithValues("node", node.Name, "upgrade", upgrade.Name).Info("Node reconciled successfully.")
+
+	return ctrl.Result{}, nil
+}
+
+// reconcileUpgrade handles the reconciliation of an upgrade resource.
+func (c *Controller) reconcileUpgrade(ctx context.Context, upgrade *upgradesv1alpha.Upgrade) (ctrl.Result, error) {
 	c.logger.WithValues("upgrade", upgrade.Name, "phase", upgrade.Status.Phase).Info("Reconciling upgrade.")
 
-	switch {
-	case upgrade.Status.Phase == upgradesv1alpha.UpgradePhaseNodeUpgrade:
-		return c.reconcileNodeUpgrade(ctx, &upgrade)
-	case upgrade.Status.Phase == upgradesv1alpha.UpgradePhaseFeatureUpgrade:
-		return c.reconcileFeatureUpgrade(ctx, &upgrade)
+	switch upgrade.Status.Phase {
+	case upgradesv1alpha.UpgradePhaseNodeUpgrade:
+		return c.reconcileStatusNodeUpgrade(ctx, upgrade)
+	case upgradesv1alpha.UpgradePhaseFeatureUpgrade:
+		return c.reconcileStatusFeatureUpgrade(ctx, upgrade)
+	case upgradesv1alpha.UpgradePhaseCompleted:
+		c.logger.WithValues("upgrade", upgrade.Name).Info("Upgrade completed.")
+	case upgradesv1alpha.UpgradePhaseFailed:
+		// TODO(Hue): (KU-3850) Include the failure reason (error) in the upgrade status.
+		c.logger.WithValues("upgrade", upgrade.Name).Error(nil, "Upgrade has failed.")
+		return ctrl.Result{}, fmt.Errorf("upgrade %q has failed", upgrade.Name)
 	}
 
 	return ctrl.Result{}, nil
 }
 
-// reconcileNodeUpgrade checks if all nodes have been upgraded.
+// reconcileStatusNodeUpgrade checks if all nodes have been upgraded.
 // If so, it transitions to the feature upgrade phase and notifies the feature controller.
-func (c *Controller) reconcileNodeUpgrade(ctx context.Context, upgrade *upgradesv1alpha.Upgrade) (ctrl.Result, error) {
+func (c *Controller) reconcileStatusNodeUpgrade(ctx context.Context, upgrade *upgradesv1alpha.Upgrade) (ctrl.Result, error) {
 	log := c.logger.WithValues("upgrade", upgrade.Name, "step", "node-upgrade")
 	log.Info("Checking if all nodes have been upgraded.")
 
@@ -78,9 +144,9 @@ func (c *Controller) reconcileNodeUpgrade(ctx context.Context, upgrade *upgrades
 	return ctrl.Result{}, nil
 }
 
-// reconcileFeatureUpgrade triggers feature controllers to reconcile
+// reconcileStatusFeatureUpgrade triggers feature controllers to reconcile
 // and waits for them to finish.
-func (c *Controller) reconcileFeatureUpgrade(ctx context.Context, upgrade *upgradesv1alpha.Upgrade) (ctrl.Result, error) {
+func (c *Controller) reconcileStatusFeatureUpgrade(ctx context.Context, upgrade *upgradesv1alpha.Upgrade) (ctrl.Result, error) {
 	log := c.logger.WithValues("upgrade", upgrade.Name, "step", "feature-upgrade")
 
 	log.Info("Waiting for feature controllers to be ready.")
@@ -108,19 +174,12 @@ func (c *Controller) reconcileFeatureUpgrade(ctx context.Context, upgrade *upgra
 func (c *Controller) allNodesUpgraded(ctx context.Context, upgradedNodes []string) (bool, error) {
 	log := c.logger.WithValues("step", "all-nodes-upgraded")
 
-	leader, err := c.getState().Leader()
-	if err != nil {
-		return false, fmt.Errorf("failed to get leader client: %w", err)
-	}
-
-	clusterMembers, err := leader.GetClusterMembers(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to get cluster members: %w", err)
-	}
-
-	if len(upgradedNodes) < len(clusterMembers) {
-		log.Info("Not all nodes have been upgraded.", "clusterMembers", len(clusterMembers), "upgradedNodes", len(upgradedNodes))
-		return false, nil
+	// NOTE(Hue): Can Microcluster member name be different from the Kubernetes node name?
+	// Yes, but we secretly rely on the fact that they are the same.
+	// (KU-3749) This should be fixed in the future.
+	nodeList := &corev1.NodeList{}
+	if err := c.client.List(ctx, nodeList); err != nil {
+		return false, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
 	upgradedNodesMap := make(map[string]struct{})
@@ -128,14 +187,16 @@ func (c *Controller) allNodesUpgraded(ctx context.Context, upgradedNodes []strin
 		upgradedNodesMap[n] = struct{}{}
 	}
 
-	// NOTE(Hue): We only need to make sure all the nodes that are part of the cluster
-	// are upgraded. Don't care about upgraded nodes that are not part of the cluster.
-	// Maybe they've left, are removed, etc.
-	for _, member := range clusterMembers {
-		if _, ok := upgradedNodesMap[member.Name]; !ok {
-			log.Info(fmt.Sprintf("Cluster member %q is not upgraded", member.Name), "member_name", member.Name)
-			return false, nil
+	oldNodes := []string{}
+	for _, node := range nodeList.Items {
+		if _, ok := upgradedNodesMap[node.Name]; !ok {
+			oldNodes = append(oldNodes, node.Name)
 		}
+	}
+
+	if len(oldNodes) > 0 {
+		log.Info("Some nodes are not upgraded yet", "oldNodes", oldNodes)
+		return false, nil
 	}
 
 	return true, nil
@@ -166,6 +227,22 @@ func (c *Controller) waitForFeatureReconciliations(ctx context.Context, log logr
 func (c *Controller) transitionTo(ctx context.Context, upgrade *upgradesv1alpha.Upgrade, phase upgradesv1alpha.UpgradePhase) error {
 	p := ctrlclient.MergeFrom(upgrade.DeepCopy())
 	upgrade.Status.Phase = phase
+	if err := c.client.Status().Patch(ctx, upgrade, p); err != nil {
+		return fmt.Errorf("failed to patch: %w", err)
+	}
+	return nil
+}
+
+// addToUpgradedNodes adds the given node to the list of upgraded nodes in the upgrade resource.
+func (c *Controller) addToUpgradedNodes(ctx context.Context, upgrade *upgradesv1alpha.Upgrade, node *corev1.Node) error {
+	var p ctrlclient.Patch
+	if !slices.Contains(upgrade.Status.UpgradedNodes, node.Name) {
+		p = ctrlclient.MergeFrom(upgrade.DeepCopy())
+		upgrade.Status.UpgradedNodes = append(upgrade.Status.UpgradedNodes, node.Name)
+	} else {
+		c.logger.WithValues("node", node.Name, "upgrade", upgrade.Name).Info("Node already in upgraded nodes list, skipping.")
+		return nil
+	}
 	if err := c.client.Status().Patch(ctx, upgrade, p); err != nil {
 		return fmt.Errorf("failed to patch: %w", err)
 	}

--- a/src/k8s/pkg/upgrade/upgrade.go
+++ b/src/k8s/pkg/upgrade/upgrade.go
@@ -1,0 +1,12 @@
+package upgrade
+
+import (
+	"fmt"
+
+	"github.com/canonical/k8s/pkg/version"
+)
+
+// GetName returns the name of the upgrade resource based on the version info.
+func GetName(v version.Info) string {
+	return fmt.Sprintf("cluster-upgrade-to-rev-%s", v.Revision)
+}

--- a/src/k8s/pkg/version/version.go
+++ b/src/k8s/pkg/version/version.go
@@ -1,0 +1,42 @@
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	// NodeAnnotationKey is the key used for the node annotation that stores the k8s snap version.
+	NodeAnnotationKey = "k8sd.io/version"
+)
+
+// Info represents the version info of the k8s snap.
+type Info struct {
+	// Revision is the revision of the k8s snap.
+	Revision string `json:"revision"`
+
+	// NOTE(Hue): Future k8s version info can be added here.
+}
+
+// Encode encodes the version info into a byte slice.
+func (d *Info) Encode() ([]byte, error) {
+	b, err := json.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal version info: %w", err)
+	}
+	return b, nil
+}
+
+// Decode decodes the version info from the given byte slice.
+func (d *Info) Decode(data []byte) error {
+	if d == nil {
+		return fmt.Errorf("version info cannot be nil, initialize it before decoding")
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("data cannot be empty")
+	}
+	if err := json.Unmarshal(data, d); err != nil {
+		return fmt.Errorf("failed to unmarshal version info: %w", err)
+	}
+	return nil
+}

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -270,7 +270,7 @@ def test_version_downgrades_with_rollback(
     LOG.info("Rollback test complete. All downgrade segments verified.")
 
 
-@pytest.mark.node_count(3)
+@pytest.mark.node_count(4)
 @pytest.mark.no_setup()
 @pytest.mark.tags(tags.NIGHTLY)
 @pytest.mark.skipif(
@@ -291,21 +291,27 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
     """
 
     start_branch = util.previous_track(config.SNAP)
-    main = instances[0]
+    bootstrap_cp = instances[0]
+    worker = instances[-1]
 
     for instance in instances:
         instance.exec(f"snap install k8s --classic --channel={start_branch}".split())
 
-    main.exec(["k8s", "bootstrap"])
-    for instance in instances[1:]:
-        token = util.get_join_token(main, instance)
+    bootstrap_cp.exec(["k8s", "bootstrap"])
+    for instance in instances:
+        if instance.id in [bootstrap_cp.id, worker.id]:
+            continue
+        token = util.get_join_token(bootstrap_cp, instance)
         instance.exec(["k8s", "join-cluster", token])
+
+    token = util.get_join_token(bootstrap_cp, worker, "--worker")
+    worker.exec(["k8s", "join-cluster", token])
 
     # Get initial helm releases to track if they are updated correctly.
     initial_releases = {
         release["name"]: release
         for release in json.loads(
-            main.exec(
+            bootstrap_cp.exec(
                 [
                     "/snap/k8s/current/bin/helm",
                     "--kubeconfig",
@@ -322,9 +328,12 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
         )
     }
 
-    # Refresh each node after each other and verify that the upgrade CR is updated correctly.
+    # Refresh each CP node after each other and verify that the upgrade CR is updated correctly.
     for idx, instance in enumerate(instances):
         util.setup_k8s_snap(instance, tmp_path, config.SNAP)
+
+        if instance.id == worker.id:
+            continue
 
         # The crd will be created once the node is up and ready, so we might need to wait for it.
         expected_instances = [instance.id for instance in instances[: idx + 1]]
@@ -344,84 +353,89 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
             text=True,
         ).stdout
 
-        if idx == len(instances) - 1:
-            assert phase in [
-                "FeatureUpgrade",
-                "Completed",
-            ], f"Right after the last upgrade, expected phase to be FeatureUpgrade or Complete but got {phase}"
+        assert (
+            phase == "NodeUpgrade"
+        ), f"While upgrading, expected phase to be NodeUpgrade but got {phase}"
 
-            # TODO(ben): Check that new fields are set in the feature config.
-            # TODO(ben): Check that connectivity (e.g. for gateway) is working during the upgrade.
+        current_helm_releases = instance.exec(
+            [
+                "/snap/k8s/current/bin/helm",
+                "--kubeconfig",
+                "/etc/kubernetes/admin.conf",
+                "list",
+                "-n",
+                "kube-system",
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+        ).stdout
 
-            util.stubbornly(retries=15, delay_s=5).on(instance).until(
-                lambda p: p.stdout == "Completed",
-            ).exec(
-                "k8s kubectl get upgrade -o=jsonpath={.items[0].status.phase}".split(),
-                capture_output=True,
-                text=True,
-            )
-
-            p = instance.exec(
-                [
-                    "/snap/k8s/current/bin/helm",
-                    "--kubeconfig",
-                    "/etc/kubernetes/admin.conf",
-                    "list",
-                    "-n",
-                    "kube-system",
-                    "-o",
-                    "json",
-                ],
-                capture_output=True,
-                text=True,
-            )
-
-            current_releases = json.loads(p.stdout)
-            for name, initial_rel in initial_releases.items():
-                new_rel = None
-                for r in current_releases:
-                    if r["name"] == name:
-                        new_rel = r
-                        break
-                assert new_rel, f"Release {name} not in helm output"
-                if initial_rel["updated"] == new_rel["updated"]:
-                    LOG.warning(
-                        "Release %s was not updated during upgrade. "
-                        "This might be due to a skipped helm apply due to same values or chart versions",
-                        name,
-                    )
-
-        else:
+        for release in json.loads(current_helm_releases):
+            LOG.info(json.dumps(json.loads(current_helm_releases), indent=2))
+            LOG.info("Checking helm release %s", release["name"])
+            name = release["name"]
             assert (
-                phase == "NodeUpgrade"
-            ), f"While upgrading, expected phase to be NodeUpgrade but got {phase}"
+                release["updated"] == initial_releases[name]["updated"]
+            ), f"{release['name']} was updated while upgrading {instance.id} but should not \
+                have been ({initial_releases[name]['updated']}, {release['updated']})"
 
-            current_helm_releases = instance.exec(
-                [
-                    "/snap/k8s/current/bin/helm",
-                    "--kubeconfig",
-                    "/etc/kubernetes/admin.conf",
-                    "list",
-                    "-n",
-                    "kube-system",
-                    "-o",
-                    "json",
-                ],
-                capture_output=True,
-                text=True,
-            ).stdout
+    # perform the final upgrade on the worker node.
+    util.setup_k8s_snap(worker, tmp_path, config.SNAP)
 
-            for release in json.loads(current_helm_releases):
-                LOG.info(json.dumps(json.loads(current_helm_releases), indent=2))
-                LOG.info("Checking helm release %s", release["name"])
-                name = release["name"]
-                assert (
-                    release["updated"] == initial_releases[name]["updated"]
-                ), f"{release['name']} was updated while upgrading {instance.id} but should not \
-                    have been ({initial_releases[name]['updated']}, {release['updated']})"
+    expected_instances = [instance.id for instance in instances]
+    util.stubbornly(retries=15, delay_s=5).on(bootstrap_cp).until(
+        lambda p: _waiting_for_upgraded_nodes(json.loads(p.stdout), expected_instances),
+    ).exec(
+        "k8s kubectl get upgrade -o=jsonpath={.items[0].status.upgradedNodes}".split(),
+        capture_output=True,
+        text=True,
+    )
+
+    # TODO(ben): Check that new fields are set in the feature config.
+    # TODO(ben): Check that connectivity (e.g. for gateway) is working during the upgrade.
+
+    util.stubbornly(retries=15, delay_s=5).on(bootstrap_cp).until(
+        lambda p: p.stdout == "Completed",
+    ).exec(
+        "k8s kubectl get upgrade -o=jsonpath={.items[0].status.phase}".split(),
+        capture_output=True,
+        text=True,
+    )
+
+    p = bootstrap_cp.exec(
+        [
+            "/snap/k8s/current/bin/helm",
+            "--kubeconfig",
+            "/etc/kubernetes/admin.conf",
+            "list",
+            "-n",
+            "kube-system",
+            "-o",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    current_releases = json.loads(p.stdout)
+    for name, initial_rel in initial_releases.items():
+        new_rel = None
+        for r in current_releases:
+            if r["name"] == name:
+                new_rel = r
+                break
+        assert new_rel, f"Release {name} not in helm output"
+        if initial_rel["updated"] == new_rel["updated"]:
+            LOG.warning(
+                "Release %s was not updated during upgrade. "
+                "This might be due to a skipped helm apply due to same values or chart versions",
+                name,
+            )
 
 
-def _waiting_for_upgraded_nodes(upgraded_nodes, expected_nodes) -> True:
+def _waiting_for_upgraded_nodes(upgraded_nodes, expected_nodes) -> bool:
     LOG.info("Waiting for upgraded nodes %s to be: %s", upgraded_nodes, expected_nodes)
     return set(upgraded_nodes) == set(expected_nodes)
 


### PR DESCRIPTION
### Overview

This PR implements a way to wait for the worker nodes in the upgrade process as well, before triggering the feature controllers.

### Implementation
We've introduced a `version.Data` struct that contains all the necessary information about the current version of the installed k8s-snap. The node label controller is responsible for annotating the node with this struct.
The upgrade controller will watch for this annotation and add the node name to the list of `upgradedNodes`.
Once all the nodes (including workers) are available in the `upgradedNodes` list, the upgrade controller will transition the upgrade phase from `NodeUpgrade` to `FeatureUpgrade`, triggering the feature controllers and proceeding with the upgrade.