### PR TITLE
ci: Use Github token to authenticate GH requests in CI

### DIFF
--- a/.github/workflows/update-pre-release-branches.yaml
+++ b/.github/workflows/update-pre-release-branches.yaml
@@ -21,6 +21,8 @@ jobs:
     outputs:
       preRelease: ${{ steps.determine.outputs.preRelease }}
       branch: ${{ steps.determine.outputs.branch }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/build-scripts/k8s_release.py
+++ b/build-scripts/k8s_release.py
@@ -17,9 +17,12 @@ EXEC_TIMEOUT = 60
 LOG = logging.getLogger(__name__)
 
 
-def _url_get(url: str) -> str:
-    """Make a GET request to the given URL and return the response text."""
-    response = requests.get(url, timeout=5)
+def _url_get(url):
+    headers = {}
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    response = requests.get(url, headers=headers)
     response.raise_for_status()
     return response.text
 


### PR DESCRIPTION
We otherwise run into rate-limits, e.g. https://github.com/canonical/k8s-snap/actions/runs/16417613513/job/46387321621

