### PR TITLE
test: Make instance restart harness-dependent

### DIFF
--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -6,7 +6,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/weekly-test.yaml
-
 permissions:
   contents: read
   actions: read

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -305,7 +305,7 @@ def instances(
         try:
             util.remove_k8s_snap(instance)
         finally:
-            h.delete_instance(instance.id)
+            instance.delete()
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/tests/test_restart.py
+++ b/tests/integration/tests/test_restart.py
@@ -25,9 +25,9 @@ STATUS_PATTERNS = [
 
 @pytest.mark.tags(tags.WEEKLY)
 @pytest.mark.node_count(3)
-def test_reboot(instances: List[harness.Instance]):
+def test_restart(instances: List[harness.Instance]):
     """
-    Test that a reboot of the instance does not break the k8s snap.
+    Test that a restart of the instance does not break the k8s snap.
     """
 
     main = instances[0]
@@ -44,10 +44,10 @@ def test_reboot(instances: List[harness.Instance]):
         ).exec(["k8s", "status", "--wait-ready"])
 
     for instance in instances:
-        LOG.info("Rebooting the instance %s", instance.id)
-        instance.reboot()
+        LOG.info("Restart the instance %s", instance.id)
+        instance.restart()
 
-    LOG.info("Waiting for k8s to be ready after reboot")
+    LOG.info("Waiting for k8s to be ready after restart")
     util.wait_until_k8s_ready(instance, [instance])
     for instance in instances:
         LOG.info("Waiting for the instance %s to come back up", instance.id)

--- a/tests/integration/tests/test_util/etcd.py
+++ b/tests/integration/tests/test_util/etcd.py
@@ -252,7 +252,7 @@ class EtcdCluster:
 
     def cleanup(self):
         for instance in self.instances:
-            self.harness.delete_instance(instance.id)
+            instance.delete()
         self.instances = []
 
     @property

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -106,6 +106,15 @@ class Harness:
         """
         raise NotImplementedError
 
+    def restart_instance(self, instance_id: str):
+        """Restart an previously created instance.
+
+        :param instance_id: The instance_id, as returned by new_instance()
+
+        If the operation fails, a HarnessError is raised.
+        """
+        raise NotImplementedError
+
     def delete_instance(self, instance_id: str):
         """Delete a previously created instance.
 

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -3,6 +3,7 @@
 #
 import subprocess
 from functools import cached_property, partial
+from typing import List
 
 
 class HarnessError(Exception):
@@ -36,8 +37,12 @@ class Instance:
             ["dpkg", "--print-architecture"], text=True, capture_output=True
         ).stdout.strip()
 
-    def reboot(self) -> None:
-        """Reboot the instance"""
+    def open_ports(self, ports: List[int]) -> None:
+        """Open ports on the instance"""
+        self._h.open_ports(self.id, ports)
+
+    def restart(self) -> None:
+        """Restart the instance"""
         self._h.restart_instance(self.id)
 
     def delete(self) -> None:
@@ -112,6 +117,17 @@ class Harness:
         :param instance_id: The instance_id, as returned by new_instance()
 
         If the operation fails, a HarnessError is raised.
+        """
+        raise NotImplementedError
+
+    def open_ports(self, instance_id: str, ports: List[int]):
+        """Open ports on the instance.
+
+        :param instance_id: The instance_id, as returned by new_instance()
+        :param ports: List of ports to open on the instance.
+
+        Ports will be opened on a best effort basis. If the port is already open,
+        or no firewall is installed, no error will be raised.
         """
         raise NotImplementedError
 

--- a/tests/integration/tests/test_util/harness/base.py
+++ b/tests/integration/tests/test_util/harness/base.py
@@ -24,7 +24,6 @@ class Instance:
         self.send_file = partial(h.send_file, id)
         self.pull_file = partial(h.pull_file, id)
         self.exec = partial(h.exec, id)
-        self.delete_instance = partial(h.delete_instance, id)
 
     @property
     def id(self) -> str:
@@ -39,7 +38,11 @@ class Instance:
 
     def reboot(self) -> None:
         """Reboot the instance"""
-        self.exec(["sudo", "reboot"], check=True)
+        self._h.restart_instance(self.id)
+
+    def delete(self) -> None:
+        """Delete the instance"""
+        self._h.delete_instance(self.id)
 
     def __str__(self) -> str:
         return f"{self._h.name}:{self.id}"

--- a/tests/integration/tests/test_util/harness/juju.py
+++ b/tests/integration/tests/test_util/harness/juju.py
@@ -6,6 +6,7 @@ import logging
 import shlex
 import subprocess
 from pathlib import Path
+from typing import List
 
 from test_util import config
 from test_util.harness import Harness, HarnessError, Instance
@@ -193,6 +194,10 @@ class JujuHarness(Harness):
 
     def restart_instance(self, instance_id):
         self.exec(instance_id, ["sudo", "reboot"])
+
+    def open_ports(self, instance_id: str, ports: List[int]):
+        for port in ports:
+            self.exec(instance_id, ["open-port", port])
 
     def delete_instance(self, instance_id: str):
         if instance_id not in self.instances:

--- a/tests/integration/tests/test_util/harness/juju.py
+++ b/tests/integration/tests/test_util/harness/juju.py
@@ -191,6 +191,9 @@ class JujuHarness(Harness):
             completed.check_returncode()
         return completed
 
+    def restart_instance(self, instance_id):
+        self.exec(instance_id, ["sudo", "reboot"])
+
     def delete_instance(self, instance_id: str):
         if instance_id not in self.instances:
             raise HarnessError(f"unknown instance {instance_id}")

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import subprocess
 from pathlib import Path
+from typing import List
 
 from test_util import config
 from test_util.harness import Harness, HarnessError, Instance
@@ -247,6 +248,10 @@ class LXDHarness(Harness):
             run(["lxc", "restart", instance_id, "--force"], timeout=60 * 5)
         except subprocess.CalledProcessError as e:
             raise HarnessError(f"failed to restart instance {instance_id}") from e
+
+    def open_ports(self, instance_id: str, ports: List[int]):
+        # Note(Ben): We don't use a firewall in LXD containers, so this is a no-op for now.
+        pass
 
     def delete_instance(self, instance_id: str):
         if instance_id not in self.instances:

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -239,6 +239,15 @@ class LXDHarness(Harness):
             **kwargs,
         )
 
+    def restart_instance(self, instance_id):
+        if instance_id not in self.instances:
+            raise HarnessError(f"unknown instance {instance_id}")
+
+        try:
+            run(["lxc", "restart", instance_id, "--force"], timeout=60 * 5)
+        except subprocess.CalledProcessError as e:
+            raise HarnessError(f"failed to restart instance {instance_id}") from e
+
     def delete_instance(self, instance_id: str):
         if instance_id not in self.instances:
             raise HarnessError(f"unknown instance {instance_id}")

--- a/tests/integration/tests/test_util/harness/multipass.py
+++ b/tests/integration/tests/test_util/harness/multipass.py
@@ -209,6 +209,17 @@ class MultipassHarness(Harness):
             **kwargs,
         )
 
+    def restart_instance(self, instance_id):
+        if instance_id not in self.instances:
+            raise HarnessError(f"unknown instance {instance_id}")
+
+        try:
+            stubbornly(delay_s=5, retries=20).exec(
+                ["multipass", "restart", instance_id], timeout=60 * 5
+            )
+        except subprocess.CalledProcessError as e:
+            raise HarnessError(f"failed to restart instance {instance_id}") from e
+
     def delete_instance(self, instance_id: str):
         if instance_id not in self.instances:
             raise HarnessError(f"unknown instance {instance_id}")

--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -201,7 +201,7 @@ class Registry:
     def cleanup(self):
         if self.instance:
             LOG.info("Cleaning up registry instance: %s", self.instance.id)
-            self.harness.delete_instance(self.instance.id)
+            self.instance.delete()
             self.instance = None
         else:
             LOG.info("Registry instance already cleaned up.")


### PR DESCRIPTION
## Description

The multipass tests were failing because rebooting needs to happen via `multipass restart` instead of an `sudo reboot` from within the instance. See https://github.com/canonical/k8s-snap/actions/runs/16878895760/job/47819464883?pr=1702

## Solution

* Refactored the reboot and delete functions to call the underlying harness function to restart/delete an instance
* Renamed reboot to restart to match lxd/multipass naming conventions
