### PR TITLE
chore: upgrade cilium image tag

### DIFF
--- a/src/k8s/pkg/k8sd/features/cilium/chart.go
+++ b/src/k8s/pkg/k8sd/features/cilium/chart.go
@@ -39,13 +39,13 @@ var (
 	ciliumAgentImageRepo = "ghcr.io/canonical/cilium"
 
 	// CiliumAgentImageTag is the tag to use for the cilium-agent image.
-	CiliumAgentImageTag = "1.17.9-ck6"
+	CiliumAgentImageTag = "1.17.9-ck9"
 
 	// ciliumOperatorImageRepo is the image to use for cilium-operator.
 	ciliumOperatorImageRepo = "ghcr.io/canonical/cilium-operator"
 
 	// ciliumOperatorImageTag is the tag to use for the cilium-operator image.
-	ciliumOperatorImageTag = "1.17.9-ck3"
+	ciliumOperatorImageTag = "1.17.9-ck4"
 
 	ciliumDefaultVXLANPort = 8472
 


### PR DESCRIPTION
## Description

Upgrades the Cilium image tags: See https://github.com/canonical/cilium-rocks/pull/41 for more detail