### PR TITLE
ci: add release-1.34

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -56,6 +56,7 @@ jobs:
          # TODO: automatically retrieve the list of channels.
          - { branch: release-1.32, channel: 1.32-classic/edge }
          - { branch: release-1.33, channel: 1.33-classic/edge }
+         - { branch: release-1.34, channel: 1.34-classic/edge }
    uses: ./.github/workflows/security-scan.yaml
    with:
      channel: ${{ matrix.channel }}

--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -24,6 +24,7 @@ jobs:
           # Keep main branch up to date
           - main
           # Supported release branches
+          - release-1.34
           - release-1.33
           - release-1.32
 


### PR DESCRIPTION
## Description

Add release-1.34 to ci workflows trivy and update component verions.

## Backport

Yes, 1.34

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
