### PR TITLE
fix: set k8s-dqlite rpath manually

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -79,7 +79,16 @@ parts:
     plugin: nil
     source: build-scripts/components/k8s-dqlite
     build-attributes: [enable-patchelf]
-    override-build: $CRAFT_PROJECT_DIR/build-scripts/build-component.sh k8s-dqlite
+    override-build: |
+      # Note: This field must match the base field above.
+      BASE=core22
+
+      $CRAFT_PROJECT_DIR/build-scripts/build-component.sh k8s-dqlite
+
+      # Seems like snapcraft auto patching is not working as expected here, so we do it manually.
+      for binary in k8s-dqlite dqlite; do
+        patchelf --force-rpath --set-rpath "\$ORIGIN/../../lib:/snap/$BASE/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR" "$CRAFT_PART_INSTALL/bin/${binary}"
+      done
 
   etcd:
     after: [build-deps]


### PR DESCRIPTION
## Description

We've discovered that a `release-1.34` node with the k8s-dqlite datastore is failing on Ubuntu 20.04 hosts due to linking issues.

`k8s-dqlite` fails with the following message;
```
Dec 08 11:22:10 k8s-integration-2-15dcbc k8s.k8s-dqlite[10651]: /snap/k8s/4539/bin/k8s-dqlite: symbol lookup error: /lib/x86_64-linux-gnu/libpthread.so.0: undefined symbol: __libc_pthread_init, version GLIBC_PRIVATE
``` 

Checking with `LD_DEBUG=libs` and `LD_DEBUG=file` shows that `libcrypto` and other libraries are not searched under the `core` paths. This means that k8s-dqlite binary was using libs from the host instead of the core, the reason why this is observed on 20.04 is of a glibc version mismatch.

This is likely due to auto patchelf of snapcraft not working correctly.

## Solution

Manually force setting the rpath as suggested by snapcraft via `patchelf`.

## Backport

`release-1.34`

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 