### PR TITLE
chore: Use go/1.24-fips

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -10,7 +10,7 @@ sed -i "s,^VERSION.*$,VERSION=${VERSION}," Makefile
 sed -i "s,^REVISION.*$,REVISION=${REVISION}," Makefile
 
 export GOTOOLCHAIN=local
-# # export GOEXPERIMENT=opensslcrypto
+export GOEXPERIMENT=opensslcrypto
 export CGO_ENABLED=1
 export GO_BUILDTAGS="linux cgo"
 for bin in containerd; do

--- a/build-scripts/components/etcd/build.sh
+++ b/build-scripts/components/etcd/build.sh
@@ -7,7 +7,7 @@ mkdir -p "${INSTALL}"
 
 export GOTOOLCHAIN=local
 export CGO_ENABLED=1
-#export GOEXPERIMENT=opensslcrypto
+export GOEXPERIMENT=opensslcrypto
 export GOFLAGS="-tags=linux,cgo"
 
 make build

--- a/build-scripts/components/helm/build.sh
+++ b/build-scripts/components/helm/build.sh
@@ -7,6 +7,6 @@ mkdir -p "${INSTALL}"
 
 export GOTOOLCHAIN=local
 export CGO_ENABLED=1
-# # export GOEXPERIMENT=opensslcrypto
+export GOEXPERIMENT=opensslcrypto
 make VERSION="${VERSION}" TAGS="linux,cgo"
 cp bin/helm "${INSTALL}/helm"

--- a/build-scripts/components/k8s-dqlite/build.sh
+++ b/build-scripts/components/k8s-dqlite/build.sh
@@ -8,7 +8,7 @@ if [ -d "${SNAPCRAFT_STAGE}/dynamic-dqlite-deps" ]; then
 fi
 
 export GOTOOLCHAIN=local
-# # export GOEXPERIMENT=opensslcrypto
+export GOEXPERIMENT=opensslcrypto
 export CGO_ENABLED=1
 make dynamic -j
 

--- a/build-scripts/components/kubernetes/build.sh
+++ b/build-scripts/components/kubernetes/build.sh
@@ -7,7 +7,7 @@ export KUBE_GIT_VERSION_FILE="${PWD}/.version.sh"
 
 for app in kubernetes; do
   export GOTOOLCHAIN=local
-  # # export GOEXPERIMENT=opensslcrypto
+  export GOEXPERIMENT=opensslcrypto
   export CGO_ENABLED=1
   make WHAT="cmd/${app}" KUBE_CGO_OVERRIDES="${app}" GOFLAGS="-tags=providerless,linux,cgo"
   cp _output/bin/"${app}" "${INSTALL}/${app}"

--- a/docs/canonicalk8s/snap/howto/contribute.md
+++ b/docs/canonicalk8s/snap/howto/contribute.md
@@ -90,7 +90,7 @@ these steps:
 ```
 module github.com/canonical/k8s
 
-go 1.23.0
+go 1.24.4
 
 replace github.com/canonical/k8s-snap-api => /path/to/k8s-snap-api
 

--- a/k8s/wrappers/services/k8sd
+++ b/k8s/wrappers/services/k8sd
@@ -5,16 +5,5 @@
 # required to open unix-socket in the snap
 export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.k8sd"
 
-if k8s::common::on_fips_host; then
-  # The Microsoft/go toolchain 1.23 TLS implementation contains a bug
-  # that causes TLS connections to fail when FIPS is enabled.
-  # This is fixed in 1.24 but won't be backported to 1.23.
-  # See https://github.com/microsoft/go/issues/1626
-  # and https://github.com/golang-fips/openssl/pull/272
-  #
-  # As a workaround for 1.23, we set the minTLSVersion to 1.2.
-  # See https://github.com/canonical/lxd/blob/9f30d5799ec0dc45364b95d9e609ab09508d337e/shared/network.go#L65
-  export LXD_INSECURE_TLS=1
-fi
 
 k8s::common::execute k8sd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,7 @@ parts:
   build-deps:
     plugin: nil
     build-snaps:
-      - go/1.24/stable
+      - go/1.24-fips/stable
     build-attributes: [enable-patchelf]
     build-packages:
       - sudo
@@ -125,7 +125,7 @@ parts:
       export DQLITE_BUILD_SCRIPTS_DIR="${CRAFT_STAGE}/static-dqlite-deps"
       export CGO_ENABLED=1
       export GOTOOLCHAIN=local
-      # export GOEXPERIMENT=opensslcrypto
+      export GOEXPERIMENT=opensslcrypto
 
       make dynamic -j
 


### PR DESCRIPTION
### Overview

This PR uses `go/1.24-fips/stable` snap and adds necessary changes such as:
* Adding `GOEXPERIMENT=opensslcrypto`
* Removing the TLS1.2 min version workaround for LXD (TLS min version will be 1.3)