### PR TITLE
fix: bump metrics-server image 0.8.0-ck3

### DIFF
--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/metrics-server"
 
 	// imageTag is the image tag to use for metrics-server.
-	imageTag = "0.8.0-ck1"
+	imageTag = "0.8.0-ck3"
 )


### PR DESCRIPTION
## Description

We rebuilt the image with the fips toolchain. See https://github.com/canonical/metrics-server-rock/pull/12

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
