### PR TITLE
fix: cni build on 1.35

### DIFF
--- a/build-scripts/components/cni/build.sh
+++ b/build-scripts/components/cni/build.sh
@@ -13,6 +13,6 @@ export CGO_ENABLED=1
 export GOTOOLCHAIN=local
 export GOEXPERIMENT=opensslcrypto
 
-go build -tags "linux,cgo,ms_tls13kdf" -o cni -ldflags "-s -w -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${VERSION}" ./cni.go
+go build -tags "linux,cgo,ms_tls13kdf" -o cni -ldflags "-linkmode external -s -w -X github.com/containernetworking/plugins/pkg/utils/buildversion.BuildVersion=${VERSION}" ./cni.go
 
 cp cni "${INSTALL}/cni"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -143,7 +143,7 @@ parts:
     after: [build-deps]
     plugin: nil
     source: build-scripts/components/cni
-    build-attributes: [enable-patchelf]
+    build-attributes: [no-patchelf]
     override-build: $CRAFT_PROJECT_DIR/build-scripts/build-component.sh cni
 
   kubernetes:


### PR DESCRIPTION
## Description

CNI part fails to build for 1.35 due to Go 1.25 [changing](https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#go-125-aug-2025) things. Specifically:

> The systemcrypto goexperiment is now enabled by default on Windows and Linux. To disable it, set GOEXPERIMENT=nosystemcrypto.

Using the above setting fixes the build. I also removed `CGO_ENABLED=0` as @bschimke95 mentioned it's not necessary.

## Backport

1.34 as we found out that CNI needs to be built dynamically for FIPS.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
