### PR TITLE
test: cleanup node before running tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -202,14 +202,10 @@ jobs:
       matrix:
         test: ${{ inputs.parallel && fromJson(needs.prepare.outputs.tests) || fromJson('["e2e-test"]') }}
     steps:
-      - name: Node disk size before clean up
-        run: df -h
       - name: Node Cleanup
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune --all --force
-      - name: Node disk size after clean up
-        run: df -h
       - name: Check out code
         uses: actions/checkout@v4
       - name: Setup Python


### PR DESCRIPTION
## Description

Some of the tests are failing because GH runners going out of disk. This is because the runners have about 20GB available on the root filesystem. Each LXD instance takes about ~5GB and when the test creates enough instances, the runner will run out of space. This PR removes some of the predefined tools on runners to increase the initial space to about 37GB. 