### PR TITLE
chore: Collect upgrades in inspection report, Fix feature upgrades test

### DIFF
--- a/k8s/scripts/inspect.sh
+++ b/k8s/scripts/inspect.sh
@@ -95,6 +95,7 @@ function collect_cluster_info {
   fi
 
   run_with_timeout "k8s kubectl cluster-info dump $FLAGS --output-directory $INSPECT_DUMP/cluster-info &>/dev/null"
+  run_with_timeout "k8s kubectl get upgrades -ojson $FLAGS > $INSPECT_DUMP/cluster-info/upgrades.json"
 }
 
 function collect_sbom {

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -336,10 +336,10 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
 
     # Refresh each CP node after each other and verify that the upgrade CR is updated correctly.
     for idx, instance in enumerate(instances):
-        util.setup_k8s_snap(instance, tmp_path, config.SNAP)
-
         if instance.id == worker.id:
             continue
+
+        util.setup_k8s_snap(instance, tmp_path, config.SNAP)
 
         # The crd will be created once the node is up and ready, so we might need to wait for it.
         expected_instances = [instance.id for instance in instances[: idx + 1]]


### PR DESCRIPTION
### Overview

* Collects upgrade resources in inspection reports.
* Solve the following issue in the upgrade tests by preventing multiple refreshes on the worker nodes:
```
Jul 26 00:19:57 k8s-integration-2-ae8a84 k8s.k8sd[6402]: I0726 00:19:57.167245    6402 upgrade/reconcile.go:83] "Reconciling node version." logger="k8sd.controller-coordinator" node="k8s-integration-5-8ce294" version="x2"
Jul 26 00:19:57 k8s-integration-2-ae8a84 k8s.k8sd[6402]: I0726 00:19:57.167284    6402 upgrade/reconcile.go:89] "No upgrade found for revision, skipping reconciliation." logger="k8sd.controller-coordinator" node="k8s-integration-5-8ce294" revision="x2"
```