### PR TITLE
feat(kube-apiserver-proxy): Retry endpoint retrieval

### DIFF
--- a/src/k8s/pkg/proxy/apiserver.go
+++ b/src/k8s/pkg/proxy/apiserver.go
@@ -103,7 +103,7 @@ func (p *APIServerProxy) watchForNewEndpoints(ctx context.Context, cancel func()
 		case len(newEndpoints) == len(endpoints) && reflect.DeepEqual(newEndpoints, endpoints):
 			continue
 		}
-		log = log.WithValues("endpoints", endpoints)
+		log = log.WithValues("endpoints", newEndpoints)
 		log.Info("Updating endpoints")
 
 		if err := WriteEndpointsConfig(newEndpoints, p.EndpointsConfigFile); err != nil {


### PR DESCRIPTION
### Overview

Upon removal of a control plane node, the worker node might get stuck in a situation that it's not able to communicate with the remaining API servers (the kubelet) and hence its status is declared as `NotReady` in the cluster. 