### PR TITLE
fix: Move Trivy out of the Nightly test workflow

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -42,35 +42,13 @@ jobs:
       channel-1: latest/edge
       channel-2: 1.32-classic/stable
 
-  Trivy:
-   permissions:
-     contents: read # for actions/checkout to fetch code
-     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-   strategy:
-     matrix:
-       include:
-         # Latest branches
-         - { branch: main, channel: latest/edge }
-         # Stable branches
-         # Add branches to test here
-         # TODO: automatically retrieve the list of channels.
-         - { branch: release-1.32, channel: 1.32-classic/edge }
-         - { branch: release-1.33, channel: 1.33-classic/edge }
-         - { branch: release-1.34, channel: 1.34-classic/edge }
-   uses: ./.github/workflows/security-scan.yaml
-   with:
-     channel: ${{ matrix.channel }}
-     checkout-ref: ${{ matrix.branch }}
-     upload-reports-to-jira: true
-   secrets: inherit
-
   Mattermost:
    name: Notify Mattermost
    # Notify on success or failure but only if the event is a scheduled run.
    # We don't want to ping people of failed PRs.
    if: ${{ always() && github.event_name == 'schedule' }}
    # Note: Update results check below if you change the "needs" list.
-   needs: [test-integration, test-performance, Trivy]
+   needs: [test-integration, test-performance]
    runs-on: ubuntu-latest
    steps:
      - name: Set current formatted date as env variable

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,37 @@
+name: Trivy Security Scan
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs every midnight
+  pull_request:
+    paths:
+      - .github/workflows/security-scan.yaml
+      - .github/workflows/trivy.yaml
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  Trivy:
+   permissions:
+     contents: read # for actions/checkout to fetch code
+     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+   strategy:
+     matrix:
+       include:
+         # Latest branches
+         - { branch: main, channel: latest/edge }
+         # Stable branches
+         # Add branches to test here
+         # TODO: automatically retrieve the list of channels.
+         - { branch: release-1.32, channel: 1.32-classic/edge }
+         - { branch: release-1.33, channel: 1.33-classic/edge }
+         - { branch: release-1.34, channel: 1.34-classic/edge }
+   uses: ./.github/workflows/security-scan.yaml
+   with:
+     channel: ${{ matrix.channel }}
+     checkout-ref: ${{ matrix.branch }}
+     upload-reports-to-jira: true
+   secrets: inherit
+


### PR DESCRIPTION
## Description

Trivy is reported as failing if any  steps in the Nightly tests fail. For instance:
<img width="1348" height="626" alt="image" src="https://github.com/user-attachments/assets/ccb838ed-d42e-4ed9-87de-617ae1672ae0" />
... where only the branch management workflow [failed](https://github.com/canonical/k8s-snap/actions/runs/18223531799).
## Solution

Moving the step to an external workflow file would improve the security tab reporting.

## Backport

Should this PR be backported? If so, to which release?

No, the workflow already handles the supported releases.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 