### PR TITLE
chore: update cilium image tag

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,7 +39,7 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.1-ck5"
+	CiliumAgentImageTag = "1.17.1-ck6"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"


### PR DESCRIPTION
## Description

Previous Cilium rock image was failing to remove temporary files in case the CNI binary call failed for whatever reason. This PR updates the rock image tag that contains the fix.