### PR TITLE
ci: collect tests from the PR branch instead of main

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -140,6 +140,7 @@ jobs:
       datastore: ${{ matrix.datastore }}
       test-tags: ${{ needs.get-e2e-tags.outputs.test-tags }}
       artifact: k8s-${{ matrix.arch }}.snap
+      test-collection-branch: ${{ github.head_ref }}
       parallel: true
 
   security-scan:


### PR DESCRIPTION
## Description

Currently PR integration tests are collected from the main channel since `test-collection-branch` is not provided to the `e2e-tests` workflow. This is particularly problematic when the PR introduces changes to the tests since the modified or newly created tests are not collected.

## Solution

Collect the tests from the PR branch.