### PR TITLE
docs: Add patch notices to the 1.33 release notes

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -110,6 +110,7 @@ CommonName
 conf
 config
 configMap
+ConfigMap
 ConfigMaps
 ConnectError
 containerd
@@ -457,6 +458,8 @@ rw
 S3
 sandboxed
 SANs
+SARIF
+structs
 SBOM
 scalable
 scalability

--- a/docs/canonicalk8s/snap/reference/versions/1.33.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.33.md
@@ -50,7 +50,7 @@ information is collected in the tarball see our
 - Other documentation improvements
 
 ```{note}
-Changes to default configuration values apply only to new clusters and do not
+Changes to the default configuration of the LoadBalancer apply only to new clusters and do not
 affect existing clusters during upgrade.
 ```
 

--- a/docs/canonicalk8s/snap/reference/versions/1.33.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.33.md
@@ -11,24 +11,24 @@ methods. For specific requirements, see the [Installation guides].
 
 - **Kubernetes 1.33** - read more about the upstream release [here].
 
-- **Controlled feature upgrade process** - With the second release of 
-{{product}}, seamlessly upgrade from one version to the next. With a 
-coordinated approach to our feature upgrades and snap refreshes, version 
-drift is prevented and this ensures a smooth, predictable upgrade path for 
+- **Controlled feature upgrade process** - With the second release of
+{{product}}, seamlessly upgrade from one version to the next. With a
+coordinated approach to our feature upgrades and snap refreshes, version
+drift is prevented and this ensures a smooth, predictable upgrade path for
 cluster features.
 
 - **Support updating node certificates** - Users
-can now update their external certificates on a 
-running node. See our [external certificate refresh guide] for more 
+can now update their external certificates on a
+running node. See our [external certificate refresh guide] for more
 information.
 
-- **`k8s certs-status` command** - This new command provides a detailed view of 
+- **`k8s certs-status` command** - This new command provides a detailed view of
 the certificates status on a node.
 
-- **`k8s inspect` command** - This new command collects diagnostics and other 
-relevant information from a Kubernetes node, either control-plane or worker 
-node, and compiles them into a tarball report.To find out more about what 
-information is collected in the tarball see our 
+- **`k8s inspect` command** - This new command collects diagnostics and other
+relevant information from a Kubernetes node, either control-plane or worker
+node, and compiles them into a tarball report.To find out more about what
+information is collected in the tarball see our
 [inspection reports reference guide].
 
 
@@ -50,14 +50,14 @@ information is collected in the tarball see our
 - Other documentation improvements
 
 ```{note}
-Changes to default configuration values apply only to new clusters and do not 
+Changes to default configuration values apply only to new clusters and do not
 affect existing clusters during upgrade.
 ```
 
 ## Deprecations and API changes
 
-- Upstream - Please review the 
-[upstream release notes][upstream-changelog-1.33], which include depreciation 
+- Upstream - Please review the
+[upstream release notes][upstream-changelog-1.33], which include depreciation
 notices and API changes for Kubernetes 1.33.
 
 ## Fixed bugs and issues
@@ -74,11 +74,64 @@ notices and API changes for Kubernetes 1.33.
 - Fixed custom containerd paths ([#1046])
 - Fixed certificates usage during control plane join ([#1029])
 
-## Upgrade notes 
+## Upgrade notes
 
-See our [upgrade notes] page for instructions on how to upgrade to 1.33. 
-For dual-stack environments, there are additional configuration steps you 
+See our [upgrade notes] page for instructions on how to upgrade to 1.33.
+For dual-stack environments, there are additional configuration steps you
 may need to implement for a successful upgrade.
+
+## Patch notices
+
+Aug 25, 2025
+
+- Change the default cluster datastore to managed etcd ([#1561]). Existing
+clusters deployed with k8s-dqlite will not be affected.
+    - Add managed etcd service to the inspection report([#1724])
+    - Add etcd port checks to bootstrap verifications([#1770])
+    - Build etcd v3.6.2 from upstream ([#1709])
+    - Add etcd service definition to pebble services ([#1695])
+    - Sort `--initial-clusters` in etcd setup ([#1631])
+    - Derive initial-cluster from etcd member list ([#1764])
+- Update CIS hardening docs and quorum recovery pages to include etcd
+recommendations
+- Improve the feature controller by:
+    - Triggering the feature controller on k8sd startup([#1783])
+    - Update node IP addresses on k8sd post-refresh ([#1714])
+    - Collect upgrades information in the inspection report
+    - Wait for worker nodes to get upgraded before triggering the feature
+    controller upgrades ([#1643])
+    - Use controller-gen to generate CRD yaml file from Go structs ([#1327])
+    - Prevent multiple refreshes on worker nodes
+- Set `auto-tls` options explicitly to false
+- Bump k8s-dqlite to v1.3.4
+- Update Kubernetes to v1.33.4 and Helm to v3.18.6
+- Use -ck tags for MetalLB FRR and Rawfile-LocalPV rocks ([#1735])
+- Include control-plane-taints in the k8sd configmap  ([#1716])
+- Update containerd v1.7.28 to and runc to v1.3.0
+- Add coordinator to use a single manager for managed controllers ([#1453])
+- Add upgrade docs for 1.33
+- Bump Helm to v3.18.4 to fix CVE-2025-53547
+- Bump Microcluster to v2.2.0 and Go to v1.24.5
+- Bump rawfile-localpv chart to v0.9.1
+- Update Kubernetes to v1.33.2
+- Fix issues with the charm e2e tests
+
+<!--
+- ci: Assign a category to the sarif uploads ([#1687]) -->
+<!-- - Fetch etcd 3.4.30 sources from Ubuntu archive to help with maintenance and
+security efforts -->
+
+Jul 22, 2025
+
+- Added fixes to the feature controller to allow smoother updates by adding
+additional tests, adding jitter to reconciliation retries and not allowing
+multiple simultaneous upgrades of the same resource by adding a pending state
+and feature lock. ([#1615], [#1637])
+- Update Helm to v3.18.4
+- Add 1.33 release notes
+- Update ports and services page, add how to configure containerd override_path
+and document Auto Namespace creation and RBD disable in our docs
+- Ask the user about removing Cilium VXLAN interface ([#1598])
 
 <!-- LINKS -->
 [Installation guides]: /snap/howto/install/index
@@ -101,3 +154,22 @@ may need to implement for a successful upgrade.
 [#1061]: https://github.com/canonical/k8s-snap/commit/62b3e79a071542f1175e13e1d26febfac8ed504e
 [#1046]: https://github.com/canonical/k8s-snap/commit/d5f52206bcee1b2a61d8d6bc507cf3a881954c2a
 [#1029]: https://github.com/canonical/k8s-snap/commit/391e8cd17745de15b9fb8f0f56c5585b482672df
+
+[#1783]: https://github.com/canonical/k8s-snap/pull/1783
+[#1714]: https://github.com/canonical/k8s-snap/pull/1714
+[#1716]: https://github.com/canonical/k8s-snap/pull/1716
+[#1687]: https://github.com/canonical/k8s-snap/pull/1687
+[#1643]: https://github.com/canonical/k8s-snap/pull/1643
+[#1453]: https://github.com/canonical/k8s-snap/pull/1453
+[#1615]: https://github.com/canonical/k8s-snap/pull/1615
+[#1637]: https://github.com/canonical/k8s-snap/pull/1637
+[#1598]: https://github.com/canonical/k8s-snap/pull/1598
+[#1561]: https://github.com/canonical/k8s-snap/pull/1561
+[#1724]: https://github.com/canonical/k8s-snap/pull/1724
+[#1770]: https://github.com/canonical/k8s-snap/pull/1770
+[#1709]: https://github.com/canonical/k8s-snap/pull/1709
+[#1695]: https://github.com/canonical/k8s-snap/pull/1695
+[#1631]: https://github.com/canonical/k8s-snap/pull/1631
+[#1764]: https://github.com/canonical/k8s-snap/pull/1764
+[#1735]: https://github.com/canonical/k8s-snap/pull/1735
+[#1327]: https://github.com/canonical/k8s-snap/pull/1327

--- a/docs/canonicalk8s/snap/reference/versions/1.33.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.33.md
@@ -85,9 +85,9 @@ may need to implement for a successful upgrade.
 Aug 25, 2025
 
 - Change the default cluster datastore to managed etcd ([#1561]). Existing
-clusters deployed with k8s-dqlite will not be affected.
+clusters deployed with k8s-dqlite will not be affected
     - Add managed etcd service to the inspection report([#1724])
-    - Add etcd port checks to bootstrap verifications([#1770])
+    - Add etcd port checks to bootstrap verification ([#1770])
     - Build etcd v3.6.2 from upstream ([#1709])
     - Add etcd service definition to pebble services ([#1695])
     - Sort `--initial-clusters` in etcd setup ([#1631])
@@ -105,28 +105,23 @@ recommendations
 - Set `auto-tls` options explicitly to false
 - Bump k8s-dqlite to v1.3.4
 - Update Kubernetes to v1.33.4 and Helm to v3.18.6
-- Use -ck tags for MetalLB FRR and Rawfile-LocalPV rocks ([#1735])
-- Include control-plane-taints in the k8sd configmap  ([#1716])
+- Use -ck tags for MetalLB FRR and `rawfile-localpv` rocks ([#1735])
+- Include control-plane-taints in the k8sd ConfigMap  ([#1716])
 - Update containerd v1.7.28 to and runc to v1.3.0
 - Add coordinator to use a single manager for managed controllers ([#1453])
 - Add upgrade docs for 1.33
 - Bump Helm to v3.18.4 to fix CVE-2025-53547
 - Bump Microcluster to v2.2.0 and Go to v1.24.5
-- Bump rawfile-localpv chart to v0.9.1
+- Bump `rawfile-localpv` chart to v0.9.1
 - Update Kubernetes to v1.33.2
 - Fix issues with the charm e2e tests
-
-<!--
-- ci: Assign a category to the sarif uploads ([#1687]) -->
-<!-- - Fetch etcd 3.4.30 sources from Ubuntu archive to help with maintenance and
-security efforts -->
 
 Jul 22, 2025
 
 - Added fixes to the feature controller to allow smoother updates by adding
 additional tests, adding jitter to reconciliation retries and not allowing
 multiple simultaneous upgrades of the same resource by adding a pending state
-and feature lock. ([#1615], [#1637])
+and feature lock ([#1615], [#1637])
 - Update Helm to v3.18.4
 - Add 1.33 release notes
 - Update ports and services page, add how to configure containerd override_path


### PR DESCRIPTION
## Description

We do not have a changelog or automated release notes so we need to update them with patch notices manually

## Solution

Adding 1.33 patch notices 

## Issue

N/A

## Backport

1.33

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.