### PR TITLE
chore: (release-1.32) Bump `CoreDNS` image

### DIFF
--- a/src/k8s/pkg/k8sd/features/coredns/chart.go
+++ b/src/k8s/pkg/k8sd/features/coredns/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/coredns"
 
 	// ImageTag is the tag to use for the CoreDNS image.
-	ImageTag = "1.12.0-ck1"
+	ImageTag = "1.12.4-ck0"
 )


### PR DESCRIPTION
## Description

Update the CoreDNS image tag, using the latest tag.

## Backport
Backports should be handled independently to the release branches.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 