### PR TITLE
fix: test_build

### DIFF
--- a/tests/integration/tests/test_build.py
+++ b/tests/integration/tests/test_build.py
@@ -40,8 +40,6 @@ def test_build(instances: List[harness.Instance]):
         "ctr",
         "runc",
         "cni",
-        "containerd-shim",
-        "containerd-shim-runc-v1",
         "containerd-shim-runc-v2",
     ]
 


### PR DESCRIPTION
## Description

Follow-up on fixing test_build: removing checks no longer relevant for containerd v2.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
