### PR TITLE
docs: fix mistake in example intermediate ca Secret

### DIFF
--- a/docs/canonicalk8s/capi/howto/intermediate-ca.md
+++ b/docs/canonicalk8s/capi/howto/intermediate-ca.md
@@ -35,7 +35,7 @@ cat <<EOF > myca/ca-secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: mycluster
+  name: mycluster-ca
 type: Opaque
 stringData:
   tls.crt: |


### PR DESCRIPTION
## Description

Renames a secret used in the examples for CAPI and Intermediate CA Secret

## Backport

Should this PR be backported? If so, to which release? Not sure?


## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
