### PR TITLE
fix: CNI build not linking to core22 libc

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -143,7 +143,7 @@ parts:
     after: [build-deps]
     plugin: nil
     source: build-scripts/components/cni
-    build-attributes: [no-patchelf]
+    build-attributes: [enable-patchelf]
     override-build: $CRAFT_PROJECT_DIR/build-scripts/build-component.sh cni
 
   kubernetes:


### PR DESCRIPTION
## Description

In a previous [PR](https://github.com/canonical/k8s-snap/pull/2128), I made changes to make CNI link dynamically rather than statically. Turns the produced binary was linking against host libc rather than core22 one. This PR brings back `enable-patchelf` which after testing locally I found does link properly to core22 and the produced binary doesn't segfault.

## Backport

Needs backporting to 1.34 along with previous PR that failed to backport.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
