### PR TITLE
test: Support installing from channel+revision for promotion upgrades

### DIFF
--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -172,6 +172,7 @@ JUJU_MACHINES = os.getenv("TEST_JUJU_MACHINES") or ""
 # A list of space-separated channels for which the upgrade tests should be run in sequential order.
 # First entry is the bootstrap channel. Afterwards, upgrades are done in order.
 # Alternatively, use 'recent <num> <flavour>' to get the latest <num> channels for <flavour>.
+# If a channel includes an '@' symbol, the part after '@' is treated as the snap revision
 VERSION_UPGRADE_CHANNELS = (
     os.environ.get("TEST_VERSION_UPGRADE_CHANNELS", "").strip().split()
 )

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -244,6 +244,7 @@ def setup_k8s_snap(
             a snap track to install
             a snap channel to install
             a snap revision to install
+            a snap channel@revision to install
             a path to the snap to install
         tmp_path:   path to store the snap on the instance (optional, defaults to /home/ubuntu)
     """
@@ -266,7 +267,7 @@ def setup_k8s_snap(
         cmd += [config.SNAP_NAME, "--revision", which_snap]
     elif "/" in which_snap or which_snap in RISKS:
         LOG.info("Install k8s snap by specific channel: %s", which_snap)
-        cmd += [config.SNAP_NAME, "--channel", which_snap]
+        cmd += [config.SNAP_NAME, *snap_channel_args(which_snap)]
     elif channel := tracks_least_risk(which_snap, instance.arch):
         LOG.info("Install k8s snap by least risky channel: %s", channel)
         cmd += [config.SNAP_NAME, "--channel", channel]
@@ -275,6 +276,21 @@ def setup_k8s_snap(
     if connect_interfaces:
         LOG.info("Ensure k8s interfaces and network requirements")
         instance.exec(["/snap/k8s/current/k8s/hack/init.sh"], stdout=subprocess.DEVNULL)
+
+
+def snap_channel_args(channel: str) -> List[str]:
+    """Parse channel string and return snap arguments.
+
+    If the channel includes an '@' symbol, the part after '@' is treated as the snap revision.
+    """
+    # Options for channel include
+    # 1. a channel name like '1.32-classic/stable'
+    # 2. a channel and revision number like '1.32-classic/stable@1234'
+    if "@" in channel:
+        chan, revision = channel.split("@", maxsplit=1)
+        return ["--channel", chan, "--revision", revision]
+    else:
+        return ["--channel", channel]
 
 
 def remove_k8s_snap(instance: harness.Instance):


### PR DESCRIPTION
This pull request improves how snap channel and revision arguments are handled in integration tests, enabling support for specifying both a channel and a revision together (using the `channel@revision` syntax). The main enhancement is the introduction of a helper function to parse these arguments, which is then used throughout the test utilities and test cases to ensure consistent and correct snap installation and refresh commands.

**Enhancements to snap channel and revision handling:**

* Added a new helper function `snap_channel_args` in `test_util/util.py` that parses channel strings and returns the appropriate snap command arguments, supporting the `channel@revision` format.
* Updated the `setup_k8s_snap` function in `test_util/util.py` to use the new `snap_channel_args` helper when installing snaps by channel, ensuring correct handling of channels that include a revision.
* Updated docstrings and comments in `test_util/util.py` and `test_util/config.py` to document the new `channel@revision` support. [[1]](diffhunk://#diff-765a6c110620b1ff5a80a7f549d5d2138f096a5fc6cd2e90cc7ef7d4337574c8R247) [[2]](diffhunk://#diff-c6765638516beaefce3022298321dfaad612f264783ef921a9c3e92b79effb74R175)

**Refactoring of test cases to use the new helper:**

* Refactored all relevant snap install and refresh commands in `test_version_upgrades.py` to use the `snap_channel_args` helper, ensuring consistent handling of channels with or without revisions. [[1]](diffhunk://#diff-53fa21c9db8107d9ef5e1d5247457e95d79c558b464199611344a9ea082e5975L133-R138) [[2]](diffhunk://#diff-53fa21c9db8107d9ef5e1d5247457e95d79c558b464199611344a9ea082e5975L249-R248) [[3]](diffhunk://#diff-53fa21c9db8107d9ef5e1d5247457e95d79c558b464199611344a9ea082e5975L264-R263) [[4]](diffhunk://#diff-53fa21c9db8107d9ef5e1d5247457e95d79c558b464199611344a9ea082e5975L280-R278) [[5]](diffhunk://#diff-53fa21c9db8107d9ef5e1d5247457e95d79c558b464199611344a9ea082e5975L322-R321) [[6]](diffhunk://#diff-53fa21c9db8107d9ef5e1d5247457e95d79c558b464199611344a9ea082e5975L494-R499)
* Updated imports in `test_version_upgrades.py` to include the new helper function.
