### PR TITLE
docs: Update MAAS CAPI instructions

### DIFF
--- a/docs/canonicalk8s/capi/tutorial/getting-started.md
+++ b/docs/canonicalk8s/capi/tutorial/getting-started.md
@@ -92,56 +92,6 @@ export AWS_B64ENCODED_CREDENTIALS=$(clusterawsadm bootstrap credentials encode-a
 
 You are now all set to deploy the AWS CAPI infrastructure provider.
 ````
-
-````{group-tab} MAAS
-Start by setting up environment variables to allow access to MAAS:
-
-```
-export MAAS_API_KEY="<maas-api-key>"
-export MAAS_ENDPOINT="http://<maas-endpoint>/MAAS"
-export MAAS_DNS_DOMAIN="<maas-dns-domain>"
-```
-The MAAS infrastructure provider uses these credentials to deploy machines,
-create DNS records and perform various other operations for workload clusters.
-
-```{warning}
-The management cluster needs to resolve DNS records from the MAAS domain,
-therefore it should be deployed on a MAAS machine.
-```
-
-Define further environment variables for the machine image and minimum compute
-resources of the control plane and worker nodes:
-
-```
-export CONTROL_PLANE_MACHINE_MINCPU="1"
-export CONTROL_PLANE_MACHINE_MINMEMORY="2048"
-export CONTROL_PLANE_MACHINE_IMAGE="ubuntu"
-
-export WORKER_MACHINE_MINCPU="1"
-export WORKER_MACHINE_MINMEMORY="2048"
-export WORKER_MACHINE_IMAGE="ubuntu"
-```
-
-```{note}
-The minimum resource variables are used to select machines with resources more
-than or equal to the provided values.
-```
-
-Optional environment variables can be defined for specifying resource pools
-and machine tags:
-
-```
-# (optional) Configure resource pools for control plane and worker machines
-# export CONTROL_PLANE_MACHINE_RESOURCEPOOL="kvm-pool"
-# export WORKER_MACHINE_RESOURCEPOOL="bare-metal-pool"
-
-# (optional) Configure (comma-separated) tags for control plane and worker machines
-# export CONTROL_PLANE_MACHINE_TAGS="control-plane,controller"
-# export WORKER_MACHINE_TAGS="worker,compute"
-```
-
-You are now all set to deploy the MAAS CAPI infrastructure provider.
-````
 `````
 
 ## Initialize the management cluster


### PR DESCRIPTION
### Overview

CAPI MAAS provider has some chalenges. A user on a slack channel mentioned how it's not possible to install this provider on the management cluster using our "Getting started" guide. Since these images need to be provided, updated, and put into place, we could consider temporarily removing the MAAS instructions for CAPI.

### Backport

Needs to be backport to 1.32, 1.33, and 1.34.