### PR TITLE
fix: error PRs where components change major versions on release branches

### DIFF
--- a/.github/workflows/component-version-check.yaml
+++ b/.github/workflows/component-version-check.yaml
@@ -86,7 +86,7 @@ jobs:
               )
             })
 
-      #Fail the job if invalid
+      # Fail the job if invalid
       - name: Fail job if invalid
         if: steps.validate.outputs.invalid == 'true'
         run: exit 1

--- a/build-scripts/hack/check-component-versions.py
+++ b/build-scripts/hack/check-component-versions.py
@@ -1,28 +1,28 @@
 #!/usr/bin/env python3
 import sys
 import re
-from packaging.version import Version
+import argparse
+from packaging.version import InvalidVersion, Version
 
-VERSION_FILE_PATTERN = re.compile(r'^(\+\+\+|---) a?\.?/build-scripts/components/[^/]+/version')
+VERSION_FILE_PATTERN = re.compile(r'^(?:\+\+\+|---) [ab](/build-scripts/components/[^/]+/version)')
 
-def parse_version(line):
-    line = line.strip()[1:].strip()  # Remove leading + or -
+def parse_version(line: str):
     try:
-        return Version(line)
-    except Exception:
+        return Version(line.strip())
+    except InvalidVersion:
         return None
 
-def main(diff_file):
+def main(git_diff_file):
     current_file = None
     old_version = None
     new_version = None
     invalid_changes = []
 
-    with open(diff_file) as f:
+    with open(git_diff_file) as f:
         for line in f:
             # Track which file we're looking at
-            if VERSION_FILE_PATTERN.match(line):
-                current_file = line.strip().split()[-1]  # last token: file path
+            if match := VERSION_FILE_PATTERN.match(line):
+                current_file = "." + match.group(1)  # Extract file path from regex match
                 old_version = None
                 new_version = None
                 continue
@@ -30,32 +30,24 @@ def main(diff_file):
             if not current_file:
                 continue
 
-            # Skip the diff headers
-            if line.startswith('---') or line.startswith('+++'):
-                continue
-
             if line.startswith('-'):
-                old_version = parse_version(line)
+                old_version = parse_version(line[1:])
             elif line.startswith('+'):
-                new_version = parse_version(line)
+                new_version = parse_version(line[1:])
 
             if old_version and new_version:
                 # Compare major/minor
-                if (old_version.major != new_version.major or
-                    old_version.minor != new_version.minor):
+                if old_version.release[:2] != new_version.release[:2]:
                     invalid_changes.append((current_file, old_version, new_version))
                 old_version = None
                 new_version = None
 
-    if invalid_changes:
-        for f, old_v, new_v in invalid_changes:
-            print(f"Invalid version change in {f}: {old_v} → {new_v}", file=sys.stderr)
-        sys.exit(1)
-    else:
-        sys.exit(0)
+    for f, old_v, new_v in invalid_changes:
+        print(f"Invalid version change in {f}: {old_v} → {new_v}", file=sys.stderr)
+    sys.exit(1 if invalid_changes else 0)
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: check-component-versions.py <diff-file>", file=sys.stderr)
-        sys.exit(1)
-    main(sys.argv[1])
+    parser = argparse.ArgumentParser(description="Check component version changes in a git diff file.")
+    parser.add_argument("git_diff_file", help="Path to the git diff file")
+    args = parser.parse_args()
+    main(args.git_diff_file)


### PR DESCRIPTION
## Description

Automated PRs raised by bots have the ability to step components on release branches pasts their maj.min revisions.  We want to only allow patch revisions to be updated on release branches. 

## Solution

This PR establishes a PR action to confirm the diff doesn't step upgrades any of the "components" past their maj.min revisions.

## Checklist

- [X] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
