### PR TITLE
chore: add security-events to integration workflow

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -123,6 +123,7 @@ jobs:
       artifact: ${{ needs.build-snap.outputs.snap-artifact }}
     permissions:
       contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
 
   get-charm-channel:
     name: Determine the charm channel


### PR DESCRIPTION
## Description

Adds necessary security scan permissions to lint-and-integration workflow, thanks to @addyess derived from #1749 

## Backport

`release-1.32`
`release-1.33`

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
