### PR TITLE
docs: Add 1.33 charm release notes

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -584,3 +584,4 @@ ZooKeeper
 zsh
 tmpfs
 ErrImagePull
+rapour

--- a/docs/canonicalk8s/charm/howto/install/install-terraform.md
+++ b/docs/canonicalk8s/charm/howto/install/install-terraform.md
@@ -56,13 +56,13 @@ k8s:
   units: 3
   base: ubuntu@24.04
   constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
-  channel: 1.32/stable
+  channel: 1.33/stable
   config: {}
 k8s-worker:
   units: 2
   base: ubuntu@24.04
   constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-  channel: 1.32/stable
+  channel: 1.33/stable
   config: {}
 ```
 

--- a/docs/canonicalk8s/charm/howto/upgrade-minor.md
+++ b/docs/canonicalk8s/charm/howto/upgrade-minor.md
@@ -214,5 +214,5 @@ to ensure that the cluster is fully functional.
 [juju-docs]:           https://documentation.ubuntu.com/juju/3.6/howto/manage-models/
 [release-notes]:       ../reference/releases
 [upgrade-notes]:       ../reference/upgrade-notes
-[upstream-notes]:      https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation
+[upstream-notes]:      https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#deprecation
 [version-skew-policy]: https://kubernetes.io/releases/version-skew-policy/

--- a/docs/canonicalk8s/charm/reference/releases.md
+++ b/docs/canonicalk8s/charm/reference/releases.md
@@ -11,6 +11,7 @@ new features, bug fixes and backwards-incompatible changes.
 :titlesonly:
 :maxdepth: 2
 /charm/reference/versions/1.32
+/charm/reference/versions/1.33
 ```
 
 

--- a/docs/canonicalk8s/charm/reference/versions/1.33.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.33.md
@@ -11,12 +11,12 @@ for {{product}}! These release notes cover the highlights of this release.
 [here][upstream release].
 - **{{product}} Snap 1.33** - read more about the snap release
 [here][snap release page].
-- **Updated Canonical Observability Stack** - Updates to the Prometheus alert 
+- **Updated Canonical Observability Stack** - updates to the Prometheus alert 
 rules, Grafana dashboards and COS integration in the charm [#516].
 
 ## Bug fixes
 
-- Safely set datastore in case of dqlite [#560]
+- Safely set datastore in case of Dqlite [#560]
 
 ## Upstream deprecations and API changes
 

--- a/docs/canonicalk8s/charm/reference/versions/1.33.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.33.md
@@ -1,6 +1,6 @@
 # 1.33
 
-**{{product}} Charms 1.33 - Release notes - 03 October 2025**
+**{{product}} Charms 1.33 - Release notes - 07 October 2025**
 
 Welcome to the 1.33 release of {{product}} charms, the Juju operators
 for {{product}}! These release notes cover the highlights of this release.

--- a/docs/canonicalk8s/charm/reference/versions/1.33.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.33.md
@@ -1,0 +1,56 @@
+# 1.33
+
+**{{product}} Charms 1.33 - Release notes - 03 October 2025**
+
+Welcome to the 1.33 release of {{product}} charms, the Juju operators
+for {{product}}! These release notes cover the highlights of this release.
+
+## What’s new
+
+- **Kubernetes 1.33** - read more about the upstream release
+[here][upstream release].
+- **{{product}} Snap 1.33** - read more about the snap release
+[here][snap release page].
+- **Updated Canonical Observability Stack** - Updates to the Prometheus alert 
+rules, Grafana dashboards and COS integration in the charm [#516].
+
+## Bug fixes
+
+- Safely set datastore in case of dqlite [#560]
+
+## Upstream deprecations and API changes
+
+For details of other deprecation notices and API changes for Kubernetes 1.33,
+please see the
+relevant sections of the [upstream release notes][upstream-changelog-1.33].
+
+[upstream-changelog-1.33]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#deprecation
+
+## Also in this release
+
+- Read quoted argument for containerd config path [#466]
+- Run `kubectl` commands with a timeout by default [#473]
+
+## Contributors
+
+Many thanks to [@addyess], [@mateoflorido], [@louiseschmidtgen],
+[@ktsakalozos], [@rapour], [@HomayoonAlimohammadi]
+
+<!--     MISC       -->
+[upstream release]: https://kubernetes.io/blog/2025/04/23/kubernetes-v1-33-release/
+[snap release page]: /snap/reference/versions/1.33.md
+
+<!-- LINKS -->
+<!-- PR -->
+[#466]: https://github.com/canonical/k8s-operator/pull/466
+[#473]: https://github.com/canonical/k8s-operator/pull/473
+[#516]: https://github.com/canonical/k8s-operator/pull/516
+[#560]: https://github.com/canonical/k8s-operator/pull/560
+
+<!--    CONTRIBUTORS     -->
+[@louiseschmidtgen]: https://github.com/louiseschmidtgen
+[@mateoflorido]: https://github.com/mateoflorido
+[@addyess]: https://github.com/addyess
+[@HomayoonAlimohammadi]: https://github.com/HomayoonAlimohammadi
+[@ktsakalozos]: https://github.com/ktsakalozos
+[@rapour]: https://github.com/rapour


### PR DESCRIPTION
### Overview

This PR adds 1.33 charm release notes and updates instructions to point to this version.

### Backport

Should be backported to `release-1.33` and `release-1.34`