### PR TITLE
fix: Update kubectl.md

### DIFF
--- a/docs/canonicalk8s/snap/tutorial/kubectl.md
+++ b/docs/canonicalk8s/snap/tutorial/kubectl.md
@@ -107,7 +107,7 @@ First, open a new terminal so you can watch the changes as they happen. Run
 this command in a new terminal:
 
 ```
-sudo k8s kubectl get pods --all-namespace --watch
+sudo k8s kubectl get pods --all-namespaces --watch
 ```
 
 Now, go back to your original terminal and run:


### PR DESCRIPTION
In the command "namespaces" is missing the 's' at the end.  This edit makes the command valid.

## Description

Attempting to make the command valid so users can use it without troubleshooting.

## Solution

In the command the word "namespace" is invalid unless a 's' is added to the end to make it "namespaces".

## Issue

Github issue number not available as far as I know.

## Backport

Not sure if this PR be backported.  Probably not?

## Checklist

- [ x] PR title formatted as `type: title`
- [\ ] Covered by manual test (not unit tests)
- [ ] Covered by integration tests (nope)
- [ x] Documentation updated (it is documentation)
- [ ] CLA signed (no)
- [ ] Backport label added if necessary (not necessary)

If any item on the checklist is not complete, please provide justification why.

The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit
