### PR TITLE
docs: Add patch notices for latest snap 

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -367,6 +367,7 @@ no_proxy
 NodeInternalIP
 NodePort
 NodeRestriction
+NodeStatus
 nohz
 Nota
 NUMA
@@ -477,6 +478,7 @@ Spark
 Spark History Server
 Spark Job
 Spark Submit
+SQLite
 Squashfs
 SR-IOV
 src

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -93,7 +93,7 @@ controller and passing the correct context to NodeStatus call in
 [#1494](https://github.com/canonical/k8s-snap/pull/1494)
 - Remove printing k8s binary outputs in CLI
 [#1547](https://github.com/canonical/k8s-snap/pull/1547)
-- Link dqlite against the SQLite we build to fix snap build issue
+- Link Dqlite against the SQLite we build to fix snap build issue
 [#1525](https://github.com/canonical/k8s-snap/pull/1525)
 - Use Pebble for k8s snap revision during upgrades
 [#1431](https://github.com/canonical/k8s-snap/pull/1431)

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -65,6 +65,54 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Jun 25, 2025
+
+- Add steps to configure a custom registry with containerd override_path in our
+docs [#1601](https://github.com/canonical/k8s-snap/pull/1601)
+- Ask the user about removing cilium VXLAN interface
+[#1597](https://github.com/canonical/k8s-snap/pull/1597)
+- Update Kubernetes version to v1.32.6
+[#1596](https://github.com/canonical/k8s-snap/pull/1596)
+- Add retry to get_join_token helper
+[#1581](https://github.com/canonical/k8s-snap/pull/1581)
+- Wait for the load balancer to be deployed in load balancer test
+[#1579](https://github.com/canonical/k8s-snap/pull/1579)
+- Consider user provided values before deciding helm values changes
+[#1568](https://github.com/canonical/k8s-snap/pull/1568)
+- Add snap patch notice for 1.32.5
+[#1550](https://github.com/canonical/k8s-snap/pull/1550)
+- Bump k8s-dqlite to v1.3.2
+[#1559](https://github.com/canonical/k8s-snap/pull/1559)
+- Remove docs spelling checks temporarily
+[#1552](https://github.com/canonical/k8s-snap/pull/1552)
+- Address `test_loadbalancer` flakiness
+[#1515](https://github.com/canonical/k8s-snap/pull/1515)
+- Reduce API server calls by
+updating Helm configuration during upgrade, updating the upgrade controller
+logic, adding max retry attempts to the feature controller and passing the
+correct context to NodeStatus call in
+[#1494](https://github.com/canonical/k8s-snap/pull/1494)
+- Remove printing k8s binary outputs in CLI
+[#1547](https://github.com/canonical/k8s-snap/pull/1547)
+- Link dqlite against the SQLite we build to fix snap build issue
+[#1525](https://github.com/canonical/k8s-snap/pull/1525)
+- Use pebble for k8s snap revision during upgrades
+[#1431](https://github.com/canonical/k8s-snap/pull/1431)
+- Increase the timeouts for populating resource caches
+[#1505](https://github.com/canonical/k8s-snap/pull/1505)
+- Fix annotation test to keep k8s-dqlite in sync
+[#1536](https://github.com/canonical/k8s-snap/pull/1536)
+- Patch upgrade status object
+[#1436](https://github.com/canonical/k8s-snap/pull/1436)
+- Address test_clustering flakiness
+[#1522](https://github.com/canonical/k8s-snap/pull/1522)
+- Fix issue in test_disable_separate_feature_upgrades
+[#1518](https://github.com/canonical/k8s-snap/pull/1518)
+- Handle cleanup of custom containerd path
+[#1497](https://github.com/canonical/k8s-snap/pull/1497)
+- Disable feature and update controllers
+[#1490](https://github.com/canonical/k8s-snap/pull/1490)
+
 Jun 5, 2025
 
 - Revert Cilium 1.17 upgrade due to compatibility issues
@@ -445,7 +493,6 @@ Jan 16, 2025
 [#913](https://github.com/canonical/k8s-snap/pull/913) and
 [#928](https://github.com/canonical/k8s-snap/pull/928)
 
-
 ## Contributors
 
 Many thanks to [@neoaggelos], [@bschimke95], [@evilnick],
@@ -456,8 +503,7 @@ Many thanks to [@neoaggelos], [@bschimke95], [@evilnick],
 
 <!-- LINKS -->
 [LTS release]: https://canonical.com/blog/12-year-lts-for-kubernetes
-[Installation guides]: ../../howto/install/index
-[tutorial]: ../../tutorial/getting-started
+[Installation guides]: /snap/howto/install/index
 [here]: https://kubernetes.io/blog/2024/12/11/kubernetes-v1-32-release/
 [upstream-changelog-1.32]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation
 

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -54,7 +54,7 @@ Kubernetes 1.32, please see the relevant sections of the
 ## Fixed bugs and issues
 
 - Fixed nightly tests ([#876])
-- Fixed containerd pebble path ([#874])
+- Fixed containerd Pebble path ([#874])
 - Fixed MicroK8s snap check ([#861])
 - Set default k8s snap track for registry in integration tests ([#852])
 - Fixed cilium ingress, refactor string literals ([#848])
@@ -67,19 +67,19 @@ Kubernetes 1.32, please see the relevant sections of the
 
 Jun 25, 2025
 
-- Add steps to configure a custom registry with containerd override_path in our
-docs [#1601](https://github.com/canonical/k8s-snap/pull/1601)
-- Ask the user about removing cilium VXLAN interface
+- Add steps to configure a custom registry with containerd `override_path` in
+our docs [#1601](https://github.com/canonical/k8s-snap/pull/1601)
+- Ask the user about removing Cilium VXLAN interface
 [#1597](https://github.com/canonical/k8s-snap/pull/1597)
 - Update Kubernetes version to v1.32.6
 [#1596](https://github.com/canonical/k8s-snap/pull/1596)
-- Add retry to get_join_token helper
+- Add retry to `get_join_token` helper
 [#1581](https://github.com/canonical/k8s-snap/pull/1581)
 - Wait for the load balancer to be deployed in load balancer test
 [#1579](https://github.com/canonical/k8s-snap/pull/1579)
-- Consider user provided values before deciding helm values changes
+- Consider user provided values before deciding Helm values changes
 [#1568](https://github.com/canonical/k8s-snap/pull/1568)
-- Add snap patch notice for 1.32.5
+- Add snap patch notices for 1.32.5
 [#1550](https://github.com/canonical/k8s-snap/pull/1550)
 - Bump k8s-dqlite to v1.3.2
 [#1559](https://github.com/canonical/k8s-snap/pull/1559)
@@ -87,16 +87,15 @@ docs [#1601](https://github.com/canonical/k8s-snap/pull/1601)
 [#1552](https://github.com/canonical/k8s-snap/pull/1552)
 - Address `test_loadbalancer` flakiness
 [#1515](https://github.com/canonical/k8s-snap/pull/1515)
-- Reduce API server calls by
-updating Helm configuration during upgrade, updating the upgrade controller
-logic, adding max retry attempts to the feature controller and passing the
-correct context to NodeStatus call in
+- Reduce API server calls by updating Helm configuration during upgrade,
+updating the upgrade controller logic, adding max retry attempts to the feature
+controller and passing the correct context to NodeStatus call in
 [#1494](https://github.com/canonical/k8s-snap/pull/1494)
 - Remove printing k8s binary outputs in CLI
 [#1547](https://github.com/canonical/k8s-snap/pull/1547)
 - Link dqlite against the SQLite we build to fix snap build issue
 [#1525](https://github.com/canonical/k8s-snap/pull/1525)
-- Use pebble for k8s snap revision during upgrades
+- Use Pebble for k8s snap revision during upgrades
 [#1431](https://github.com/canonical/k8s-snap/pull/1431)
 - Increase the timeouts for populating resource caches
 [#1505](https://github.com/canonical/k8s-snap/pull/1505)
@@ -104,13 +103,13 @@ correct context to NodeStatus call in
 [#1536](https://github.com/canonical/k8s-snap/pull/1536)
 - Patch upgrade status object
 [#1436](https://github.com/canonical/k8s-snap/pull/1436)
-- Address test_clustering flakiness
+- Address `test_clustering` flakiness
 [#1522](https://github.com/canonical/k8s-snap/pull/1522)
-- Fix issue in test_disable_separate_feature_upgrades
+- Fix issue in `test_disable_separate_feature_upgrades`
 [#1518](https://github.com/canonical/k8s-snap/pull/1518)
 - Handle cleanup of custom containerd path
 [#1497](https://github.com/canonical/k8s-snap/pull/1497)
-- Disable feature and update controllers
+- Disable feature and update controllers temporarily
 [#1490](https://github.com/canonical/k8s-snap/pull/1490)
 
 Jun 5, 2025


### PR DESCRIPTION
## Description

We must keep our release notes up to date

## Solution

Patch notices foe the snap updated for K8s version 1.32.6

## Issue

N/A

## Backport

1.32, 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
