### PR TITLE
fix: Bump ROCKs to include build tag fix

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,13 +39,13 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.9-ck0"
+	CiliumAgentImageTag = "1.17.9-ck1"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.9-ck0"
+	ciliumOperatorImageTag = "1.17.9-ck1"
 
 	ciliumDefaultVXLANPort = 8472
 

--- a/src/k8s/pkg/k8sd/features/coredns/chart.go
+++ b/src/k8s/pkg/k8sd/features/coredns/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/coredns"
 
 	// ImageTag is the tag to use for the CoreDNS image.
-	ImageTag = "1.13.1-ck0"
+	ImageTag = "1.13.1-ck1"
 )

--- a/src/k8s/pkg/k8sd/features/metallb/chart.go
+++ b/src/k8s/pkg/k8sd/features/metallb/chart.go
@@ -25,17 +25,17 @@ var (
 	controllerImageRepo = "ghcr.io/canonical/metallb-controller"
 
 	// ControllerImageTag is the tag to use for metallb-controller.
-	ControllerImageTag = "v0.14.9-ck3"
+	ControllerImageTag = "v0.14.9-ck4"
 
 	// speakerImageRepo is the image to use for metallb-speaker.
 	speakerImageRepo = "ghcr.io/canonical/metallb-speaker"
 
 	// speakerImageTag is the tag to use for metallb-speaker.
-	speakerImageTag = "v0.14.9-ck3"
+	speakerImageTag = "v0.14.9-ck4"
 
 	// frrImageRepo is the image to use for frrouting.
 	frrImageRepo = "ghcr.io/canonical/frr"
 
 	// frrImageTag is the tag to use for frrouting.
-	frrImageTag = "9.1.3-ck4"
+	frrImageTag = "9.1.3-ck5"
 )

--- a/src/k8s/pkg/k8sd/features/metrics-server/chart.go
+++ b/src/k8s/pkg/k8sd/features/metrics-server/chart.go
@@ -18,5 +18,5 @@ var (
 	imageRepo = "ghcr.io/canonical/metrics-server"
 
 	// imageTag is the image tag to use for metrics-server.
-	imageTag = "0.8.0-ck3"
+	imageTag = "0.8.0-ck4"
 )


### PR DESCRIPTION
## Description

A missing build tag caused some binaries in the ROCKs to panik if they start to open up a TLS connection.

This commit bumps the ROCKs to the fixed versions.

https://github.com/canonical/cilium-rocks/pull/31
https://github.com/canonical/coredns-rock/pull/53
https://github.com/canonical/metrics-server-rock/pull/15 https://github.com/canonical/metallb-rocks

## Backport

Yes, to 1.34 since this is the first version with FIPS support

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests - already covered
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
