### PR TITLE
docs: Release notes snap patch notices November 25 [Backport release-1.32]

### DIFF
--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -65,6 +65,29 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Nov 17, 2025
+
+- Prevent feature controller from running on worker nodes 
+([#1938](https://github.com/canonical/k8s-snap/pull/1938))
+- Bump metrics-server image to 0.7.2-ck7
+- Revert change on patching upgrade object during rolling upgrades 
+([#1972](https://github.com/canonical/k8s-snap/pull/1972))
+- Bump CoreDNS image to 1.12.4-ck0
+- Remove unsupported recycle reclaim policy in local storage 
+([#1958](https://github.com/canonical/k8s-snap/pull/1958))
+- Fix cluster config merge checks 
+([#1956](https://github.com/canonical/k8s-snap/pull/1956))
+- Add a fix to force remove lost nodes from the cluster 
+([#1901](https://github.com/canonical/k8s-snap/pull/1901))
+- Improve the way k8s-api-server discovers k8s endpoints by no longer querying
+through the proxy and instead using current endpoints 
+([#1947](https://github.com/canonical/k8s-snap/pull/1947))
+- Use JSON marshal to sanitize Helm arguments 
+([#1942](https://github.com/canonical/k8s-snap/pull/1942))
+- Bump Helm to v3.18.6
+- Update DISA STIG guidelines to incorporate etcd instructions 
+([#1808](https://github.com/canonical/k8s-snap/pull/1808))
+
 Oct 22, 2025
 
 - Resolve issue where etcd metrics aren't exposed.


### PR DESCRIPTION
## Description

Manual backport of #2069 due to not all files being available on all branches

## Solution

Only 1.32 updated

## Issue

Include a link to the Github issue number if applicable.

## Backport

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
