### PR TITLE
docs: Patch release of kubernetes 1.32.9

### DIFF
--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -65,6 +65,16 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Oct 22, 2025
+
+- Resolve issue where etcd metrics aren't exposed.
+[#671](https://github.com/canonical/k8s-operator/pull/671)
+- Hardened TLS cipher suites for kube-apiserver.
+[#1803](https://github.com/canonical/k8s-snap/pull/1803)
+- Update Kubernetes to v1.32.9
+[#1842](https://github.com/canonical/k8s-snap/pull/1842)
+
+
 Aug 25, 2025
 
 - Trigger feature controller on k8sd startup


### PR DESCRIPTION
## Description

Release notes for 1.32.9

## Solution

Download and unpack differing revisions.

```sh
snap download k8s --revision 4176
snap download k8s --revision 4306
```

commits between revisions:
4176 - 4b7ed942f1db1ebd0fcbd4070c749e4e82ad92e5
4306 - 65187d805413e496fc7fe94c7030f2aeffd01217

[git compare](https://github.com/canonical/k8s-snap/compare/4b7ed942f1db1ebd0fcbd4070c749e4e82ad92e5...65187d805413e496fc7fe94c7030f2aeffd01217)



## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
