### PR TITLE
fix: allow node to get endpointslices

### DIFF
--- a/build-scripts/components/kubernetes/patches/v1.34.0/0001-fix-allow-node-to-get-endpointslices.patch
+++ b/build-scripts/components/kubernetes/patches/v1.34.0/0001-fix-allow-node-to-get-endpointslices.patch
@@ -15,7 +15,7 @@ index 447b0bc2e99..daa3bde6b1c 100644
  		// TODO: add to the Node authorizer and restrict to endpoints referenced by pods or PVs bound to the node
  		// Needed for glusterfs volumes
  		rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("endpoints").RuleOrDie(),
-+		rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("endpointslices").RuleOrDie(),
++		rbacv1helpers.NewRule("get", "list", "watch").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
  		// Used to create a certificatesigningrequest for a node-specific client certificate, and watch
  		// for it to be signed. This allows the kubelet to rotate it's own certificate.
  		rbacv1helpers.NewRule("create", "get", "list", "watch").Groups(certificatesGroup).Resources("certificatesigningrequests").RuleOrDie(),


### PR DESCRIPTION
## Description

https://github.com/canonical/k8s-snap/pull/1829 Introduced EndpointSlices due to deprecation from upstream. However, `NodeRules` do not offer authorization for this resource.
## Solution

Provide a Git patch to enable support for EndpointSlices

## Backport

Same as the original PR:

`release-1.33`
`release-1.34`

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
