### PR TITLE
chore: Remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*               @canonical/kubernetes


### PR DESCRIPTION
The codeowners are required for all PRs and are auto-assigned automatically. This causes a lot of notification spam with little value. We should be more mindful about who is added to a PR and select individuals manually.

## Backport

Yes, otherwise old releases would not be affected and spam the team every time there is a backport created.
