### PR TITLE
docs: usg interpretation

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/disa-stig.md
+++ b/docs/canonicalk8s/snap/howto/install/disa-stig.md
@@ -288,6 +288,7 @@ audit settings, do one of the following:
 [supported version]: https://ubuntu.com/about/release-cycle#canonical-kubernetes-release-cycle
 [ports and services]: /snap/reference/ports-and-services/
 [FIPS installation guide]: fips.md
+[configure UFW]: /snap/howto/networking/ufw.md
 [configuration files]: /snap/reference/config-files/index.md
 [USG tool]: https://documentation.ubuntu.com/security/docs/compliance/usg/
 [Kubernetes Pod Security Admission documentation]: https://kubernetes.io/docs/concepts/security/pod-security-admission/


### PR DESCRIPTION
## Description

This PR adds k8s specific usg audit interpretations to the DISA STIG how-to guide.

Read the docs shortcut: https://canonical-ubuntu-documentation-library--2150.com.readthedocs.build/canonical-kubernetes/2150/snap/howto/install/disa-stig/#apply-host-stig

## Backport

1.34

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
