### PR TITLE
chore: update cilium tag to 1.17.9 (#1970)

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,13 +39,13 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.1-ck3"
+	CiliumAgentImageTag = "1.17.9-ck0"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.1-ck3"
+	ciliumOperatorImageTag = "1.17.9-ck0"
 
 	ciliumDefaultVXLANPort = 8472
 

--- a/tests/integration/lxd-profile.yaml
+++ b/tests/integration/lxd-profile.yaml
@@ -1,6 +1,6 @@
 description: "LXD profile for Canonical Kubernetes"
 config:
-  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,iptable_raw,netlink_diag,nf_nat,overlay,br_netfilter,xt_socket,nf_conntrack
+  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,ip6table_raw,iptable_raw,netlink_diag,nf_nat,overlay,br_netfilter,xt_socket,nf_conntrack
   raw.lxc: |
     lxc.apparmor.profile=unconfined
     lxc.mount.auto=proc:rw sys:rw cgroup:rw


### PR DESCRIPTION
1.34 backport of #1970 

(cherry picked from commit 33d524d24aaf4b273219119acebd23fe61674293)

