### PR TITLE
chore: Bump metallb image tags

### DIFF
--- a/src/k8s/pkg/k8sd/features/metallb/chart.go
+++ b/src/k8s/pkg/k8sd/features/metallb/chart.go
@@ -25,17 +25,17 @@ var (
 	controllerImageRepo = "ghcr.io/canonical/metallb-controller"
 
 	// ControllerImageTag is the tag to use for metallb-controller.
-	ControllerImageTag = "v0.14.9-ck2"
+	ControllerImageTag = "v0.14.9-ck3"
 
 	// speakerImageRepo is the image to use for metallb-speaker.
 	speakerImageRepo = "ghcr.io/canonical/metallb-speaker"
 
 	// speakerImageTag is the tag to use for metallb-speaker.
-	speakerImageTag = "v0.14.9-ck2"
+	speakerImageTag = "v0.14.9-ck3"
 
 	// frrImageRepo is the image to use for frrouting.
 	frrImageRepo = "ghcr.io/canonical/frr"
 
 	// frrImageTag is the tag to use for frrouting.
-	frrImageTag = "9.1.3-ck3"
+	frrImageTag = "9.1.3-ck4"
 )


### PR DESCRIPTION
This versions fixes a build bug that caused the binaries to not be compiled with the correct Go toolchain.

