### PR TITLE
test: Don't setup nodes before airgapped test

### DIFF
--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -68,7 +68,7 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
 
 
 @pytest.mark.node_count(2)
-@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.no_setup()
 @pytest.mark.tags(tags.NIGHTLY)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="runner size too small on multipass"


### PR DESCRIPTION
The airgapped test is marked as `disable_k8s_bootstrapping` which will not run `k8s bootstrap` on the node but still install the snap on the node. The airgapped test then later tries to actually setup the node within the test. Since the snap is already installed, this causes a snap refresh/upgrade from a potentially non-supported upgrade path. Marking this test as `no_setup` gives full setup control to the test itself and avoids this scenario.

## Issue

https://github.com/canonical/k8s-snap/actions/runs/19484748307/job/55764474151

## Backport

Yes, to all releases
