### PR TITLE
ci: 1.32 add test-runners outputs to e2e prepare

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     outputs:
       tests: ${{ steps.collect-tests.outputs.tests }}
+      test-runners: ${{ steps.compute-test-runners.outputs.test_runners }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Adds the missing outputs entry to `e2e-tests` for runners.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

