### PR TITLE
docs: review and restructure ports and services page

### DIFF
--- a/docs/canonicalk8s/snap/reference/ports-and-services.md
+++ b/docs/canonicalk8s/snap/reference/ports-and-services.md
@@ -2,11 +2,6 @@
 
 ## Network services
 
-There are mainly two kinds of services:
-
-- Those that operate in all nodes
-- Those that operate in control plane nodes only
-
 ### Services on all nodes
 
 | Interface & Port | Protocol | Service        | Description                                                                                              |


### PR DESCRIPTION
## Description

Review correctness of [ports and services docs page](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/reference/ports-and-services/) and differentiate between control plane and worker services.

## Solution

I deployed a three node cluster with two control plane nodes and a worker node. Then I used ss tool to find out what ports are being listened on and on what interfaces on each of the nodes. Additionally, I have changed the structure of the services and ports page such that we have two sections one for all nodes and one for control plane nodes only. I also added the service network interface to the ports column.

## Backport

1.34, 1.33, 1.32

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

Note that the [UFW docs page](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/ufw/) part of the Jira story is being worked on by @louiseschmidtgen in https://github.com/canonical/k8s-snap/pull/2034
