### PR TITLE
chore: Skip automated downgrades (#2048)

### DIFF
--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -42,7 +42,8 @@ jobs:
 
       - name: Check for new component versions
         run: |
-          ./build-scripts/hack/update-component-versions.py
+          ./build-scripts/hack/update-component-versions.py \
+             $(test "$GITHUB_EVENT_NAME" = "pull_request" && echo "--dry-run")
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6

--- a/build-scripts/hack/update-component-versions.py
+++ b/build-scripts/hack/update-component-versions.py
@@ -173,9 +173,25 @@ def update_component_versions(dry_run: bool):
         LOG.info("Updating version for %s", component)
         version: str = get_version()
         path = COMPONENTS / component / "version"
+        existing = Path(path)
+        existing_version_text = existing.read_text().strip() if existing.exists() else None
+        upstream_version_text = version.strip()
+
+        existing_parsed = parse_version(existing_version_text) if existing_version_text else None
+        upstream_parsed = parse_version(upstream_version_text)
+
+        # If both versions parse and the existing one is greater than upstream, skip update.
+        if existing_parsed and upstream_parsed and existing_parsed > upstream_parsed:
+            LOG.info(
+            "Existing version %s is greater than upstream %s; keeping existing version",
+            existing_version_text,
+            upstream_version_text,
+            )
+            continue
+
         LOG.info("Update %s version to %s in %s", component, version, path)
         if not dry_run:
-            Path(path).write_text(version.strip() + "\n")
+            Path(path).write_text(upstream_version_text + "\n")
 
     update_go_version(dry_run)
 


### PR DESCRIPTION
The update-components workflow pulls the newest upstream version and overwrites the local value. Certain cases require keeping a specific version, such as when one component (runc) must align with another (containerd) that is already end-of-life but still needs a controlled version pin.

The change updates the workflow to perform replacements only when the upstream version is newer than the current one. It does not handle the opposite scenario; the workflow will continue proposing upgrades even when an older version is intentionally retained.

(cherry picked from commit 6f1adf57f26719573e92cf5074ac7d89d4e97203)

