### PR TITLE
fix: [Release 1.34] Pin to minor versions of k8s and helm

### DIFF
--- a/build-scripts/hack/update-component-versions.py
+++ b/build-scripts/hack/update-component-versions.py
@@ -36,7 +36,7 @@ CHARTS = DIR.parent.parent / "k8s" / "manifests" / "charts"
 # - "https://dl.k8s.io/release/stable.txt"
 # - "https://dl.k8s.io/release/stable-1.xx.txt"
 # - "https://dl.k8s.io/release/latest-1.xx.txt" (e.g. for release candidate builds)
-KUBERNETES_VERSION_MARKER = "https://dl.k8s.io/release/stable.txt"
+KUBERNETES_VERSION_MARKER = "https://dl.k8s.io/release/stable-1.34.txt"
 
 # Containerd release branch to track. The most recent tag in the branch will be used.
 CONTAINERD_RELEASE_BRANCH = "release/1.7"
@@ -45,7 +45,7 @@ CONTAINERD_RELEASE_BRANCH = "release/1.7"
 #
 # - None for main branch
 # - Version("3.14") (e.g. for release candidate builds)
-HELM_BRANCH, HELM_RELEASE_SEMVER = "main", None
+HELM_BRANCH, HELM_RELEASE_SEMVER = "main", Version("3.19")
 
 # MetalLB Helm repository and chart version
 METALLB_REPO = "https://metallb.github.io/metallb"


### PR DESCRIPTION
## Description

Prevent the auto-component job from stepping outside of minor versions of helm and k8s

## Solution

Pins the sources

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 