### PR TITLE
feat: build for more architectures

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # e.g. strict - right now we only support the classic flavor
         patch: [""]
-        arch: ["amd64", "arm64", "ppc64le", "s390x"]
+        arch: ["amd64", "arm64", "ppc64el", "s390x"]
     with:
       flavor: ${{ matrix.patch }}
       arch: ${{ matrix.arch }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,7 @@ environment:
 architectures:
   - build-on: [amd64]
   - build-on: [arm64]
-  - build-on: [ppc64le]
+  - build-on: [ppc64el]
   - build-on: [s390x]
 
 parts:


### PR DESCRIPTION
## Description

This PR attempts to add builds for the `ppc64le` and `s390x` architectures.

## Solution

`snapcraft.yaml` and the `lint_and_integration.yaml` CI have been updated to build and tests these architectures.

The charm e2e tests were not updated since they're currently only run with the `amd64` architecture. But presumably we should run these as well.

## Issue

Resolves #2076

## Backport

This might be necessary to get releases for these architectures on the existing channels?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [x] ~Covered by unit tests~
- [x] Covered by integration tests
- [x] ~Documentation updated~
- [x] CLA signed
- [x] ~Backport label added if necessary~

<!--
If any item on the checklist is not complete, please provide justification why.

The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit
-->