### PR TITLE
chore: set auto-tls explicitly to false

### DIFF
--- a/src/k8s/pkg/k8sd/setup/etcd.go
+++ b/src/k8s/pkg/k8sd/setup/etcd.go
@@ -67,6 +67,8 @@ func Etcd(snap snap.Snap, name string, nodeIP net.IP, clientPort, peerPort int, 
 		"--peer-trusted-ca-file":        filepath.Join(snap.EtcdPKIDir(), "ca.crt"),
 		"--peer-cert-file":              filepath.Join(snap.EtcdPKIDir(), "peer.crt"),
 		"--peer-key-file":               filepath.Join(snap.EtcdPKIDir(), "peer.key"),
+		"--auto-tls":                    "false",
+		"--peer-auto-tls":               "false",
 	}
 
 	if _, err := snaputil.UpdateServiceArguments(snap, "etcd", args, nil); err != nil {

--- a/src/k8s/pkg/k8sd/setup/etcd_test.go
+++ b/src/k8s/pkg/k8sd/setup/etcd_test.go
@@ -57,6 +57,8 @@ func TestEtcd(t *testing.T) {
 			{key: "--peer-trusted-ca-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "ca.crt")},
 			{key: "--peer-cert-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "peer.crt")},
 			{key: "--peer-key-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "peer.key")},
+			{key: "--auto-tls", expectedVal: "false"},
+			{key: "--peer-auto-tls", expectedVal: "false"},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {
@@ -100,6 +102,8 @@ func TestEtcd(t *testing.T) {
 			{key: "--peer-trusted-ca-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "ca.crt")},
 			{key: "--peer-cert-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "peer.crt")},
 			{key: "--peer-key-file", expectedVal: filepath.Join(s.EtcdPKIDir(), "peer.key")},
+			{key: "--auto-tls", expectedVal: "false"},
+			{key: "--peer-auto-tls", expectedVal: "false"},
 		}
 		for _, tc := range tests {
 			t.Run(tc.key, func(t *testing.T) {


### PR DESCRIPTION
## Description

CIS and DISA STIG require some etcd arguments to be set to certain values.  

## Solution

While the default values satisfy the requirements, having them explicitly set will make the guidelines audits easier and also provides better maintainability. The DISA STIG guideline checks would fail without these arguments explicitly set. 