### PR TITLE
ci: Assign a category to the sarif uploads

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -64,6 +64,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "./.trivy/sarifs"
+          category: ${{ inputs.channel }}-${{ inputs.artifact }}-${{ inputs.checkout-ref }}-scan
       - name: Send vulnerability records
         if: ${{ inputs.upload-reports-to-jira == true }}
         uses: canonical/k8s-workflows/.github/actions/send-cve-reports@main


### PR DESCRIPTION
## Description

We run into https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

## Solution

This adds a specific category as explained in https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload/

## Backport

We need to backport this as we have the same workflow in the release branches