### PR TITLE
fix: allow switching from locally built snaps to a remote snap

### DIFF
--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -69,6 +69,9 @@ def test_version_upgrades(
         added = False
 
         for i in range(len(channels)):
+            if "latest" in channels[i]:
+                continue
+
             # e.g.: 1.32-classic/stable
             chan_ver_parts = channels[i].split("-")[0].split(".")
             chan_ver = (int(chan_ver_parts[0]), int(chan_ver_parts[1]))
@@ -110,7 +113,6 @@ def test_version_upgrades(
 
     LOG.info(f"Installed {len(instances)} nodes on channel {current_channel}")
 
-    local_installed = False
     for channel in channels[1:]:
         for instance in instances:
             LOG.info(
@@ -133,19 +135,14 @@ def test_version_upgrades(
                     config.SNAP_NAME,
                     "--channel",
                     channel,
+                    "--amend",
                     "--classic",
                 ]
-                # NOTE: (Mateo): Last refresh included a local snap. Allow snapd to amend
-                # the installation and perform an upgrade to a store owned snap.
-                if local_installed:
-                    cmd.insert(-1, "--amend")
 
             instance.exec(cmd)
             util.wait_until_k8s_ready(cp, instances)
             LOG.info(f"Upgraded {instance.id} on channel {channel}")
 
-        # Set local_installed after all instances have been upgraded.
-        local_installed = True if channel.startswith("/") else False
         current_channel = channel
         LOG.info(f"Upgraded all instances to channel {channel}")
 


### PR DESCRIPTION
## Description

In previous release branches, the snap can't refresh from a locally built version to a remote one. This issue causes the CI to fail during the version upgrade process, affecting releases and backports. We need to update the CI to enable refreshing from locally built snaps to remote store snaps.

## Solution

Use `--amend` when refreshing the snap from a previously installed locally built version.

## Issue

Examples: [1](https://github.com/canonical/k8s-snap/actions/runs/17477557295/job/49642163963?pr=1825), [2](https://github.com/canonical/k8s-snap/actions/runs/17297509538/job/49163138481?pr=1804)

## Backport

Should this PR be backported? If so, to which release?

Yes, all the supported release branches (i.e., `1.32`, `1.33`, and `1.34`).

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
