### PR TITLE
docs: fips explanation page

### DIFF
--- a/docs/canonicalk8s/snap/explanation/security/fips.md
+++ b/docs/canonicalk8s/snap/explanation/security/fips.md
@@ -1,0 +1,28 @@
+# FIPS Compliance
+
+[FIPS 140-3] (Federal Information Processing Standard) is a U.S. government
+standard for cryptographic modules. In order to comply with FIPS standards,
+each cryptographic module must meet specific security requirements and must
+undergo testing and validation by the U.S. National Institute of Standards
+and Technology ([NIST]).
+
+## Why is FIPS important for Kubernetes?
+
+{{ product }} is built with FIPS compliant cryptographic
+modules, ensuring that users can meet the security requirements set forth
+for the use in federal and other regulated environments. All of our components
+including the built-in features such networking or load-balancer are built
+with FIPS compliant libraries. By choosing a compliant Kubernetes distribution,
+such as {{ product }}, organizations can minimize their security
+risks and adhere to compliance requirements. When building workloads on top of
+{{ product }}, it is essential that organizations build these in a FIPS
+compliant manner to comply with the FIPS security requirements.
+
+## Use FIPS with {{product}}
+
+If you would like to use FIPS in your cluster see our [how-to guide].
+
+<!-- LINKS -->
+[FIPS 140-3]: https://csrc.nist.gov/pubs/fips/140-3/final
+[how-to guide]: /snap/howto/security/fips.md
+[NIST]: https://www.nist.gov/

--- a/docs/canonicalk8s/snap/explanation/security/index.md
+++ b/docs/canonicalk8s/snap/explanation/security/index.md
@@ -9,6 +9,7 @@ Security overview <security-overview>
 Authentication and authorization <auth.md>
 certificates
 cis
+fips
 crypto
 ```
 <!-- Add back in once we have this page complete Cryptography <cryptography> -->


### PR DESCRIPTION
## Description

This PR adds the FIPS explanation page.
It links to the not yet merged how-to guide: https://github.com/canonical/k8s-snap/pull/1727.

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
