### PR TITLE
docs: Remove linkcheck (Backport #1912)

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -10,9 +10,34 @@ permissions:
 
 jobs:
   documentation-checks:
-    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
-    with:
-      working-directory: "docs/canonicalk8s"
-      fetch-depth: 0
+    #    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
+    #    with:
+      #   working-directory: "docs/canonicalk8s"
+      #  fetch-depth: 0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+
+      - id: spell-check
+        name: Spell Check
+        if: success() || failure()
+        uses: canonical/documentation-workflows/spellcheck@main
+        with:
+          working-directory: docs/canonicalk8s
+
+      - name: Inclusive Language Check
+        id: woke-step
+        if: success() || failure()
+        uses: canonical/documentation-workflows/inclusive-language@main
+        with:
+          working-directory: docs/canonicalk8s
+
+
 
 

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -49,7 +49,6 @@ Deploy with Juju </charm/index.md>
 Deploy with Cluster API </capi/index.md>
 Community </community.md>
 Release notes </releases.md>
-
 ```
 
 ````{grid} 1 1 1 1


### PR DESCRIPTION
There are intermitent failures in our CI in relation to the linkcheck test. There has been investigation into the issue and there needs to be work done to make the test more suitable for our needs. For now, I am removing the check and will reinstate when the better solution is reached


(cherry picked from commit 8b70d1fdd66e36ba8dda2d7826fb4681da6ed956)
