### PR TITLE
feat: add etcd to pebble services

### DIFF
--- a/k8s/pebble/000-k8s.yaml
+++ b/k8s/pebble/000-k8s.yaml
@@ -16,6 +16,12 @@ services:
     startup: disabled
     before: [kube-apiserver]
 
+  etcd:
+    override: replace
+    command: bash -c "$SNAP/k8s/wrappers/services/etcd"
+    startup: disabled
+    before: [kube-apiserver]
+
   kube-apiserver:
     override: replace
     command: bash -c "$SNAP/k8s/wrappers/services/kube-apiserver"


### PR DESCRIPTION
## Description

Adds the missing etcd service definition to pebble for CAPI testing.


## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

