### PR TITLE
fix: wait k8s-dqlite ready

### DIFF
--- a/src/k8s/pkg/k8sd/app/cluster_util.go
+++ b/src/k8s/pkg/k8sd/app/cluster_util.go
@@ -3,19 +3,28 @@ package app
 import (
 	"context"
 	"fmt"
+	"path"
+	"time"
 
+	"github.com/canonical/k8s/pkg/client/dqlite"
 	"github.com/canonical/k8s/pkg/k8sd/setup"
+	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
 	snaputil "github.com/canonical/k8s/pkg/snap/util"
 )
 
-func startControlPlaneServices(ctx context.Context, snap snap.Snap, datastore string) error {
+func startControlPlaneServices(ctx context.Context, snap snap.Snap, datastore string, nodeAdress string) error {
 	// Start services
 	switch datastore {
 	case "k8s-dqlite":
 		if err := snaputil.StartK8sDqliteServices(ctx, snap); err != nil {
 			return fmt.Errorf("failed to start k8s-dqlite services: %w", err)
 		}
+
+		if err := waitK8sDqliteReady(ctx, snap, nodeAdress); err != nil {
+			return fmt.Errorf("failed to ensure that the node joined the cluster: %w", err)
+		}
+
 	case "etcd":
 		if err := snaputil.StartEtcdServices(ctx, snap); err != nil {
 			return fmt.Errorf("failed to start etcd services: %w", err)
@@ -44,4 +53,49 @@ func waitApiServerReady(ctx context.Context, snap snap.Snap) error {
 	}
 
 	return nil
+}
+
+// waitK8sDqliteReady waits until the joining node is reflected as a cluster member by the k8s-qlite leader.
+func waitK8sDqliteReady(ctx context.Context, snap snap.Snap, nodeAddress string) error {
+	log := log.FromContext(ctx)
+	log.Info("waiting for k8s-dqlite to be ready", "nodeAddress", nodeAddress)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+			// Create a dqlite client to check cluster membership
+			clusterYamlPath := path.Join(snap.K8sDqliteStateDir(), "cluster.yaml")
+			clusterCertPath := path.Join(snap.K8sDqliteStateDir(), "cluster.crt")
+			clusterKeyPath := path.Join(snap.K8sDqliteStateDir(), "cluster.key")
+
+			client, err := dqlite.NewClient(ctx, dqlite.ClientOpts{
+				ClusterYAML: clusterYamlPath,
+				ClusterCert: clusterCertPath,
+				ClusterKey:  clusterKeyPath,
+			})
+			if err != nil {
+				log.Info("failed to create dqlite client, retrying", "error", err)
+				continue
+			}
+
+			// Get cluster members from the dqlite leader
+			members, err := client.ListMembers(ctx)
+			if err != nil {
+				log.Info("failed to get dqlite cluster members, retrying", "error", err)
+				continue
+			}
+
+			// Check if the current node is present in the cluster
+			for _, member := range members {
+				if member.Address == nodeAddress {
+					log.Info("node found in k8s-dqlite cluster", "nodeAddress", nodeAddress, "role", member.Role)
+					return nil
+				}
+			}
+
+			log.Info("node not yet found in k8s-dqlite cluster, retrying", "nodeAddress", nodeAddress)
+		}
+	}
 }

--- a/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
+++ b/src/k8s/pkg/k8sd/app/hooks_bootstrap.go
@@ -546,8 +546,9 @@ func (a *App) onBootstrapControlPlane(ctx context.Context, s state.State, bootst
 	// Start services
 	// This may fail if the node controllers try to restart the services at the same time, hence the retry.
 	log.Info("Starting control-plane services")
+	nodeAddress := fmt.Sprintf("%s:%d", utils.ToIPString(nodeIP), cfg.Datastore.GetK8sDqlitePort())
 	if err := control.RetryFor(ctx, 5, 5*time.Second, func() error {
-		if err := startControlPlaneServices(ctx, snap, cfg.Datastore.GetType()); err != nil {
+		if err := startControlPlaneServices(ctx, snap, cfg.Datastore.GetType(), nodeAddress); err != nil {
 			return fmt.Errorf("failed to start services: %w", err)
 		}
 		return nil

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -297,8 +297,9 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 	// Start services
 	// This may fail if the node controllers try to restart the services at the same time, hence the retry.
 	log.Info("Starting control-plane services")
+	nodeAddress := fmt.Sprintf("%s:%d", utils.ToIPString(nodeIP), cfg.Datastore.GetK8sDqlitePort())
 	if err := control.RetryFor(ctx, 5, 5*time.Second, func() error {
-		if err := startControlPlaneServices(ctx, snap, cfg.Datastore.GetType()); err != nil {
+		if err := startControlPlaneServices(ctx, snap, cfg.Datastore.GetType(), nodeAddress); err != nil {
 			return fmt.Errorf("failed to start services: %w", err)
 		}
 		return nil


### PR DESCRIPTION
## Description

This PR adds a wait on k8s-dqlite DB to be ready. The bootstrap/join command should only return when the leader of k8s-dqlite has recognized the new node as a cluster member.


## Issue

NA

## Backport

NA

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
