### PR TITLE
chore: switch disk related failing tests to self-hosted runners

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -47,7 +47,39 @@ on:
           (e.g. use ["self-hosted", "linux", "jammy", "xlarge"] instead of ["self-hosted-linux-amd64-noble-2xlarge"])
         type: string
         required: false
-        default: '{"tests/test_version_upgrades.py::test_version_upgrades": ["self-hosted", "linux", "jammy", "large"], "tests/test_airgapped.py::test_airgapped_with_image_mirror": ["self-hosted", "linux", "jammy", "large"]}'
+        default: |
+          {
+            "tests/test_version_upgrades.py::test_version_upgrades": [
+              "self-hosted",
+              "linux",
+              "jammy",
+              "large"
+            ],
+            "tests/test_airgapped.py::test_airgapped_with_image_mirror": [
+              "self-hosted",
+              "linux",
+              "jammy",
+              "large"
+            ],
+            "tests/test_node_availability_zone.py::test_node_availability_zone[k8s-dqlite-False]": [
+              "self-hosted",
+              "linux",
+              "jammy",
+              "large"
+            ],
+            "tests/test_node_availability_zone.py::test_node_availability_zone[k8s-dqlite-True]": [
+              "self-hosted",
+              "linux",
+              "jammy",
+              "large"
+            ],
+            "tests/test_version_upgrades.py::test_version_downgrades_with_rollback": [
+              "self-hosted",
+              "linux",
+              "jammy",
+              "large"
+            ],
+          }
       extra-test-env:
         description: 'Additional environment variables in KEY1=VALUE1,KEY2=VALUE2 format'
         type: string


### PR DESCRIPTION
## Description

Switches the tests that are failing with out of disk error to self-hosted runners. A follow-up work to figure out if we can improve these tests to consume less resources is in order.