### PR TITLE
refactor(controllers): Initialize controllers separately

### DIFF
--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -227,29 +227,33 @@ func (a *App) setupControlPlaneControllers() error {
 	a.controllerCoordinator = controllers.NewCoordinator(
 		a.config.Snap,
 		a.readyWg.Wait,
-		a.config.DisableUpgradeController,
-		upgrade.ControllerOptions{
-			FeatureControllerReadyCh:   a.featureController.ReadyCh(),
-			NotifyNetworkFeature:       a.NotifyNetwork,
-			NotifyGatewayFeature:       a.NotifyGateway,
-			NotifyIngressFeature:       a.NotifyIngress,
-			NotifyLoadBalancerFeature:  a.NotifyLoadBalancer,
-			NotifyLocalStorageFeature:  a.NotifyLocalStorage,
-			NotifyMetricsServerFeature: a.NotifyMetricsServer,
-			NotifyDNSFeature:           a.NotifyDNS,
-			FeatureToReconciledCh: map[types.FeatureName]<-chan struct{}{
-				features.Network:       a.featureController.ReconciledNetworkCh(),
-				features.Gateway:       a.featureController.ReconciledGatewayCh(),
-				features.Ingress:       a.featureController.ReconciledIngressCh(),
-				features.DNS:           a.featureController.ReconciledDNSCh(),
-				features.LoadBalancer:  a.featureController.ReconciledLoadBalancerCh(),
-				features.LocalStorage:  a.featureController.ReconciledLocalStorageCh(),
-				features.MetricsServer: a.featureController.ReconciledMetricsServerCh(),
+		controllers.UpgradeControllerOptions{
+			Disable: a.config.DisableUpgradeController,
+			ControllerOptions: upgrade.ControllerOptions{
+				FeatureControllerReadyCh:   a.featureController.ReadyCh(),
+				NotifyNetworkFeature:       a.NotifyNetwork,
+				NotifyGatewayFeature:       a.NotifyGateway,
+				NotifyIngressFeature:       a.NotifyIngress,
+				NotifyLoadBalancerFeature:  a.NotifyLoadBalancer,
+				NotifyLocalStorageFeature:  a.NotifyLocalStorage,
+				NotifyMetricsServerFeature: a.NotifyMetricsServer,
+				NotifyDNSFeature:           a.NotifyDNS,
+				FeatureToReconciledCh: map[types.FeatureName]<-chan struct{}{
+					features.Network:       a.featureController.ReconciledNetworkCh(),
+					features.Gateway:       a.featureController.ReconciledGatewayCh(),
+					features.Ingress:       a.featureController.ReconciledIngressCh(),
+					features.DNS:           a.featureController.ReconciledDNSCh(),
+					features.LoadBalancer:  a.featureController.ReconciledLoadBalancerCh(),
+					features.LocalStorage:  a.featureController.ReconciledLocalStorageCh(),
+					features.MetricsServer: a.featureController.ReconciledMetricsServerCh(),
+				},
+				FeatureControllerReadyTimeout:     10 * time.Minute,
+				FeatureControllerReconcileTimeout: 2 * time.Minute,
 			},
-			FeatureControllerReadyTimeout:     10 * time.Minute,
-			FeatureControllerReconcileTimeout: 2 * time.Minute,
 		},
-		a.config.DisableCSRSigningController,
+		controllers.CSRSigningControllerOptions{
+			Disable: a.config.DisableCSRSigningController,
+		},
 	)
 
 	return nil

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration.go
@@ -52,14 +52,6 @@ func (c *ControlPlaneConfigurationController) Run(ctx context.Context, getCluste
 		case <-c.triggerCh:
 		}
 
-		if isWorker, err := snaputil.IsWorker(c.snap); err != nil {
-			log.Error(err, "Failed to check if running on a worker node")
-			continue
-		} else if isWorker {
-			log.Info("Stopping on worker node")
-			return
-		}
-
 		config, err := getClusterConfig(ctx)
 		if err != nil {
 			log.Error(err, "Failed to retrieve cluster configuration")

--- a/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/control_plane_configuration_test.go
@@ -28,302 +28,216 @@ func (c *configProvider) getConfig(ctx context.Context) (types.ClusterConfig, er
 }
 
 func TestControlPlaneConfigController(t *testing.T) {
-	t.Run("ControlPlane", func(t *testing.T) {
-		dir := t.TempDir()
+	dir := t.TempDir()
 
-		s := &mock.Snap{
-			Mock: mock.Mock{
-				EtcdPKIDir:          filepath.Join(dir, "etcd-pki"),
-				ServiceArgumentsDir: filepath.Join(dir, "args"),
-				UID:                 os.Getuid(),
-				GID:                 os.Getgid(),
-			},
-		}
+	s := &mock.Snap{
+		Mock: mock.Mock{
+			EtcdPKIDir:          filepath.Join(dir, "etcd-pki"),
+			ServiceArgumentsDir: filepath.Join(dir, "args"),
+			UID:                 os.Getuid(),
+			GID:                 os.Getgid(),
+		},
+	}
 
-		g := NewWithT(t)
-		g.Expect(setup.EnsureAllDirectories(s)).To(Succeed())
+	g := NewWithT(t)
+	g.Expect(setup.EnsureAllDirectories(s)).To(Succeed())
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-		triggerCh := make(chan time.Time)
-		configProvider := &configProvider{}
+	triggerCh := make(chan time.Time)
+	configProvider := &configProvider{}
 
-		ctrl := controllers.NewControlPlaneConfigurationController(s, func() {}, triggerCh)
-		go ctrl.Run(ctx, configProvider.getConfig)
+	ctrl := controllers.NewControlPlaneConfigurationController(s, func() {}, triggerCh)
+	go ctrl.Run(ctx, configProvider.getConfig)
 
-		for _, tc := range []struct {
-			name   string
-			config types.ClusterConfig
+	for _, tc := range []struct {
+		name   string
+		config types.ClusterConfig
 
-			expectKubeAPIServerArgs         map[string]string
-			expectKubeControllerManagerArgs map[string]string
+		expectKubeAPIServerArgs         map[string]string
+		expectKubeControllerManagerArgs map[string]string
 
-			expectServiceRestarts []string
-			expectFilesToExist    map[string]bool
-		}{
-			{
-				name: "Default",
-				config: types.ClusterConfig{
-					Datastore: types.Datastore{
-						Type:            utils.Pointer("external"),
-						ExternalServers: utils.Pointer([]string{"http://127.0.0.1:2379"}),
-					},
-				},
-				expectKubeAPIServerArgs: map[string]string{
-					"--etcd-servers": "http://127.0.0.1:2379",
-				},
-				expectFilesToExist: map[string]bool{
-					filepath.Join(dir, "etcd-pki", "ca.crt"):     false,
-					filepath.Join(dir, "etcd-pki", "client.crt"): false,
-					filepath.Join(dir, "etcd-pki", "client.key"): false,
-				},
-				expectServiceRestarts: []string{"kube-apiserver"},
-			},
-			{
-				name: "Certs",
-				config: types.ClusterConfig{
-					Datastore: types.Datastore{
-						Type:               utils.Pointer("external"),
-						ExternalServers:    utils.Pointer([]string{"https://127.0.0.1:2379"}),
-						ExternalCACert:     utils.Pointer("CA DATA"),
-						ExternalClientCert: utils.Pointer("CERT DATA"),
-						ExternalClientKey:  utils.Pointer("KEY DATA"),
-					},
-				},
-				expectKubeAPIServerArgs: map[string]string{
-					"--etcd-servers":  "https://127.0.0.1:2379",
-					"--etcd-cafile":   filepath.Join(dir, "etcd-pki", "ca.crt"),
-					"--etcd-certfile": filepath.Join(dir, "etcd-pki", "client.crt"),
-					"--etcd-keyfile":  filepath.Join(dir, "etcd-pki", "client.key"),
-				},
-				expectFilesToExist: map[string]bool{
-					filepath.Join(dir, "etcd-pki", "ca.crt"):     true,
-					filepath.Join(dir, "etcd-pki", "client.crt"): true,
-					filepath.Join(dir, "etcd-pki", "client.key"): true,
-				},
-				expectServiceRestarts: []string{"kube-apiserver"},
-			},
-			{
-				name: "CloudProvider",
-				config: types.ClusterConfig{
-					Kubelet: types.Kubelet{
-						CloudProvider: utils.Pointer("external"),
-					},
-				},
-				expectKubeControllerManagerArgs: map[string]string{
-					"--cloud-provider": "external",
-				},
-				expectServiceRestarts: []string{"kube-controller-manager"},
-			},
-			{
-				name: "NoUpdates",
-				config: types.ClusterConfig{
-					Datastore: types.Datastore{
-						Type:               utils.Pointer("external"),
-						ExternalServers:    utils.Pointer([]string{"https://127.0.0.1:2379"}),
-						ExternalCACert:     utils.Pointer("CA DATA"),
-						ExternalClientCert: utils.Pointer("CERT DATA"),
-						ExternalClientKey:  utils.Pointer("KEY DATA"),
-					},
-					Kubelet: types.Kubelet{
-						CloudProvider: utils.Pointer("external"),
-					},
-				},
-				expectKubeAPIServerArgs: map[string]string{
-					"--etcd-servers":  "https://127.0.0.1:2379",
-					"--etcd-cafile":   filepath.Join(dir, "etcd-pki", "ca.crt"),
-					"--etcd-certfile": filepath.Join(dir, "etcd-pki", "client.crt"),
-					"--etcd-keyfile":  filepath.Join(dir, "etcd-pki", "client.key"),
-				},
-				expectFilesToExist: map[string]bool{
-					filepath.Join(dir, "etcd-pki", "ca.crt"):     true,
-					filepath.Join(dir, "etcd-pki", "client.crt"): true,
-					filepath.Join(dir, "etcd-pki", "client.key"): true,
-				},
-				expectKubeControllerManagerArgs: map[string]string{
-					"--cloud-provider": "external",
+		expectServiceRestarts []string
+		expectFilesToExist    map[string]bool
+	}{
+		{
+			name: "Default",
+			config: types.ClusterConfig{
+				Datastore: types.Datastore{
+					Type:            utils.Pointer("external"),
+					ExternalServers: utils.Pointer([]string{"http://127.0.0.1:2379"}),
 				},
 			},
-			{
-				name: "UpdateAll",
-				config: types.ClusterConfig{
-					Datastore: types.Datastore{
-						Type:            utils.Pointer("external"),
-						ExternalServers: utils.Pointer([]string{"http://127.0.0.1:2379"}),
-					},
-					Kubelet: types.Kubelet{
-						CloudProvider: utils.Pointer(""),
-					},
-				},
-				expectKubeAPIServerArgs: map[string]string{
-					"--etcd-servers":  "http://127.0.0.1:2379",
-					"--etcd-cafile":   "",
-					"--etcd-certfile": "",
-					"--etcd-keyfile":  "",
-				},
-				expectFilesToExist: map[string]bool{
-					filepath.Join(dir, "etcd-pki", "ca.crt"):     false,
-					filepath.Join(dir, "etcd-pki", "client.crt"): false,
-					filepath.Join(dir, "etcd-pki", "client.key"): false,
-				},
-				expectKubeControllerManagerArgs: map[string]string{
-					"--cloud-provider": "",
-				},
-				expectServiceRestarts: []string{"kube-apiserver", "kube-controller-manager"},
+			expectKubeAPIServerArgs: map[string]string{
+				"--etcd-servers": "http://127.0.0.1:2379",
 			},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				g := NewWithT(t)
-
-				s.RestartServicesCalledWith = nil
-
-				configProvider.config = tc.config
-
-				select {
-				case triggerCh <- time.Now():
-				case <-time.After(channelSendTimeout):
-					g.Fail("Timed out while attempting to trigger controller reconcile loop")
-				}
-
-				select {
-				case <-ctrl.ReconciledCh():
-				case <-time.After(channelSendTimeout):
-					g.Fail("Time out while waiting for the reconcile to complete")
-				}
-				if tc.expectServiceRestarts != nil {
-					var flat []string
-					for _, sub := range s.RestartServicesCalledWith {
-						flat = append(flat, sub...)
-					}
-					g.Expect(flat).To(ContainElements(tc.expectServiceRestarts))
-				} else {
-					g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
-				}
-
-				t.Run("APIServerArgs", func(t *testing.T) {
-					for earg, eval := range tc.expectKubeAPIServerArgs {
-						t.Run(earg, func(t *testing.T) {
-							g := NewWithT(t)
-
-							val, err := snaputil.GetServiceArgument(s, "kube-apiserver", earg)
-							g.Expect(err).To(Not(HaveOccurred()))
-							g.Expect(val).To(Equal(eval))
-						})
-					}
-				})
-
-				t.Run("KubeControllerManagerArgs", func(t *testing.T) {
-					for earg, eval := range tc.expectKubeControllerManagerArgs {
-						t.Run(earg, func(t *testing.T) {
-							g := NewWithT(t)
-
-							val, err := snaputil.GetServiceArgument(s, "kube-controller-manager", earg)
-							g.Expect(err).To(Not(HaveOccurred()))
-							g.Expect(val).To(Equal(eval))
-						})
-					}
-				})
-
-				t.Run("Certs", func(t *testing.T) {
-					for file, mustExist := range tc.expectFilesToExist {
-						t.Run(filepath.Base(file), func(t *testing.T) {
-							g := NewWithT(t)
-
-							_, err := os.Stat(file)
-							if mustExist {
-								g.Expect(err).To(Not(HaveOccurred()))
-							} else {
-								g.Expect(err).To(MatchError(os.ErrNotExist))
-							}
-						})
-					}
-				})
-			})
-		}
-	})
-
-	t.Run("Worker", func(t *testing.T) {
-		dir := t.TempDir()
-
-		s := &mock.Snap{
-			Mock: mock.Mock{
-				EtcdPKIDir:          filepath.Join(dir, "etcd-pki"),
-				ServiceArgumentsDir: filepath.Join(dir, "args"),
-				LockFilesDir:        filepath.Join(dir, "locks"),
-				UID:                 os.Getuid(),
-				GID:                 os.Getgid(),
+			expectFilesToExist: map[string]bool{
+				filepath.Join(dir, "etcd-pki", "ca.crt"):     false,
+				filepath.Join(dir, "etcd-pki", "client.crt"): false,
+				filepath.Join(dir, "etcd-pki", "client.key"): false,
 			},
-		}
-
-		g := NewWithT(t)
-		g.Expect(setup.EnsureAllDirectories(s)).To(Succeed())
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		triggerCh := make(chan time.Time)
-		configProvider := &configProvider{}
-
-		ctrl := controllers.NewControlPlaneConfigurationController(s, func() {}, triggerCh)
-		go ctrl.Run(ctx, configProvider.getConfig)
-
-		// mark as worker node
-		g.Expect(snaputil.MarkAsWorkerNode(s, true)).To(Succeed())
-
-		configProvider.config = types.ClusterConfig{
-			Datastore: types.Datastore{
-				Type:               utils.Pointer("external"),
-				ExternalServers:    utils.Pointer([]string{"https://127.0.0.1:2379"}),
-				ExternalCACert:     utils.Pointer("CA DATA"),
-				ExternalClientCert: utils.Pointer("CERT DATA"),
-				ExternalClientKey:  utils.Pointer("KEY DATA"),
+			expectServiceRestarts: []string{"kube-apiserver"},
+		},
+		{
+			name: "Certs",
+			config: types.ClusterConfig{
+				Datastore: types.Datastore{
+					Type:               utils.Pointer("external"),
+					ExternalServers:    utils.Pointer([]string{"https://127.0.0.1:2379"}),
+					ExternalCACert:     utils.Pointer("CA DATA"),
+					ExternalClientCert: utils.Pointer("CERT DATA"),
+					ExternalClientKey:  utils.Pointer("KEY DATA"),
+				},
 			},
-			Kubelet: types.Kubelet{
-				CloudProvider: utils.Pointer("external"),
+			expectKubeAPIServerArgs: map[string]string{
+				"--etcd-servers":  "https://127.0.0.1:2379",
+				"--etcd-cafile":   filepath.Join(dir, "etcd-pki", "ca.crt"),
+				"--etcd-certfile": filepath.Join(dir, "etcd-pki", "client.crt"),
+				"--etcd-keyfile":  filepath.Join(dir, "etcd-pki", "client.key"),
 			},
-		}
-
-		select {
-		case triggerCh <- time.Now():
-		case <-time.After(channelSendTimeout):
-			g.Fail("Timed out while attempting to trigger controller reconcile loop")
-		}
-
-		// TODO: this should be changed to call g.Eventually()
-		<-time.After(50 * time.Millisecond)
-
-		g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
-
-		t.Run("APIServerArgs", func(t *testing.T) {
-			for _, arg := range []string{"--etcd-servers", "--etcd-cafile", "--etcd-certfile", "--etcd-keyfile"} {
-				t.Run(arg, func(t *testing.T) {
-					g := NewWithT(t)
-
-					val, err := snaputil.GetServiceArgument(s, "kube-apiserver", "--etcd-servers")
-					g.Expect(err).To(HaveOccurred())
-					g.Expect(val).To(BeEmpty())
-				})
-			}
-		})
-
-		t.Run("KubeControllerManagerArgs", func(t *testing.T) {
+			expectFilesToExist: map[string]bool{
+				filepath.Join(dir, "etcd-pki", "ca.crt"):     true,
+				filepath.Join(dir, "etcd-pki", "client.crt"): true,
+				filepath.Join(dir, "etcd-pki", "client.key"): true,
+			},
+			expectServiceRestarts: []string{"kube-apiserver"},
+		},
+		{
+			name: "CloudProvider",
+			config: types.ClusterConfig{
+				Kubelet: types.Kubelet{
+					CloudProvider: utils.Pointer("external"),
+				},
+			},
+			expectKubeControllerManagerArgs: map[string]string{
+				"--cloud-provider": "external",
+			},
+			expectServiceRestarts: []string{"kube-controller-manager"},
+		},
+		{
+			name: "NoUpdates",
+			config: types.ClusterConfig{
+				Datastore: types.Datastore{
+					Type:               utils.Pointer("external"),
+					ExternalServers:    utils.Pointer([]string{"https://127.0.0.1:2379"}),
+					ExternalCACert:     utils.Pointer("CA DATA"),
+					ExternalClientCert: utils.Pointer("CERT DATA"),
+					ExternalClientKey:  utils.Pointer("KEY DATA"),
+				},
+				Kubelet: types.Kubelet{
+					CloudProvider: utils.Pointer("external"),
+				},
+			},
+			expectKubeAPIServerArgs: map[string]string{
+				"--etcd-servers":  "https://127.0.0.1:2379",
+				"--etcd-cafile":   filepath.Join(dir, "etcd-pki", "ca.crt"),
+				"--etcd-certfile": filepath.Join(dir, "etcd-pki", "client.crt"),
+				"--etcd-keyfile":  filepath.Join(dir, "etcd-pki", "client.key"),
+			},
+			expectFilesToExist: map[string]bool{
+				filepath.Join(dir, "etcd-pki", "ca.crt"):     true,
+				filepath.Join(dir, "etcd-pki", "client.crt"): true,
+				filepath.Join(dir, "etcd-pki", "client.key"): true,
+			},
+			expectKubeControllerManagerArgs: map[string]string{
+				"--cloud-provider": "external",
+			},
+		},
+		{
+			name: "UpdateAll",
+			config: types.ClusterConfig{
+				Datastore: types.Datastore{
+					Type:            utils.Pointer("external"),
+					ExternalServers: utils.Pointer([]string{"http://127.0.0.1:2379"}),
+				},
+				Kubelet: types.Kubelet{
+					CloudProvider: utils.Pointer(""),
+				},
+			},
+			expectKubeAPIServerArgs: map[string]string{
+				"--etcd-servers":  "http://127.0.0.1:2379",
+				"--etcd-cafile":   "",
+				"--etcd-certfile": "",
+				"--etcd-keyfile":  "",
+			},
+			expectFilesToExist: map[string]bool{
+				filepath.Join(dir, "etcd-pki", "ca.crt"):     false,
+				filepath.Join(dir, "etcd-pki", "client.crt"): false,
+				filepath.Join(dir, "etcd-pki", "client.key"): false,
+			},
+			expectKubeControllerManagerArgs: map[string]string{
+				"--cloud-provider": "",
+			},
+			expectServiceRestarts: []string{"kube-apiserver", "kube-controller-manager"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			val, err := snaputil.GetServiceArgument(s, "kube-controller-manager", "--cloud-provider")
-			g.Expect(err).To(HaveOccurred())
-			g.Expect(val).To(BeEmpty())
-		})
+			s.RestartServicesCalledWith = nil
 
-		t.Run("Certs", func(t *testing.T) {
-			for _, cert := range []string{"ca.crt", "client.crt", "client.key"} {
-				t.Run(cert, func(t *testing.T) {
-					g := NewWithT(t)
+			configProvider.config = tc.config
 
-					_, err := os.Stat(filepath.Join(dir, "etcd-pki", cert))
-					g.Expect(err).To(MatchError(os.ErrNotExist))
-				})
+			select {
+			case triggerCh <- time.Now():
+			case <-time.After(channelSendTimeout):
+				g.Fail("Timed out while attempting to trigger controller reconcile loop")
 			}
+
+			select {
+			case <-ctrl.ReconciledCh():
+			case <-time.After(channelSendTimeout):
+				g.Fail("Time out while waiting for the reconcile to complete")
+			}
+			if tc.expectServiceRestarts != nil {
+				var flat []string
+				for _, sub := range s.RestartServicesCalledWith {
+					flat = append(flat, sub...)
+				}
+				g.Expect(flat).To(ContainElements(tc.expectServiceRestarts))
+			} else {
+				g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
+			}
+
+			t.Run("APIServerArgs", func(t *testing.T) {
+				for earg, eval := range tc.expectKubeAPIServerArgs {
+					t.Run(earg, func(t *testing.T) {
+						g := NewWithT(t)
+
+						val, err := snaputil.GetServiceArgument(s, "kube-apiserver", earg)
+						g.Expect(err).To(Not(HaveOccurred()))
+						g.Expect(val).To(Equal(eval))
+					})
+				}
+			})
+
+			t.Run("KubeControllerManagerArgs", func(t *testing.T) {
+				for earg, eval := range tc.expectKubeControllerManagerArgs {
+					t.Run(earg, func(t *testing.T) {
+						g := NewWithT(t)
+
+						val, err := snaputil.GetServiceArgument(s, "kube-controller-manager", earg)
+						g.Expect(err).To(Not(HaveOccurred()))
+						g.Expect(val).To(Equal(eval))
+					})
+				}
+			})
+
+			t.Run("Certs", func(t *testing.T) {
+				for file, mustExist := range tc.expectFilesToExist {
+					t.Run(filepath.Base(file), func(t *testing.T) {
+						g := NewWithT(t)
+
+						_, err := os.Stat(file)
+						if mustExist {
+							g.Expect(err).To(Not(HaveOccurred()))
+						} else {
+							g.Expect(err).To(MatchError(os.ErrNotExist))
+						}
+					})
+				}
+			})
 		})
-	})
+	}
 }

--- a/src/k8s/pkg/k8sd/controllers/coordinator.go
+++ b/src/k8s/pkg/k8sd/controllers/coordinator.go
@@ -25,28 +25,31 @@ type Coordinator struct {
 	snap      snap.Snap
 	waitReady func()
 
-	// Upgrade controller
-	disableUpgradeController bool
-	upgradeControllerOpts    upgrade.ControllerOptions
+	upgradeControllerOptions    UpgradeControllerOptions
+	csrSigningControllerOptions CSRSigningControllerOptions
+}
 
-	// CSR signing controller
-	disableCSRSigningController bool
+type UpgradeControllerOptions struct {
+	upgrade.ControllerOptions
+	Disable bool
+}
+
+type CSRSigningControllerOptions struct {
+	Disable bool
 }
 
 // NewCoordinator creates a new Coordinator instance.
 func NewCoordinator(
 	snap snap.Snap,
 	waitReady func(),
-	disableUpgradeController bool,
-	upgradeControllerOpts upgrade.ControllerOptions,
-	disableCSRSiningController bool,
+	upgradeControllerOptions UpgradeControllerOptions,
+	csrSigningControllerOptions CSRSigningControllerOptions,
 ) *Coordinator {
 	return &Coordinator{
 		snap:                        snap,
 		waitReady:                   waitReady,
-		disableUpgradeController:    disableUpgradeController,
-		upgradeControllerOpts:       upgradeControllerOpts,
-		disableCSRSigningController: disableCSRSiningController,
+		upgradeControllerOptions:    upgradeControllerOptions,
+		csrSigningControllerOptions: csrSigningControllerOptions,
 	}
 }
 
@@ -132,7 +135,7 @@ func (c *Coordinator) setupUpgradeController(
 ) error {
 	logger := mgr.GetLogger()
 
-	if c.disableUpgradeController {
+	if c.upgradeControllerOptions.Disable {
 		logger.Info("Upgrade controller is disabled. Skipping setup.")
 		return nil
 	}
@@ -150,7 +153,7 @@ func (c *Coordinator) setupUpgradeController(
 	upgradeController := upgrade.NewController(
 		logger,
 		mgr.GetClient(),
-		c.upgradeControllerOpts,
+		c.upgradeControllerOptions.ControllerOptions,
 	)
 
 	if err := upgradeController.SetupWithManager(mgr); err != nil {
@@ -166,7 +169,7 @@ func (c *Coordinator) setupCSRSigningController(
 ) error {
 	logger := mgr.GetLogger()
 
-	if c.disableCSRSigningController {
+	if c.csrSigningControllerOptions.Disable {
 		logger.Info("CSR signing controller is disabled. Skipping setup.")
 		return nil
 	}

--- a/src/k8s/pkg/k8sd/controllers/node_label.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label.go
@@ -172,8 +172,8 @@ func (c *NodeLabelController) reconcile(ctx context.Context, client *kubernetes.
 
 	var errs []error
 
-	log.FromContext(ctx).Info("Reconciling node failure domain", "nodeName", node.Name)
 	if !isWorker {
+		log.FromContext(ctx).Info("Reconciling node failure domain", "nodeName", node.Name)
 		if err := c.reconcileFailureDomain(ctx, node, getDatastoreType); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile failure domain: %w", err))
 		}

--- a/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/update_node_configuration.go
@@ -8,7 +8,6 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
-	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
 )
 
@@ -52,14 +51,6 @@ func (c *UpdateNodeConfigurationController) Run(ctx context.Context, getClusterC
 		case <-ctx.Done():
 			return
 		case <-c.triggerCh:
-		}
-
-		if isWorker, err := snaputil.IsWorker(c.snap); err != nil {
-			log.Error(err, "Failed to check if running on a worker node")
-			continue
-		} else if isWorker {
-			log.Info("Stopping on worker node")
-			return
 		}
 
 		config, err := getClusterConfig(ctx)


### PR DESCRIPTION
# WIP: Not officially planned for now.

### Overview

* Refactors k8sd controller creation to separate common, CP specific and worker specific controllers.
* Uses separate structs for different controllers in the coordinator.