### PR TITLE
chore: [Backport 1.32] Cilium 1.17 changes

### DIFF
--- a/docs/canonicalk8s/snap/reference/annotations.md
+++ b/docs/canonicalk8s/snap/reference/annotations.md
@@ -74,6 +74,13 @@ v1alpha annotations are experimental and subject to change or removal in future 
 | **Values**      | string                                                                                                                                                                                                                                                    |
 | **Description** | Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing); if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route. Bridge type devices are ignored in automatic selection |
 
+## `k8sd/v1alpha1/cilium/sctp/enabled`
+
+|   |   |
+|---|---|
+|**Values**| "true"\|"false"|
+|**Description**|Enable the Cilium SCTP feature.|
+
 ## `k8sd/v1alpha1/cilium/vlan-bpf-bypass`
 
 |                 |                                                                                                                                                                                                                                                                                                                                                                                    |

--- a/src/k8s/pkg/k8sd/features/cilium/internal.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal.go
@@ -23,8 +23,8 @@ type config struct {
 	directRoutingDevice string
 	vlanBPFBypass       []int
 	cniExclusive        bool
-	tunnelPort          int
 	sctpEnabled         bool
+	tunnelPort          int
 }
 
 func validatePort(portStr string) (int, error) {
@@ -90,6 +90,10 @@ func internalConfig(annotations types.Annotations) (config, error) {
 		c.cniExclusive = true
 	}
 
+	if _, ok := annotations.Get(apiv1_annotations.AnnotationSCTPEnabled); ok {
+		c.sctpEnabled = true
+	}
+
 	if v, ok := annotations.Get(apiv1_annotations.AnnotationTunnelPort); ok {
 		tunnelPort, err := validatePort(v)
 		if err != nil {
@@ -99,10 +103,6 @@ func internalConfig(annotations types.Annotations) (config, error) {
 		c.tunnelPort = tunnelPort
 	} else {
 		c.tunnelPort = ciliumDefaultVXLANPort
-	}
-
-	if _, ok := annotations.Get(apiv1_annotations.AnnotationSCTPEnabled); ok {
-		c.sctpEnabled = true
 	}
 
 	return c, nil

--- a/src/k8s/pkg/k8sd/features/cilium/internal.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal.go
@@ -24,6 +24,7 @@ type config struct {
 	vlanBPFBypass       []int
 	cniExclusive        bool
 	tunnelPort          int
+	sctpEnabled         bool
 }
 
 func validatePort(portStr string) (int, error) {
@@ -98,6 +99,10 @@ func internalConfig(annotations types.Annotations) (config, error) {
 		c.tunnelPort = tunnelPort
 	} else {
 		c.tunnelPort = ciliumDefaultVXLANPort
+	}
+
+	if _, ok := annotations.Get(apiv1_annotations.AnnotationSCTPEnabled); ok {
+		c.sctpEnabled = true
 	}
 
 	return c, nil

--- a/src/k8s/pkg/k8sd/features/cilium/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal_test.go
@@ -80,6 +80,7 @@ func TestInternalConfig(t *testing.T) {
 				vlanBPFBypass:       nil,
 				cniExclusive:        false,
 				sctpEnabled:         true,
+				tunnelPort:          ciliumDefaultVXLANPort,
 			},
 			expectError: false,
 		},

--- a/src/k8s/pkg/k8sd/features/cilium/internal_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/internal_test.go
@@ -33,12 +33,14 @@ func TestInternalConfig(t *testing.T) {
 				apiv1_annotations.AnnotationDirectRoutingDevice: "eth0",
 				apiv1_annotations.AnnotationVLANBPFBypass:       "1,2,3",
 				apiv1_annotations.AnnotationCNIExclusive:        "true",
+				apiv1_annotations.AnnotationSCTPEnabled:         "true",
 			},
 			expectedConfig: config{
 				devices:             "eth+ lxdbr+",
 				directRoutingDevice: "eth0",
 				vlanBPFBypass:       []int{1, 2, 3},
 				cniExclusive:        true,
+				sctpEnabled:         true,
 				tunnelPort:          ciliumDefaultVXLANPort,
 			},
 			expectError: false,
@@ -64,6 +66,20 @@ func TestInternalConfig(t *testing.T) {
 			},
 			expectedConfig: config{
 				tunnelPort: 8473,
+			},
+			expectError: false,
+		},
+		{
+			name: "Cilum SCTP",
+			annotations: map[string]string{
+				apiv1_annotations.AnnotationSCTPEnabled: "true",
+			},
+			expectedConfig: config{
+				devices:             "",
+				directRoutingDevice: "",
+				vlanBPFBypass:       nil,
+				cniExclusive:        false,
+				sctpEnabled:         true,
 			},
 			expectError: false,
 		},

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -212,6 +212,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		"k8sServicePort": apiserver.GetSecurePort(),
 		// This flag enables the runtime device detection which is set to true by default in Cilium 1.16+
 		"enableRuntimeDeviceDetection": true,
+		"sessionAffinity":              true,
 		"tunnelPort":                   config.tunnelPort,
 	}
 

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -177,6 +177,9 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 			"binPath":   "/opt/cni/bin",
 			"exclusive": config.cniExclusive,
 		},
+		"sctp": map[string]any{
+			"enabled": config.sctpEnabled,
+		},
 		"operator": map[string]any{
 			"replicas": 1,
 			"image": map[string]any{

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -173,9 +173,10 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 			"enabled": true,
 		},
 		"cni": map[string]any{
-			"confPath":  "/etc/cni/net.d",
-			"binPath":   "/opt/cni/bin",
-			"exclusive": config.cniExclusive,
+			"confPath":     "/etc/cni/net.d",
+			"binPath":      "/opt/cni/bin",
+			"exclusive":    config.cniExclusive,
+			"chainingMode": "portmap",
 		},
 		"sctp": map[string]any{
 			"enabled": config.sctpEnabled,
@@ -213,7 +214,12 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		// This flag enables the runtime device detection which is set to true by default in Cilium 1.16+
 		"enableRuntimeDeviceDetection": true,
 		"sessionAffinity":              true,
-		"tunnelPort":                   config.tunnelPort,
+		"loadBalancer": map[string]any{
+			"protocolDifferentiation": map[string]any{
+				"enabled": true,
+			},
+		},
+		"tunnelPort": config.tunnelPort,
 	}
 
 	// If we are deploying with IPv6 only, we need to set the routing mode to native


### PR DESCRIPTION
This PR backports some changes regarding Cilium 1.17
- https://github.com/canonical/k8s-snap/pull/1088/files
- https://github.com/canonical/k8s-snap/pull/1146/files
- https://github.com/canonical/k8s-snap/pull/1170/files

It deliberately leaves out:
- https://github.com/canonical/k8s-snap/pull/1382/files