### PR TITLE
docs: stig post deployment instructions

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/disa-stig.md
+++ b/docs/canonicalk8s/snap/howto/install/disa-stig.md
@@ -173,8 +173,9 @@ instance each time a new service is exposed externally).
 - {ref}`242417`: User functionality must be separate from management functions
    meaning all user pods must be in user specific namespaces rather than system
    namespaces
-- {ref}`242443`: Kubernetes components must be regularly updated to avoid vulnerabilities.
-   We recommend using the latest revision of a [supported version] of {{product}}.
+- {ref}`242443`: Kubernetes components must be regularly updated to avoid
+   vulnerabilities. We recommend using the latest revision of a
+   [supported version] of {{product}}.
 
 ## Appendix
 

--- a/docs/canonicalk8s/snap/reference/disa-stig-audit.md
+++ b/docs/canonicalk8s/snap/reference/disa-stig-audit.md
@@ -5502,7 +5502,7 @@ always be at the desired security state.
 > for this to occur.
 >
 
-
+(242443)=
 
 ## [V-242443]
 


### PR DESCRIPTION
## Description

This PR adds information for the user of things they need to know for these rules post-deployment.

- V-242393: Kubernetes Worker Nodes must not have sshd service running
- V-242394: Kubernetes Worker Nodes must not have the sshd service enabled
- V-242443: Kubernetes must contain the latest updates as authorized by IAVMs, CTOs, DTMs, and STIGs

We also reference the LTS page in the post-deployment section.

## Backport

1.34

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

