### PR TITLE
fix: build containerd

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -27,7 +27,7 @@ for bin in containerd; do
 done
 
 # Shims can be built statically as they do not contain any crypto functions
-for bin in ctr containerd containerd-shim-runc-v2; do
+for bin in ctr containerd-shim-runc-v2; do
   export STATIC=1
   export CGO_ENABLED=0
   export GO_BUILDTAGS=


### PR DESCRIPTION
## Description

Containerd already gets built with FIPS env variables, it does not need to be built again statically (and not FIPS compliant).

Regression: https://github.com/canonical/k8s-snap/pull/2101

## Backport

NA

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
