### PR TITLE
docs: CIS etcd updates

### DIFF
--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -376,6 +376,10 @@ permissions=600
 
 ##### CIS Control 1.1.8
 
+`````{tabs}
+
+````{group-tab} k8s-dqlite
+
 **Description:**
 
 Ensure that the dqlite configuration file ownership is set
@@ -400,6 +404,39 @@ Run the following command on the control plane node.
 ```
 root:root
 ```
+
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the etcd configuration file ownership is set
+to root:root
+
+
+**Remediation:**
+
+Run the following command on the control plane node.
+
+`chown root:root /var/snap/k8s/common/args/etcd`
+
+
+**Audit (as root):**
+
+```
+/bin/sh -c 'if test -e /var/snap/k8s/common/args/etcd; then stat -c %U:%G /var/snap/k8s/common/args/etcd; fi'
+```
+
+**Expected output:**
+
+```
+root:root
+```
+
+````
+
+`````{tabs}
 
 ##### CIS Control 1.1.9
 
@@ -458,6 +495,10 @@ root:root
 
 ##### CIS Control 1.1.11
 
+`````{tabs}
+
+````{group-tab} k8s-dqlite
+
 **Description:**
 
 Ensure that the dqlite data directory permissions are set to
@@ -486,7 +527,47 @@ stat -c permissions=%a "$DATA_DIR"
 permissions=700
 ```
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the etcd data directory permissions are set to
+700 or more restrictive
+
+
+**Remediation:**
+
+etcd data are kept by default under
+`/var/snap/k8s/common/var/lib/etcd`.
+To comply with the spirit of this CIS recommendation:
+
+`chmod 700 /var/snap/k8s/common/var/lib/etcd`
+
+
+**Audit (as root):**
+
+```
+DATA_DIR='/var/snap/k8s/common/var/lib/etcd'
+stat -c permissions=%a "$DATA_DIR"
+```
+
+**Expected output:**
+
+```
+permissions=700
+```
+
+````
+
+`````
+
 ##### CIS Control 1.1.12
+
+`````{tabs}
+
+````{group-tab} k8s-dqlite
 
 **Description:**
 
@@ -515,6 +596,42 @@ stat -c %U:%G "$DATA_DIR"
 ```
 root:root
 ```
+
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the etcd data directory ownership is set to
+root:root
+
+
+**Remediation:**
+
+etcd data are kept by default under
+`/var/snap/k8s/common/var/lib/etcd`.
+To comply with the spirit of this CIS recommendation:
+
+`chown root:root /var/snap/k8s/common/var/lib/etcd`
+
+
+**Audit (as root):**
+
+```
+DATA_DIR='/var/snap/k8s/common/var/lib/etcd'
+stat -c %U:%G "$DATA_DIR"
+```
+
+**Expected output:**
+
+```
+root:root
+```
+
+````
+
+`````
 
 ##### CIS Control 1.1.13
 
@@ -1496,6 +1613,10 @@ file=/etc/kubernetes/pki/serviceaccount.key
 
 ##### CIS Control 1.2.25
 
+`````{tabs}
+
+````{group-tab} k8s-dqlite
+
 **Description:**
 
 Ensure that the `--etcd-certfile` and `--etcd-keyfile` arguments
@@ -1510,6 +1631,51 @@ local socket
 (`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
 accessible to users with root permissions.
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--etcd-certfile` and `--etcd-keyfile` arguments
+are set as appropriate
+
+
+**Remediation:**
+
+Edit the API server configuration file 
+`/var/snap/k8s/common/args/kube-apiserver` on the control plane node and set 
+the `--etcd-certfile` and `--etcd-keyfile` parameters to the certificate and 
+private key files respectively. 
+
+```
+--etcd-certfile="/etc/kubernetes/pki/apiserver-etcd-client.crt"
+--etcd-keyfile="/etc/kubernetes/pki/apiserver-etcd-client.key"
+
+```
+
+Restart the `kube-apiserver` service.
+
+```
+snap restart k8s.kube-apiserver
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep kube-apiserver | grep -v grep
+```
+
+**Expected output:**
+
+```
+--etcd-certfile="/etc/kubernetes/pki/apiserver-etcd-client.crt"
+--etcd-keyfile="/etc/kubernetes/pki/apiserver-etcd-client.key"
+```
+
+````
+
+`````
 
 ##### CIS Control 1.2.26
 
@@ -1580,6 +1746,10 @@ authority file.
 
 ##### CIS Control 1.2.28
 
+`````{tabs}
+
+````{group-tab} k8s-dqlite
+
 **Description:**
 
 Ensure that the `--etcd-cafile` argument is set as appropriate
@@ -1593,6 +1763,46 @@ local socket
 (`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
 accessible to users with root permissions.
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--etcd-cafile` argument is set as appropriate
+
+
+**Remediation:**
+
+Edit the API server configuration file 
+`/var/snap/k8s/common/args/kube-apiserver` on the control plane node and set 
+the `--etcd-cafile` parameter to the ca certificate file that is used by etcd. 
+
+```
+--etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
+```
+
+Restart the `kube-apiserver` service.
+
+```
+snap restart k8s.kube-apiserver
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep kube-apiserver | grep -v grep
+```
+
+**Expected output:**
+
+```
+--etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
+```
+
+````
+
+`````
 
 ##### CIS Control 1.2.29
 
@@ -1982,6 +2192,10 @@ and restart the kube-scheduler service
 
 ##### CIS Control 2.1
 
+`````{tabs}
+
+````{group-tab} k8s-dqlite
+
 **Description:**
 
 Ensure that the `--cert-file` and `--key-file` arguments are set
@@ -1996,8 +2210,54 @@ local socket
 (`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
 accessible to users with root permissions.
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--cert-file` and `--key-file` arguments are set
+as appropriate
+
+**Remediation:**
+
+Edit the etcd configuration file 
+`/var/snap/k8s/common/args/etcd` on the control plane node and set 
+the `--cert-file` and `--key-file` parameters appropriately. 
+
+```
+--cert-file="/etc/kubernetes/pki/etcd/server.crt"
+--key-file="/etc/kubernetes/pki/etcd/server.key"
+```
+
+Restart the `etcd` service.
+
+```
+snap restart k8s.etcd
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep -E 'etcd\s' | grep -v grep
+```
+
+**Expected output:**
+
+```
+--cert-file="/etc/kubernetes/pki/etcd/server.crt"
+--key-file="/etc/kubernetes/pki/etcd/server.key"
+```
+
+````
+
+`````
 
 ##### CIS Control 2.2
+
+`````{tabs}
+
+````{group-tab} k8s-dqlite
 
 **Description:**
 
@@ -2012,8 +2272,45 @@ local socket
 (`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
 accessible to users with root permissions.
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--client-cert-auth` argument is set to true
+
+**Remediation:**
+
+Edit the etcd configuration file 
+`/var/snap/k8s/common/args/etcd` on the control plane node and set 
+the `--client-cert-auth` argument to true. Then restart the `etcd` service.
+
+```
+snap restart k8s.etcd
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep -E 'etcd\s' | grep -v grep
+```
+
+**Expected output:**
+
+```
+--client-cert-auth="true"
+```
+
+````
+
+`````
 
 ##### CIS Control 2.3
+
+`````{tabs}
+
+````{group-tab} k8s-dqlite
 
 **Description:**
 
@@ -2028,8 +2325,43 @@ local socket
 (`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
 accessible to users with root permissions.
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--auto-tls` argument is not set to true
+
+**Remediation:**
+
+Edit the etcd configuration file 
+`/var/snap/k8s/common/args/etcd` on the control plane node and remove the
+`--auto-tls` argument. Then restart the `etcd` service.
+
+```
+snap restart k8s.etcd
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep -E 'etcd\s' | grep -v grep
+```
+
+**Expected output:**
+
+The `--auto-tls` should bot be present or set to `false`
+
+````
+
+`````
 
 ##### CIS Control 2.4
+
+`````{tabs}
+
+````{group-tab} k8s-dqlite
 
 **Description:**
 
@@ -2057,7 +2389,54 @@ if test -e /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt && test -e /var/s
 certs-found
 ```
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--peer-cert-file` and `--peer-key-file`
+arguments are set as appropriate
+
+**Remediation:**
+
+Edit the etcd configuration file 
+`/var/snap/k8s/common/args/etcd` on the control plane node and set 
+the `--peer-cert-file` and `--peer-key-file` parameters appropriately. 
+
+```
+--peer-cert-file="/etc/kubernetes/pki/etcd/peer.crt"
+--peer-key-file="/etc/kubernetes/pki/etcd/peer.key"
+```
+
+Restart the `etcd` service.
+
+```
+snap restart k8s.etcd
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep -E 'etcd\s' | grep -v grep
+```
+
+**Expected output:**
+
+```
+--peer-cert-file="/etc/kubernetes/pki/etcd/peer.crt"
+--peer-key-file="/etc/kubernetes/pki/etcd/peer.key"
+```
+
+````
+
+`````
+
 ##### CIS Control 2.5
+
+`````{tabs}
+
+````{group-tab} k8s-dqlite
 
 **Description:**
 
@@ -2084,7 +2463,46 @@ is set to false in
 0
 ```
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--peer-client-cert-auth` argument is set to
+true
+
+**Remediation:**
+
+Edit the etcd configuration file 
+`/var/snap/k8s/common/args/etcd` on the control plane node and set 
+the `--peer-client-cert-auth` argument to true. Then restart the `etcd` service.
+
+```
+snap restart k8s.etcd
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep -E 'etcd\s' | grep -v grep
+```
+
+**Expected output:**
+
+```
+--peer-client-cert-auth="true"
+```
+
+````
+
+`````
+
 ##### CIS Control 2.6
+
+`````{tabs}
+
+````{group-tab} k8s-dqlite
 
 **Description:**
 
@@ -2097,6 +2515,37 @@ Not applicable. Canonical K8s uses dqlite and tls peer
 communication uses the certificates
 created upon the snap creation.
 
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the `--peer-auto-tls` argument is not set to true
+
+**Remediation:**
+
+Edit the etcd configuration file 
+`/var/snap/k8s/common/args/etcd` on the control plane node and remove the
+`--peer-auto-tls` argument. Then restart the `etcd` service.
+
+```
+snap restart k8s.etcd
+```
+
+**Audit (as root):**
+
+```
+/bin/ps -ef | grep -E 'etcd\s' | grep -v grep
+```
+
+**Expected output:**
+
+The `--peer-auto-tls` should not be present or set to `false`.
+
+````
+
+`````
 
 ##### CIS Control 2.7
 
@@ -2105,13 +2554,11 @@ created upon the snap creation.
 Ensure that a unique Certificate Authority is used for the
 datastore
 
-
 **Remediation:**
 
-Not applicable. Canonical K8s uses dqlite and tls peer
-communication uses certificates
-created upon cluster setup.
-
+Not applicable. All Certificates and CAs used by the datastore,
+whether `k8s-dqlite` or `etcd` are created upon cluster setup and 
+therefore are unique.
 
 ### Control plane configuration
 

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -436,7 +436,7 @@ root:root
 
 ````
 
-`````{tabs}
+`````
 
 ##### CIS Control 1.1.9
 
@@ -541,7 +541,7 @@ Ensure that the etcd data directory permissions are set to
 
 etcd data are kept by default under
 `/var/snap/k8s/common/var/lib/etcd`.
-To comply with the spirit of this CIS recommendation:
+Modify the permissions for this directory:
 
 `chmod 700 /var/snap/k8s/common/var/lib/etcd`
 
@@ -611,7 +611,7 @@ root:root
 
 etcd data are kept by default under
 `/var/snap/k8s/common/var/lib/etcd`.
-To comply with the spirit of this CIS recommendation:
+Modify the directory ownership accordingly:
 
 `chown root:root /var/snap/k8s/common/var/lib/etcd`
 
@@ -1625,10 +1625,10 @@ are set as appropriate
 
 **Remediation:**
 
-Not applicable. Canonical K8s uses dqlite and the
-communication to this service is done through a
-local socket
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
 accessible to users with root permissions.
 
 ````
@@ -1757,10 +1757,10 @@ Ensure that the `--etcd-cafile` argument is set as appropriate
 
 **Remediation:**
 
-Not applicable. Canonical K8s uses dqlite and the
-communication to this service is done through a
-local socket
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
 accessible to users with root permissions.
 
 ````
@@ -1776,7 +1776,7 @@ Ensure that the `--etcd-cafile` argument is set as appropriate
 
 Edit the API server configuration file 
 `/var/snap/k8s/common/args/kube-apiserver` on the control plane node and set 
-the `--etcd-cafile` parameter to the ca certificate file that is used by etcd. 
+the `--etcd-cafile` parameter to the CA certificate file that is used by etcd. 
 
 ```
 --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
@@ -2204,10 +2204,10 @@ as appropriate
 
 **Remediation:**
 
-Not applicable. Canonical K8s uses dqlite and the
-communication to this service is done through a
-local socket
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
 accessible to users with root permissions.
 
 ````
@@ -2266,10 +2266,10 @@ Ensure that the `--client-cert-auth` argument is set to true
 
 **Remediation:**
 
-Not applicable. Canonical K8s uses dqlite and the
-communication to this service is done through a
-local socket
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
 accessible to users with root permissions.
 
 ````
@@ -2319,10 +2319,10 @@ Ensure that the `--auto-tls` argument is not set to true
 
 **Remediation:**
 
-Not applicable. Canonical K8s uses dqlite and the
-communication to this service is done through a
-local socket
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`)
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
 accessible to users with root permissions.
 
 ````
@@ -2351,7 +2351,7 @@ snap restart k8s.etcd
 
 **Expected output:**
 
-The `--auto-tls` should bot be present or set to `false`
+The `--auto-tls` should not be present or set to `false`
 
 ````
 
@@ -2371,7 +2371,7 @@ arguments are set as appropriate
 
 **Remediation:**
 
-The certificate pair for dqlite and tls peer communication
+The certificate pair for dqlite and TLS peer communication
 is
 `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt` and
 `/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key`.
@@ -2511,7 +2511,7 @@ Ensure that the `--peer-auto-tls` argument is not set to true
 
 **Remediation:**
 
-Not applicable. Canonical K8s uses dqlite and tls peer
+Not applicable when Canonical Kubernetes is set to use dqlite. The TLS peer
 communication uses the certificates
 created upon the snap creation.
 

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -314,35 +314,6 @@ root:root
 
 `````{tabs}
 
-````{group-tab} k8s-dqlite
-
-**Description:**
-
-Ensure that the dqlite configuration file permissions are
-set to 644 or more restrictive
-
-
-**Remediation:**
-
-Run the following command on the control plane node.
-
-`chmod 600 /var/snap/k8s/common/args/k8s-dqlite`
-
-
-**Audit (as root):**
-
-```
-/bin/sh -c 'if test -e /var/snap/k8s/common/args/k8s-dqlite; then stat -c permissions=%a /var/snap/k8s/common/args/k8s-dqlite; fi'
-```
-
-**Expected output:**
-
-```
-permissions=600
-```
-
-````
-
 ````{group-tab} etcd
 
 **Description:**
@@ -372,40 +343,40 @@ permissions=600
 
 ````
 
-`````
-
-##### CIS Control 1.1.8
-
-`````{tabs}
-
 ````{group-tab} k8s-dqlite
 
 **Description:**
 
-Ensure that the dqlite configuration file ownership is set
-to root:root
+Ensure that the dqlite configuration file permissions are
+set to 644 or more restrictive
 
 
 **Remediation:**
 
 Run the following command on the control plane node.
 
-`chown root:root /var/snap/k8s/common/args/k8s-dqlite`
+`chmod 600 /var/snap/k8s/common/args/k8s-dqlite`
 
 
 **Audit (as root):**
 
 ```
-/bin/sh -c 'if test -e /var/snap/k8s/common/args/k8s-dqlite; then stat -c %U:%G /var/snap/k8s/common/args/k8s-dqlite; fi'
+/bin/sh -c 'if test -e /var/snap/k8s/common/args/k8s-dqlite; then stat -c permissions=%a /var/snap/k8s/common/args/k8s-dqlite; fi'
 ```
 
 **Expected output:**
 
 ```
-root:root
+permissions=600
 ```
 
 ````
+
+`````
+
+##### CIS Control 1.1.8
+
+`````{tabs}
 
 ````{group-tab} etcd
 
@@ -426,6 +397,35 @@ Run the following command on the control plane node.
 
 ```
 /bin/sh -c 'if test -e /var/snap/k8s/common/args/etcd; then stat -c %U:%G /var/snap/k8s/common/args/etcd; fi'
+```
+
+**Expected output:**
+
+```
+root:root
+```
+
+````
+
+````{group-tab} k8s-dqlite
+
+**Description:**
+
+Ensure that the dqlite configuration file ownership is set
+to root:root
+
+
+**Remediation:**
+
+Run the following command on the control plane node.
+
+`chown root:root /var/snap/k8s/common/args/k8s-dqlite`
+
+
+**Audit (as root):**
+
+```
+/bin/sh -c 'if test -e /var/snap/k8s/common/args/k8s-dqlite; then stat -c %U:%G /var/snap/k8s/common/args/k8s-dqlite; fi'
 ```
 
 **Expected output:**
@@ -497,38 +497,6 @@ root:root
 
 `````{tabs}
 
-````{group-tab} k8s-dqlite
-
-**Description:**
-
-Ensure that the dqlite data directory permissions are set to
-700 or more restrictive
-
-
-**Remediation:**
-
-Dqlite data are kept by default under
-`/var/snap/k8s/common/var/lib/k8s-dqlite`.
-To comply with the spirit of this CIS recommendation:
-
-`chmod 700 /var/snap/k8s/common/var/lib/k8s-dqlite`
-
-
-**Audit (as root):**
-
-```
-DATA_DIR='/var/snap/k8s/common/var/lib/k8s-dqlite'
-stat -c permissions=%a "$DATA_DIR"
-```
-
-**Expected output:**
-
-```
-permissions=700
-```
-
-````
-
 ````{group-tab} etcd
 
 **Description:**
@@ -561,18 +529,12 @@ permissions=700
 
 ````
 
-`````
-
-##### CIS Control 1.1.12
-
-`````{tabs}
-
 ````{group-tab} k8s-dqlite
 
 **Description:**
 
-Ensure that the dqlite data directory ownership is set to
-root:root
+Ensure that the dqlite data directory permissions are set to
+700 or more restrictive
 
 
 **Remediation:**
@@ -581,23 +543,29 @@ Dqlite data are kept by default under
 `/var/snap/k8s/common/var/lib/k8s-dqlite`.
 To comply with the spirit of this CIS recommendation:
 
-`chown root:root /var/snap/k8s/common/var/lib/k8s-dqlite`
+`chmod 700 /var/snap/k8s/common/var/lib/k8s-dqlite`
 
 
 **Audit (as root):**
 
 ```
 DATA_DIR='/var/snap/k8s/common/var/lib/k8s-dqlite'
-stat -c %U:%G "$DATA_DIR"
+stat -c permissions=%a "$DATA_DIR"
 ```
 
 **Expected output:**
 
 ```
-root:root
+permissions=700
 ```
 
 ````
+
+`````
+
+##### CIS Control 1.1.12
+
+`````{tabs}
 
 ````{group-tab} etcd
 
@@ -620,6 +588,38 @@ Modify the directory ownership accordingly:
 
 ```
 DATA_DIR='/var/snap/k8s/common/var/lib/etcd'
+stat -c %U:%G "$DATA_DIR"
+```
+
+**Expected output:**
+
+```
+root:root
+```
+
+````
+
+````{group-tab} k8s-dqlite
+
+**Description:**
+
+Ensure that the dqlite data directory ownership is set to
+root:root
+
+
+**Remediation:**
+
+Dqlite data are kept by default under
+`/var/snap/k8s/common/var/lib/k8s-dqlite`.
+To comply with the spirit of this CIS recommendation:
+
+`chown root:root /var/snap/k8s/common/var/lib/k8s-dqlite`
+
+
+**Audit (as root):**
+
+```
+DATA_DIR='/var/snap/k8s/common/var/lib/k8s-dqlite'
 stat -c %U:%G "$DATA_DIR"
 ```
 
@@ -1615,24 +1615,6 @@ file=/etc/kubernetes/pki/serviceaccount.key
 
 `````{tabs}
 
-````{group-tab} k8s-dqlite
-
-**Description:**
-
-Ensure that the `--etcd-certfile` and `--etcd-keyfile` arguments
-are set as appropriate
-
-
-**Remediation:**
-
-Not applicable when Canonical Kubernetes is set to use dqlite. The 
-communication to this service is done through a 
-local socket 
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
-accessible to users with root permissions.
-
-````
-
 ````{group-tab} etcd
 
 **Description:**
@@ -1672,6 +1654,24 @@ snap restart k8s.kube-apiserver
 --etcd-certfile="/etc/kubernetes/pki/apiserver-etcd-client.crt"
 --etcd-keyfile="/etc/kubernetes/pki/apiserver-etcd-client.key"
 ```
+
+````
+
+````{group-tab} k8s-dqlite
+
+**Description:**
+
+Ensure that the `--etcd-certfile` and `--etcd-keyfile` arguments
+are set as appropriate
+
+
+**Remediation:**
+
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
+accessible to users with root permissions.
 
 ````
 
@@ -1748,23 +1748,6 @@ authority file.
 
 `````{tabs}
 
-````{group-tab} k8s-dqlite
-
-**Description:**
-
-Ensure that the `--etcd-cafile` argument is set as appropriate
-
-
-**Remediation:**
-
-Not applicable when Canonical Kubernetes is set to use dqlite. The 
-communication to this service is done through a 
-local socket 
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
-accessible to users with root permissions.
-
-````
-
 ````{group-tab} etcd
 
 **Description:**
@@ -1799,6 +1782,23 @@ snap restart k8s.kube-apiserver
 ```
 --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
 ```
+
+````
+
+````{group-tab} k8s-dqlite
+
+**Description:**
+
+Ensure that the `--etcd-cafile` argument is set as appropriate
+
+
+**Remediation:**
+
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
+accessible to users with root permissions.
 
 ````
 
@@ -2194,24 +2194,6 @@ and restart the kube-scheduler service
 
 `````{tabs}
 
-````{group-tab} k8s-dqlite
-
-**Description:**
-
-Ensure that the `--cert-file` and `--key-file` arguments are set
-as appropriate
-
-
-**Remediation:**
-
-Not applicable when Canonical Kubernetes is set to use dqlite. The 
-communication to this service is done through a 
-local socket 
-(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
-accessible to users with root permissions.
-
-````
-
 ````{group-tab} etcd
 
 **Description:**
@@ -2251,17 +2233,12 @@ snap restart k8s.etcd
 
 ````
 
-`````
-
-##### CIS Control 2.2
-
-`````{tabs}
-
 ````{group-tab} k8s-dqlite
 
 **Description:**
 
-Ensure that the `--client-cert-auth` argument is set to true
+Ensure that the `--cert-file` and `--key-file` arguments are set
+as appropriate
 
 
 **Remediation:**
@@ -2273,6 +2250,12 @@ local socket
 accessible to users with root permissions.
 
 ````
+
+`````
+
+##### CIS Control 2.2
+
+`````{tabs}
 
 ````{group-tab} etcd
 
@@ -2304,17 +2287,11 @@ snap restart k8s.etcd
 
 ````
 
-`````
-
-##### CIS Control 2.3
-
-`````{tabs}
-
 ````{group-tab} k8s-dqlite
 
 **Description:**
 
-Ensure that the `--auto-tls` argument is not set to true
+Ensure that the `--client-cert-auth` argument is set to true
 
 
 **Remediation:**
@@ -2326,6 +2303,12 @@ local socket
 accessible to users with root permissions.
 
 ````
+
+`````
+
+##### CIS Control 2.3
+
+`````{tabs}
 
 ````{group-tab} etcd
 
@@ -2355,41 +2338,28 @@ The `--auto-tls` should not be present or set to `false`
 
 ````
 
+````{group-tab} k8s-dqlite
+
+**Description:**
+
+Ensure that the `--auto-tls` argument is not set to true
+
+
+**Remediation:**
+
+Not applicable when Canonical Kubernetes is set to use dqlite. The 
+communication to this service is done through a 
+local socket 
+(`/var/snap/k8s/common/var/lib/k8s-dqlite/k8s-dqlite.sock`) 
+accessible to users with root permissions.
+
+````
+
 `````
 
 ##### CIS Control 2.4
 
 `````{tabs}
-
-````{group-tab} k8s-dqlite
-
-**Description:**
-
-Ensure that the `--peer-cert-file` and `--peer-key-file`
-arguments are set as appropriate
-
-
-**Remediation:**
-
-The certificate pair for dqlite and TLS peer communication
-is
-`/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt` and
-`/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key`.
-
-
-**Audit (as root):**
-
-```
-if test -e /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt && test -e /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key; then echo 'certs-found'; fi
-```
-
-**Expected output:**
-
-```
-certs-found
-```
-
-````
 
 ````{group-tab} etcd
 
@@ -2430,40 +2400,41 @@ snap restart k8s.etcd
 
 ````
 
-`````
-
-##### CIS Control 2.5
-
-`````{tabs}
-
 ````{group-tab} k8s-dqlite
 
 **Description:**
 
-Ensure that the `--peer-client-cert-auth` argument is set to
-true
+Ensure that the `--peer-cert-file` and `--peer-key-file`
+arguments are set as appropriate
 
 
 **Remediation:**
 
-Dqlite peer communication uses TLS unless the `--enable-tls`
-is set to false in
-`/var/snap/k8s/common/args/k8s-dqlite`.
+The certificate pair for dqlite and TLS peer communication
+is
+`/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt` and
+`/var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key`.
 
 
 **Audit (as root):**
 
 ```
-/bin/cat /var/snap/k8s/common/args/k8s-dqlite | /bin/grep enable-tls || true; echo $?
+if test -e /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.crt && test -e /var/snap/k8s/common/var/lib/k8s-dqlite/cluster.key; then echo 'certs-found'; fi
 ```
 
 **Expected output:**
 
 ```
-0
+certs-found
 ```
 
 ````
+
+`````
+
+##### CIS Control 2.5
+
+`````{tabs}
 
 ````{group-tab} etcd
 
@@ -2496,26 +2467,40 @@ snap restart k8s.etcd
 
 ````
 
+````{group-tab} k8s-dqlite
+
+**Description:**
+
+Ensure that the `--peer-client-cert-auth` argument is set to
+true
+
+
+**Remediation:**
+
+Dqlite peer communication uses TLS unless the `--enable-tls`
+is set to false in
+`/var/snap/k8s/common/args/k8s-dqlite`.
+
+
+**Audit (as root):**
+
+```
+/bin/cat /var/snap/k8s/common/args/k8s-dqlite | /bin/grep enable-tls || true; echo $?
+```
+
+**Expected output:**
+
+```
+0
+```
+
+````
+
 `````
 
 ##### CIS Control 2.6
 
 `````{tabs}
-
-````{group-tab} k8s-dqlite
-
-**Description:**
-
-Ensure that the `--peer-auto-tls` argument is not set to true
-
-
-**Remediation:**
-
-Not applicable when Canonical Kubernetes is set to use dqlite. The TLS peer
-communication uses the certificates
-created upon the snap creation.
-
-````
 
 ````{group-tab} etcd
 
@@ -2542,6 +2527,21 @@ snap restart k8s.etcd
 **Expected output:**
 
 The `--peer-auto-tls` should not be present or set to `false`.
+
+````
+
+````{group-tab} k8s-dqlite
+
+**Description:**
+
+Ensure that the `--peer-auto-tls` argument is not set to true
+
+
+**Remediation:**
+
+Not applicable when Canonical Kubernetes is set to use dqlite. The TLS peer
+communication uses the certificates
+created upon the snap creation.
 
 ````
 

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -312,6 +312,10 @@ root:root
 
 ##### CIS Control 1.1.7
 
+`````{tabs}
+
+````{group-tab} k8s-dqlite
+
 **Description:**
 
 Ensure that the dqlite configuration file permissions are
@@ -336,6 +340,39 @@ Run the following command on the control plane node.
 ```
 permissions=600
 ```
+
+````
+
+````{group-tab} etcd
+
+**Description:**
+
+Ensure that the etcd configuration file permissions are
+set to 644 or more restrictive
+
+
+**Remediation:**
+
+Run the following command on the control plane node.
+
+`chmod 600 /var/snap/k8s/common/args/etcd`
+
+
+**Audit (as root):**
+
+```
+/bin/sh -c 'if test -e /var/snap/k8s/common/args/etcd; then stat -c permissions=%a /var/snap/k8s/common/args/etcd; fi'
+```
+
+**Expected output:**
+
+```
+permissions=600
+```
+
+````
+
+`````
 
 ##### CIS Control 1.1.8
 


### PR DESCRIPTION
## Description

This PR updates the CIS hardening guides in documentation to take into effect the steps needed for the new etcd datastore. A similar PR for DISA STIG will be introduced as a follow up. 

## Backport
`release-1.32`
`release-1.33`