### PR TITLE
ci(upgrades_test): Retry getting the latest release to avoid 503 error

### DIFF
--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -3,6 +3,7 @@
 #
 import json
 import logging
+import time
 from pathlib import Path
 from typing import List
 
@@ -296,7 +297,18 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
     The test will also verify that the feature version is not upgraded until all nodes are upgraded.
     """
 
-    start_branch = util.previous_track(config.SNAP)
+    for _ in range(10):
+        try:
+            start_branch = util.previous_track(config.SNAP)
+            break
+        except Exception as e:
+            LOG.warning(
+                "Failed to get previous track of snap %s: %s. Retrying...",
+                config.SNAP,
+                e,
+            )
+            time.sleep(5)
+
     main = instances[0]
 
     for instance in instances:


### PR DESCRIPTION
### Overview

In the `test_feature_upgrades`, we've been seeing two main failures:
1. **No upgrades resources getting created**
This was due to a Dqilte error and should be resolved as we've moved to Etcd.
```
error executing jsonpath "{.items[0].status.upgradedNodes}": Error executing template: array index out of bounds: index 0, length 0
```
In the `k8sd` logs:
```
Jul 11 00:18:58 k8s-integration-2-d990de k8s.k8sd[5996]: E0711 00:18:58.933958    5996 app/hooks_start.go:23] "Failed to mark node as ready" err="failed to execute onNodeReady hook: failed to run post-refresh hook: failed to perform post-upgrade: failed to create upgrade: rpc error: code = Unknown desc = exec (try: 500): database is locked" logger="k8sd"
```

2. **503 error while trying to get the latest k8s release from upstream**
```
urllib.error.HTTPError: HTTP Error 503: Timed out while waiting
```

This PR introduces a retry upon getting the previous track to address this flakiness.


### Backport

Should be backported to 1.32 and 1.33 to fix this issue there as well.