### PR TITLE
chore: update 1.34 single binary patch

### DIFF
--- a/build-scripts/components/kubernetes/patches/v1.34.0/0001-single-kubernetes-binary.patch
+++ b/build-scripts/components/kubernetes/patches/v1.34.0/0001-single-kubernetes-binary.patch
@@ -1,4 +1,4 @@
-From 2325dd1fa719932c32002a39416181b158be3b0d Mon Sep 17 00:00:00 2001
+From dca9c99f96637100d1717c67879f0d6b369926cf Mon Sep 17 00:00:00 2001
 From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
 Date: Tue, 2 Jan 2024 16:43:16 +0200
 Subject: [PATCH] single kubernetes binary
@@ -125,7 +125,7 @@ index 4351585e684..0be23f51829 100644
  	// set appropriate level here, because in the normal flow the flag parsing,
  	// including the logging verbosity, happens inside cli.RunNoErrOutput.
 diff --git a/cmd/kubelet/kubelet.go b/cmd/kubelet/kubelet.go
-index c6a73a0034d..24656e8727e 100644
+index 114cbd4aabc..096ac6dc451 100644
 --- a/cmd/kubelet/kubelet.go
 +++ b/cmd/kubelet/kubelet.go
 @@ -19,7 +19,7 @@ limitations under the License.
@@ -136,14 +136,14 @@ index c6a73a0034d..24656e8727e 100644
 +package kubelet
  
  import (
- 	"os"
-@@ -31,7 +31,7 @@ import (
+ 	"context"
+@@ -32,7 +32,7 @@ import (
  	"k8s.io/kubernetes/cmd/kubelet/app"
  )
  
 -func main() {
 +func Main() {
- 	command := app.NewKubeletCommand()
+ 	command := app.NewKubeletCommand(context.Background())
  	code := cli.Run(command)
  	os.Exit(code)
 diff --git a/cmd/kubernetes/main.go b/cmd/kubernetes/main.go
@@ -187,5 +187,5 @@ index 00000000000..9c82c6a89ee
 +	}
 +}
 -- 
-2.41.0
+2.43.0
 


### PR DESCRIPTION
## Description

Update/rebase single binary patch based on upstream changes, (kubelet now explicitly gets a `context.Background()` passed)

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary