### PR TITLE
fix: explicitly set MTU in jumbo profile

### DIFF
--- a/tests/integration/lxd-jumbo-profile.yaml
+++ b/tests/integration/lxd-jumbo-profile.yaml
@@ -4,4 +4,10 @@ devices:
     name: eth0
     network: LXD_JUMBO_NETWORK
     type: nic
-    mtu: "9000"
+config: 
+  user.network-config: |
+    version: 2
+    ethernets:
+      eth0:
+        dhcp4: true
+        mtu: 9000


### PR DESCRIPTION
In k8s-dqlite, the snap integration tests fail on test_jumbo in test_networking: https://github.com/canonical/k8s-dqlite/actions/runs/19368302433/job/55628973477?pr=338 

The error logs indicate that the worker node fails to join the cluster, and I believe the reason for this is a mismatch in configurations for the MTU between the bridge (which is correctly set to 9000) and the containers, which are left as default (probably 1500). This causes packet drops that prevent cluster joining. 

This was fixed in k8s-dqlite by modifying the testing harness in that repo to include the necessary LXD bridges, but in general we shouldn't be assuming the guest OS happens to be correctly configured like that. Consequently, this PR adds a network config specification to explicitly tell the guest that it needs an MTU of 9000 when running this test instead of hoping that the container OS listens to the hint provided by the host.
