### PR TITLE
fix: sanitize not-applicable feature gates in configure hook [Backport release-1.32]

### DIFF
--- a/k8s/lib.sh
+++ b/k8s/lib.sh
@@ -187,3 +187,76 @@ k8s::containerd::ensure_systemd_defaults() {
   fi
 
 }
+
+# Sanitize feature gates in kube-apiserver arguments
+# This removes any feature gates that are not present in the current apiserver version
+# from the --feature-gates argument in /var/snap/k8s/common/args/kube-apiserver.
+# Usage: k8s::apiserver::sanitize_feature_gates
+k8s::apiserver::sanitize_feature_gates() {
+  local args_file="/var/snap/k8s/common/args/kube-apiserver"
+
+  # Check if the args file exists
+  if [ ! -f "$args_file" ]; then
+    return 0
+  fi
+
+  # Return early if no feature gates are configured
+  if ! grep -q "^--feature-gates=" "$args_file"; then
+    return 0
+  fi
+
+  # Get the list of supported feature gates from kube-apiserver
+  local supported_gates=""
+  if [ -x "/snap/k8s/current/bin/kube-apiserver" ]; then
+    # Extract feature gate names from help output (format: kube:FeatureName=true|false)
+    supported_gates=$(/snap/k8s/current/bin/kube-apiserver --help 2>/dev/null | awk '/^ *kube:/{print $1}' | sed 's/^kube://' | sed 's/=.*//')
+  fi
+
+  # If we couldn't get supported gates, return without changes
+  if [ -z "$supported_gates" ]; then
+    return 0
+  fi
+
+  # Convert supported gates to array
+  declare -A supported_gates_map
+  while IFS= read -r gate; do
+    [[ -n "$gate" ]] && supported_gates_map["$gate"]=1
+  done <<< "$supported_gates"
+
+  # Get the current feature gates line
+  local current_line=$(grep "^--feature-gates=" "$args_file")
+  local feature_gates_value="${current_line#--feature-gates=}"
+
+  # Remove surrounding quotes if present
+  feature_gates_value="${feature_gates_value%\"}"
+  feature_gates_value="${feature_gates_value#\"}"
+
+  local updated_gates=""
+
+  # Split by comma and filter out unsupported gates
+  IFS=',' read -ra gates <<< "$feature_gates_value"
+  for gate in "${gates[@]}"; do
+    local gate_name="${gate%%=*}"
+
+    # Skip unsupported gates
+    if [[ -z "${supported_gates_map[$gate_name]}" ]]; then
+      continue
+    fi
+
+    # Add the gate to the updated list
+    if [ -n "$updated_gates" ]; then
+      updated_gates="${updated_gates},${gate}"
+    else
+      updated_gates="${gate}"
+    fi
+  done
+
+  # Update the file in-place
+  if [ -n "$updated_gates" ]; then
+    # Replace the line with updated gates (add quotes back)
+    sed -i "s/^--feature-gates=.*$/--feature-gates=\"${updated_gates}\"/" "$args_file"
+  else
+    # Remove the line if all gates were removed
+    sed -i '/^--feature-gates=/d' "$args_file"
+  fi
+}

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -7,3 +7,7 @@ k8s::common::setup_env
 k8s::cmd::k8s x-snapd-config reconcile
 
 k8s::containerd::ensure_systemd_defaults
+
+# Sanitize kube-apiserver feature gates that
+# do not apply to this version of Kubernetes.
+k8s::apiserver::sanitize_feature_gates


### PR DESCRIPTION
# Description
Backport of #1871 to `release-1.32`.