### PR TITLE
fix: Use -ck tags for metallb frr and rawfile-localpv rocks

### DIFF
--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "0.8.2"
+	ImageTag = "0.8.2-ck1"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"

--- a/src/k8s/pkg/k8sd/features/metallb/chart.go
+++ b/src/k8s/pkg/k8sd/features/metallb/chart.go
@@ -37,5 +37,5 @@ var (
 	frrImageRepo = "ghcr.io/canonical/frr"
 
 	// frrImageTag is the tag to use for frrouting.
-	frrImageTag = "9.1.3"
+	frrImageTag = "9.1.3-ck1"
 )


### PR DESCRIPTION
### Overview

This PR adds a `-ck` suffix to metallb frr and rawfile-localpv image tags which should've had this suffix before. These tags DO NOT include FIPS changes.

NOTES:
* `-ck1` for rawfile-localpv was discussed with the team internally.
* `-ck1` for metallb frr is based on the [images history](https://github.com/canonical/metallb-rocks/pkgs/container/frr). `-ck2` was created last week with the FIPS changed, and `-ck1` is a month old with the contents prior to FIPS changes.