### PR TITLE
feat: simplify flavor support and create fips flavor

### DIFF
--- a/build-scripts/build-k8s-binaries.sh
+++ b/build-scripts/build-k8s-binaries.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+INSTALL="${SNAPCRAFT_PART_INSTALL}"
+
+export DQLITE_BUILD_SCRIPTS_DIR="${CRAFT_STAGE}/static-dqlite-deps"
+
+export GOTOOLCHAIN=local
+
+if [ "${FLAVOR}" = "fips" ]; then
+  export GOEXPERIMENT=opensslcrypto
+  export CGO_ENABLED=1
+  export EXTRA_LDFLAGS="-X 'github.com/canonical/k8s/pkg/config.buildFlavor=fips'"
+
+  make dynamic -j
+
+  mkdir -p "${INSTALL}/bin"
+  mkdir -p "${INSTALL}/lib"
+  for binary in k8s k8sd k8s-apiserver-proxy; do
+  cp -P "bin/dynamic/${binary}" "${INSTALL}/bin/${binary}"
+  done
+  cp -P bin/dynamic/lib/*.so* "${INSTALL}/lib/"
+
+  LD_LIBRARY_PATH="${DQLITE_BUILD_SCRIPTS_DIR}/.deps/dynamic/lib" "${INSTALL}/bin/k8s" list-images > "${INSTALL}/images.txt"
+else
+  make static -j
+
+  mkdir -p "${INSTALL}/bin"
+  for binary in k8s k8sd k8s-apiserver-proxy; do
+  cp -P "bin/static/${binary}" "${INSTALL}/bin/${binary}"
+  done
+  ./bin/static/k8s list-images > "${INSTALL}/images.txt"
+fi

--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -10,23 +10,22 @@ sed -i "s,^VERSION.*$,VERSION=${VERSION}," Makefile
 sed -i "s,^REVISION.*$,REVISION=${REVISION}," Makefile
 
 export GOTOOLCHAIN=local
-# # export GOEXPERIMENT=opensslcrypto
-export CGO_ENABLED=1
-export GO_BUILDTAGS="linux cgo"
-for bin in containerd; do
+
+export STATIC=1
+for bin in ctr containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2; do
   make "bin/${bin}"
   cp "bin/${bin}" "${INSTALL}/${bin}"
 done
 
-# Shims can be built statically as they do not contain any crypto functions
-for bin in ctr containerd-shim containerd-shim-runc-v1 containerd-shim-runc-v2; do
-  export STATIC=1
-  export CGO_ENABLED=0
-  export GO_BUILDTAGS=
-  export SHIM_CGO_ENABLED=0
-  export SHIM_GO_BUILDTAGS=
-  export GOEXPERIMENT=
+if [ "${FLAVOR}" = "fips" ]; then
+  # Shims can be built statically as they do not contain any crypto functions
+  export STATIC=0
+  export GOEXPERIMENT=opensslcrypto
+  export CGO_ENABLED=1
+  export GO_BUILDTAGS="linux cgo"
+fi
 
+for bin in containerd; do
   make "bin/${bin}"
   cp "bin/${bin}" "${INSTALL}/${bin}"
 done

--- a/build-scripts/components/etcd/build.sh
+++ b/build-scripts/components/etcd/build.sh
@@ -6,9 +6,12 @@ INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
 export GOTOOLCHAIN=local
-export CGO_ENABLED=1
-#export GOEXPERIMENT=opensslcrypto
-export GOFLAGS="-tags=linux,cgo"
+
+if [ "${FLAVOR}" = "fips" ]; then
+  export CGO_ENABLED=1
+  export GOEXPERIMENT=opensslcrypto
+  export GOFLAGS="-tags=linux,cgo"
+fi
 
 make build
 cp bin/* "${INSTALL}/"

--- a/build-scripts/components/helm/build.sh
+++ b/build-scripts/components/helm/build.sh
@@ -6,7 +6,14 @@ INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"
 
 export GOTOOLCHAIN=local
-export CGO_ENABLED=1
-# # export GOEXPERIMENT=opensslcrypto
-make VERSION="${VERSION}" TAGS="linux,cgo"
+
+export TAGS=""
+
+if [ "${FLAVOR}" = "fips" ]; then
+  export CGO_ENABLED=1
+  export GOEXPERIMENT=opensslcrypto
+  export TAGS="linux,cgo"
+fi
+
+make VERSION="${VERSION}" TAGS="${TAGS}"
 cp bin/helm "${INSTALL}/helm"

--- a/build-scripts/components/k8s-dqlite/build.sh
+++ b/build-scripts/components/k8s-dqlite/build.sh
@@ -2,17 +2,24 @@
 
 INSTALL="${1}/bin"
 
-## Use built dqlite dependencies (if any)
-if [ -d "${SNAPCRAFT_STAGE}/dynamic-dqlite-deps" ]; then
-  export DQLITE_BUILD_SCRIPTS_DIR="${SNAPCRAFT_STAGE}/dynamic-dqlite-deps"
+export GOTOOLCHAIN=local
+
+export BUILD_STRATEGY="static"
+
+if [ "${FLAVOR}" = "fips" ]; then
+  export GOEXPERIMENT=opensslcrypto
+  export CGO_ENABLED=1
+  export BUILD_STRATEGY="dynamic"
 fi
 
-export GOTOOLCHAIN=local
-# # export GOEXPERIMENT=opensslcrypto
-export CGO_ENABLED=1
-make dynamic -j
+## Use built dqlite dependencies (if any)
+if [ -d "${SNAPCRAFT_STAGE}/${BUILD_STRATEGY}-dqlite-deps" ]; then
+  export DQLITE_BUILD_SCRIPTS_DIR="${SNAPCRAFT_STAGE}/${BUILD_STRATEGY}-dqlite-deps"
+fi
+
+make $BUILD_STRATEGY -j
 
 mkdir -p "${INSTALL}"
 for binary in k8s-dqlite dqlite; do
-  cp -P "bin/dynamic/${binary}" "${INSTALL}/${binary}"
+  cp -P "bin/${BUILD_STRATEGY}/${binary}" "${INSTALL}/${binary}"
 done

--- a/build-scripts/components/kubernetes/build.sh
+++ b/build-scripts/components/kubernetes/build.sh
@@ -5,11 +5,18 @@ mkdir -p "${INSTALL}"
 
 export KUBE_GIT_VERSION_FILE="${PWD}/.version.sh"
 
-for app in kubernetes; do
-  export GOTOOLCHAIN=local
-  # # export GOEXPERIMENT=opensslcrypto
+export GOTOOLCHAIN=local
+
+export TAGS="providerless"
+
+if [ "${FLAVOR}" = "fips" ]; then
+  export GOEXPERIMENT=opensslcrypto
   export CGO_ENABLED=1
-  make WHAT="cmd/${app}" KUBE_CGO_OVERRIDES="${app}" GOFLAGS="-tags=providerless,linux,cgo"
+  export TAGS="${TAGS},linux,cgo"
+fi
+
+for app in kubernetes; do
+  make WHAT="cmd/${app}" KUBE_STATIC_OVERRIDES="${app}" KUBE_CGO_OVERRIDES="${app}" GOFLAGS="-tags=${TAGS}"
   cp _output/bin/"${app}" "${INSTALL}/${app}"
 done
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,6 +78,8 @@ parts:
     plugin: nil
     source: build-scripts/components/k8s-dqlite
     build-attributes: [enable-patchelf]
+    # build-environment:
+    #   - FLAVOR: fips
     override-build: $CRAFT_PROJECT_DIR/build-scripts/build-component.sh k8s-dqlite
 
   etcd:
@@ -88,6 +90,8 @@ parts:
     # due to https://github.com/NixOS/patchelf/issues/446.
     # Instead, we use a custom script based on LIEF to manually patch the rpath and interpreter.
     build-attributes: [no-patchelf]
+    # build-environment:
+    #   - FLAVOR: fips
     override-build: |
       # Note(Ben): This field must match the base field above.
       BASE=core22
@@ -118,25 +122,10 @@ parts:
     after: [dqlite]
     source: src/k8s
     build-attributes: [enable-patchelf]
+    # build-environment:
+    #   - FLAVOR: fips
     plugin: nil
-    override-build: |
-      INSTALL="${CRAFT_PART_INSTALL}"
-
-      export DQLITE_BUILD_SCRIPTS_DIR="${CRAFT_STAGE}/static-dqlite-deps"
-      export CGO_ENABLED=1
-      export GOTOOLCHAIN=local
-      # export GOEXPERIMENT=opensslcrypto
-
-      make dynamic -j
-
-      mkdir -p "${INSTALL}/bin"
-      mkdir -p "${INSTALL}/lib"
-      for binary in k8s k8sd k8s-apiserver-proxy; do
-        cp -P "bin/dynamic/${binary}" "${INSTALL}/bin/${binary}"
-      done
-      cp -P bin/dynamic/lib/*.so* "${INSTALL}/lib/"
-
-      LD_LIBRARY_PATH="${DQLITE_BUILD_SCRIPTS_DIR}/.deps/dynamic/lib" "${INSTALL}/bin/k8s" list-images > "${INSTALL}/images.txt"
+    override-build: $CRAFT_PROJECT_DIR/build-scripts/build-k8s-binaries.sh
 
   cni:
     after: [build-deps]
@@ -150,6 +139,8 @@ parts:
     plugin: nil
     source: build-scripts
     build-attributes: [enable-patchelf]
+    # build-environment:
+    #   - FLAVOR: fips
     override-build: $CRAFT_PROJECT_DIR/build-scripts/build-component.sh kubernetes
 
   kubernetes-version:
@@ -162,6 +153,8 @@ parts:
     build-attributes: [enable-patchelf]
     plugin: nil
     source: build-scripts/components/helm
+    # build-environment:
+    #   - FLAVOR: fips
     override-build: $CRAFT_PROJECT_DIR/build-scripts/build-component.sh helm
 
   libmnl:
@@ -205,6 +198,8 @@ parts:
     plugin: nil
     build-attributes: [enable-patchelf]
     source: build-scripts/components/containerd
+    # build-environment:
+    #   - FLAVOR: fips
     override-build: $CRAFT_PROJECT_DIR/build-scripts/build-component.sh containerd
 
   runc:

--- a/src/k8s/hack/dynamic-go-build.sh
+++ b/src/k8s/hack/dynamic-go-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xeu
+#!/bin/bash -xe
 
 DIR="$(realpath `dirname "${0}"`)"
 
@@ -9,9 +9,11 @@ if [[ "$DEBUG_BUILD" == "y" ]]; then
   go build \
   -gcflags=all="-N -l" \
   -tags dqlite,libsqlite3 \
+  -ldflags "${EXTRA_LDFLAGS}" \
   "${@}"
 else
   go build \
   -tags dqlite,libsqlite3 \
+  -ldflags "${EXTRA_LDFLAGS}" \
   "${@}"
 fi

--- a/src/k8s/hack/dynamic-go-install.sh
+++ b/src/k8s/hack/dynamic-go-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xeu
+#!/bin/bash -xe
 
 DIR="$(realpath `dirname "${0}"`)"
 
@@ -6,5 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go install \
   -tags dqlite,libsqlite3 \
-  -ldflags '-s -w' \
+  -ldflags "-s -w ${EXTRA_LDFLAGS}" \
   "${@}"

--- a/src/k8s/hack/dynamic-go-test.sh
+++ b/src/k8s/hack/dynamic-go-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xeu
+#!/bin/bash -xe
 
 DIR="$(realpath `dirname "${0}"`)"
 
@@ -6,4 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go test \
   -tags dqlite,libsqlite3 \
+  -ldflags "${EXTRA_LDFLAGS}" \
   "${@}"

--- a/src/k8s/hack/static-go-build.sh
+++ b/src/k8s/hack/static-go-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xeu
+#!/bin/bash -xe
 
 DIR="$(realpath `dirname "${0}"`)"
 
@@ -9,11 +9,11 @@ if [[ "$DEBUG_BUILD" == "y" ]]; then
   go build \
     -gcflags=all="-N -l" \
     -tags dqlite,libsqlite3 \
-    -ldflags '--linkmode "external" -extldflags "-static"' \
+    -ldflags "-linkmode 'external' -extldflags '-static' ${EXTRA_LDFLAGS}" \
     "${@}"
 else
   go build \
     -tags dqlite,libsqlite3 \
-    -ldflags '--linkmode "external" -extldflags "-static"' \
+    -ldflags "-linkmode 'external' -extldflags '-static' ${EXTRA_LDFLAGS}" \
     "${@}"
 fi

--- a/src/k8s/hack/static-go-install.sh
+++ b/src/k8s/hack/static-go-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xeu
+#!/bin/bash -xe
 
 DIR="$(realpath `dirname "${0}"`)"
 
@@ -6,5 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go install \
   -tags dqlite,libsqlite3 \
-  -ldflags '-s -w -linkmode "external" -extldflags "-static"' \
+  -ldflags "-s -w -linkmode 'external' -extldflags '-static' ${EXTRA_LDFLAGS}" \
   "${@}"

--- a/src/k8s/hack/static-go-test.sh
+++ b/src/k8s/hack/static-go-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xeu
+#!/bin/bash -xe
 
 DIR="$(realpath `dirname "${0}"`)"
 
@@ -6,5 +6,5 @@ DIR="$(realpath `dirname "${0}"`)"
 
 go test \
   -tags dqlite,libsqlite3 \
-  -ldflags '-linkmode "external" -extldflags "-static"' \
+  -ldflags "-linkmode 'external' -extldflags '-static' ${EXTRA_LDFLAGS}" \
   "${@}"

--- a/src/k8s/pkg/config/config.go
+++ b/src/k8s/pkg/config/config.go
@@ -5,3 +5,29 @@ const (
 	// the REST API is exposed by default.
 	DefaultPort = 6400
 )
+
+var (
+	// buildFlavor determines the flavor of k8s-snap being built.
+	// It can be overridden at build time using -ldflags "-X ...".
+	buildFlavor = "default"
+)
+
+type Flavor string
+
+const (
+	FlavorDefault Flavor = "default"
+	FlavorFIPS    Flavor = "fips"
+)
+
+// GetFlavor returns the flavor of k8s-snap being built.
+// This function panics if the flavor set at build-time is unknown.
+func GetFlavor() Flavor {
+	flavor := Flavor(buildFlavor)
+
+	switch flavor {
+	case FlavorDefault, FlavorFIPS:
+		return flavor
+	default:
+		panic("unknown build flavor: " + string(flavor))
+	}
+}

--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -4,6 +4,9 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
+	k8sdConfig "github.com/canonical/k8s/pkg/config"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
 )
 
 var (
@@ -35,19 +38,39 @@ var (
 		ManifestPath: filepath.Join("charts", "ck-gateway-cilium"),
 	}
 
-	// ciliumAgentImageRepo represents the image to use for cilium-agent.
-	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
-
-	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.1-ck2"
-
-	// ciliumOperatorImageRepo is the image to use for cilium-operator.
-	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
-
-	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.1-ck2"
-
 	ciliumDefaultVXLANPort = 8472
 
 	ciliumVXLANDeviceName = "cilium_vxlan"
 )
+
+func CiliumAgentImage() types.Image {
+	agentRepo := "ghcr.io/canonical/cilium"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: agentRepo,
+			Tag:        "1.17.1-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: agentRepo,
+		Tag:        "1.17.1-ck2",
+	}
+}
+
+func CiliumOperatorImage() types.Image {
+	operatorRepo := "ghcr.io/canonical/cilium-operator"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: operatorRepo,
+			Tag:        "1.17.1-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: operatorRepo,
+		Tag:        "1.17.1-ck2",
+	}
+}

--- a/src/k8s/pkg/k8sd/features/cilium/gateway.go
+++ b/src/k8s/pkg/k8sd/features/cilium/gateway.go
@@ -37,7 +37,7 @@ func enableGateway(ctx context.Context, snap snap.Snap) (types.FeatureStatus, er
 		err = fmt.Errorf("failed to install Gateway API CRDs: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -47,7 +47,7 @@ func enableGateway(ctx context.Context, snap snap.Snap) (types.FeatureStatus, er
 		err = fmt.Errorf("failed to install Gateway API GatewayClass: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -68,7 +68,7 @@ func enableGateway(ctx context.Context, snap snap.Snap) (types.FeatureStatus, er
 		err = fmt.Errorf("failed to upgrade Gateway API cilium configuration: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -76,7 +76,7 @@ func enableGateway(ctx context.Context, snap snap.Snap) (types.FeatureStatus, er
 	if !changed {
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: EnabledMsg,
 		}, nil
 	}
@@ -85,14 +85,14 @@ func enableGateway(ctx context.Context, snap snap.Snap) (types.FeatureStatus, er
 		err = fmt.Errorf("failed to rollout restart cilium to enable Gateway API: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeployFailedMsgTmpl, err),
 		}, err
 	}
 
 	return types.FeatureStatus{
 		Enabled: true,
-		Version: CiliumAgentImageTag,
+		Version: CiliumAgentImage().Tag,
 		Message: EnabledMsg,
 	}, nil
 }
@@ -105,7 +105,7 @@ func disableGateway(ctx context.Context, snap snap.Snap, network types.Network) 
 		err = fmt.Errorf("failed to delete Gateway API GatewayClass: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeleteFailedMsgTmpl, err),
 		}, err
 	}
@@ -115,7 +115,7 @@ func disableGateway(ctx context.Context, snap snap.Snap, network types.Network) 
 		err = fmt.Errorf("failed to delete Gateway API cilium configuration: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeleteFailedMsgTmpl, err),
 		}, err
 	}
@@ -126,7 +126,7 @@ func disableGateway(ctx context.Context, snap snap.Snap, network types.Network) 
 		err = fmt.Errorf("failed to delete Gateway API CRDs: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeleteFailedMsgTmpl, err),
 		}, err
 	}
@@ -134,7 +134,7 @@ func disableGateway(ctx context.Context, snap snap.Snap, network types.Network) 
 	if !changed {
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: DisabledMsg,
 		}, nil
 	}
@@ -143,14 +143,14 @@ func disableGateway(ctx context.Context, snap snap.Snap, network types.Network) 
 		err = fmt.Errorf("failed to rollout restart cilium to disable Gateway API: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(GatewayDeployFailedMsgTmpl, err),
 		}, err
 	}
 
 	return types.FeatureStatus{
 		Enabled: false,
-		Version: CiliumAgentImageTag,
+		Version: CiliumAgentImage().Tag,
 		Message: DisabledMsg,
 	}, nil
 }

--- a/src/k8s/pkg/k8sd/features/cilium/gateway_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/gateway_test.go
@@ -42,7 +42,7 @@ func TestGatewayEnabled(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.GatewayDeployFailedMsgTmpl, err)))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 	})
@@ -67,7 +67,7 @@ func TestGatewayEnabled(t *testing.T) {
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(status.Enabled).To(BeTrue())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(cilium.EnabledMsg))
 
 		helmCiliumArgs := helmM.ApplyCalledWith[2]
@@ -100,7 +100,7 @@ func TestGatewayEnabled(t *testing.T) {
 
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.GatewayDeployFailedMsgTmpl, err)))
 	})
 
@@ -141,7 +141,7 @@ func TestGatewayEnabled(t *testing.T) {
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(status.Enabled).To(BeTrue())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(cilium.EnabledMsg))
 	})
 }
@@ -169,7 +169,7 @@ func TestGatewayDisabled(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.GatewayDeleteFailedMsgTmpl, err)))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 	})
@@ -192,7 +192,7 @@ func TestGatewayDisabled(t *testing.T) {
 		status, err := cilium.ApplyGateway(context.Background(), snapM, gateway, network, nil)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(cilium.DisabledMsg))
 
 		helmCiliumArgs := helmM.ApplyCalledWith[1]
@@ -223,7 +223,7 @@ func TestGatewayDisabled(t *testing.T) {
 		status, err := cilium.ApplyGateway(context.Background(), snapM, gateway, network, nil)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.GatewayDeployFailedMsgTmpl, err)))
 	})
 
@@ -264,7 +264,7 @@ func TestGatewayDisabled(t *testing.T) {
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(status.Message).To(Equal(cilium.DisabledMsg))
 	})
 }

--- a/src/k8s/pkg/k8sd/features/cilium/ingress.go
+++ b/src/k8s/pkg/k8sd/features/cilium/ingress.go
@@ -61,14 +61,14 @@ func ApplyIngress(ctx context.Context, snap snap.Snap, ingress types.Ingress, ne
 			err = fmt.Errorf("failed to enable ingress: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(IngressDeployFailedMsgTmpl, err),
 			}, err
 		} else {
 			err = fmt.Errorf("failed to disable ingress: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(IngressDeleteFailedMsgTmpl, err),
 			}, err
 		}
@@ -78,13 +78,13 @@ func ApplyIngress(ctx context.Context, snap snap.Snap, ingress types.Ingress, ne
 		if ingress.GetEnabled() {
 			return types.FeatureStatus{
 				Enabled: true,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: EnabledMsg,
 			}, nil
 		} else {
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: DisabledMsg,
 			}, nil
 		}
@@ -93,7 +93,7 @@ func ApplyIngress(ctx context.Context, snap snap.Snap, ingress types.Ingress, ne
 	if !ingress.GetEnabled() {
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: DisabledMsg,
 		}, nil
 	}
@@ -102,14 +102,14 @@ func ApplyIngress(ctx context.Context, snap snap.Snap, ingress types.Ingress, ne
 		err = fmt.Errorf("failed to rollout restart cilium to apply ingress: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(IngressDeployFailedMsgTmpl, err),
 		}, err
 	}
 
 	return types.FeatureStatus{
 		Enabled: true,
-		Version: CiliumAgentImageTag,
+		Version: CiliumAgentImage().Tag,
 		Message: EnabledMsg,
 	}, nil
 }

--- a/src/k8s/pkg/k8sd/features/cilium/ingress_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/ingress_test.go
@@ -105,7 +105,7 @@ func TestIngress(t *testing.T) {
 			}
 			g.Expect(status.Enabled).To(Equal(tc.statusEnabled))
 			g.Expect(status.Message).To(Equal(tc.statusMsg))
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 			callArgs := helmM.ApplyCalledWith[0]
@@ -148,7 +148,7 @@ func TestIngressRollout(t *testing.T) {
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.IngressDeployFailedMsgTmpl, err)))
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -194,7 +194,7 @@ func TestIngressRollout(t *testing.T) {
 		g.Expect(err).To(Not(HaveOccurred()))
 		g.Expect(status.Enabled).To(BeTrue())
 		g.Expect(status.Message).To(Equal(cilium.EnabledMsg))
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]

--- a/src/k8s/pkg/k8sd/features/cilium/loadbalancer.go
+++ b/src/k8s/pkg/k8sd/features/cilium/loadbalancer.go
@@ -30,13 +30,13 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 			err = fmt.Errorf("failed to disable LoadBalancer: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(LbDeleteFailedMsgTmpl, err),
 			}, err
 		}
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: DisabledMsg,
 		}, nil
 	}
@@ -45,7 +45,7 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 		err = fmt.Errorf("failed to enable LoadBalancer: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(LbDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -54,19 +54,19 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 	case loadbalancer.GetBGPMode():
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(lbEnabledMsgTmpl, "BGP"),
 		}, nil
 	case loadbalancer.GetL2Mode():
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(lbEnabledMsgTmpl, "L2"),
 		}, nil
 	default:
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(lbEnabledMsgTmpl, "Unknown"),
 		}, nil
 	}

--- a/src/k8s/pkg/k8sd/features/cilium/loadbalancer_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/loadbalancer_test.go
@@ -44,7 +44,7 @@ func TestLoadBalancerDisabled(t *testing.T) {
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.LbDeleteFailedMsgTmpl, err)))
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -74,7 +74,7 @@ func TestLoadBalancerDisabled(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(Equal(cilium.DisabledMsg))
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(2))
 
 		firstCallArgs := helmM.ApplyCalledWith[0]
@@ -117,7 +117,7 @@ func TestLoadBalancerEnabled(t *testing.T) {
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.LbDeployFailedMsgTmpl, err)))
-		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+		g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -217,7 +217,7 @@ func TestLoadBalancerEnabled(t *testing.T) {
 
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.Enabled).To(BeTrue())
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(status.Message).To(Equal(tc.statusMessage))
 
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(2))

--- a/src/k8s/pkg/k8sd/features/cilium/network.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network.go
@@ -78,13 +78,13 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 			err = fmt.Errorf("failed to uninstall network: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(NetworkDeleteFailedMsgTmpl, err),
 			}, err
 		}
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: DisabledMsg,
 		}, nil
 	}
@@ -94,7 +94,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		err = fmt.Errorf("failed to parse annotations: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -104,7 +104,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		err = fmt.Errorf("failed to determine localhost address: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -114,7 +114,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		err = fmt.Errorf("failed to parse node IP address %q", s.Address().Hostname())
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -124,7 +124,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		err = fmt.Errorf("failed to find cidr of default interface: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -134,7 +134,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		err = fmt.Errorf("invalid kube-proxy --cluster-cidr value: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -152,7 +152,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 	if err := checkAndSanitizeCiliumVXLAN(config.tunnelPort); err != nil {
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 		}, err
 	}
@@ -165,8 +165,8 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 	values := map[string]any{
 		"bpf": bpfValues,
 		"image": map[string]any{
-			"repository": ciliumAgentImageRepo,
-			"tag":        CiliumAgentImageTag,
+			"repository": CiliumAgentImage().Repository,
+			"tag":        CiliumAgentImage().Tag,
 			"useDigest":  false,
 		},
 		"socketLB": map[string]any{
@@ -184,8 +184,8 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		"operator": map[string]any{
 			"replicas": 1,
 			"image": map[string]any{
-				"repository": ciliumOperatorImageRepo,
-				"tag":        ciliumOperatorImageTag,
+				"repository": CiliumOperatorImage().Repository,
+				"tag":        CiliumOperatorImage().Tag,
 				"useDigest":  false,
 			},
 		},
@@ -239,7 +239,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 			err = fmt.Errorf("failed to get bpf mount path: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 			}, err
 		}
@@ -249,7 +249,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 			err = fmt.Errorf("failed to get cgroup2 mount path: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 			}, err
 		}
@@ -272,7 +272,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 			err = fmt.Errorf("failed to get mount propagation type for /sys: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 			}, err
 		}
@@ -286,7 +286,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 				err := fmt.Errorf("/sys is not a shared mount on the LXD container, this might be resolved by updating LXD on the host to version 5.0.2 or newer")
 				return types.FeatureStatus{
 					Enabled: false,
-					Version: CiliumAgentImageTag,
+					Version: CiliumAgentImage().Tag,
 					Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 				}, err
 			}
@@ -294,7 +294,7 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 			err = fmt.Errorf("/sys is not a shared mount")
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: CiliumAgentImageTag,
+				Version: CiliumAgentImage().Tag,
 				Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 			}, err
 		}
@@ -304,14 +304,14 @@ func ApplyNetwork(ctx context.Context, snap snap.Snap, s state.State, apiserver 
 		err = fmt.Errorf("failed to enable network: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: CiliumAgentImageTag,
+			Version: CiliumAgentImage().Tag,
 			Message: fmt.Sprintf(NetworkDeployFailedMsgTmpl, err),
 		}, err
 	}
 
 	return types.FeatureStatus{
 		Enabled: true,
-		Version: CiliumAgentImageTag,
+		Version: CiliumAgentImage().Tag,
 		Message: EnabledMsg,
 	}, nil
 }

--- a/src/k8s/pkg/k8sd/features/cilium/network_test.go
+++ b/src/k8s/pkg/k8sd/features/cilium/network_test.go
@@ -55,7 +55,7 @@ func TestNetworkDisabled(t *testing.T) {
 			g.Expect(err).To(MatchError(applyErr))
 			g.Expect(status.Enabled).To(BeFalse())
 			g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.NetworkDeleteFailedMsgTmpl, err)))
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 			callArgs := helmM.ApplyCalledWith[0]
@@ -85,7 +85,7 @@ func TestNetworkDisabled(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.Enabled).To(BeFalse())
 			g.Expect(status.Message).To(Equal(cilium.DisabledMsg))
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 			callArgs := helmM.ApplyCalledWith[0]
@@ -119,7 +119,7 @@ func TestNetworkEnabled(t *testing.T) {
 
 			g.Expect(err).To(HaveOccurred())
 			g.Expect(status.Enabled).To(BeFalse())
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(BeEmpty())
 		})
 
@@ -146,7 +146,7 @@ func TestNetworkEnabled(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.Enabled).To(BeTrue())
 			g.Expect(status.Message).To(Equal(cilium.EnabledMsg))
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 			callArgs := helmM.ApplyCalledWith[0]
@@ -180,7 +180,7 @@ func TestNetworkEnabled(t *testing.T) {
 			g.Expect(err).To(MatchError(applyErr))
 			g.Expect(status.Enabled).To(BeFalse())
 			g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.NetworkDeployFailedMsgTmpl, err)))
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 			callArgs := helmM.ApplyCalledWith[0]
@@ -216,7 +216,7 @@ func TestNetworkEnabled(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.Enabled).To(BeTrue())
 			g.Expect(status.Message).To(Equal(cilium.EnabledMsg))
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 			callArgs := helmM.ApplyCalledWith[0]
@@ -254,7 +254,7 @@ func TestNetworkEnabled(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(status.Enabled).To(BeTrue())
 			g.Expect(status.Message).To(Equal(cilium.EnabledMsg))
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 			callArgs := helmM.ApplyCalledWith[0]
@@ -306,7 +306,7 @@ func TestNetworkMountPath(t *testing.T) {
 				g.Expect(err).To(MatchError(mountPathErr))
 				g.Expect(status.Enabled).To(BeFalse())
 				g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.NetworkDeployFailedMsgTmpl, err)))
-				g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+				g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 				g.Expect(helmM.ApplyCalledWith).To(BeEmpty())
 			})
 		}
@@ -344,7 +344,7 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			g.Expect(status.Enabled).To(BeFalse())
 			g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.NetworkDeployFailedMsgTmpl, err)))
 
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(BeEmpty())
 		})
 
@@ -378,7 +378,7 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			g.Expect(status.Enabled).To(BeFalse())
 			g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.NetworkDeployFailedMsgTmpl, err)))
 
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(BeEmpty())
 			testingLogger, ok := logger.GetSink().(ktesting.Underlier)
 			if !ok {
@@ -415,7 +415,7 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			g.Expect(status.Enabled).To(BeFalse())
 			g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.NetworkDeployFailedMsgTmpl, err)))
 
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(BeEmpty())
 		})
 
@@ -446,7 +446,7 @@ func TestNetworkMountPropagationType(t *testing.T) {
 			g.Expect(status.Enabled).To(BeFalse())
 			g.Expect(status.Message).To(Equal(fmt.Sprintf(cilium.NetworkDeployFailedMsgTmpl, err)))
 
-			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImageTag))
+			g.Expect(status.Version).To(Equal(cilium.CiliumAgentImage().Tag))
 			g.Expect(helmM.ApplyCalledWith).To(BeEmpty())
 		})
 	})

--- a/src/k8s/pkg/k8sd/features/cilium/register.go
+++ b/src/k8s/pkg/k8sd/features/cilium/register.go
@@ -8,7 +8,7 @@ import (
 
 func init() {
 	images.Register(
-		fmt.Sprintf("%s:%s", ciliumAgentImageRepo, CiliumAgentImageTag),
-		fmt.Sprintf("%s-generic:%s", ciliumOperatorImageRepo, ciliumOperatorImageTag),
+		CiliumAgentImage().String(),
+		fmt.Sprintf("%s-generic:%s", CiliumOperatorImage().Repository, CiliumOperatorImage().Tag),
 	)
 }

--- a/src/k8s/pkg/k8sd/features/coredns/chart.go
+++ b/src/k8s/pkg/k8sd/features/coredns/chart.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
+	k8sdConfig "github.com/canonical/k8s/pkg/config"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 )
 
 var (
@@ -13,10 +15,21 @@ var (
 		Namespace:    "kube-system",
 		ManifestPath: filepath.Join("charts", "coredns-1.39.2.tgz"),
 	}
-
-	// imageRepo is the image to use for CoreDNS.
-	imageRepo = "ghcr.io/canonical/coredns"
-
-	// ImageTag is the tag to use for the CoreDNS image.
-	ImageTag = "1.12.0-ck1"
 )
+
+// CoreDNSImage returns the image to use for CoreDNS.
+func CoreDNSImage() types.Image {
+	agentRepo := "ghcr.io/canonical/coredns"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: agentRepo,
+			Tag:        "1.12.0-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: agentRepo,
+		Tag:        "1.12.0-ck1",
+	}
+}

--- a/src/k8s/pkg/k8sd/features/coredns/coredns.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns.go
@@ -33,21 +33,21 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 			err = fmt.Errorf("failed to uninstall coredns: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: ImageTag,
+				Version: CoreDNSImage().Tag,
 				Message: fmt.Sprintf(deleteFailedMsgTmpl, err),
 			}, "", err
 		}
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: ImageTag,
+			Version: CoreDNSImage().Tag,
 			Message: disabledMsg,
 		}, "", nil
 	}
 
 	values := map[string]any{
 		"image": map[string]any{
-			"repository": imageRepo,
-			"tag":        ImageTag,
+			"repository": CoreDNSImage().Repository,
+			"tag":        CoreDNSImage().Tag,
 		},
 		"service": map[string]any{
 			"name":      "coredns",
@@ -99,7 +99,7 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 		err = fmt.Errorf("failed to apply coredns: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: ImageTag,
+			Version: CoreDNSImage().Tag,
 			Message: fmt.Sprintf(deployFailedMsgTmpl, err),
 		}, "", err
 	}
@@ -109,7 +109,7 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 		err = fmt.Errorf("failed to create kubernetes client: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: ImageTag,
+			Version: CoreDNSImage().Tag,
 			Message: fmt.Sprintf(deployFailedMsgTmpl, err),
 		}, "", err
 	}
@@ -118,14 +118,14 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 		err = fmt.Errorf("failed to retrieve the coredns service: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: ImageTag,
+			Version: CoreDNSImage().Tag,
 			Message: fmt.Sprintf(deployFailedMsgTmpl, err),
 		}, "", err
 	}
 
 	return types.FeatureStatus{
 		Enabled: true,
-		Version: ImageTag,
+		Version: CoreDNSImage().Tag,
 		Message: fmt.Sprintf(enabledMsgTmpl, dnsIP),
 	}, dnsIP, err
 }

--- a/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
@@ -44,7 +44,7 @@ func TestDisabled(t *testing.T) {
 		g.Expect(status.Message).To(ContainSubstring(applyErr.Error()))
 		g.Expect(status.Message).To(ContainSubstring("failed to uninstall coredns"))
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(coredns.ImageTag))
+		g.Expect(status.Version).To(Equal(coredns.CoreDNSImage().Tag))
 
 		callArgs := helmM.ApplyCalledWith[0]
 		g.Expect(callArgs.Chart).To(Equal(coredns.Chart))
@@ -71,7 +71,7 @@ func TestDisabled(t *testing.T) {
 		g.Expect(str).To(BeEmpty())
 		g.Expect(status.Message).To(Equal("disabled"))
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(coredns.ImageTag))
+		g.Expect(status.Version).To(Equal(coredns.CoreDNSImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -106,7 +106,7 @@ func TestEnabled(t *testing.T) {
 		g.Expect(status.Message).To(ContainSubstring(applyErr.Error()))
 		g.Expect(status.Message).To(ContainSubstring("failed to apply coredns"))
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(coredns.ImageTag))
+		g.Expect(status.Version).To(Equal(coredns.CoreDNSImage().Tag))
 
 		callArgs := helmM.ApplyCalledWith[0]
 		g.Expect(callArgs.Chart).To(Equal(coredns.Chart))
@@ -135,7 +135,7 @@ func TestEnabled(t *testing.T) {
 		g.Expect(str).To(BeEmpty())
 		g.Expect(status.Message).To(ContainSubstring("failed to retrieve the coredns service"))
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(coredns.ImageTag))
+		g.Expect(status.Version).To(Equal(coredns.CoreDNSImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -175,7 +175,7 @@ func TestEnabled(t *testing.T) {
 		g.Expect(str).To(Equal(clusterIp))
 		g.Expect(status.Message).To(ContainSubstring("enabled at " + clusterIp))
 		g.Expect(status.Enabled).To(BeTrue())
-		g.Expect(status.Version).To(Equal(coredns.ImageTag))
+		g.Expect(status.Version).To(Equal(coredns.CoreDNSImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]

--- a/src/k8s/pkg/k8sd/features/coredns/register.go
+++ b/src/k8s/pkg/k8sd/features/coredns/register.go
@@ -1,13 +1,11 @@
 package coredns
 
 import (
-	"fmt"
-
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
 func init() {
 	images.Register(
-		fmt.Sprintf("%s:%s", imageRepo, ImageTag),
+		CoreDNSImage().String(),
 	)
 }

--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
+	k8sdConfig "github.com/canonical/k8s/pkg/config"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 )
 
 var (
@@ -13,18 +15,84 @@ var (
 		Namespace:    "kube-system",
 		ManifestPath: filepath.Join("charts", "rawfile-csi-0.9.1.tgz"),
 	}
-
-	// imageRepo is the repository to use for Rawfile LocalPV CSI.
-	imageRepo = "ghcr.io/canonical/rawfile-localpv"
-	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "0.8.2-ck1"
-
-	// csiNodeDriverImage is the image to use for the CSI node driver.
-	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"
-	// csiProvisionerImage is the image to use for the CSI provisioner.
-	csiProvisionerImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner:v5.0.2"
-	// csiResizerImage is the image to use for the CSI resizer.
-	csiResizerImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer:v1.11.2"
-	// csiSnapshotterImage is the image to use for the CSI snapshotter.
-	csiSnapshotterImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter:v8.0.2"
 )
+
+func LocalPVImage() types.Image {
+	imageRepo := "ghcr.io/canonical/rawfile-localpv"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "0.8.2-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "0.8.2-ck1",
+	}
+}
+
+func CSINodeDriverImage() types.Image {
+	imageRepo := "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "v2.10.1-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "v2.10.1",
+	}
+}
+
+func CSIProvisionerImage() types.Image {
+	imageRepo := "ghcr.io/canonical/k8s-snap/sig-storage/csi-provisioner"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "v5.0.2-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "v5.0.2",
+	}
+}
+
+func CSIResizerImage() types.Image {
+	imageRepo := "ghcr.io/canonical/k8s-snap/sig-storage/csi-resizer"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "v1.11.2-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "v1.11.2",
+	}
+}
+
+func CSISnapshotterImage() types.Image {
+	imageRepo := "ghcr.io/canonical/k8s-snap/sig-storage/csi-snapshotter"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "v8.0.2-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "v8.0.2",
+	}
+}

--- a/src/k8s/pkg/k8sd/features/localpv/localpv.go
+++ b/src/k8s/pkg/k8sd/features/localpv/localpv.go
@@ -37,24 +37,24 @@ func ApplyLocalStorage(ctx context.Context, snap snap.Snap, cfg types.LocalStora
 		"controller": map[string]any{
 			"csiDriverArgs": []string{"--args", "rawfile", "csi-driver", "--disable-metrics"},
 			"image": map[string]any{
-				"repository": imageRepo,
-				"tag":        ImageTag,
+				"repository": LocalPVImage().Repository,
+				"tag":        LocalPVImage().Tag,
 			},
 		},
 		"node": map[string]any{
 			"image": map[string]any{
-				"repository": imageRepo,
-				"tag":        ImageTag,
+				"repository": LocalPVImage().Repository,
+				"tag":        LocalPVImage().Tag,
 			},
 			"storage": map[string]any{
 				"path": cfg.GetLocalPath(),
 			},
 		},
 		"images": map[string]any{
-			"csiNodeDriverRegistrar": csiNodeDriverImage,
-			"csiProvisioner":         csiProvisionerImage,
-			"csiResizer":             csiResizerImage,
-			"csiSnapshotter":         csiSnapshotterImage,
+			"csiNodeDriverRegistrar": CSINodeDriverImage().String(),
+			"csiProvisioner":         CSIProvisionerImage().String(),
+			"csiResizer":             CSIResizerImage().String(),
+			"csiSnapshotter":         CSISnapshotterImage().String(),
 		},
 	}
 
@@ -63,14 +63,14 @@ func ApplyLocalStorage(ctx context.Context, snap snap.Snap, cfg types.LocalStora
 			err = fmt.Errorf("failed to install rawfile-csi helm package: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: ImageTag,
+				Version: LocalPVImage().Tag,
 				Message: fmt.Sprintf(deployFailedMsgTmpl, err),
 			}, err
 		} else {
 			err = fmt.Errorf("failed to delete rawfile-csi helm package: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: ImageTag,
+				Version: LocalPVImage().Tag,
 				Message: fmt.Sprintf(deleteFailedMsgTmpl, err),
 			}, err
 		}
@@ -79,13 +79,13 @@ func ApplyLocalStorage(ctx context.Context, snap snap.Snap, cfg types.LocalStora
 	if cfg.GetEnabled() {
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: ImageTag,
+			Version: LocalPVImage().Tag,
 			Message: fmt.Sprintf(enabledMsg, cfg.GetLocalPath()),
 		}, nil
 	} else {
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: ImageTag,
+			Version: LocalPVImage().Tag,
 			Message: disabledMsg,
 		}, nil
 	}

--- a/src/k8s/pkg/k8sd/features/localpv/localpv_test.go
+++ b/src/k8s/pkg/k8sd/features/localpv/localpv_test.go
@@ -39,7 +39,7 @@ func TestDisabled(t *testing.T) {
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(ContainSubstring(applyErr.Error()))
-		g.Expect(status.Version).To(Equal(localpv.ImageTag))
+		g.Expect(status.Version).To(Equal(localpv.LocalPVImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -68,7 +68,7 @@ func TestDisabled(t *testing.T) {
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
-		g.Expect(status.Version).To(Equal(localpv.ImageTag))
+		g.Expect(status.Version).To(Equal(localpv.LocalPVImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -104,7 +104,7 @@ func TestEnabled(t *testing.T) {
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(ContainSubstring(applyErr.Error()))
-		g.Expect(status.Version).To(Equal(localpv.ImageTag))
+		g.Expect(status.Version).To(Equal(localpv.LocalPVImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -133,7 +133,7 @@ func TestEnabled(t *testing.T) {
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeTrue())
-		g.Expect(status.Version).To(Equal(localpv.ImageTag))
+		g.Expect(status.Version).To(Equal(localpv.LocalPVImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]

--- a/src/k8s/pkg/k8sd/features/localpv/register.go
+++ b/src/k8s/pkg/k8sd/features/localpv/register.go
@@ -1,19 +1,17 @@
 package localpv
 
 import (
-	"fmt"
-
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
 func init() {
 	images.Register(
 		// Rawfile LocalPV CSI driver images
-		fmt.Sprintf("%s:%s", imageRepo, ImageTag),
+		LocalPVImage().String(),
 		// CSI images
-		csiNodeDriverImage,
-		csiProvisionerImage,
-		csiResizerImage,
-		csiSnapshotterImage,
+		CSINodeDriverImage().String(),
+		CSIProvisionerImage().String(),
+		CSIResizerImage().String(),
+		CSISnapshotterImage().String(),
 	)
 }

--- a/src/k8s/pkg/k8sd/features/metallb/chart.go
+++ b/src/k8s/pkg/k8sd/features/metallb/chart.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
+	k8sdConfig "github.com/canonical/k8s/pkg/config"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 )
 
 var (
@@ -20,22 +22,52 @@ var (
 		Namespace:    "metallb-system",
 		ManifestPath: filepath.Join("charts", "ck-loadbalancer"),
 	}
-
-	// controllerImageRepo is the image to use for metallb-controller.
-	controllerImageRepo = "ghcr.io/canonical/metallb-controller"
-
-	// ControllerImageTag is the tag to use for metallb-controller.
-	ControllerImageTag = "v0.14.9-ck0"
-
-	// speakerImageRepo is the image to use for metallb-speaker.
-	speakerImageRepo = "ghcr.io/canonical/metallb-speaker"
-
-	// speakerImageTag is the tag to use for metallb-speaker.
-	speakerImageTag = "v0.14.9-ck0"
-
-	// frrImageRepo is the image to use for frrouting.
-	frrImageRepo = "ghcr.io/canonical/frr"
-
-	// frrImageTag is the tag to use for frrouting.
-	frrImageTag = "9.1.3-ck1"
 )
+
+func MetalLBControllerImage() types.Image {
+	imageRepo := "ghcr.io/canonical/metallb-controller"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "v0.14.9-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "v0.14.9-ck0",
+	}
+}
+
+func MetalLBSpeakerImage() types.Image {
+	imageRepo := "ghcr.io/canonical/metallb-speaker"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "v0.14.9-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "v0.14.9-ck0",
+	}
+}
+
+func FRRImage() types.Image {
+	imageRepo := "ghcr.io/canonical/frr"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "9.1.3-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "9.1.3-ck1",
+	}
+}

--- a/src/k8s/pkg/k8sd/features/metallb/loadbalancer.go
+++ b/src/k8s/pkg/k8sd/features/metallb/loadbalancer.go
@@ -27,13 +27,13 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 			err = fmt.Errorf("failed to disable LoadBalancer: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: ControllerImageTag,
+				Version: MetalLBControllerImage().Tag,
 				Message: fmt.Sprintf(deleteFailedMsgTmpl, err),
 			}, err
 		}
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: ControllerImageTag,
+			Version: MetalLBControllerImage().Tag,
 			Message: DisabledMsg,
 		}, nil
 	}
@@ -42,7 +42,7 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 		err = fmt.Errorf("failed to enable LoadBalancer: %w", err)
 		return types.FeatureStatus{
 			Enabled: false,
-			Version: ControllerImageTag,
+			Version: MetalLBControllerImage().Tag,
 			Message: fmt.Sprintf(deployFailedMsgTmpl, err),
 		}, err
 	}
@@ -51,19 +51,19 @@ func ApplyLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.L
 	case loadbalancer.GetBGPMode():
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: ControllerImageTag,
+			Version: MetalLBControllerImage().Tag,
 			Message: fmt.Sprintf(enabledMsgTmpl, "BGP"),
 		}, nil
 	case loadbalancer.GetL2Mode():
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: ControllerImageTag,
+			Version: MetalLBControllerImage().Tag,
 			Message: fmt.Sprintf(enabledMsgTmpl, "L2"),
 		}, nil
 	default:
 		return types.FeatureStatus{
 			Enabled: true,
-			Version: ControllerImageTag,
+			Version: MetalLBControllerImage().Tag,
 			Message: fmt.Sprintf(enabledMsgTmpl, "Unknown"),
 		}, nil
 	}
@@ -88,15 +88,15 @@ func enableLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.
 	metalLBValues := map[string]any{
 		"controller": map[string]any{
 			"image": map[string]any{
-				"repository": controllerImageRepo,
-				"tag":        ControllerImageTag,
+				"repository": MetalLBControllerImage().Repository,
+				"tag":        MetalLBControllerImage().Tag,
 			},
 			"command": "/controller",
 		},
 		"speaker": map[string]any{
 			"image": map[string]any{
-				"repository": speakerImageRepo,
-				"tag":        speakerImageTag,
+				"repository": MetalLBSpeakerImage().Repository,
+				"tag":        MetalLBSpeakerImage().Tag,
 			},
 			"command": "/speaker",
 			// TODO(neoaggelos): make frr enable/disable configurable through an annotation
@@ -104,8 +104,8 @@ func enableLoadBalancer(ctx context.Context, snap snap.Snap, loadbalancer types.
 			"frr": map[string]any{
 				"enabled": false,
 				"image": map[string]any{
-					"repository": frrImageRepo,
-					"tag":        frrImageTag,
+					"repository": FRRImage().Repository,
+					"tag":        FRRImage().Tag,
 				},
 			},
 		},

--- a/src/k8s/pkg/k8sd/features/metallb/loadbalancer_test.go
+++ b/src/k8s/pkg/k8sd/features/metallb/loadbalancer_test.go
@@ -40,7 +40,7 @@ func TestDisabled(t *testing.T) {
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(ContainSubstring(applyErr.Error()))
-		g.Expect(status.Version).To(Equal(metallb.ControllerImageTag))
+		g.Expect(status.Version).To(Equal(metallb.MetalLBControllerImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -66,7 +66,7 @@ func TestDisabled(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(Equal(metallb.DisabledMsg))
-		g.Expect(status.Version).To(Equal(metallb.ControllerImageTag))
+		g.Expect(status.Version).To(Equal(metallb.MetalLBControllerImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(2))
 
 		firstCallArgs := helmM.ApplyCalledWith[0]
@@ -103,7 +103,7 @@ func TestEnabled(t *testing.T) {
 		g.Expect(err).To(MatchError(applyErr))
 		g.Expect(status.Enabled).To(BeFalse())
 		g.Expect(status.Message).To(ContainSubstring(applyErr.Error()))
-		g.Expect(status.Version).To(Equal(metallb.ControllerImageTag))
+		g.Expect(status.Version).To(Equal(metallb.MetalLBControllerImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(1))
 
 		callArgs := helmM.ApplyCalledWith[0]
@@ -164,7 +164,7 @@ func TestEnabled(t *testing.T) {
 
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(status.Enabled).To(BeTrue())
-		g.Expect(status.Version).To(Equal(metallb.ControllerImageTag))
+		g.Expect(status.Version).To(Equal(metallb.MetalLBControllerImage().Tag))
 		g.Expect(helmM.ApplyCalledWith).To(HaveLen(2))
 
 		firstCallArgs := helmM.ApplyCalledWith[0]

--- a/src/k8s/pkg/k8sd/features/metallb/register.go
+++ b/src/k8s/pkg/k8sd/features/metallb/register.go
@@ -1,15 +1,13 @@
 package metallb
 
 import (
-	"fmt"
-
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
 func init() {
 	images.Register(
-		fmt.Sprintf("%s:%s", controllerImageRepo, ControllerImageTag),
-		fmt.Sprintf("%s:%s", speakerImageRepo, speakerImageTag),
-		fmt.Sprintf("%s:%s", frrImageRepo, frrImageTag),
+		MetalLBControllerImage().String(),
+		MetalLBSpeakerImage().String(),
+		FRRImage().String(),
 	)
 }

--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/k8s/pkg/client/helm"
+	k8sdConfig "github.com/canonical/k8s/pkg/config"
+	"github.com/canonical/k8s/pkg/k8sd/types"
 )
 
 var (
@@ -13,10 +15,20 @@ var (
 		Namespace:    "kube-system",
 		ManifestPath: filepath.Join("charts", "metrics-server-3.12.2.tgz"),
 	}
-
-	// imageRepo is the image to use for metrics-server.
-	imageRepo = "ghcr.io/canonical/metrics-server"
-
-	// imageTag is the image tag to use for metrics-server.
-	imageTag = "0.7.2-ck0"
 )
+
+func MetricsServerImage() types.Image {
+	imageRepo := "ghcr.io/canonical/metrics-server"
+
+	if k8sdConfig.GetFlavor() == k8sdConfig.FlavorFIPS {
+		return types.Image{
+			Repository: imageRepo,
+			Tag:        "0.7.2-fips-ck0",
+		}
+	}
+
+	return types.Image{
+		Repository: imageRepo,
+		Tag:        "0.7.2-ck0",
+	}
+}

--- a/src/k8s/pkg/k8sd/features/metrics-server/internal.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/internal.go
@@ -12,8 +12,8 @@ type config struct {
 
 func internalConfig(annotations types.Annotations) config {
 	config := config{
-		imageRepo: imageRepo,
-		imageTag:  imageTag,
+		imageRepo: MetricsServerImage().Repository,
+		imageTag:  MetricsServerImage().Tag,
 	}
 
 	if v, ok := annotations.Get(apiv1_annotations.AnnotationImageRepo); ok {

--- a/src/k8s/pkg/k8sd/features/metrics-server/metrics_server.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/metrics_server.go
@@ -44,14 +44,14 @@ func ApplyMetricsServer(ctx context.Context, snap snap.Snap, cfg types.MetricsSe
 			err = fmt.Errorf("failed to install metrics server chart: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: imageTag,
+				Version: MetricsServerImage().Tag,
 				Message: fmt.Sprintf(deployFailedMsgTmpl, err),
 			}, err
 		} else {
 			err = fmt.Errorf("failed to delete metrics server chart: %w", err)
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: imageTag,
+				Version: MetricsServerImage().Tag,
 				Message: fmt.Sprintf(deleteFailedMsgTmpl, err),
 			}, err
 		}
@@ -59,13 +59,13 @@ func ApplyMetricsServer(ctx context.Context, snap snap.Snap, cfg types.MetricsSe
 		if cfg.GetEnabled() {
 			return types.FeatureStatus{
 				Enabled: true,
-				Version: imageTag,
+				Version: MetricsServerImage().Tag,
 				Message: enabledMsg,
 			}, nil
 		} else {
 			return types.FeatureStatus{
 				Enabled: false,
-				Version: imageTag,
+				Version: MetricsServerImage().Tag,
 				Message: disabledMsg,
 			}, nil
 		}

--- a/src/k8s/pkg/k8sd/features/metrics-server/register.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/register.go
@@ -1,13 +1,11 @@
 package metrics_server
 
 import (
-	"fmt"
-
 	"github.com/canonical/k8s/pkg/k8sd/images"
 )
 
 func init() {
 	images.Register(
-		fmt.Sprintf("%s:%s", imageRepo, imageTag),
+		MetricsServerImage().String(),
 	)
 }

--- a/src/k8s/pkg/k8sd/types/image.go
+++ b/src/k8s/pkg/k8sd/types/image.go
@@ -1,0 +1,12 @@
+package types
+
+import "fmt"
+
+type Image struct {
+	Repository string
+	Tag        string
+}
+
+func (i Image) String() string {
+	return fmt.Sprintf("%s:%s", i.Repository, i.Tag)
+}


### PR DESCRIPTION
## Description

Simplifies flavor support by adding `Flavor` as a variable to various steps. Build scripts are adjusted so that they set right environment variables to build for fips  or build statically.

Added a build-time variable that passes the built flavor into `k8sd` which is then utilized to specify different image tags for fips. This could also be adopted to other flavors where an entirely different feature is required instead of using `//go:build` directives and having patches to switch over implementations.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
