### PR TITLE
docs: Add FIPS warning to 1.32 DISA STIG

### DIFF
--- a/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/disa-stig-assessment.md
@@ -1,7 +1,7 @@
 # How to assess DISA STIG for {{product}}
 
 ```{attention}  
-To be fully DISA STIG compliant, you must use FIPS certified crypotographic libraries. Upgrade your Canonical Kubernetes snap to version 1.34 to access this feature.
+To be fully DISA STIG compliant, you must use FIPS certified cryptographic libraries. Upgrade your Canonical Kubernetes snap to version 1.34 to access this feature.
 ```
 
 Security Technical Implementation Guides (STIGs) are developed by the Defense


### PR DESCRIPTION
## Description

To achieve full DISA STIG compliance, you need to use FIPS certified crypto libs. This feature was added in 1.34. 

## Solution

Users can still assess their DISA STIG compliance but should be aware if they stay on 1.32, they will not have FIPS.

## Issue

N/A

## Backport

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
