### PR TITLE
fix: Make charm-e2e-test artifacts uniquely named

### DIFF
--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -128,5 +128,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-run-artifacts
+          name: charm-e2e-tests-${{ inputs.arch }}
           path: ${{ steps.collect-juju-status.outputs.path }}


### PR DESCRIPTION
## Description

While reviewing #1726, i spotted an error with the charm-e2e-test
https://github.com/canonical/k8s-snap/actions/runs/16804748815/job/47595805069?pr=1726

## Solution

Provide unique gh artifact names so any juju-crashdump can be uploaded

## Backport

Should this PR be backported? If so, to which release?
I'm not sure @canonical/kubernetes where else should it go?

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
