### PR TITLE
fix: skip instances that are no longer in the harness (deleted)

### DIFF
--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -322,7 +322,7 @@ def instances(
         if instance.id not in h.instances:
             LOG.debug("Instance %s already deleted, skipping", instance.id)
             continue
-        
+
         try:
             util.remove_k8s_snap(instance)
         finally:


### PR DESCRIPTION
Running the integration tests for the k8s-snap in other repos (i.e. dqlite: https://github.com/canonical/k8s-dqlite/actions/runs/19368302433/job/55625847319?pr=338) fails because the teardown for the test harness attempts to uninstall k8s from all instances. The issue with that is some tests intentionally nuke a node at the VM level, causing a mismatch between what the harness thinks needs to be cleaned and what actually exists.

This is fixed by adding a check that skips an instance if its not also in the harness's instance collection