### PR TITLE
ci: move datastore spread testing to weekly

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -28,13 +28,11 @@ jobs:
             "1.33-classic/edge",
             "1.32-classic/edge",
           ]
-        datastore: ["etcd", "k8s-dqlite"]
       fail-fast: false
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       arch: ${{ matrix.arch }}
       os: ${{ matrix.os }}
-      datastore: ${{ matrix.datastore }}
       channel: ${{ matrix.channel }}
       test-tags: "up_to_nightly"
       parallel: true

--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -31,6 +31,25 @@ jobs:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
       LAUNCHPAD_K8S_CI_BOT_PASSWORD: ${{ secrets.LAUNCHPAD_K8S_CI_BOT_PASSWORD }}
 
+  test-spread-datastore:
+    name: Spread tests across different datastores
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
+        datastore: ["etcd", "k8s-dqlite"]
+        channel: ["latest/edge"]
+      fail-fast: false
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      arch: ${{ matrix.arch }}
+      datastore: ${{ matrix.datastore }}
+      channel: ${{ matrix.channel }}
+      test-tags: "up_to_nightly"
+      parallel: true
+      # We need to reduce the max parallelism here to avoid occupying all runners.
+      # os * arch * channel * max-parallel = 160 jobs
+      max-parallel: 10
+
   cncf:
     name: CNCF conformance test
     strategy:


### PR DESCRIPTION
## Description
Addition of the datastore to the nightly matrix resulted in github not being able to load the nightly run page at all.

## Solution

Instead we move the testing to weekly to run on latest/edge for amd64 and arm64.

## Backport

Will be cherry picked to #2103 #2104 #2106.

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
