### PR TITLE
feat: Included managed-etcd service inspection

### DIFF
--- a/docs/canonicalk8s/snap/reference/inspection-reports.md
+++ b/docs/canonicalk8s/snap/reference/inspection-reports.md
@@ -35,6 +35,7 @@ The command output is similar to the following:
 Collecting service information
 Running inspection on a control-plane node
  INFO:  Service k8s.containerd is running
+ INFO:  Service k8s.etcd is not-running
  INFO:  Service k8s.kube-proxy is running
  INFO:  Service k8s.k8s-dqlite is running
  INFO:  Service k8s.k8sd is running

--- a/k8s/scripts/inspect.sh
+++ b/k8s/scripts/inspect.sh
@@ -293,7 +293,7 @@ mkdir -p "$INSPECT_DUMP"
 
 printf -- 'Collecting service information\n'
 
-control_plane_services=("k8s.containerd" "k8s.kube-proxy" "k8s.k8s-dqlite" "k8s.k8sd" "k8s.kube-apiserver" "k8s.kube-controller-manager" "k8s.kube-scheduler" "k8s.kubelet")
+control_plane_services=("k8s.containerd" "k8s.etcd" "k8s.kube-proxy" "k8s.k8s-dqlite" "k8s.k8sd" "k8s.kube-apiserver" "k8s.kube-controller-manager" "k8s.kube-scheduler" "k8s.kubelet")
 worker_services=("k8s.containerd" "k8s.k8s-apiserver-proxy" "k8s.kubelet" "k8s.k8sd" "k8s.kube-proxy")
 
 if is_worker_node; then


### PR DESCRIPTION
## Description

Add etcd service to inspection reports

## Solution

Adds another service to the list to be inspected

## Backport

* 1.32
* 1.33


## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.

No code changes needing unit/integration tests