### PR TITLE
Backport 1.33 fix charm e2e

### DIFF
--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -41,8 +41,8 @@ jobs:
           artifact: ${{ inputs.artifact }}
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.3
-      - name: Install tox
-        run: sudo apt-get install -y tox
+      - name: Install virtualenv
+        run: sudo apt install -y python3.10-venv
       - name: Generate snap tarball
         run: |
           mkdir snap_installation
@@ -99,9 +99,12 @@ jobs:
           ls -lh $snapInstallRes
 
           cd k8s-operator
-          sudo --user "$USER" --preserve-env --preserve-env=PATH \
-            -- env -- \
-            tox -e integration \
+
+          python3 -m venv env
+          source env/bin/activate
+          pip install tox
+
+          tox -r -e integration \
             -- \
             --charm-file $k8sCharmFile \
             --charm-file $k8sWorkerChamFile \

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: canonical/k8s-operator
-          ref: main
+          ref: ${{ github.base_ref || github.ref_name }}
           path: k8s-operator
       - name: Disable lxd ipv6
         run: |


### PR DESCRIPTION
### Overview

This PR backports https://github.com/canonical/k8s-snap/pull/1659 to `release-1.33`. Automatic backport was not possible due to conflicts.