### PR TITLE
docs: Add 1.32 patch notices to release notes

### DIFF
--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -139,9 +139,6 @@ controller upgrades [#1643](https://github.com/canonical/k8s-snap/pull/1643)
 [#1654](https://github.com/canonical/k8s-snap/pull/1654)
 - Bump `rawfile-localpv` chart to v0.9.1
 [#1647](https://github.com/canonical/k8s-snap/pull/1647)
-<!-- - Fix test_ingress contour ingressClassName -->
-<!-- - Sort --initial-clusters in etcd setup
-[#1631](https://github.com/canonical/k8s-snap/pull/1631) -->
 - Change the default cluster datastore to managed etcd
 [#1638](https://github.com/canonical/k8s-snap/pull/1638). Existing
 clusters deployed with k8s-dqlite will not be affected.
@@ -633,4 +630,3 @@ Many thanks to [@neoaggelos], [@bschimke95], [@evilnick],
 [@YanisaHS]: https://github.com/YanisaHS
 [@hemanthnakkina]: https://github.com/hemanthnakkina
 [@dulmandakh]: https://github.com/dulmandakh
-


### PR DESCRIPTION
## Description

We do not have automated release notes updates so we need to add the patch notices manually

## Solution

Adding patch notices for latest 1.32 stable release

## Issue

N/A

## Backport

1.32, 1.33

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.