### PR TITLE
feat: bump csi rock versions

### DIFF
--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -20,11 +20,11 @@ var (
 	ImageTag = "0.8.2-ck3"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
-	csiNodeDriverImage = "ghcr.io/canonical/csi-node-driver-registrar:2.15.0"
+	csiNodeDriverImage = "ghcr.io/canonical/csi-node-driver-registrar:2.15.0-ck0"
 	// csiProvisionerImage is the image to use for the CSI provisioner.
-	csiProvisionerImage = "ghcr.io/canonical/csi-provisioner:5.3.0"
+	csiProvisionerImage = "ghcr.io/canonical/csi-provisioner:5.3.0-ck0"
 	// csiResizerImage is the image to use for the CSI resizer.
-	csiResizerImage = "ghcr.io/canonical/csi-resizer:1.14.0"
+	csiResizerImage = "ghcr.io/canonical/csi-resizer:1.14.0-ck0"
 	// csiSnapshotterImage is the image to use for the CSI snapshotter.
-	csiSnapshotterImage = "ghcr.io/canonical/csi-snapshotter:8.3.0"
+	csiSnapshotterImage = "ghcr.io/canonical/csi-snapshotter:8.3.0-ck0"
 )


### PR DESCRIPTION
## Description

This PR bumps the CSI-Rock versions for details on the version jumps see https://github.com/canonical/csi-rocks/pull/29.

## Backport

NA

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
