### PR TITLE
fix: Exclude metall-system from PodSecurityPolicy

### DIFF
--- a/k8s/resources/configurations/pod-security-admission-baseline.yaml
+++ b/k8s/resources/configurations/pod-security-admission-baseline.yaml
@@ -13,4 +13,4 @@ plugins:
         warn: "baseline"
         warn-version: "latest"
       exemptions:
-        namespaces: ["kube-system", "kube-public"]
+        namespaces: ["kube-system", "kube-public", "metallb-system"]

--- a/k8s/resources/configurations/pod-security-admission-restricted.yaml
+++ b/k8s/resources/configurations/pod-security-admission-restricted.yaml
@@ -13,4 +13,4 @@ plugins:
         warn: "restricted"
         warn-version: "latest"
       exemptions:
-        namespaces: ["kube-system", "kube-public"]
+        namespaces: ["kube-system", "kube-public", "metallb-system"]


### PR DESCRIPTION
Metallb requires some elevated privledges by design which is why we need to exclude it from the policy.
Otherwise, the pods would not schedule because of
```
Error creating: pods "metallb-speaker-cwxw5" is forbidden:
violates PodSecurity "baseline:latest": non-default capabilities
(container "speaker" must not include "NET_RAW" in
securityContext.capabilities.add), host namespaces (hostNetwork=true),
hostPort (container "speaker" uses host  Ports 7472, 7946)
```
