### PR TITLE
docs: update homepage docset descriptions

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -34,6 +34,7 @@ Anbox
 Anbox Cloud
 api
 APIs
+API's
 apiserver
 apparmor
 args

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -72,7 +72,7 @@ The `k8s` charms take care of installing, configuring and managing {{product}} o
 :link: capi/
 ### [Canonical Kubernetes and Cluster API ›](/capi/index)
 
-Using the declarative APIs and tooling provided by Cluster API, deploy and manage multiple {{product}} clusters.
+Using Cluster API's declarative tooling, deploy and manage multiple {{product}} clusters.
 ```
 
 ````

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -27,7 +27,7 @@ your needs. If you would like to jump straight in, head to the
 <!-- markdownlint-disable -->
 {{product}} can be deployed as a standalone snap, as a charm as part of a
 Juju cluster or with Cluster API. Find out more about which {{product}}
-installation method is best for your
+deployment method is best for your
 project's needs with
 **[choosing a {{product}} installation method.](/snap/explanation/installation-methods.md)**
 <!-- markdownlint-restore -->
@@ -52,30 +52,27 @@ Release notes </releases.md>
 
 ```
 
-````{grid} 1 1 1 1
+````{grid} 3
 
 ```{grid-item-card}
 :link: snap/
-### [Install with a snap ›](/snap/index)
+### [Canonical Kubernetes snap ›](/snap/index)
 
-Our tutorials, how-to guides and other pages will explain how to install,
- configure and use the {{product}} 'k8s' snap. If you are new to Kubernetes, start here.
+The `k8s` snap is a self-contained, secure and dependency-free Linux app package used to deploy and manage a {{product}} cluster. If you are new to Kubernetes, start here.
 ```
 
 ```{grid-item-card}
 :link: charm/
-### [Deploy with Juju ›](/charm/index)
+### [Canonical Kubernetes charms ›](/charm/index)
 
-Our tutorials, how-to guides and other pages will explain how to install,
- configure and use the {{product}} 'k8s' charm.
+The `k8s` charms take care of installing, configuring and managing {{product}} on cloud instances managed by Juju.
 ```
 
 ```{grid-item-card}
 :link: capi/
-### [Deploy with Cluster API ›](/capi/index)
+### [Canonical Kubernetes and Cluster API ›](/capi/index)
 
-Our tutorials, how-to guides and other pages will explain how to install,
- configure and use {{product}} through CAPI.
+Using the declarative APIs and tooling provided by Cluster API, deploy and manage multiple {{product}} clusters.
 ```
 
 ````

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -25,7 +25,7 @@ your needs. If you would like to jump straight in, head to the
 
 ## In this documentation
 <!-- markdownlint-disable -->
-{{product}} can be deployed as a standalone snap, as a charm as part of a
+{{product}} can be deployed and managed as a standalone snap, as a charm as part of a
 Juju cluster or with Cluster API. Find out more about which {{product}}
 deployment method is best for your
 project's needs with


### PR DESCRIPTION
## Description

We recently received some feedback on the layout and wording of our landing page could be misleading

## Solution

Place the three docs sets (snap,capi,charm) side by side to not insinuate order 
Reword the cards to actually have some relevant info

## Issue

N/A

## Backport

1.32, 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.