### PR TITLE
ci: add more clustering test cases

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -8,6 +8,10 @@ on:
       - .github/workflows/e2e-tests.yaml
       - .github/workflows/security-scan.yaml
       - .github/workflows/nightly-test.yaml
+  # TODO: rm me I'm for testing
+  push:
+    branches:
+      - KU-4094/clustering-tests
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -8,10 +8,6 @@ on:
       - .github/workflows/e2e-tests.yaml
       - .github/workflows/security-scan.yaml
       - .github/workflows/nightly-test.yaml
-  # TODO: rm me I'm for testing
-  push:
-    branches:
-      - KU-4094/clustering-tests
 
 permissions:
   contents: read

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -150,7 +150,7 @@ def test_concurrent_membership_operations(instances: List[harness.Instance]):
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
         executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_A.id])
         executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_B.id])
-        
+
     util.wait_until_k8s_ready(cluster_node, [cluster_node])
 
     nodes = util.ready_nodes(cluster_node)

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -138,10 +138,10 @@ def test_concurrent_membership_operations(instances: List[harness.Instance]):
     assert join_token_A != join_token_B, "Join tokens should be different"
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-        util.stubbornly(retries=5, delay_s=1).on(cluster_node).run(
+        util.stubbornly(retries=5, delay_s=1).on(cluster_node).execute(
             executor.submit(util.join_cluster, joining_cp_A, join_token_A)
         )
-        util.stubbornly(retries=5, delay_s=1).on(cluster_node).run(
+        util.stubbornly(retries=5, delay_s=1).on(cluster_node).execute(
             executor.submit(util.join_cluster, joining_cp_B, join_token_B)
         )
 
@@ -152,10 +152,10 @@ def test_concurrent_membership_operations(instances: List[harness.Instance]):
     assert "control-plane" in util.get_local_node_status(joining_cp_B)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-        util.stubbornly(retries=5, delay_s=1).on(cluster_node).run(
+        util.stubbornly(retries=5, delay_s=1).on(cluster_node).execute(
             executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_A.id])
         )
-        util.stubbornly(retries=5, delay_s=1).on(cluster_node).run(
+        util.stubbornly(retries=5, delay_s=1).on(cluster_node).execute(
             executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_B.id])
         )
 
@@ -258,10 +258,10 @@ def test_node_join_succeeds_when_original_control_plane_is_down(
     ), "Join tokens should be different"
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-        util.stubbornly(retries=5, delay_s=1).on(cluster_node).run(
+        util.stubbornly(retries=5, delay_s=1).on(cluster_node).execute(
             executor.submit(util.join_cluster, joining_cp_A, join_token_A)
         )
-        util.stubbornly(retries=5, delay_s=1).on(cluster_node).run(
+        util.stubbornly(retries=5, delay_s=1).on(cluster_node).execute(
             executor.submit(util.join_cluster, joining_cp_B, join_token_B)
         )
 

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -174,9 +174,9 @@ def test_concurrent_membership_operations(instances: List[harness.Instance]):
                 time.sleep(1)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-        executor.submit(remove_node_with_retry, joining_cp_A)
-        executor.submit(remove_node_with_retry, joining_cp_B)
-        concurrent.futures.wait()
+        future_A = executor.submit(remove_node_with_retry, joining_cp_A)
+        future_B = executor.submit(remove_node_with_retry, joining_cp_B)
+        concurrent.futures.wait([future_A, future_B])
 
     util.wait_until_k8s_ready(cluster_node, [cluster_node])
 
@@ -309,7 +309,7 @@ def test_node_join_succeeds_when_original_control_plane_is_down(
         and joining_cp_C.id in [node["metadata"]["name"] for node in nodes]
     ), f"{joining_cp_A.id}, {joining_cp_B.id}, and {joining_cp_C.id} should be ready and in the cluster"
 
-    joining_cp_C.exec(["k8s", "remove-node", cluster_node.id])
+    joining_cp_C.exec(["k8s", "remove-node", cluster_node.id, "--force"])
     nodes = util.ready_nodes(joining_cp_C)
     assert (
         len(nodes) == 3

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -190,6 +190,9 @@ def test_concurrent_membership_operations(instances: List[harness.Instance]):
 
 @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.xfail(
+    reason="The node join whiile there is a dead node does not work currently due to a microcluster bug."
+)
 def test_mixed_concurrent_membership_operations(instances: List[harness.Instance]):
     cluster_node = instances[0]
     joining_cp_A = instances[1]

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -488,7 +488,7 @@ def test_cert_refresh(instances: List[harness.Instance]):
 
 
 def join_node_with_retry(
-    cluster_node, joining_node, retries=15, delay_s=1, worker=False
+    cluster_node, joining_node, retries=25, delay_s=1, worker=False
 ):
     """Join cluster with retry, generating a new token on each attempt"""
     for attempt in range(retries):
@@ -508,7 +508,7 @@ def join_node_with_retry(
             time.sleep(delay_s)
 
 
-def remove_node_with_retry(cluster_node, remove_node, retries=5, delay_s=1):
+def remove_node_with_retry(cluster_node, remove_node, retries=25, delay_s=1):
     """Remove node with retry"""
     for attempt in range(retries):
         try:

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2025 Canonical, Ltd.
 #
+import concurrent.futures
 import datetime
 import logging
 import os
@@ -120,6 +121,198 @@ def test_disa_stig_clustering(instances: List[harness.Instance]):
     assert "control-plane" in util.get_local_node_status(cluster_node)
     assert "control-plane" in util.get_local_node_status(joining_cp)
     assert "worker" in util.get_local_node_status(joining_worker)
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_concurrent_membership_operations(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_cp_A = instances[1]
+    joining_cp_B = instances[2]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    join_token_A = util.get_join_token(cluster_node, joining_cp_A)
+    join_token_B = util.get_join_token(cluster_node, joining_cp_B)
+
+    assert join_token_A != join_token_B, "Join tokens should be different"
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        executor.submit(util.join_cluster, joining_cp_A, join_token_A)
+        executor.submit(util.join_cluster, joining_cp_B, join_token_B)
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_cp_A)
+    assert "control-plane" in util.get_local_node_status(joining_cp_B)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_A.id])
+        executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_B.id])
+        
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    nodes = util.ready_nodes(cluster_node)
+    assert (
+        len(nodes) == 1
+    ), "two control-plane nodes should have been removed from cluster"
+
+    assert cluster_node.id in [node["metadata"]["name"] for node in nodes]
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_mixed_concurrent_membership_operations(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_cp_A = instances[1]
+    joining_cp_B = instances[2]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    join_token_A = util.get_join_token(cluster_node, joining_cp_A)
+    join_token_B = util.get_join_token(cluster_node, joining_cp_B)
+
+    assert join_token_A != join_token_B, "Join tokens should be different"
+
+    util.join_cluster(joining_cp_A, join_token_A)
+    util.wait_until_k8s_ready(cluster_node, [cluster_node, joining_cp_A])
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_cp_A)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_A.id])
+        executor.submit(util.join_cluster, joining_cp_B, join_token_B)
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node, joining_cp_B])
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_cp_B)
+
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 2, "two control-plane nodes should be in the cluster"
+
+    assert cluster_node.id in [
+        node["metadata"]["name"] for node in nodes
+    ] and joining_cp_B.id in [
+        node["metadata"]["name"] for node in nodes
+    ], f"only {cluster_node.id} and {joining_cp_B.id} should be left in cluster"
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_concurrent_membership_restart_operations(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_cp_A = instances[1]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    join_token_A = util.get_join_token(cluster_node, joining_cp_A)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        executor.submit(util.join_cluster, joining_cp_A, join_token_A)
+        executor.submit(cluster_node.exec, ["snap", "restart", config.SNAP_NAME])
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 2, "two control-plane nodes should be in the cluster"
+
+    assert cluster_node.id in [
+        node["metadata"]["name"] for node in nodes
+    ] and joining_cp_A.id in [
+        node["metadata"]["name"] for node in nodes
+    ], f"{cluster_node.id} and {joining_cp_A.id} should be in the cluster"
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_cp_A)
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_node_removal_during_concurrent_join_prevents_membership(
+    instances: List[harness.Instance],
+):
+    cluster_node = instances[0]
+    joining_cp_A = instances[1]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    join_token_A = util.get_join_token(cluster_node, joining_cp_A)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        executor.submit(util.join_cluster, joining_cp_A, join_token_A)
+        executor.submit(cluster_node.exec, ["k8s", "remove-node", joining_cp_A.id])
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+
+    nodes = util.ready_nodes(cluster_node)
+    assert (
+        len(nodes) == 1
+    ), "The joined and removed node should not have joined the cluster"
+
+    assert cluster_node.id in [node["metadata"]["name"] for node in nodes]
+
+
+@pytest.mark.node_count(4)
+@pytest.mark.tags(tags.NIGHTLY)
+def test_node_join_succeeds_when_original_control_plane_is_down(
+    instances: List[harness.Instance],
+):
+    cluster_node = instances[0]
+    joining_cp_A = instances[1]
+    joining_cp_B = instances[2]
+    joining_cp_C = instances[3]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    join_token_A = util.get_join_token(cluster_node, joining_cp_A)
+    join_token_B = util.get_join_token(cluster_node, joining_cp_B)
+    join_token_C = util.get_join_token(cluster_node, joining_cp_C)
+
+    assert (
+        join_token_A != join_token_B and join_token_B != join_token_C
+    ), "Join tokens should be different"
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        executor.submit(util.join_cluster, joining_cp_A, join_token_A)
+        executor.submit(util.join_cluster, joining_cp_B, join_token_B)
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node, joining_cp_A, joining_cp_B])
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_cp_A)
+    assert "control-plane" in util.get_local_node_status(joining_cp_B)
+
+    cluster_node.exec(["snap", "stop", config.SNAP_NAME])
+
+    util.join_cluster(joining_cp_C, join_token_C)
+
+    util.wait_until_k8s_ready(joining_cp_A, [joining_cp_A, joining_cp_B, joining_cp_C])
+
+    nodes = util.ready_nodes(joining_cp_A)
+    assert (
+        len(nodes) == 3
+    ), "three control plane nodes should be ready, original node is still down"
+
+    assert (
+        joining_cp_A.id in [node["metadata"]["name"] for node in nodes]
+        and joining_cp_B.id in [node["metadata"]["name"] for node in nodes]
+        and joining_cp_C.id in [node["metadata"]["name"] for node in nodes]
+    ), f"{joining_cp_A.id}, {joining_cp_B.id}, and {joining_cp_C.id} should be ready and in the cluster"
+
+    joining_cp_C.exec(["k8s", "remove-node", cluster_node.id])
+    nodes = util.ready_nodes(joining_cp_C)
+    assert (
+        len(nodes) == 3
+    ), "three control plane nodes should be ready, original node is removed"
+
+    assert (
+        joining_cp_A.id in [node["metadata"]["name"] for node in nodes]
+        and joining_cp_B.id in [node["metadata"]["name"] for node in nodes]
+        and joining_cp_C.id in [node["metadata"]["name"] for node in nodes]
+    ), f"{joining_cp_A.id}, {joining_cp_B.id}, and {joining_cp_C.id} should be ready and in the cluster"
 
 
 @pytest.mark.node_count(3)

--- a/tests/integration/tests/test_clustering.py
+++ b/tests/integration/tests/test_clustering.py
@@ -134,7 +134,7 @@ def test_concurrent_membership_operations(instances: List[harness.Instance]):
 
     util.wait_until_k8s_ready(cluster_node, [cluster_node])
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
         future_A = executor.submit(join_node_with_retry, cluster_node, joining_cp_A)
         future_B = executor.submit(join_node_with_retry, cluster_node, joining_cp_B)
         future_C = executor.submit(
@@ -148,7 +148,7 @@ def test_concurrent_membership_operations(instances: List[harness.Instance]):
         assert "control-plane" in util.get_local_node_status(node)
     assert "worker" in util.get_local_node_status(joining_worker_C)
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
         future_A = executor.submit(remove_node_with_retry, cluster_node, joining_cp_A)
         future_B = executor.submit(remove_node_with_retry, cluster_node, joining_cp_B)
         future_C = executor.submit(


### PR DESCRIPTION
## ci: add more clustering test cases

This PR introduces more test cases on our nightly CI to test membership operations under more conditions: (parallel joins/removals, mixed join and removal operations) as well as disruptions such as snap restarts.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
