### PR TITLE
ci: Add tox-uv to charm test infra

### DIFF
--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -50,6 +50,12 @@ jobs:
           mkdir snap_installation
           mv ${{ steps.download-snap.outputs.snap-path }} snap_installation/k8s.snap
           tar cvzf snap_installation.tar.gz -C snap_installation/ .
+      - name: Setup Astral UV
+        uses: astral-sh/setup-uv@v6.4.1
+        with:
+          python-version: ${{ env.python-version }}
+      - name: Install tox with UV
+        run: uv tool install tox --with tox-uv
       - name: Install charmcraft, juju, juju-crashdump
         run: |
           sudo snap install charmcraft --classic

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -107,10 +107,6 @@ jobs:
 
           cd ${{ env.K8S_OPERATOR }}
 
-          python3 -m venv env
-          source env/bin/activate
-          pip install tox
-
           tox -r -e integration \
             -- \
             --charm-file $k8sCharmFile \


### PR DESCRIPTION
The charm tests introduced an dependency to uv that we need to ensure on the charm e2e test as well. https://github.com/canonical/k8s-snap/actions/runs/16438350077/job/46454442835?pr=1681
.

## Backport

Only to 1.33 since we don't have that test for 1.32.