### PR TITLE
feat: Trigger feature controller on k8sd startup

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -135,5 +135,10 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 		}
 	}()
 
+	// NOTE(Hue): We notify all features here to ensure that they are
+	// reconciled at least once after the app starts. This is important specifically
+	// when k8sd gets restarted before getting the chance to reconcile features.
+	a.NotifyFeatureController(true, true, true, true, true, true, true)
+
 	return nil
 }


### PR DESCRIPTION
### Overview

This PR kicks k8sd to reconcile feature on start up to make sure features are reconciled even after an unfortunate k8sd restart.