### PR TITLE
fix: [1.32] Fix patching upgrade status during a rolling upgrade

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -483,12 +483,9 @@ func handleUpgradeInProgress(ctx context.Context, s state.State, k8sClient *kube
 
 	log.Info("Marking node as upgraded", "node", nodeName)
 
-	upgradedNodes := upgrade.Status.UpgradedNodes
-	if !slices.Contains(upgradedNodes, nodeName) {
-		upgradedNodes = append(upgradedNodes, nodeName)
-	}
-	status := upgradesv1alpha.UpgradeStatus{
-		UpgradedNodes: append(upgrade.Status.UpgradedNodes, nodeName),
+	status := upgrade.Status
+	if !slices.Contains(status.UpgradedNodes, nodeName) {
+		status.UpgradedNodes = append(status.UpgradedNodes, nodeName)
 	}
 
 	return k8sClient.PatchUpgradeStatus(ctx, upgrade, status)


### PR DESCRIPTION
### Overview

This PR fixes how we patch upgrade object during a rolling upgrade.

This error was introduced in a faulty backport of https://github.com/canonical/k8s-snap/pull/1492/commits/b994e17baa39e1082a66dfdd9f279b1eaa777595