### PR TITLE
fix: e2e test runs out of resources

### DIFF
--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -126,8 +126,7 @@ jobs:
           free -g
       - name: Bootstrap Juju controller (lxd)
         run: |
-          juju bootstrap localhost lxd \
-            --bootstrap-constraints "mem=32G cores=12"
+          juju bootstrap localhost lxd
       - uses: actions/checkout@v4
         with:
           repository: canonical/k8s-operator


### PR DESCRIPTION
Running the charm e2e integration test fails from what looks like resource constraints. The LXD container running juju has 2 cores and 8gb RAM (acc to logs), which is struggling to handle the pressure of running metrics observability tests on top of the existing load. 

We can see this in how the exact same integration tests pass "locally" in k8s-operator's workflow, but fail here. This PR ups the CPU and RAM allocated from the SHR to juju. 


After some discussion, we decided to update this workflow to just run the smoke tests on charmed k8s. The load required to provision some of the other tests exceed what our runners are capable of when having to run the k8s-snap alongside them. It looks like that may have been the original intention of this workflow, but due to a typo, it has never run as intended. Now there is no longer a need to up the runner resources.