### PR TITLE
docs: add charm patch notices

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -418,12 +418,14 @@ PreInitChecks
 prev
 proc
 programmatically
+proxied
 provisioner
 PRs
 PSP
 Pushgateway
 PV
 PVCs
+py
 Pydantic
 Python
 qdisc

--- a/docs/canonicalk8s/charm/reference/versions/1.32.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.32.md
@@ -87,53 +87,27 @@ inspection [#589](https://github.com/canonical/k8s-operator/pull/589)
 [#583](https://github.com/canonical/k8s-operator/pull/583)
 - Check pods across a configurable set of namespaces to declare workloads
 'active/idle' [#584](https://github.com/canonical/k8s-operator/pull/584)
-<!-- - Update k8s snap revisions to amd64-3952 and arm64-3949  [#582](https://github.com/canonical/k8s-operator/pull/582) -->
-
 - Add support to apply charm extra-args at runtime
 [#485](https://github.com/canonical/k8s-operator/pull/485)
 - Add embedded-etcd to the list of valid datastores
 [#574](https://github.com/canonical/k8s-operator/pull/574)
-
-<!-- - Update k8s snap revisions to amd64-3921 and arm64-3923  [#580](https://github.com/canonical/k8s-operator/pull/580)
-- Update k8s snap revisions to amd64-3890 and arm64-3896  [#570](https://github.com/canonical/k8s-operator/pull/570)
-- Update k8s snap revisions to amd64-3842 and arm64-3845 [#552](https://github.com/canonical/k8s-operator/pull/552) -->
-
-- Check features when the node status is in not ready state [#549](https://github.com/canonical/k8s-operator/pull/549)
+- Check features when the node status is in not ready state
+[#549](https://github.com/canonical/k8s-operator/pull/549)
 - Improve cluster name logic
 [#547](https://github.com/canonical/k8s-operator/pull/547)
 - Restore testing with py38 to continue Focal support
 [#544](https://github.com/canonical/k8s-operator/pull/544)
-- Improve COS integration and add a kubectl timeout [#538](https://github.com/canonical/k8s-operator/pull/538)
-
-<!-- Update the snap revisions [#537](https://github.com/canonical/k8s-operator/pull/537) -->
-
-<!-- - Update CLA check to v2 [#530](https://github.com/canonical/k8s-operator/pull/530) -->
+- Improve COS integration and add a kubectl timeout
+[#538](https://github.com/canonical/k8s-operator/pull/538)
 - Update k8s snap revision to include feature controller fixes
 [#521](https://github.com/canonical/k8s-operator/pull/521)
-<!-- - Fix issue in CI by skipping publishing libs and docs automatically
-[#523](https://github.com/canonical/k8s-operator/pull/523)
-- Pin version of operator-workflows to main in CI
-[#519](https://github.com/canonical/k8s-operator/pull/519) -->
-
-<!-- - Update k8s snap revisions to amd64-3708 and arm64-3709 [#511](https://github.com/canonical/k8s-operator/pull/511)
-- Update k8s snap revisions amd64-3581 and arm64-3575 [#498](https://github.com/canonical/k8s-operator/pull/498)
-- Update k8s snap revisions amd64-3315 and arm64-3319 [#475](https://github.com/canonical/k8s-operator/pull/475)
-- Update k8s snap revisions amd64-3475 and arm64-3449 [#474](https://github.com/canonical/k8s-operator/pull/474) -->
 - Fix bug when reading quoted argument for containerd config path
 [#469](https://github.com/canonical/k8s-operator/pull/469)
-<!-- - Update k8s snap revisions  to amd64-3315 and arm64-3319[#462](https://github.com/canonical/k8s-operator/pull/462) -->
-
 - Add configurable timeout to tests
 [#458](https://github.com/canonical/k8s-operator/pull/458)
-<!-- - Fix the promote-charm action in the CI
-[#454](https://github.com/canonical/k8s-operator/pull/454) -->
-
-<!-- - Update k8s snap revisions amd64-3260 and arm64-3171
-[#442](https://github.com/canonical/k8s-operator/pull/442) -->
 - Address issue of multiple workers joining the cluster at once
 [#440](https://github.com/canonical/k8s-operator/commit/3edf37461b8a503ec7d93cef3788e48baedf1241)
-<!-- - Update k8s snap revisions amd64-2907 and arm64-2908
-[#431]https://github.com/canonical/k8s-operator/pull/431() -->
+
 
 Mar 25, 2025
 

--- a/docs/canonicalk8s/charm/reference/versions/1.32.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.32.md
@@ -54,6 +54,87 @@ relevant sections of the [upstream release notes][upstream-changelog-1.32].
 
 ## Patch notices
 
+Aug 25, 2025
+
+- Provide immutablity for charm's bootstrap-* config
+[#629](https://github.com/canonical/k8s-operator/pull/629)
+- Update k8s snap revisions to amd64-4176 and arm64-4180
+[#635](https://github.com/canonical/k8s-operator/pull/635)
+- Address Vale errors in our docs
+[#631](https://github.com/canonical/k8s-operator/pull/631)
+- Fix issues with etcd simultaneous join
+[#627](https://github.com/canonical/k8s-operator/pull/627)
+- Stop the charm from managing service restarts when performing a snap refresh
+[#625](https://github.com/canonical/k8s-operator/pull/625)
+- Update Juju provider version constraint for Terraform
+[#622](https://github.com/canonical/k8s-operator/pull/622)
+- Bump Cilium to v1.17.1-ck2
+[#617](https://github.com/canonical/k8s-operator/pull/617)
+- Provide fix to regenerate tokens when node-join fails
+[#616](https://github.com/canonical/k8s-operator/pull/616)
+- Update k8s snaps revision to change the default datastore to etcd 3.6
+[#600](https://github.com/canonical/k8s-operator/pull/600) . Existing clusters
+deployed with k8s-dqlite will not be affected.
+- Sort keys in proxied systemd environment files
+[#605](https://github.com/canonical/k8s-operator/pull/605)
+- Use `ops_test.fast_forwards` to speed up testing
+[#597](https://github.com/canonical/k8s-operator/pull/597)
+- Wait for public IP address to be assigned to confirm it is not clashing with
+the LB IP address [#593](https://github.com/canonical/k8s-operator/pull/593)
+- Catch a broader `httpx` exception to signal a failure during cluster
+inspection [#589](https://github.com/canonical/k8s-operator/pull/589)
+- Allow extra-args to remove args
+[#583](https://github.com/canonical/k8s-operator/pull/583)
+- Check pods across a configurable set of namespaces to declare workloads
+'active/idle' [#584](https://github.com/canonical/k8s-operator/pull/584)
+<!-- - Update k8s snap revisions to amd64-3952 and arm64-3949  [#582](https://github.com/canonical/k8s-operator/pull/582) -->
+
+- Add support to apply charm extra-args at runtime
+[#485](https://github.com/canonical/k8s-operator/pull/485)
+- Add embedded-etcd to the list of valid datastores
+[#574](https://github.com/canonical/k8s-operator/pull/574)
+
+<!-- - Update k8s snap revisions to amd64-3921 and arm64-3923  [#580](https://github.com/canonical/k8s-operator/pull/580)
+- Update k8s snap revisions to amd64-3890 and arm64-3896  [#570](https://github.com/canonical/k8s-operator/pull/570)
+- Update k8s snap revisions to amd64-3842 and arm64-3845 [#552](https://github.com/canonical/k8s-operator/pull/552) -->
+
+- Check features when the node status is in not ready state [#549](https://github.com/canonical/k8s-operator/pull/549)
+- Improve cluster name logic
+[#547](https://github.com/canonical/k8s-operator/pull/547)
+- Restore testing with py38 to continue Focal support
+[#544](https://github.com/canonical/k8s-operator/pull/544)
+- Improve COS integration and add a kubectl timeout [#538](https://github.com/canonical/k8s-operator/pull/538)
+
+<!-- Update the snap revisions [#537](https://github.com/canonical/k8s-operator/pull/537) -->
+
+<!-- - Update CLA check to v2 [#530](https://github.com/canonical/k8s-operator/pull/530) -->
+- Update k8s snap revision to include feature controller fixes
+[#521](https://github.com/canonical/k8s-operator/pull/521)
+<!-- - Fix issue in CI by skipping publishing libs and docs automatically
+[#523](https://github.com/canonical/k8s-operator/pull/523)
+- Pin version of operator-workflows to main in CI
+[#519](https://github.com/canonical/k8s-operator/pull/519) -->
+
+<!-- - Update k8s snap revisions to amd64-3708 and arm64-3709 [#511](https://github.com/canonical/k8s-operator/pull/511)
+- Update k8s snap revisions amd64-3581 and arm64-3575 [#498](https://github.com/canonical/k8s-operator/pull/498)
+- Update k8s snap revisions amd64-3315 and arm64-3319 [#475](https://github.com/canonical/k8s-operator/pull/475)
+- Update k8s snap revisions amd64-3475 and arm64-3449 [#474](https://github.com/canonical/k8s-operator/pull/474) -->
+- Fix bug when reading quoted argument for containerd config path
+[#469](https://github.com/canonical/k8s-operator/pull/469)
+<!-- - Update k8s snap revisions  to amd64-3315 and arm64-3319[#462](https://github.com/canonical/k8s-operator/pull/462) -->
+
+- Add configurable timeout to tests
+[#458](https://github.com/canonical/k8s-operator/pull/458)
+<!-- - Fix the promote-charm action in the CI
+[#454](https://github.com/canonical/k8s-operator/pull/454) -->
+
+<!-- - Update k8s snap revisions amd64-3260 and arm64-3171
+[#442](https://github.com/canonical/k8s-operator/pull/442) -->
+- Address issue of multiple workers joining the cluster at once
+[#440](https://github.com/canonical/k8s-operator/commit/3edf37461b8a503ec7d93cef3788e48baedf1241)
+<!-- - Update k8s snap revisions amd64-2907 and arm64-2908
+[#431]https://github.com/canonical/k8s-operator/pull/431() -->
+
 Mar 25, 2025
 
 - Bypass operator-workflows promote task which is limited to Charmcraft 2 base

--- a/docs/canonicalk8s/charm/reference/versions/1.32.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.32.md
@@ -56,7 +56,7 @@ relevant sections of the [upstream release notes][upstream-changelog-1.32].
 
 Aug 25, 2025
 
-- Provide immutablity for charm's bootstrap-* config
+- Provide immutability for charm's bootstrap-* config
 [#629](https://github.com/canonical/k8s-operator/pull/629)
 - Update k8s snap revisions to amd64-4176 and arm64-4180
 [#635](https://github.com/canonical/k8s-operator/pull/635)


### PR DESCRIPTION
## Description

We have no automation or change log so we must add our patch notices manually

## Solution

Adding patch notices for the 1.32 charm 

## Issue

N/A

## Backport

1.32, 1.33, 1.34

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.