### PR TITLE
ci: always generate names for artifacts

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -226,6 +226,7 @@ jobs:
       - name: Install tox
         run: sudo apt-get install -y tox
       - name: Generate names for step and artifacts
+        if: ${{ always() }}
         run: |
           FULL_TEST_NODE_ID="${{ matrix.test }}"
           # Extract short test name (part after '::') for the step display name


### PR DESCRIPTION
## Description

Result and log collection steps sometimes fail due to job failing earlier in the setup phase, which results in name generation being skipped. See the [example nightly failure.](https://github.com/canonical/k8s-snap/actions/runs/19653408811/job/56285020836) Instead we configure the name generation step to always run regardless of failure.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
