### PR TITLE
test: Configurable runners for each test [Backport release-1.32]

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -29,6 +29,21 @@ on:
         description: Test flavor (e.g. moonray or strict)
         default: ""
         type: string
+      extra-test-args:
+        description: |
+          Additional pytest arguments, use "-k <test_name>" to run a specific test
+        default: ""
+        type: string
+      runner-tags:
+        description: |
+          Optional dictionary mapping test names to specific runner and tags.
+          This is useful if specific tests require more powerful/larger runners, e.g. for version upgrade tests.
+          The amount of self-hosted runners is limited so we should selectively assign tests to them.
+          The arch tag will automatically be assigned based on the 'arch' input, so don't use the full tags here.
+          (e.g. use ["self-hosted", "linux", "jammy", "xlarge"] instead of ["self-hosted-linux-amd64-noble-2xlarge"])
+        type: string
+        required: false
+        default: '{"tests/test_version_upgrades.py::test_version_upgrades": ["self-hosted", "linux", "jammy", "large"]}'
 
 jobs:
   prepare:
@@ -45,6 +60,13 @@ jobs:
           python-version: "3.12"
       - name: Install tox
         run: sudo apt-get install -y tox
+      - name: Compute test runners
+        id: compute-test-runners
+        run: |
+          # Github Actions does not support dynamic concatination of lists, so we need to add the arch tag here.
+          # See https://github.com/orgs/community/discussions/11401
+          TEST_RUNNERS=$(jq -c -n '${{ inputs.runner-tags }}' | jq -c 'with_entries(.value += ["${{ inputs.arch }}"])')
+          echo "test_runners=$TEST_RUNNERS" >> $GITHUB_OUTPUT
       - name: Collect tests
         id: collect-tests
         run: |
@@ -69,7 +91,7 @@ jobs:
   run-tests:
     name: ${{ matrix.test }}
     needs: prepare
-    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ fromJson(needs.prepare.outputs.test-runners)[matrix.test] || (inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Manual backport of #1839 to `release-1.32`
