### PR TITLE
docs(CAPI): Fix files field to represent an array

### DIFF
--- a/docs/canonicalk8s/capi/reference/configs.md
+++ b/docs/canonicalk8s/capi/reference/configs.md
@@ -61,7 +61,7 @@ existing files.
 ```yaml
 spec:
   files:
-    path: "/path/to/my-file"
+  - path: "/path/to/my-file"
     content: |
       #!/bin/bash -xe
       echo "hello from my-file
@@ -74,7 +74,7 @@ spec:
 ```yaml
 spec:
   files:
-    path: "/path/to/my-file"
+  - path: "/path/to/my-file"
     contentFrom:
       secret:
         # Name of the secret in the CK8sBootstrapConfig's namespace to use.


### PR DESCRIPTION
### Overview

This PR fixes a typo in the CAPI docs so that the `files` field will represent an array.

Fixes:
- https://github.com/canonical/k8s-snap/issues/1765