### PR TITLE
fix: [Backport 1.32] Prevent feature controller from running on worker nodes (#1895)

### DIFF
--- a/src/k8s/pkg/k8sd/controllers/feature.go
+++ b/src/k8s/pkg/k8sd/controllers/feature.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
 	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
 	"github.com/canonical/k8s/pkg/utils"
 	timeutils "github.com/canonical/k8s/pkg/utils/time"
 	"github.com/canonical/microcluster/v2/state"
@@ -142,6 +143,17 @@ func (c *FeatureController) Run(
 ) {
 	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "feature"))
 	log := log.FromContext(ctx)
+
+	isWorker, err := snaputil.IsWorker(c.snap)
+	if err != nil {
+		log.Error(err, "Failed to determine if the node is a worker")
+	}
+
+	if isWorker {
+		log.Info("Node is a worker - skipping feature controllers")
+		return
+	}
+
 	log.Info("Starting feature controller")
 	c.waitReady()
 


### PR DESCRIPTION
This pull request updates the `FeatureController` in `feature.go` to ensure that feature controllers only run on non-worker nodes. It introduces a check using the `IsWorker` function, and if the node is identified as a worker, the feature controllers are skipped. This prevents unnecessary or incorrect controller execution on worker nodes.

Backports: https://github.com/canonical/k8s-snap/pull/1895

Node role check and controller execution:

* Added import for `snaputil` and used its `IsWorker` function to determine if the node is a worker, logging and skipping feature controller execution on worker nodes.