### PR TITLE
fix: add etcd client port to firewall page

### DIFF
--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -108,6 +108,7 @@ Allow access to etcd on all control plane nodes:
 
 ```sh
 sudo ufw allow 2380/tcp
+sudo ufw allow 2379/tcp
 ```
 ````
 


### PR DESCRIPTION
## Description

This PR adds the etcd client port to firewall page

## Backport

1.34

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 


