### PR TITLE
docs: Replace k8s-dqlite with etcd

### DIFF
--- a/docs/canonicalk8s/.sphinx/.wordlist.txt
+++ b/docs/canonicalk8s/.sphinx/.wordlist.txt
@@ -61,6 +61,7 @@ UI
 UUID
 VM
 webhook
+WAL
 YAML
 
 AAM

--- a/docs/canonicalk8s/assets/arch.dsl
+++ b/docs/canonicalk8s/assets/arch.dsl
@@ -11,13 +11,13 @@ workspace "Canonical K8s Workspace" {
         storage = softwareSystem "Storage" "External storage, offered by the substrate (cloud). Could be replaced by any storage solution." "Extern"
         iam = softwareSystem "Identity Management System" "The external identity system, offered by the substrate (cloud). Could be replaced by any alternative system." "Extern"
         external_datastore = softwareSystem "External datastore" "etcd" "Extern"
-  
+
        k8s_snap = softwareSystem "K8s Snap Distribution" "The Kubernetes distribution in a snap" {
 
             kubectl = container "Kubectl" "kubectl client for accessing the cluster"
 
             kubernetes = container "Kubernetes Services" "API server, kubelet, kube-proxy, scheduler, kube-controller" {
-                systemd = component "systemd daemons" "Daemons holding the k8s services" 
+                systemd = component "systemd daemons" "Daemons holding the k8s services"
                 apiserver = component "API server"
                 kubelet = component "kubelet"
                 kube_proxy = component "kube-proxy"
@@ -42,7 +42,7 @@ workspace "Canonical K8s Workspace" {
 
             state = container "State" "Datastores holding the cluster state" {
                 k8sd_db = component "k8sd-dqlite" "MicroCluster DB"
-                k8s_dqlite = component "k8s-dqlite" "Datastore holding the K8s cluster state"
+                etcd = component "etcd" "Datastore holding the K8s cluster state"
             }
         }
 
@@ -55,7 +55,7 @@ workspace "Canonical K8s Workspace" {
         k8s_snap -> storage "Hosted workloads use storage"
         k8s_snap -> iam "Users identity is retrieved"
 
-        k8s_dqlite -> external_datastore "Stores cluster data" "" "Runtime"
+        etcd -> external_datastore "Stores cluster data" "" "Runtime"
         loadbalancer -> external_lb "Routes client requests" "" "Runtime"
 
         cluster_manager -> systemd "Configures"
@@ -87,7 +87,7 @@ workspace "Canonical K8s Workspace" {
     views {
 
         systemLandscape Overview "K8s Snap Overview" {
-          include * 
+          include *
           autoLayout
         }
 

--- a/docs/canonicalk8s/assets/example-bootstrap-config.yaml
+++ b/docs/canonicalk8s/assets/example-bootstrap-config.yaml
@@ -27,8 +27,9 @@ pod-cidr: 10.100.0.0/16
 service-cidr: 10.200.0.0/16
 disable-rbac: false
 secure-port: 6443
-k8s-dqlite-port: 9090
-datastore-type: k8s-dqlite
+etcd-port: 2390
+etcd-peer-port: 2391
+datastore-type: etcd
 extra-sans:
 - custom.kubernetes
 extra-node-config-files:
@@ -45,5 +46,5 @@ extra-node-kubelet-args:
   --authentication-token-webhook-cache-ttl: 3m
 extra-node-containerd-args:
   --log-level: debug
-extra-node-k8s-dqlite-args:
-  --watch-storage-available-size-interval: 6s
+extra-node-etcd-args:
+  --heartbeat-interval: 200ms

--- a/docs/canonicalk8s/assets/k8s-container.puml
+++ b/docs/canonicalk8s/assets/k8s-container.puml
@@ -19,7 +19,7 @@ System_Boundary("K8sSnapDistribution_boundary", "K8s Snap Distribution", $tags="
   Container(K8sSnapDistribution.K8sd, "K8sd", $techn="", $descr="Daemon implementing the features available in the k8s snap", $tags="", $link="")
   Container(K8sSnapDistribution.K8sddatastore, "Cluster Datastore", $techn="", $descr="Uses dqlite to store cluster configuration", $tags="", $link="")
   Container(K8sSnapDistribution.Kubectl, "Kubectl", $techn="", $descr="kubectl client for accessing the cluster", $tags="", $link="")
-  Container(K8sSnapDistribution.Kubernetesdatastore, "Kubernetes Datastore", $techn="", $descr="Uses etcd (or dqlite) to store cluster data", $tags="", $link="")
+  Container(K8sSnapDistribution.Kubernetesdatastore, "Kubernetes Datastore", $techn="", $descr="Uses etcd (or k8s-dqlite) to store cluster data", $tags="", $link="")
 }
 
 Rel(K8sAdmin, K8sSnapDistribution.K8sd, "Sets up and configures the cluster", $techn="", $tags="", $link="")

--- a/docs/canonicalk8s/assets/k8s-container.puml
+++ b/docs/canonicalk8s/assets/k8s-container.puml
@@ -19,7 +19,7 @@ System_Boundary("K8sSnapDistribution_boundary", "K8s Snap Distribution", $tags="
   Container(K8sSnapDistribution.K8sd, "K8sd", $techn="", $descr="Daemon implementing the features available in the k8s snap", $tags="", $link="")
   Container(K8sSnapDistribution.K8sddatastore, "Cluster Datastore", $techn="", $descr="Uses dqlite to store cluster configuration", $tags="", $link="")
   Container(K8sSnapDistribution.Kubectl, "Kubectl", $techn="", $descr="kubectl client for accessing the cluster", $tags="", $link="")
-  Container(K8sSnapDistribution.Kubernetesdatastore, "Kubernetes Datastore", $techn="", $descr="Uses etcd to store cluster data", $tags="", $link="")
+  Container(K8sSnapDistribution.Kubernetesdatastore, "Kubernetes Datastore", $techn="", $descr="Uses etcd (or dqlite) to store cluster data", $tags="", $link="")
 }
 
 Rel(K8sAdmin, K8sSnapDistribution.K8sd, "Sets up and configures the cluster", $techn="", $tags="", $link="")

--- a/docs/canonicalk8s/assets/k8s-container.puml
+++ b/docs/canonicalk8s/assets/k8s-container.puml
@@ -19,7 +19,7 @@ System_Boundary("K8sSnapDistribution_boundary", "K8s Snap Distribution", $tags="
   Container(K8sSnapDistribution.K8sd, "K8sd", $techn="", $descr="Daemon implementing the features available in the k8s snap", $tags="", $link="")
   Container(K8sSnapDistribution.K8sddatastore, "Cluster Datastore", $techn="", $descr="Uses dqlite to store cluster configuration", $tags="", $link="")
   Container(K8sSnapDistribution.Kubectl, "Kubectl", $techn="", $descr="kubectl client for accessing the cluster", $tags="", $link="")
-  Container(K8sSnapDistribution.Kubernetesdatastore, "Kubernetes Datastore", $techn="", $descr="Uses k8s-dqlite to store cluster data", $tags="", $link="")
+  Container(K8sSnapDistribution.Kubernetesdatastore, "Kubernetes Datastore", $techn="", $descr="Uses etcd to store cluster data", $tags="", $link="")
 }
 
 Rel(K8sAdmin, K8sSnapDistribution.K8sd, "Sets up and configures the cluster", $techn="", $tags="", $link="")

--- a/docs/canonicalk8s/assets/k8sd-component.puml
+++ b/docs/canonicalk8s/assets/k8sd-component.puml
@@ -13,7 +13,7 @@ Person(K8sAdmin, "K8s Admin", $descr="Responsible for the K8s cluster, has eleva
 Container(K8sSnapDistribution.Runtime, "Runtime", $techn="", $descr="Containerd and runc", $tags="", $link="")
 System(CharmK8s, "Charm K8s", $descr="Orchestrating the lifecycle management of K8s", $tags="", $link="")
 Container(K8sSnapDistribution.ClusterDatastore, "Cluster datastore", $techn="", $descr="Uses dqlite to store cluster configuration", $tags="", $link="")
-Container(K8sSnapDistribution.KubernetesDatastore, "Kubernetes datastore", $techn="", $descr="Uses k8s-dqlite or etcd to store cluster data", $tags="", $link="")
+Container(K8sSnapDistribution.KubernetesDatastore, "Kubernetes datastore", $techn="", $descr="Uses etcd or k8s-dqlite to store cluster data", $tags="", $link="")
 Container(K8sSnapDistribution.KubernetesCoreComponents, "Kubernetes Core Components", $techn="", $descr="API server, kubelet, kube-proxy, scheduler, kube-controller", $tags="", $link="")
 
 Container_Boundary("K8sSnapDistribution.K8sd_boundary", "K8sd", $tags="") {

--- a/docs/canonicalk8s/capi/howto/troubleshooting.md
+++ b/docs/canonicalk8s/capi/howto/troubleshooting.md
@@ -128,7 +128,7 @@ Services running only on the control-plane nodes:
 * `kube-apiserver`
 * `kube-controller-manager`
 * `kube-scheduler`
-* `k8s-dqlite`
+* `etcd`
 
 Services running only on the worker nodes:
 

--- a/docs/canonicalk8s/capi/reference/configs.md
+++ b/docs/canonicalk8s/capi/reference/configs.md
@@ -459,7 +459,7 @@ spec:
     datastoreServersSecretRef:
       name: sfName
       key: sfKey
-    k8sDqlitePort: 2379
+    etcdPort: 2379
     microclusterAddress: my.address
     microclusterPort: ":2380"
     extraKubeAPIServerArgs:

--- a/docs/canonicalk8s/capi/reference/configs.md
+++ b/docs/canonicalk8s/capi/reference/configs.md
@@ -223,13 +223,13 @@ spec:
 
 **Fields:**
 
-| Name                         | Type                | Description                                                   | Default |
-|------------------------------|---------------------|---------------------------------------------------------------|---------|
+| Name                         | Type                | Description                                                  | Default |
+|------------------------------|---------------------|--------------------------------------------------------------|---------|
 | `annotations`                | `map[string]string` | Are used to configure the behavior of the built-in features. | `nil`   |
-| `enableDefaultDNS`           | `bool`              | Specifies whether to enable the default DNS configuration.    | `true`  |
-| `enableDefaultLocalStorage`  | `bool`              | Specifies whether to enable the default local storage.        | `true`  |
-| `enableDefaultMetricsServer` | `bool`              | Specifies whether to enable the default metrics server.       | `true`  |
-| `enableDefaultNetwork`       | `bool`              | Specifies whether to enable the default CNI.                  | `true`  |
+| `enableDefaultDNS`           | `bool`              | Specifies whether to enable the default DNS configuration.   | `true`  |
+| `enableDefaultLocalStorage`  | `bool`              | Specifies whether to enable the default local storage.       | `true`  |
+| `enableDefaultMetricsServer` | `bool`              | Specifies whether to enable the default metrics server.      | `true`  |
+| `enableDefaultNetwork`       | `bool`              | Specifies whether to enable the default CNI.                 | `true`  |
 
 
 **Example usage:**
@@ -438,7 +438,7 @@ spec:
 | `nodeTaints`                | `[]string`                  | Taints to add to the control plane kubelet nodes.                                              | `[]`      |
 | `datastoreType`             | `string`                    | The type of datastore to use for the control plane.                                            | `""`      |
 | `datastoreServersSecretRef` | `struct{name:str, key:str}` | A reference to a secret containing the datastore servers.                                      | `{}`      |
-| `k8sDqlitePort`             | `int`                       | The port to use for k8s-dqlite. If unset, 2379 (etcd) will be used.                            | `2379`    |
+| `etcdPort`                  | `int`                       | The port to use for etcd. If unset, 2379 will be used.                                         | `2379`    |
 | `microclusterAddress`       | `string`                    | The address (or CIDR) to use for Microcluster. If unset, the default node interface is chosen. | `""`      |
 | `microclusterPort`          | `int`                       | The port to use for Microcluster. If unset, ":2380" (etcd peer) will be used.                  | `":2380"` |
 | `extraKubeAPIServerArgs`    | `map[string]string`         | Extra arguments to add to kube-apiserver.                                                      | `map[]`   |
@@ -453,7 +453,7 @@ spec:
     cloudProvider: external
     nodeTaints:
       - myTaint
-    datastoreType: k8s-dqlite
+    datastoreType: etcd
     datastoreServersSecretRef:
       name: sfName
       key: sfKey

--- a/docs/canonicalk8s/capi/reference/configs.md
+++ b/docs/canonicalk8s/capi/reference/configs.md
@@ -431,17 +431,19 @@ spec:
 
 **Fields:**
 
-| Name                        | Type                        | Description                                                                                    | Default   |
-|-----------------------------|-----------------------------|------------------------------------------------------------------------------------------------|-----------|
-| `extraSANs`                 | `[]string`                  | A list of SANs to include in the server certificates.                                          | `[]`      |
-| `cloudProvider`             | `string`                    | The cloud-provider configuration option to set.                                                | `""`      |
-| `nodeTaints`                | `[]string`                  | Taints to add to the control plane kubelet nodes.                                              | `[]`      |
-| `datastoreType`             | `string`                    | The type of datastore to use for the control plane.                                            | `""`      |
-| `datastoreServersSecretRef` | `struct{name:str, key:str}` | A reference to a secret containing the datastore servers.                                      | `{}`      |
-| `etcdPort`                  | `int`                       | The port to use for etcd. If unset, 2379 will be used.                                         | `2379`    |
-| `microclusterAddress`       | `string`                    | The address (or CIDR) to use for Microcluster. If unset, the default node interface is chosen. | `""`      |
-| `microclusterPort`          | `int`                       | The port to use for Microcluster. If unset, ":2380" (etcd peer) will be used.                  | `":2380"` |
-| `extraKubeAPIServerArgs`    | `map[string]string`         | Extra arguments to add to kube-apiserver.                                                      | `map[]`   |
+| Name                        | Type                        | Description                                                                                                      | Default   |
+|-----------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------|-----------|
+| `extraSANs`                 | `[]string`                  | A list of SANs to include in the server certificates.                                                            | `[]`      |
+| `cloudProvider`             | `string`                    | The cloud-provider configuration option to set.                                                                  | `""`      |
+| `nodeTaints`                | `[]string`                  | Taints to add to the control plane kubelet nodes.                                                                | `[]`      |
+| `datastoreType`             | `string`                    | The type of datastore to use for the control plane.                                                              | `""`      |
+| `datastoreServersSecretRef` | `struct{name:str, key:str}` | A reference to a secret containing the datastore servers.                                                        | `{}`      |
+| `etcdPort`                  | `int`                       | The port to use for etcd. If unset, 2379 will be used.                                                           | `2379`    |
+| `etcdPeerPort`              | `int`                       | The port to use for etcd peer communication. If unset, 2381 will be used.                                        | `2381`    |
+| `k8sDqlitePort`             | `int`                       | The port to use for k8s-dqlite. Requires `datastoreType` to be set to `k8s-dqlite`. If unset, 2379 will be used. | `2379`    |
+| `microclusterAddress`       | `string`                    | The address (or CIDR) to use for Microcluster. If unset, the default node interface is chosen.                   | `""`      |
+| `microclusterPort`          | `int`                       | The port to use for Microcluster. If unset, ":2380" (etcd peer) will be used.                                    | `":2380"` |
+| `extraKubeAPIServerArgs`    | `map[string]string`         | Extra arguments to add to kube-apiserver.                                                                        | `map[]`   |
 
 **Example usage:**
 

--- a/docs/canonicalk8s/charm/howto/etcd.md
+++ b/docs/canonicalk8s/charm/howto/etcd.md
@@ -1,9 +1,11 @@
-# How to integrate {{product}} with etcd
+# How to integrate {{product}} with external etcd
 
 Integrating [etcd][] with your {{product}} deployment provides a
 robust, distributed key-value store that is essential for storing critical
-data needed for Kubernetes' clustering operations. This guide will walk you
-through the process of deploying {{product}} with an external etcd
+data needed for Kubernetes' clustering operations. While {{product}} comes with etcd
+as the default datastore, it can be replaced by an externally-managed etcd to have more
+fine-grained control over the database cluster.
+This guide will walk you through the process of deploying {{product}} with an external etcd
 cluster.
 
 ## Prerequisites

--- a/docs/canonicalk8s/charm/howto/etcd.md
+++ b/docs/canonicalk8s/charm/howto/etcd.md
@@ -2,11 +2,11 @@
 
 Integrating [etcd][] with your {{product}} deployment provides a
 robust, distributed key-value store that is essential for storing critical
-data needed for Kubernetes' clustering operations. While {{product}} comes with etcd
-as the default datastore, it can be replaced by an externally-managed etcd to have more
-fine-grained control over the database cluster.
-This guide will walk you through the process of deploying {{product}} with an external etcd
-cluster.
+data needed for Kubernetes' clustering operations. While {{product}} comes
+with etcd as the default datastore, it can be replaced by an externally-managed
+etcd to have more fine-grained control over the database cluster.
+This guide will walk you through the process of deploying {{product}}
+with an external etcd cluster.
 
 ## Prerequisites
 

--- a/docs/canonicalk8s/charm/howto/install/install-custom.md
+++ b/docs/canonicalk8s/charm/howto/install/install-custom.md
@@ -20,7 +20,7 @@ options. Here's an example configuration, which for this guide we'll save as
 ```yaml
 k8s:
   # Specify the datastore type
-  bootstrap-datastore: dqlite
+  bootstrap-datastore: etcd
 
   # Configure pod and service CIDR ranges
   bootstrap-pod-cidr: "192.168.0.0/16"

--- a/docs/canonicalk8s/charm/howto/troubleshooting.md
+++ b/docs/canonicalk8s/charm/howto/troubleshooting.md
@@ -142,7 +142,7 @@ Services running only on the control-plane nodes:
 * `kube-apiserver`
 * `kube-controller-manager`
 * `kube-scheduler`
-* `k8s-dqlite`
+* `etcd`
 
 Services running only on the worker nodes:
 

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -141,8 +141,8 @@ and flexible {{product}} deployment managed through Juju.
 
 <!-- IMAGES -->
 
-[cluster1]: https://assets.ubuntu.com/v1/de97f360-snap10-04.svg
-[cluster2]: https://assets.ubuntu.com/v1/24ea67c0-k8sd10-04.svg
+[cluster1]: https://assets.ubuntu.com/v1/60234b03-snap-14-08.svg
+[cluster2]: https://assets.ubuntu.com/v1/b0ae732e-k8sd-13-08.svg
 [cluster4]: https://assets.ubuntu.com/v1/53a083a9-charms.svg
 [cluster5]: https://assets.ubuntu.com/v1/bcfe150f-overview.svg
 

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -43,9 +43,10 @@ allows integrations with alternative storage solutions.
 - **Identity management**: Out of the box the K8s snap offers credentials for
 an admin user. The admin user can complete the integration with any identity
 management system available or do user management manually.
-- **External datastore**: By default, Canonical Kubernetes uses etcd to keep track of
-state. However, users can choose to switch to k8s-dqlite or use an end client
- owned datastore installation such as the use of an external `etcd`.
+- **External datastore**: By default, Canonical Kubernetes uses etcd to
+keep track of state. However, users can choose to switch to k8s-dqlite or
+use an end client owned datastore installation such as the use of an
+external `etcd`.
 
 ## The k8s snap
 

--- a/docs/canonicalk8s/snap/explanation/architecture.md
+++ b/docs/canonicalk8s/snap/explanation/architecture.md
@@ -43,9 +43,9 @@ allows integrations with alternative storage solutions.
 - **Identity management**: Out of the box the K8s snap offers credentials for
 an admin user. The admin user can complete the integration with any identity
 management system available or do user management manually.
-- **External datastore**: By default, Kubernetes uses etcd to keep track of
-state. Our K8s snap comes with [Dqlite] as its datastore. However, we permit
-end client owned datastore installation such as the use of an external `etcd`.
+- **External datastore**: By default, Canonical Kubernetes uses etcd to keep track of
+state. However, users can choose to switch to k8s-dqlite or use an end client
+ owned datastore installation such as the use of an external `etcd`.
 
 ## The k8s snap
 
@@ -59,8 +59,8 @@ The `k8s` snap distribution includes the following:
 and drive the cluster operations.
 - **K8s core components**: These are all the Kubernetes services as well as core
 workloads built from upstream and shipped in the snap.
-- **Kubernetes datastore**: uses Dqlite to store data on the state of the
-cluster. It can be replaced by an external datastore.
+- **Kubernetes datastore**: uses etcd to store data on the state of the
+cluster. It can be replaced by [k8s-dqlite] or an external datastore.
 - **Cluster datastore**: uses Dqlite managed by [Microcluster] as a replicated
 database to store cluster configuration. It is used
 by `k8sd` in order to carry out the orchestration of the additional Kubernetes
@@ -151,5 +151,5 @@ and flexible {{product}} deployment managed through Juju.
 [K8s-Worker charm]:   https://charmhub.io/k8s-worker
 [Juju docs]:          https://juju.is/docs/juju
 [COS docs]:           https://ubuntu.com/observability
-[Dqlite]:             https://github.com/canonical/k8s-dqlite
+[k8s-dqlite]:             https://github.com/canonical/k8s-dqlite
 [Microcluster]:       https://github.com/canonical/microcluster

--- a/docs/canonicalk8s/snap/explanation/clustering.md
+++ b/docs/canonicalk8s/snap/explanation/clustering.md
@@ -48,7 +48,7 @@ plane node's components include:
 - **Controller Manager (kube-controller-manager)**: Runs controller processes
     that regulate the state of the cluster, ensuring the desired state matches
     the observed state.
-- **k8s-dqlite**: A fast, embedded, persistent in-memory key-value store with
+- **etcd**: A fast, embedded, persistent in-memory key-value store with
     Raft consensus used to store all cluster data.
 - **k8sd**: Implements and exposes the operations functionality needed for
     managing the Kubernetes cluster.

--- a/docs/canonicalk8s/snap/explanation/security/crypto.md
+++ b/docs/canonicalk8s/snap/explanation/security/crypto.md
@@ -13,7 +13,7 @@ robust protection for sensitive data in transit. By default, {{product}} uses
 self-signed certificates, but users are able to use an intermediate CA or
 provide their own certificates instead.
 
-## Dqlite encryption at rest
+## Encryption at rest
 
 {{product}} uses AES-256-GCM (Advanced Encryption Standard - Galois/Counter
 Mode) to encrypt cluster data at rest.

--- a/docs/canonicalk8s/snap/howto/external-datastore.md
+++ b/docs/canonicalk8s/snap/howto/external-datastore.md
@@ -1,7 +1,7 @@
 # How to use an external datastore
 
 {{product}} supports using an external datastore such as etcd
-instead of the bundled dqlite datastore.
+instead of the bundled etcd datastore.
 This guide walks you through configuring an external etcd datastore.
 
 ## Prerequisites
@@ -16,7 +16,7 @@ This guide assumes the following:
 
 ```{warning}
 The selection of the backing datastore can only be changed during the bootstrap process.
-There is no migration path between the bundled dqlite and the external datastores.
+There is no migration path between the bundled etcd and the external datastores.
 ```
 
 ## Adjust the bootstrap configuration

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -10,7 +10,7 @@ nodes in your {{product}} cluster.
 
 ```{warning}
 Only Kubernetes component certificates refreshes are supported with the
- `k8s refresh-certs` command. Microcluster and k8s-dqlite certificates' expiration
+ `k8s refresh-certs` command. Microcluster and etcd certificates' expiration
  is set to 20 years, so renewal is not typically necessary. They are not automatically
  renewed by the command and currently cannot be refreshed manually.
  Additionally, like upstream Kubernetes, rotating the Certificate Authority (CA) is not supported.

--- a/docs/canonicalk8s/snap/howto/troubleshooting.md
+++ b/docs/canonicalk8s/snap/howto/troubleshooting.md
@@ -26,7 +26,7 @@ You should see a command output similar to the following:
 cluster status:           ready
 control plane nodes:      10.94.106.249:6400 (voter), 10.94.106.208:6400 (voter), 10.94.106.99:6400 (voter)
 high availability:        yes
-datastore:                k8s-dqlite
+datastore:                etcd
 network:                  enabled
 dns:                      enabled at 10.152.183.106
 ingress:                  disabled
@@ -121,7 +121,7 @@ Services running only on control-plane nodes:
 * `kube-apiserver`
 * `kube-controller-manager`
 * `kube-scheduler`
-* `k8s-dqlite`
+* `etcd`
 
 Services running only on worker nodes:
 

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -97,7 +97,7 @@ information between the `k8s` and `k8s-worker` charms
 <!-- IMAGES -->
 
 [cluster1]: https://assets.ubuntu.com/v1/de97f360-snap10-04.svg
-[cluster2]: https://assets.ubuntu.com/v1/24ea67c0-k8sd10-04.svg
+[cluster2]: https://assets.ubuntu.com/v1/b0ae732e-k8sd-13-08.svg
 [cluster4]: https://assets.ubuntu.com/v1/53a083a9-charms.svg
 [cluster5]: https://assets.ubuntu.com/v1/bcfe150f-overview.svg
 

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -41,8 +41,8 @@ The `k8s` snap distribution includes the following:
 and drive the cluster operations.
 - **K8s core components**: the Kubernetes services, as well as core
 workloads built from upstream and shipped in the snap.
-- **Kubernetes datastore**: uses [Dqlite] to store data on the state of the
-cluster. It can be replaced by an external datastore.
+- **Kubernetes datastore**: uses etcd to store data on the state of the
+cluster. It can be replaced by [Dqlite] or an external datastore.
 - **Cluster datastore**: uses Dqlite as a replicated database to store cluster
 configuration.
 - **Container runtime**: `containerd` is the shipped container runtime.

--- a/docs/canonicalk8s/snap/reference/architecture.md
+++ b/docs/canonicalk8s/snap/reference/architecture.md
@@ -96,7 +96,7 @@ information between the `k8s` and `k8s-worker` charms
 
 <!-- IMAGES -->
 
-[cluster1]: https://assets.ubuntu.com/v1/de97f360-snap10-04.svg
+[cluster1]: https://assets.ubuntu.com/v1/60234b03-snap-14-08.svg 
 [cluster2]: https://assets.ubuntu.com/v1/b0ae732e-k8sd-13-08.svg
 [cluster4]: https://assets.ubuntu.com/v1/53a083a9-charms.svg
 [cluster5]: https://assets.ubuntu.com/v1/bcfe150f-overview.svg

--- a/docs/canonicalk8s/snap/reference/certificates.md
+++ b/docs/canonicalk8s/snap/reference/certificates.md
@@ -9,11 +9,11 @@ This table outlines the common certificate authorities (CAs) used in a
 Kubernetes environment, detailing their specific purposes, usage,
 and locations on the disk.
 
-| **Common Name**                            | **Purpose** | **File Location**  | **Primary Function**          |
-|--------------------------------------------|-----------|----------------------|-------------------------------|
-| `kubernetes-ca`               | General Kubernetes CA               | `/etc/kubernetes/pki/ca.crt`             | Signing all Kubernetes-related certificates |
-| `kubernetes-front-proxy-ca`   | CA for front-end proxy              | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy    |
-| `client-ca`                   | CA for client certificates          | `/etc/kubernetes/pki/client-ca.crt`      | Signing certificates for the client         |
+| **Common Name**             | **Purpose**                | **File Location**                        | **Primary Function**                        |
+|-----------------------------|----------------------------|------------------------------------------|---------------------------------------------|
+| `kubernetes-ca`             | General Kubernetes CA      | `/etc/kubernetes/pki/ca.crt`             | Signing all Kubernetes-related certificates |
+| `kubernetes-front-proxy-ca` | CA for front-end proxy     | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy    |
+| `client-ca`                 | CA for client certificates | `/etc/kubernetes/pki/client-ca.crt`      | Signing certificates for the client         |
 
 
 ## Certificates
@@ -23,18 +23,18 @@ including their roles, storage paths, and the entities responsible for
 their issuance.
 
 
-| **Common Name**                            | **Purpose** | **File Location**  | **Primary Function**            | **Signed By**               |
-|--------------------------------------------|-----------|------------------------------------------------------|------------------------------------------------------------------|-----------------------------|
-| `kube-apiserver`                           | Server    | `/etc/kubernetes/pki/apiserver.crt`                  | Securing the API server endpoint                                 | `kubernetes-ca`             |
-| `apiserver-kubelet-client`            | Client    | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`   | API server communication with kubelet                           | `kubernetes-ca-client`      |
-| `kube-apiserver-etcd-client`               | Client    | `/etc/kubernetes/pki/apiserver-etcd-client.crt`      | API server communication with etcd                               | `kubernetes-ca-client`      |
-| `front-proxy-client`                       | Client    | `/etc/kubernetes/pki/front-proxy-client.crt`         | API server communication with the front-proxy                    | `kubernetes-front-proxy-ca` |
-| `system:kube-controller-manager`                  | Client    | `/etc/kubernetes/pki/controller-manager.crt`         | Communication between the controller manager and the API server  | `kubernetes-ca-client`      |
-| `system:kube-scheduler`                           | Client    | `/etc/kubernetes/pki/scheduler.crt`                  | Communication between the scheduler and the API server           | `kubernetes-ca-client`      |
-| `system:kube-proxy`                               | Client    | `/etc/kubernetes/pki/proxy.crt`                      | Communication between kube-proxy and the API server              | `kubernetes-ca-client`      |
-| `system:node:$hostname`                    | Client    | `/etc/kubernetes/pki/kubelet-client.crt`             | Authentication of kubelet to the API server                     | `kubernetes-ca-client`      |
-| `k8s-dqlite`                               | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`| Communication between k8s-dqlite nodes and API server            | `self-signed`               |
-| `root@$hostname`                          | Client    | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt`             | Communication between k8sd nodes | `self-signed`      |
+| **Common Name**                  | **Purpose** | **File Location**                                     | **Primary Function**                                            | **Signed By**               |
+|----------------------------------|-------------|-------------------------------------------------------|-----------------------------------------------------------------|-----------------------------|
+| `kube-apiserver`                 | Server      | `/etc/kubernetes/pki/apiserver.crt`                   | Securing the API server endpoint                                | `kubernetes-ca`             |
+| `apiserver-kubelet-client`       | Client      | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`    | API server communication with kubelet                           | `kubernetes-ca-client`      |
+| `kube-apiserver-etcd-client`     | Client      | `/etc/kubernetes/pki/apiserver-etcd-client.crt`       | API server communication with etcd                              | `kubernetes-ca-client`      |
+| `front-proxy-client`             | Client      | `/etc/kubernetes/pki/front-proxy-client.crt`          | API server communication with the front-proxy                   | `kubernetes-front-proxy-ca` |
+| `system:kube-controller-manager` | Client      | `/etc/kubernetes/pki/controller-manager.crt`          | Communication between the controller manager and the API server | `kubernetes-ca-client`      |
+| `system:kube-scheduler`          | Client      | `/etc/kubernetes/pki/scheduler.crt`                   | Communication between the scheduler and the API server          | `kubernetes-ca-client`      |
+| `system:kube-proxy`              | Client      | `/etc/kubernetes/pki/proxy.crt`                       | Communication between kube-proxy and the API server             | `kubernetes-ca-client`      |
+| `system:node:$hostname`          | Client      | `/etc/kubernetes/pki/kubelet-client.crt`              | Authentication of kubelet to the API server                     | `kubernetes-ca-client`      |
+| `etcd`                           | Client      | `/etc/kubernetes/pki/etcd`                            | Communication between etcd and API server                       | `self-signed`               |
+| `root@$hostname`                 | Client      | `/var/snap/k8s/common/var/lib/k8sd/state/cluster.crt` | Communication between k8sd nodes                                | `self-signed`               |
 
 
 ## Configuration files for Kubernetes components
@@ -46,19 +46,19 @@ communicate with the cluster services.
 
 Control-plane nodes use the following configuration files.
 
-| **Configuration File**             | **Purpose**                            | **File Location**                          | **Primary Function**                                 |
-|------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|
-| `admin.conf`                       | Administrator Client Config            | `/etc/kubernetes/admin.conf`               | Admin access to the cluster                  |
-| `controller-manager.conf`          | Controller Manager Client Config       | `/etc/kubernetes/controller-manager.conf`  | Communication with the API server            |
-| `scheduler.conf`                   | Scheduler Client Config                | `/etc/kubernetes/scheduler.conf`           | Communication with the API server            |
-| `kubelet.conf`                     | Kubelet Client Config                  | `/etc/kubernetes/kubelet.conf`             | Node registration and communication with API server |
-| `proxy.conf`                       | Proxy Client Config                    | `/etc/kubernetes/proxy.conf`               | Communication with the API server            |
+| **Configuration File**    | **Purpose**                      | **File Location**                         | **Primary Function**                                |
+|---------------------------|----------------------------------|-------------------------------------------|-----------------------------------------------------|
+| `admin.conf`              | Administrator Client Config      | `/etc/kubernetes/admin.conf`              | Admin access to the cluster                         |
+| `controller-manager.conf` | Controller Manager Client Config | `/etc/kubernetes/controller-manager.conf` | Communication with the API server                   |
+| `scheduler.conf`          | Scheduler Client Config          | `/etc/kubernetes/scheduler.conf`          | Communication with the API server                   |
+| `kubelet.conf`            | Kubelet Client Config            | `/etc/kubernetes/kubelet.conf`            | Node registration and communication with API server |
+| `proxy.conf`              | Proxy Client Config              | `/etc/kubernetes/proxy.conf`              | Communication with the API server                   |
 
 ### Worker node
 
 Worker nodes use the following configuration files.
 
-| **Configuration File**             | **Purpose**                            | **File Location**                          | **Primary Function**                                 |
-|------------------------------------|----------------------------------------|--------------------------------------------|----------------------------------------------|
-| `proxy.conf`                       | Proxy Client Config                    | `/etc/kubernetes/proxy.conf`               | Communication with the API server            |
-| `kubelet.conf`                     | Kubelet Client Config                  | `/etc/kubernetes/kubelet.conf`             | Node registration and communication with API server |
+| **Configuration File** | **Purpose**           | **File Location**              | **Primary Function**                                |
+|------------------------|-----------------------|--------------------------------|-----------------------------------------------------|
+| `proxy.conf`           | Proxy Client Config   | `/etc/kubernetes/proxy.conf`   | Communication with the API server                   |
+| `kubelet.conf`         | Kubelet Client Config | `/etc/kubernetes/kubelet.conf` | Node registration and communication with API server |

--- a/docs/canonicalk8s/snap/reference/certificates.md
+++ b/docs/canonicalk8s/snap/reference/certificates.md
@@ -23,19 +23,19 @@ including their roles, storage paths, and the entities responsible for
 their issuance.
 
 
-| **Common Name**                  | **Purpose** | **File Location**                                     | **Primary Function**                                            | **Signed By**               |
-|----------------------------------|-------------|-------------------------------------------------------|-----------------------------------------------------------------|-----------------------------|
-| `kube-apiserver`                 | Server      | `/etc/kubernetes/pki/apiserver.crt`                   | Securing the API server endpoint                                | `kubernetes-ca`             |
-| `apiserver-kubelet-client`       | Client      | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`    | API server communication with kubelet                           | `kubernetes-ca-client`      |
-| `kube-apiserver-etcd-client`     | Client      | `/etc/kubernetes/pki/apiserver-etcd-client.crt`       | API server communication with etcd                              | `kubernetes-ca-client`      |
-| `front-proxy-client`             | Client      | `/etc/kubernetes/pki/front-proxy-client.crt`          | API server communication with the front-proxy                   | `kubernetes-front-proxy-ca` |
-| `system:kube-controller-manager` | Client      | `/etc/kubernetes/pki/controller-manager.crt`          | Communication between the controller manager and the API server | `kubernetes-ca-client`      |
-| `system:kube-scheduler`          | Client      | `/etc/kubernetes/pki/scheduler.crt`                   | Communication between the scheduler and the API server          | `kubernetes-ca-client`      |
-| `system:kube-proxy`              | Client      | `/etc/kubernetes/pki/proxy.crt`                       | Communication between kube-proxy and the API server             | `kubernetes-ca-client`      |
-| `system:node:$hostname`          | Client      | `/etc/kubernetes/pki/kubelet-client.crt`              | Authentication of kubelet to the API server                     | `kubernetes-ca-client`      |
-| `etcd`                           | Client      | `/etc/kubernetes/pki/etcd`                            | Communication between etcd and API server                       | `self-signed`               |
-| `root@$hostname`                 | Client      | `/var/snap/k8s/common/var/lib/k8sd/state/cluster.crt` | Communication between k8sd nodes                                | `self-signed`               |
-
+| **Common Name**                  | **Purpose** | **File Location**                                     | **Primary Function**                                                                             | **Signed By**               |
+|----------------------------------|-------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------|-----------------------------|
+| `kube-apiserver`                 | Server      | `/etc/kubernetes/pki/apiserver.crt`                   | Securing the API server endpoint                                                                 | `kubernetes-ca`             |
+| `apiserver-kubelet-client`       | Client      | `/etc/kubernetes/pki/apiserver-kubelet-client.crt`    | API server communication with kubelet                                                            | `kubernetes-ca-client`      |
+| `kube-apiserver-etcd-client`     | Client      | `/etc/kubernetes/pki/apiserver-etcd-client.crt`       | API server communication with etcd                                                               | `kubernetes-ca-client`      |
+| `front-proxy-client`             | Client      | `/etc/kubernetes/pki/front-proxy-client.crt`          | API server communication with the front-proxy                                                    | `kubernetes-front-proxy-ca` |
+| `system:kube-controller-manager` | Client      | `/etc/kubernetes/pki/controller-manager.crt`          | Communication between the controller manager and the API server                                  | `kubernetes-ca-client`      |
+| `system:kube-scheduler`          | Client      | `/etc/kubernetes/pki/scheduler.crt`                   | Communication between the scheduler and the API server                                           | `kubernetes-ca-client`      |
+| `system:kube-proxy`              | Client      | `/etc/kubernetes/pki/proxy.crt`                       | Communication between kube-proxy and the API server                                              | `kubernetes-ca-client`      |
+| `system:node:$hostname`          | Client      | `/etc/kubernetes/pki/kubelet-client.crt`              | Authentication of kubelet to the API server                                                      | `kubernetes-ca-client`      |
+| `etcd`                           | Client      | `/etc/kubernetes/pki/etcd`                            | Communication between etcd and API server                                                        | `self-signed`               |
+| `k8s-dqlite`                     | Client      | `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt` | Communication between k8s-dqlite nodes and API server (if datastore type is set to `k8s-dqlite`) | `self-signed`               |
+| `root@$hostname`                 | Client      | `/var/snap/k8s/common/var/lib/k8sd/state/cluster.crt` | Communication between k8sd nodes                                                                 | `self-signed`               |
 
 ## Configuration files for Kubernetes components
 

--- a/docs/canonicalk8s/snap/reference/dqlite.md
+++ b/docs/canonicalk8s/snap/reference/dqlite.md
@@ -1,8 +1,10 @@
 # Dqlite database
 
-{{product}} uses not one, but two Dqlite databases:
+{{product}} may use not one, but two Dqlite databases:
 
-* k8s-dqlite - used by Kubernetes itself (as an ETCD replacement)
+* k8s-dqlite – By default, Kubernetes uses etcd as its datastore,
+but you can choose k8s-dqlite as an alternative. Any references to k8s-dqlite
+are relevant only if it has been selected as the Kubernetes datastore.
 * k8sd - Kubernetes cluster management data
 
 ## Database files

--- a/docs/canonicalk8s/snap/reference/dqlite.md
+++ b/docs/canonicalk8s/snap/reference/dqlite.md
@@ -4,7 +4,8 @@
 
 * k8s-dqlite – By default, Kubernetes uses etcd as its datastore,
 but you can choose k8s-dqlite as an alternative. Any references to k8s-dqlite
-are relevant only if it has been selected as the Kubernetes datastore.
+are relevant only if it has been selected as the Kubernetes datastore
+on bootstrap.
 * k8sd - Kubernetes cluster management data
 
 ## Database files

--- a/docs/canonicalk8s/snap/reference/etcd.md
+++ b/docs/canonicalk8s/snap/reference/etcd.md
@@ -1,7 +1,8 @@
 # Etcd database
 
 {{product}} uses **etcd** as the default Kubernetes datastore.
-etcd is a distributed key-value store that holds all Kubernetes cluster state data.
+etcd is a distributed key-value store that holds all Kubernetes
+cluster state data.
 
 ## Database files
 
@@ -11,7 +12,8 @@ The etcd database has its state directory under the snap path:
 
 This directory normally contains:
 
-* `member/` – etcd member data, including the write-ahead log (WAL) and snapshots
+* `member/` – etcd member data, including the write-ahead log (WAL)
+and snapshots
 
   * `snap/` – snapshot files of the key-value store
   * `wal/` – write-ahead logs for durability and recovery
@@ -20,8 +22,10 @@ This directory normally contains:
 
 ## Inspecting the database
 
-The `etcdctl` command-line client can be used to directly interact with etcd. It is **not included** in the {{product}} snap.
-You will need to obtain `etcdctl` separately from the [official etcd releases] or your OS package manager.
+The `etcdctl` command-line client can be used to directly interact with etcd.
+It is **not included** in the {{product}} snap.
+You will need to obtain `etcdctl` separately from the [official etcd releases]
+or your OS package manager.
 
 Once `etcdctl` is available, you can connect to the etcd database as follows:
 
@@ -58,9 +62,12 @@ etcdctl \
 
 ## Notes
 
-* etcd in {{product}} runs with TLS enabled by default to secure communication between members and clients.
-* All Kubernetes API objects are stored as serialized JSON in etcd, indexed by their API path keys.
-* Care should be taken when directly modifying etcd data, as it may corrupt cluster state.
+* etcd in {{product}} runs with TLS enabled by default to secure communication
+between members and clients.
+* All Kubernetes API objects are stored as serialized JSON in etcd, indexed by
+their API path keys.
+* Care should be taken when directly modifying etcd data, as it may corrupt
+cluster state.
 
 <!-- LINKS -->
 

--- a/docs/canonicalk8s/snap/reference/etcd.md
+++ b/docs/canonicalk8s/snap/reference/etcd.md
@@ -8,7 +8,7 @@ cluster state data.
 
 The etcd database has its state directory under the snap path:
 
-* `/var/snap/k8s/common/var/lib/etcd`
+* `/var/snap/k8s/common/var/lib/etcd/data`
 
 This directory normally contains:
 

--- a/docs/canonicalk8s/snap/reference/etcd.md
+++ b/docs/canonicalk8s/snap/reference/etcd.md
@@ -1,0 +1,67 @@
+# Etcd database
+
+{{product}} uses **etcd** as the default Kubernetes datastore.
+etcd is a distributed key-value store that holds all Kubernetes cluster state data.
+
+## Database files
+
+The etcd database has its state directory under the snap path:
+
+* `/var/snap/k8s/common/var/lib/etcd`
+
+This directory normally contains:
+
+* `member/` – etcd member data, including the write-ahead log (WAL) and snapshots
+
+  * `snap/` – snapshot files of the key-value store
+  * `wal/` – write-ahead logs for durability and recovery
+* `server.crt`, `server.key` – TLS certificates for secure communication
+* `ca.crt` – certificate authority for validating peer and client connections
+
+## Inspecting the database
+
+The `etcdctl` command-line client can be used to directly interact with etcd. It is **not included** in the {{product}} snap.
+You will need to obtain `etcdctl` separately from the [official etcd releases] or your OS package manager.
+
+Once `etcdctl` is available, you can connect to the etcd database as follows:
+
+```
+etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cert=/var/snap/k8s/common/var/lib/etcd/server.crt \
+  --key=/var/snap/k8s/common/var/lib/etcd/server.key \
+  --cacert=/var/snap/k8s/common/var/lib/etcd/ca.crt \
+  get "" --prefix --keys-only
+```
+
+To retrieve values for a given prefix:
+
+```
+etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cert=/var/snap/k8s/common/var/lib/etcd/server.crt \
+  --key=/var/snap/k8s/common/var/lib/etcd/server.key \
+  --cacert=/var/snap/k8s/common/var/lib/etcd/ca.crt \
+  get /registry/pods/default --prefix
+```
+
+To check the current cluster leader and member status:
+
+```
+etcdctl \
+  --endpoints=https://127.0.0.1:2379 \
+  --cert=/var/snap/k8s/common/var/lib/etcd/server.crt \
+  --key=/var/snap/k8s/common/var/lib/etcd/server.key \
+  --cacert=/var/snap/k8s/common/var/lib/etcd/ca.crt \
+  endpoint status --write-out=table
+```
+
+## Notes
+
+* etcd in {{product}} runs with TLS enabled by default to secure communication between members and clients.
+* All Kubernetes API objects are stored as serialized JSON in etcd, indexed by their API path keys.
+* Care should be taken when directly modifying etcd data, as it may corrupt cluster state.
+
+<!-- LINKS -->
+
+[official etcd releases]: https://etcd.io/docs/

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -13,6 +13,7 @@ Overview <self>
 ```{toctree}
 :titlesonly:
 architecture
+etcd
 dqlite
 ```
 

--- a/docs/canonicalk8s/snap/reference/inspection-reports.md
+++ b/docs/canonicalk8s/snap/reference/inspection-reports.md
@@ -36,7 +36,7 @@ Collecting service information
 Running inspection on a control-plane node
  INFO:  Service k8s.containerd is running
  INFO:  Service k8s.kube-proxy is running
- INFO:  Service k8s.k8s-dqlite is running
+ INFO:  Service k8s.etcd is running
  INFO:  Service k8s.k8sd is running
  INFO:  Service k8s.kube-apiserver is running
  INFO:  Service k8s.kube-controller-manager is running

--- a/docs/canonicalk8s/snap/reference/ports-and-services.md
+++ b/docs/canonicalk8s/snap/reference/ports-and-services.md
@@ -11,18 +11,19 @@ meaning they can only be accessed from within the host.
 
 ### Services binding to the default Host interface
 
-| Port  | Protocol | Service         | Description                                                                                              |
-|-------|----------|-----------------|----------------------------------------------------------------------------------------------------------|
-| 2379  | TCP      | etcd            | SSL encrypted client connection to etcd. Client certificate required.                                    |
-| 4244  | TCP      | cilium-agent    | Listening address for Hubble.                                                                            |
-| 4240  | TCP      | cilium-agent    | TCP port for cluster-wide network connectivity and Cilium agent health API.                              |
-| 6400  | TCP      | k8sd            | Default REST API port for Canonical Kubernetes daemon.                                                   |
-| 6443  | TCP      | kube-apiserver  | Kubernetes API server. SSL encrypted. Clients must present a valid password from a Static Password File. |
-| 8472  | UDP      | cilium-agent    | Default VXLAN port used by Cilium.                                                                       |
-| 9963  | TCP      | cilium-operator | Prometheus metric endpoint for the Cilium operator.                                                      |
-| 10250 | TCP      | kubelet         | Kubelet API. Anonymous authentication is disabled. X509 client certificate required.                     |
-| 10257 | TCP      | kube-controller | Kubernetes controller manager API. HTTPS with authentication and authorization.                          |
-| 10259 | TCP      | kube-scheduler  | Kubernetes scheduler API. HTTPS with authentication and authorization.                                   |
+| Port  | Protocol | Service         | Description                                                                                                                   |
+|-------|----------|-----------------|-------------------------------------------------------------------------------------------------------------------------------|
+| 2379  | TCP      | etcd            | SSL encrypted client connection to etcd. Client certificate required.                                                         |
+| 4244  | TCP      | cilium-agent    | Listening address for Hubble.                                                                                                 |
+| 4240  | TCP      | cilium-agent    | TCP port for cluster-wide network connectivity and Cilium agent health API.                                                   |
+| 6400  | TCP      | k8sd            | Default REST API port for Canonical Kubernetes daemon.                                                                        |
+| 6443  | TCP      | kube-apiserver  | Kubernetes API server. SSL encrypted. Clients must present a valid password from a Static Password File.                      |
+| 8472  | UDP      | cilium-agent    | Default VXLAN port used by Cilium.                                                                                            |
+| 9000  | TCP      | k8s-dqlite      | SSL encrypted connection for k8s-dqlite. Client certificates required. Only applies if datastore type is set to `k8s-dqlite`. |
+| 9963  | TCP      | cilium-operator | Prometheus metric endpoint for the Cilium operator.                                                                           |
+| 10250 | TCP      | kubelet         | Kubelet API. Anonymous authentication is disabled. X509 client certificate required.                                          |
+| 10257 | TCP      | kube-controller | Kubernetes controller manager API. HTTPS with authentication and authorization.                                               |
+| 10259 | TCP      | kube-scheduler  | Kubernetes scheduler API. HTTPS with authentication and authorization.                                                        |
 
 ### Services binding to the localhost interface
 

--- a/docs/canonicalk8s/snap/reference/ports-and-services.md
+++ b/docs/canonicalk8s/snap/reference/ports-and-services.md
@@ -4,31 +4,31 @@
 
 There are two main types of services based on the network interface they use:
 
-* Default Host Interface Services: These services bind to the default host 
+* Default Host Interface Services: These services bind to the default host
 interface, making them accessible from outside the host.
 * Localhost Services: These services bind to the localhost interface,
 meaning they can only be accessed from within the host.
 
 ### Services binding to the default Host interface
 
-| Port  | Protocol | Service         |Description                                                                                               |
+| Port  | Protocol | Service         | Description                                                                                              |
 |-------|----------|-----------------|----------------------------------------------------------------------------------------------------------|
+| 2379  | TCP      | etcd            | SSL encrypted client connection to etcd. Client certificate required.                                    |
 | 4244  | TCP      | cilium-agent    | Listening address for Hubble.                                                                            |
 | 4240  | TCP      | cilium-agent    | TCP port for cluster-wide network connectivity and Cilium agent health API.                              |
 | 6400  | TCP      | k8sd            | Default REST API port for Canonical Kubernetes daemon.                                                   |
 | 6443  | TCP      | kube-apiserver  | Kubernetes API server. SSL encrypted. Clients must present a valid password from a Static Password File. |
 | 8472  | UDP      | cilium-agent    | Default VXLAN port used by Cilium.                                                                       |
-| 9000  | TCP      | k8s-dqlite      | SSL encrypted connection for k8s-dqlite. Client certificates required.                                   |
 | 9963  | TCP      | cilium-operator | Prometheus metric endpoint for the Cilium operator.                                                      |
 | 10250 | TCP      | kubelet         | Kubelet API. Anonymous authentication is disabled. X509 client certificate required.                     |
 | 10257 | TCP      | kube-controller | Kubernetes controller manager API. HTTPS with authentication and authorization.                          |
 | 10259 | TCP      | kube-scheduler  | Kubernetes scheduler API. HTTPS with authentication and authorization.                                   |
 
-
 ### Services binding to the localhost interface
 
 | Port  | Protocol | Service         | Description                                                             |
 |-------|----------|-----------------|-------------------------------------------------------------------------|
+| 2380  | TCP      | etcd            | SSL encrypted peer connection to etcd. Client certificate required.     |
 | 9234  | TCP      | cilium-operator | cilium-operator  Address to serve API requests.                         |
 | 9879  | TCP      | cilium-agent    | TCP port for the Cilium agent health status API.                        |
 | 9890  | TCP      | cilium-agent    | cilium agent [gops](https://github.com/google/gops) server endpoint.    |
@@ -36,13 +36,13 @@ meaning they can only be accessed from within the host.
 | 10248 | TCP      | kubelet         | Localhost health check endpoint.                                        |
 | 10249 | TCP      | kube-proxy      | Port for the metrics server.                                            |
 | 10256 | TCP      | kube-proxy      | Port for binding the health check server.                               |
- 
+
 ## Socket Service
 
 ### Containerd
 
 Containerd is being exposed through unix socket.
 
-| Service      | Socket                                 |
-|--------------|----------------------------------------|
-| containerd 	 | unix:///run/containerd/containerd.sock |
+| Service    | Socket                                 |
+|------------|----------------------------------------|
+| containerd | unix:///run/containerd/containerd.sock |


### PR DESCRIPTION
Updates the documentation to use etcd instead of dqlite as the default datastore in various places. Note that this PR does not contain the updates of the CIS/STIG compliance. I will address this in a separate PR.

## Backport

Requires backport since etcd is also backported

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
