### PR TITLE
chore: Update cilium image tag

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,13 +39,13 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.9-ck2"
+	CiliumAgentImageTag = "1.17.9-ck6"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.9-ck2"
+	ciliumOperatorImageTag = "1.17.9-ck3"
 
 	ciliumDefaultVXLANPort = 8472
 


### PR DESCRIPTION
This PR upgrades Cilium to a version that contains the fix for a bug where the image binaries cannot be run on a FIPS-enabled 24.04 Ubuntu due to OPENSS_MODULES dir not being set. For more information please see https://github.com/canonical/cilium-rocks/pull/37