### PR TITLE
chore: weekly cncf tests for all releases

### DIFF
--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: ["ubuntu:22.04", "ubuntu:24.04"]
         arch: ["amd64"]
-        channel: ["latest/edge"]
+        channel: ["latest/edge", "1.32-classic/stable", "1.33-classic/stable", "1.34-classic/stable"]
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       arch: ${{ matrix.arch }}


### PR DESCRIPTION
## Description

Expands the weekly CNCF conformance test to cover all released channels i.e. 1.34, 1.33, 1.32