### PR TITLE
docs: Release notes snap patch notices November 25 [Backport release-1.34] 

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -464,6 +464,7 @@ runtimes
 rw
 S3
 sandboxed
+sanitization
 SANs
 SARIF
 structs
@@ -471,6 +472,7 @@ SBOM
 scalable
 scalability
 SCHED
+schedulable
 sControlPlane
 SCTP
 sd

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -65,6 +65,29 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Nov 17, 2025
+
+- Prevent feature controller from running on worker nodes 
+([#1938](https://github.com/canonical/k8s-snap/pull/1938))
+- Bump metrics-server image to 0.7.2-ck7
+- Revert change on patching upgrade object during rolling upgrades 
+([#1972](https://github.com/canonical/k8s-snap/pull/1972))
+- Bump CoreDNS image to 1.12.4-ck0
+- Remove unsupported recycle reclaim policy in local storage 
+([#1958](https://github.com/canonical/k8s-snap/pull/1958))
+- Fix cluster config merge checks 
+([#1956](https://github.com/canonical/k8s-snap/pull/1956))
+- Add a fix to force remove lost nodes from the cluster 
+([#1901](https://github.com/canonical/k8s-snap/pull/1901))
+- Improve the way k8s-api-server discovers k8s endpoints by no longer querying
+through the proxy and instead using current endpoints 
+([#1947](https://github.com/canonical/k8s-snap/pull/1947))
+- Use JSON marshal to sanitize Helm arguments 
+([#1942](https://github.com/canonical/k8s-snap/pull/1942))
+- Bump Helm to v3.18.6
+- Update DISA STIG guidelines to incorporate etcd instructions 
+([#1808](https://github.com/canonical/k8s-snap/pull/1808))
+
 Oct 22, 2025
 
 - Resolve issue where etcd metrics aren't exposed.

--- a/docs/canonicalk8s/snap/reference/versions/1.33.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.33.md
@@ -82,6 +82,24 @@ may need to implement for a successful upgrade.
 
 ## Patch notices
 
+18 Nov, 202
+
+- Version bumps 
+  - containerd v1.7.29 
+  - runc to v1.3.3
+  - metrics-server 0.7.2-ck7
+  - CoreDNS 1.12.4-ck0
+- Revert change on patching upgrade object during rolling upgrades 
+([#1971](https://github.com/canonical/k8s-snap/pull/1971))
+- Remove unsupported recycle reclaim policy in local storage
+- Add a fix to force remove lost nodes from the cluster
+- For greater security, bump Helm version to v3.18.6 and introduce 
+value sanitization
+- Improve the way k8s-api-server discovers k8s endpoints by no longer querying
+through the proxy and instead using current endpoints
+- During a k8s version downgrade, sanitize any feature gates that were 
+introduced in later k8s versions 
+
 Aug 25, 2025
 
 - Change the default cluster datastore to managed etcd ([#1561]). Existing

--- a/docs/canonicalk8s/snap/reference/versions/1.34.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.34.md
@@ -59,6 +59,27 @@ upgrade and will continue to use k8s-dqlite.
 
 ## Patch notices
 
+November 10, 2025
+
+- Version bumps 
+    - containerd v1.7.29
+    - runc v1.3.3
+    - Cilium 1.17.9-ck1
+    - CoreDNS 1.13.1-ck1
+    - MetalLB 1.13.1-ck1
+    - metrics-server 0.8.0-ck4
+- Address issue with missing build tags causing panic in ROCKS when opening
+ TLS connections ([#1997](https://github.com/canonical/k8s-snap/pull/1995))
+- Exclude `metallb-system` from PodSecurityPolicy to ensure they are 
+schedulable
+- Remove unsupported recycle reclaim policy in local storage
+- Add a guide on how to [configure your firewall with UFW]
+- Add a fix to force remove lost nodes from the cluster
+- For greater security, bump Helm version to v3.19.0 and introduce value 
+sanitization
+- During a k8s version downgrade, sanitize any feature gates that were 
+introduced in later k8s versions
+
 October 17, 2025
 
 - Add how to [deploy a Canonical Kubernetes cluster with FIPS compliance] guide


### PR DESCRIPTION
## Description

Manual backport of #2069 due to not all files being available on all branches

## Solution

1.34, 1.33 and 1.32 updated

## Issue

Include a link to the Github issue number if applicable.

## Backport

N/A

## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
