### PR TITLE
docs: Based on user feedback, update the tutorials

### DIFF
--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -36,17 +36,17 @@ The bootstrap command initializes your cluster and configures your host system
 as a Kubernetes node. Bootstrapping the cluster is only done once at cluster
 creation.
 
+To explore configurations options available on bootstrap you can run:
+
+```
+sudo k8s bootstrap --help
+```
+
 If you would like to bootstrap a Kubernetes cluster with
 default configuration run:
 
 ```
 sudo k8s bootstrap
-```
-
-For custom configurations, you can explore additional options using:
-
-```
-sudo k8s bootstrap --help
 ```
 
 Once the bootstrap command has been successfully ran, the output should list the
@@ -97,8 +97,8 @@ sudo k8s kubectl get pods -n kube-system
 ```
 
 You will observe at least four pods running. The status of the pods may be in
-`ContainerCreating` while they are being initialized. They should turn to
-`Running` after a few seconds.
+`ContainerCreating` while they are being initialized. Run the command again
+after a few seconds and they should report status as `Running`.
 
 The functions of these pods are:
 
@@ -204,6 +204,8 @@ Begin by removing the pod along with the persistent volume claim:
 sudo k8s kubectl delete pod storage-writer-pod
 sudo k8s kubectl delete pvc myclaim
 ```
+
+This may take a few moments as the cluster cleans up its resources.
 
 Next, disable the local storage:
 

--- a/docs/canonicalk8s/snap/tutorial/kubectl.md
+++ b/docs/canonicalk8s/snap/tutorial/kubectl.md
@@ -1,4 +1,4 @@
-# Basic operations with Kubernetes using kubectl
+# Basic operations with {{product}} using kubectl
 
 Kubernetes provides a command line tool for communicating with a Kubernetes
 cluster's control plane, using the Kubernetes API. This guide outlines how some
@@ -12,7 +12,7 @@ Before you begin, make sure you have the following:
 - A bootstrapped {{product}} cluster (See
   [Getting Started])
 
-### 1. The kubectl command
+### The kubectl command
 
 The `kubectl` command communicates with the
 [Kubernetes API server][kubernetes-api-server].
@@ -21,7 +21,7 @@ The `kubectl` command communicates with the
 original upstream source into the `k8s` snap you have installed and is
 configured to work with the cluster out of the box.
 
-### 2. How to use kubectl
+### How to use kubectl
 
 To access `kubectl`, run the following:
 
@@ -40,7 +40,7 @@ The format of `kubectl` commands are:
 sudo k8s kubectl <command>
 ```
 
-### 3. Configuration
+### Configuration
 
 In {{product}}, the `kubeconfig` file that is being read to display
 the configuration when you run `kubectl config view` lives at
@@ -51,7 +51,7 @@ command.
 To find out more, you can visit
 [the official kubeconfig documentation][kubeconfig-doc]
 
-### 4. Viewing objects
+### Viewing objects
 
 Let's review what was created in the [Getting Started]
 guide.
@@ -76,7 +76,7 @@ The `kubernetes` service in the `default` namespace is where the Kubernetes API
 server resides, and it's the endpoint with which other nodes in your cluster
 will communicate.
 
-### 5. Creating and managing objects
+### Creating and managing objects
 
 Let's deploy an NGINX server using this command:
 
@@ -122,8 +122,9 @@ The above command deletes all pods in the cluster that are labeled with
 You'll notice the original 3 pods will have a status of `Terminating` and 3 new
 pods will have a status of `ContainerCreating`.
 
-## Further information
+## Next steps
 
+- Continue learning about {{product}} and how to grow your cluster with our [adding and removing nodes tutorial]
 - Explore Kubernetes commands with our
   [Command Reference Guide]
 - See the official `kubectl` reference
@@ -136,3 +137,4 @@ pods will have a status of `ContainerCreating`.
 [kubernetes-api-server]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 [kubeconfig-doc]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [kubectl-reference]: https://kubernetes.io/docs/reference/kubectl/
+[adding and removing nodes tutorial]: add-remove-nodes.md

--- a/docs/canonicalk8s/snap/tutorial/kubectl.md
+++ b/docs/canonicalk8s/snap/tutorial/kubectl.md
@@ -124,7 +124,8 @@ pods will have a status of `ContainerCreating`.
 
 ## Next steps
 
-- Continue learning about {{product}} and how to grow your cluster with our [adding and removing nodes tutorial]
+- Continue learning about {{product}} and how to grow your cluster with our
+[adding and removing nodes tutorial]
 - Explore Kubernetes commands with our
   [Command Reference Guide]
 - See the official `kubectl` reference


### PR DESCRIPTION
## Description

Improve the experience of users going through our tutorials.

## Solution

Having the options after the default bootstrap config option was confusing to users. 
Waiting for the pvc to delete was taking a while and confusing users so added a disclaimer.
Removed numbering from the kubectl tutorial. 
Tried to continue the tutorial by linking to the next adding/removing nodes tutorial.

## Issue

N/A

## Backport
1.32, 1.33

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
