### PR TITLE
refactor: use EndpointSlice instead of deprecated Endpoints

### DIFF
--- a/src/k8s/pkg/client/kubernetes/endpoints.go
+++ b/src/k8s/pkg/client/kubernetes/endpoints.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/k8s/pkg/utils"
-	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
@@ -13,10 +13,12 @@ import (
 // GetKubeAPIServerEndpoints retrieves the known kube-apiserver endpoints of the cluster.
 // GetKubeAPIServerEndpoints returns an error if the list of endpoints is empty.
 func (c *Client) GetKubeAPIServerEndpoints(ctx context.Context) ([]string, error) {
-	var endpoints *v1.Endpoints
+	var endpointSlices *discoveryv1.EndpointSliceList
 	var err error
 	err = retry.OnError(retry.DefaultBackoff, func(err error) bool { return true }, func() error {
-		endpoints, err = c.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+		endpointSlices, err = c.DiscoveryV1().EndpointSlices("default").List(ctx, metav1.ListOptions{
+			LabelSelector: "kubernetes.io/service-name=kubernetes",
+		})
 		if err != nil {
 			return err
 		}
@@ -25,11 +27,11 @@ func (c *Client) GetKubeAPIServerEndpoints(ctx context.Context) ([]string, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to get endpoints for kubernetes service: %w", err)
 	}
-	if endpoints == nil {
+	if endpointSlices == nil {
 		return nil, fmt.Errorf("endpoints for kubernetes service not found")
 	}
 
-	addresses := utils.ParseEndpoints(endpoints)
+	addresses := utils.ParseEndpoints(endpointSlices)
 	if len(addresses) == 0 {
 		return nil, fmt.Errorf("empty list of endpoints for the kubernetes service")
 	}

--- a/src/k8s/pkg/proxy/endpoints.go
+++ b/src/k8s/pkg/proxy/endpoints.go
@@ -20,13 +20,15 @@ func getKubernetesEndpoints(ctx context.Context, kubeconfigFile string) ([]strin
 		return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
 	}
 
-	endpoints, err := clientset.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	endpointSlices, err := clientset.DiscoveryV1().EndpointSlices("default").List(ctx, metav1.ListOptions{
+		LabelSelector: "kubernetes.io/service-name=kubernetes",
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve endpoints for kubernetes service: %w", err)
 	}
-	if endpoints == nil {
+	if endpointSlices == nil {
 		return nil, nil
 	}
 
-	return utils.ParseEndpoints(endpoints), nil
+	return utils.ParseEndpoints(endpointSlices), nil
 }

--- a/src/k8s/pkg/utils/endpoints.go
+++ b/src/k8s/pkg/utils/endpoints.go
@@ -4,34 +4,46 @@ import (
 	"fmt"
 	"sort"
 
-	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
 // ParseEndpoints processes the given kube-apiserver endpoints and returns a list of
 // IPv4:port or [IPv6]:port strings.
-func ParseEndpoints(endpoints *corev1.Endpoints) []string {
-	addresses := make([]string, 0, len(endpoints.Subsets))
+func ParseEndpoints(endpointSlices *discoveryv1.EndpointSliceList) []string {
+	addresses := make([]string, 0, len(endpointSlices.Items))
 
-	for _, subset := range endpoints.Subsets {
+	for _, endpointSlice := range endpointSlices.Items {
 		portNumber := 6443
-		for _, port := range subset.Ports {
-			if port.Name == "https" {
-				portNumber = int(port.Port)
-				break
+		for _, port := range endpointSlice.Ports {
+			if *port.Name == "https" {
+				if port.Port != nil {
+					portNumber = int(*port.Port)
+					break
+				}
 			}
 		}
 
-		for _, addr := range subset.Addresses {
-			if addr.IP != "" {
-				var address string
-				if IsIPv4(addr.IP) {
-					address = addr.IP
-				} else {
-					address = fmt.Sprintf("[%s]", addr.IP)
+		for _, endpoint := range endpointSlice.Endpoints {
+			for _, addr := range endpoint.Addresses {
+				if addr != "" {
+					var address string
+					switch endpointSlice.AddressType {
+					case discoveryv1.AddressTypeIPv4:
+						address = addr
+					case discoveryv1.AddressTypeIPv6:
+						address = fmt.Sprintf("[%s]", addr)
+					case discoveryv1.AddressTypeFQDN:
+						// Not supported, skip.
+						continue
+					default:
+						// Unknown address type, skip.
+						continue
+					}
+					addresses = append(addresses, fmt.Sprintf("%s:%d", address, portNumber))
 				}
-				addresses = append(addresses, fmt.Sprintf("%s:%d", address, portNumber))
 			}
 		}
+
 	}
 
 	sort.Strings(addresses)

--- a/src/k8s/pkg/utils/endpoints_test.go
+++ b/src/k8s/pkg/utils/endpoints_test.go
@@ -4,75 +4,162 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestParseEndpoints(t *testing.T) {
+	httpsPortName := "https"
 	for _, tc := range []struct {
-		name      string
-		endpoints *v1.Endpoints
-		addresses []string
+		name           string
+		endpointSlices *discoveryv1.EndpointSliceList
+		addresses      []string
 	}{
 		{
 			name: "one",
-			endpoints: &v1.Endpoints{
-				Subsets: []v1.EndpointSubset{
-					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}}},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-1"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"1.1.1.1"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(6443))},
+						},
+					},
 				},
 			},
 			addresses: []string{"1.1.1.1:6443"},
 		},
 		{
 			name: "two",
-			endpoints: &v1.Endpoints{
-				Subsets: []v1.EndpointSubset{
-					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}}},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-2"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"1.1.1.1"}},
+							{Addresses: []string{"2.2.2.2"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(6443))},
+						},
+					},
 				},
 			},
 			addresses: []string{"1.1.1.1:6443", "2.2.2.2:6443"},
 		},
 		{
 			name: "IPv6",
-			endpoints: &v1.Endpoints{
-				Subsets: []v1.EndpointSubset{
-					{Addresses: []v1.EndpointAddress{{IP: "fe80::e0b9:bfff:fe90:8d37"}}},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-ipv6"},
+						AddressType: discoveryv1.AddressTypeIPv6,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"fe80::e0b9:bfff:fe90:8d37"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(6443))},
+						},
+					},
 				},
 			},
 			addresses: []string{"[fe80::e0b9:bfff:fe90:8d37]:6443"},
 		},
 		{
-			name: "multiple-subsets",
-			endpoints: &v1.Endpoints{
-				Subsets: []v1.EndpointSubset{
-					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}}},
-					{Addresses: []v1.EndpointAddress{{IP: "3.3.3.3"}}},
+			name: "multiple-slices",
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-multi-1"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"1.1.1.1"}},
+							{Addresses: []string{"2.2.2.2"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(6443))},
+						},
+					},
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-multi-2"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"3.3.3.3"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(6443))},
+						},
+					},
 				},
 			},
 			addresses: []string{"1.1.1.1:6443", "2.2.2.2:6443", "3.3.3.3:6443"},
 		},
 		{
 			name: "override-port",
-			endpoints: &v1.Endpoints{
-				Subsets: []v1.EndpointSubset{
-					{Addresses: []v1.EndpointAddress{{IP: "1.1.1.1"}, {IP: "2.2.2.2"}}},
-					{Addresses: []v1.EndpointAddress{{IP: "3.3.3.3"}}, Ports: []v1.EndpointPort{{Port: int32(10000), Name: "https"}}},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-port-1"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"1.1.1.1"}},
+							{Addresses: []string{"2.2.2.2"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(6443))},
+						},
+					},
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-port-2"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"3.3.3.3"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(10000))},
+						},
+					},
 				},
 			},
 			addresses: []string{"1.1.1.1:6443", "2.2.2.2:6443", "3.3.3.3:10000"},
 		},
 		{
 			name: "sort",
-			endpoints: &v1.Endpoints{
-				Subsets: []v1.EndpointSubset{
-					{Addresses: []v1.EndpointAddress{{IP: "3.3.3.3"}, {IP: "1.1.1.1"}}},
-					{Addresses: []v1.EndpointAddress{{IP: "2.2.2.2"}}, Ports: []v1.EndpointPort{{Port: int32(10000), Name: "https"}}},
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-sort-1"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"3.3.3.3"}},
+							{Addresses: []string{"1.1.1.1"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(6443))},
+						},
+					},
+					{
+						ObjectMeta:  metav1.ObjectMeta{Name: "test-sort-2"},
+						AddressType: discoveryv1.AddressTypeIPv4,
+						Endpoints: []discoveryv1.Endpoint{
+							{Addresses: []string{"2.2.2.2"}},
+						},
+						Ports: []discoveryv1.EndpointPort{
+							{Name: &httpsPortName, Port: Pointer(int32(10000))},
+						},
+					},
 				},
 			},
 			addresses: []string{"1.1.1.1:6443", "2.2.2.2:10000", "3.3.3.3:6443"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if parsed := ParseEndpoints(tc.endpoints); !reflect.DeepEqual(parsed, tc.addresses) {
+			if parsed := ParseEndpoints(tc.endpointSlices); !reflect.DeepEqual(parsed, tc.addresses) {
 				t.Fatalf("expected addresses to be %v but they were %v instead", tc.addresses, parsed)
 			}
 		})


### PR DESCRIPTION
## Description

Switch from deprecated `Endpoints` to `EndpointSlice` for fetching IPs of apiservers

## Backport

`release-1.33`
`release-1.34`

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 