### PR TITLE
docs: clarify node types in ufw page

### DIFF
--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -105,6 +105,8 @@ sudo ufw allow 8472/udp
 
 ## Firewall rules for control plane nodes only
 
+Apply the following rules on all control plane nodes.
+
 ### Allow Kubernetes control plane services
 
 Allow access to the API server:


### PR DESCRIPTION
## Description

Add etcd client port to firewall page. Clarify the difference between worker and control-plane.

## Backport

1.34

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 


