### PR TITLE
chore: switch to checking `endpointslice` to mark node as ready

### DIFF
--- a/src/k8s/pkg/client/kubernetes/status.go
+++ b/src/k8s/pkg/client/kubernetes/status.go
@@ -15,19 +15,9 @@ func (c *Client) WaitKubernetesEndpointAvailable(ctx context.Context) error {
 		// TODO: use the /readyz endpoint instead
 		// We want to retry if an error occurs (=API server not ready)
 		// returning the error would abort, thus checking for nil
-		endpoint, err := c.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
-		return err == nil && endpoint != nil, nil
+		_, err := c.GetKubeAPIServerEndpoints(ctx)
+		return err == nil, nil
 	})
-}
-
-func (c *Client) CheckKubernetesEndpoint(ctx context.Context) error {
-	if endpoint, err := c.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{}); err != nil {
-		return fmt.Errorf("failed to get kubernetes endpoint: %w", err)
-	} else if endpoint == nil {
-		return fmt.Errorf("kubernetes endpoint not found")
-	}
-
-	return nil
 }
 
 // HasReadyNodes checks the status of all nodes in the Kubernetes cluster.

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -306,10 +306,8 @@ func (a *App) markNodeReady(ctx context.Context, s state.State) error {
 		if err != nil {
 			return false, nil
 		}
-		if err := client.CheckKubernetesEndpoint(ctx); err != nil {
-			return false, nil
-		}
-		return true, nil
+		_, err = client.GetKubeAPIServerEndpoints(ctx)
+		return err == nil, nil
 	}); err != nil {
 		return fmt.Errorf("failed to wait for kubernetes endpoint: %w", err)
 	}


### PR DESCRIPTION
## Description

- Switches to checking `EndpointSlice` instead of deprecated `Endpoints` to mark a node as ready. 
- Remvoes the duplicate `CheckKubernetesEndpoint` in favor of `GetKubeAPIServerEndpoints`