### PR TITLE
docs: Update sitemaps config

### DIFF
--- a/docs/canonicalk8s/conf.py
+++ b/docs/canonicalk8s/conf.py
@@ -181,19 +181,21 @@ slug = 'canonical-kubernetes'
 
 # Base URL of RTD hosted project
 
-html_baseurl = 'https://documentation.ubuntu.com/canonical-kubernetes/'
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 html_extra_path = ["sitemapindex.xml", "robots.txt"]
 
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
-else:
-    sitemap_url_scheme = 'latest/{link}'
+sitemap_url_scheme = '{link}'
 
 sitemap_show_lastmod = True
+
+sitemap_excludes = [
+    '404/',
+    'genindex/',
+    'search/',
+]
 
 # Template and asset locations
 


### PR DESCRIPTION
## Description

The current sitemaps config is leading to 404 errors and is confusing search engines

## Solution

Update based on latest starter pack instructions [here](https://canonical-starter-pack.readthedocs-hosted.com/stable/how-to/set-up-sitemaps/)

## Issue

N/A

## Backport

1.34,1.33,1.32

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.