### PR TITLE
docs: Add node removal notice

### DIFF
--- a/docs/canonicalk8s/snap/explanation/high-availability.md
+++ b/docs/canonicalk8s/snap/explanation/high-availability.md
@@ -36,9 +36,11 @@ cluster state. Dqlite leverages the Raft consensus algorithm for leader
 election and voting, ensuring reliable data replication and failover
 capabilities. When a leader node fails, a new leader is elected seamlessly
 without administrative intervention. This mechanism allows the cluster to
-remain operational even in the event of node failures. More details on
+remain operational even in the event of node failures. 
+<!-- TODO: When Dqlite docs are back, uncomment this line
+More details on
 replication and leader elections can be found in
 the [dqlite replication documentation][Dqlite-replication].
-
+-->
 <!-- LINKS -->
-[Dqlite-replication]: https://dqlite.io/docs/explanation/replication
+<!-- [Dqlite-replication]: https://dqlite.io/docs/explanation/replication --> 

--- a/docs/canonicalk8s/snap/howto/install/uninstall.md
+++ b/docs/canonicalk8s/snap/howto/install/uninstall.md
@@ -6,13 +6,19 @@ snap from your system.
 ## Remove the node from the cluster
 
 ```{important}
-You must remove the node from the cluster **before** deleting the snap. Deleting the snap while node is part of the cluster can cause the node to enter an unreachable state.
+You must remove the node from the cluster **before** deleting the snap. Deleting the snap while the node is part of the cluster can cause the node to enter an unreachable state.
 ```
 
-From the control plane node:
+From any control plane node:
 
 ```
 sudo k8s remove-node <NODE_NAME>
+```
+
+Ensure the node has been removed from the cluster:
+
+```
+sudo k8s kubectl get nodes 
 ```
 
 ## Remove the k8s snap

--- a/docs/canonicalk8s/snap/howto/install/uninstall.md
+++ b/docs/canonicalk8s/snap/howto/install/uninstall.md
@@ -3,10 +3,21 @@
 This guide provides step-by-step instructions for removing the {{ product }}
 snap from your system.
 
+## Remove the node from the cluster
 
-## Removing the k8s snap
+```{important}
+You must remove the node from the cluster **before** deleting the snap. Deleting the snap while node is part of the cluster can cause the node to enter an unreachable state.
+```
 
-To uninstall the `k8s` snap, run the following command:
+From the control plane node:
+
+```
+sudo k8s remove-node <NODE_NAME>
+```
+
+## Remove the k8s snap
+
+Uninstall the `k8s` snap:
 
 ```
 sudo snap remove k8s

--- a/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
+++ b/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
@@ -119,7 +119,8 @@ Congratulations!
 
 It is important to clean-up your nodes before tearing down the VMs.
 
-```{note}  Purging a VM does not remove the node from your cluster. You must remove the nodes from the cluster before deleting the snap or VM.
+```{note}  Purging a VM does not remove the node from your cluster.
+You must remove the nodes from the cluster before deleting the snap or VM.
 ```
 
 Keep in mind the consequences of removing nodes:

--- a/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
+++ b/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
@@ -119,7 +119,7 @@ Congratulations!
 
 It is important to clean-up your nodes before tearing down the VMs.
 
-```{note}  Purging a VM does not remove the node from your cluster.
+```{note}  Purging a VM does not remove the node from your cluster. You must remove the nodes from the cluster before deleting the snap or VM.
 ```
 
 Keep in mind the consequences of removing nodes:


### PR DESCRIPTION
## Description

If you delete the snap before removing the node from the cluster, the node hangs and is unreachable in the cluster. 

## Solution

There is work planned to fix this, but for now adding a warning to our docs on the importance of removing the node first

## Issue

Reported on MM

## Backport

1.32, 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.