### PR TITLE
chore: Bump images to use the FIPS-compliant version

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,13 +39,13 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.1-ck2"
+	CiliumAgentImageTag = "1.17.1-ck3"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.1-ck2"
+	ciliumOperatorImageTag = "1.17.1-ck3"
 
 	ciliumDefaultVXLANPort = 8472
 

--- a/src/k8s/pkg/k8sd/features/coredns/chart.go
+++ b/src/k8s/pkg/k8sd/features/coredns/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/coredns"
 
 	// ImageTag is the tag to use for the CoreDNS image.
-	ImageTag = "1.12.0-ck1"
+	ImageTag = "1.12.0-ck0"
 )

--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,14 +17,14 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "0.8.2-ck1"
+	ImageTag = "0.8.2-ck2"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
-	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"
+	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.2"
 	// csiProvisionerImage is the image to use for the CSI provisioner.
-	csiProvisionerImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner:v5.0.2"
+	csiProvisionerImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner:v5.0.3"
 	// csiResizerImage is the image to use for the CSI resizer.
-	csiResizerImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer:v1.11.2"
+	csiResizerImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer:v1.11.3"
 	// csiSnapshotterImage is the image to use for the CSI snapshotter.
-	csiSnapshotterImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.2"
+	csiSnapshotterImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.3"
 )

--- a/src/k8s/pkg/k8sd/features/metallb/chart.go
+++ b/src/k8s/pkg/k8sd/features/metallb/chart.go
@@ -25,17 +25,17 @@ var (
 	controllerImageRepo = "ghcr.io/canonical/metallb-controller"
 
 	// ControllerImageTag is the tag to use for metallb-controller.
-	ControllerImageTag = "v0.14.9-ck0"
+	ControllerImageTag = "v0.14.9-ck1"
 
 	// speakerImageRepo is the image to use for metallb-speaker.
 	speakerImageRepo = "ghcr.io/canonical/metallb-speaker"
 
 	// speakerImageTag is the tag to use for metallb-speaker.
-	speakerImageTag = "v0.14.9-ck0"
+	speakerImageTag = "v0.14.9-ck1"
 
 	// frrImageRepo is the image to use for frrouting.
 	frrImageRepo = "ghcr.io/canonical/frr"
 
 	// frrImageTag is the tag to use for frrouting.
-	frrImageTag = "9.1.3-ck1"
+	frrImageTag = "9.1.3-ck2"
 )

--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/metrics-server"
 
 	// imageTag is the image tag to use for metrics-server.
-	imageTag = "0.7.2-ck0"
+	imageTag = "0.7.2-ck4"
 )


### PR DESCRIPTION
### Overview

This PR bumps image tags to use the FIPS-compliant versions. A documentation regarding these tags and their statuses is shared internally.

### NOTE
Some of these tags aren't available yet. This PR needs to stay open until those tags become available.