### PR TITLE
test: Switch to certified conformance tests [Backport to release-1.33]

### DIFF
--- a/tests/integration/tests/test_cncf_conformace.py
+++ b/tests/integration/tests/test_cncf_conformace.py
@@ -17,13 +17,16 @@ def test_cncf_conformance(instances: List[harness.Instance]):
     cluster_node = cluster_setup(instances)
     install_sonobuoy(cluster_node)
 
-    # TODO: Remove the test skip once the following issue has been resolved,
-    # and if sonobuoy version has been updated if the test was changed:
-    # https://github.com/kubernetes/kubernetes/issues/131150
-    # We're also adding the default --e2e-skip value.
-    skipped = "validates resource limits of pods that are allowed to run|\\[Disruptive\\]|NoExecuteTaintManager"
     cluster_node.exec(
-        ["./sonobuoy", "run", "--plugin", "e2e", "--e2e-skip", skipped, "--wait"],
+        [
+            "./sonobuoy",
+            "run",
+            "--plugin",
+            "e2e",
+            "--mode",
+            "certified-conformance",
+            "--wait",
+        ],
     )
     cluster_node.exec(
         ["./sonobuoy", "retrieve", "-f", "sonobuoy_e2e.tar.gz"],


### PR DESCRIPTION
## Description

Switching CNCF conformance tests to certified mode. The flakiness also seems to be resolved for now