### PR TITLE
fix: adds python3-pip to build-deps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,7 @@ parts:
       - pkg-config
       - rsync
       - tcl
+      - python3-pip
 
   dqlite:
     after: [build-deps]


### PR DESCRIPTION
## Description
Launchpad builders do not have pip pre-installed, this makes sure python3-pip is installed which is required for etcd elf patching.

Related to #1649

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 