### PR TITLE
chore: Bump Cilium version to 1.17.9-ck2

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,13 +39,13 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.9-ck1"
+	CiliumAgentImageTag = "1.17.9-ck2"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.9-ck1"
+	ciliumOperatorImageTag = "1.17.9-ck2"
 
 	ciliumDefaultVXLANPort = 8472
 


### PR DESCRIPTION
This version contains a FIPS cleanup.

