### PR TITLE
docs: Apply feedback based on UXR sessions [Backport release-1.33]

### DIFF
--- a/docs/canonicalk8s/capi/index.md
+++ b/docs/canonicalk8s/capi/index.md
@@ -29,7 +29,7 @@ all defined in the same way that cluster operators are already familiar with.
 
 ````{grid} 1 1 2 2
 
-```{grid-item-card} [Tutorial](tutorial/index)
+```{grid-item-card} [Tutorial](tutorial/getting-started)
 
 **Start here!** A hands-on introduction to {{product}} for new users
 ```
@@ -43,15 +43,14 @@ all defined in the same way that cluster operators are already familiar with.
 
 ````{grid} 1 1 2 2
 
+```{grid-item-card} [Explanation](explanation/index)
+
+**Discussion and clarification** of key topics
+```
 
 ```{grid-item-card} [Reference](reference/index)
 
 **Technical information** - specifications, APIs, architecture
-```
-
-```{grid-item-card} [Explanation](explanation/index)
-
-**Discussion and clarification** of key topics
 ```
 
 ````

--- a/docs/canonicalk8s/charm/index.md
+++ b/docs/canonicalk8s/charm/index.md
@@ -24,9 +24,9 @@ The `k8s` charm takes care of installing and configuring the [k8s snap
 package][] on cloud instances managed by Juju. Operating Kubernetes through
 this charm makes it significantly easier to manage at scale, on remote cloud
 instances and also to integrate other operators to enhance or customize your
-Kubernetes deployment. You can find out more about {{product}} on this
-[overview page][] or see a more detailed explanation in our [architecture
-documentation][arch].
+Kubernetes deployment. You can find out more about {{product}} on the
+[what is Canonical Kubernetes page][] or see a more detailed explanation in our 
+[architecture documentation][arch].
 
 ![Illustration depicting working on components and clouds][logo]
 
@@ -34,7 +34,7 @@ documentation][arch].
 
 ````{grid} 1 1 2 2
 
-```{grid-item-card} [Tutorial](tutorial/index)
+```{grid-item-card} [Tutorial](tutorial/getting-started)
 
 **Start here!** A hands-on introduction to Canonical K8s for new users
 ```
@@ -48,15 +48,14 @@ documentation][arch].
 
 ````{grid} 1 1 2 2
 
+```{grid-item-card} [Explanation](explanation/index)
+
+**Discussion and clarification** of key topics
+```
 
 ```{grid-item-card} [Reference](reference/index)
 
 **Technical information** - specifications, APIs, architecture
-```
-
-```{grid-item-card} [Explanation](explanation/index)
-
-**Discussion and clarification** of key topics
 ```
 
 ````
@@ -84,7 +83,7 @@ and constructive feedback.
 [community]: reference/community
 [contribute]: /snap/howto/contribute
 [releases]: /charm/reference/releases
-[overview page]: /charm/explanation/about
+[what is Canonical Kubernetes page]: /charm/explanation/about
 [arch]: /charm/explanation/architecture
 [Juju]: https://juju.is
 [k8s snap package]: /snap/index

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -28,7 +28,7 @@ sudo lxd init
 Create the VM that {{product}} will run in.
 
 ```
-lxc launch ubuntu:22.04 k8s-vm --vm -c limits.cpu=2 -c limits.memory=4GB
+lxc launch ubuntu:24.04 k8s-vm --vm -c limits.cpu=2 -c limits.memory=8GB
 ```
 
 ## Install {{product}} in an LXD VM

--- a/docs/canonicalk8s/snap/howto/install/multipass.md
+++ b/docs/canonicalk8s/snap/howto/install/multipass.md
@@ -49,13 +49,13 @@ an alternate install method using `brew`.
 
 The `k8s` snap will require a certain amount of resources, so the default
 settings for a Multipass VM aren't going to be suitable. Exactly what resources
-will be required depends on your use case. We recommend at least 4G of memory
+will be required depends on your use case. We recommend at least 8G of memory
 and 20G of disk space for each instance.
 
 Open a terminal (or Shell on Windows) and enter the following command:
 
 ```
-multipass launch 24.04 --name k8s-node --memory 4G --disk 20G --cpus 2
+multipass launch 24.04 --name k8s-node --memory 8G --disk 20G --cpus 2
 ```
 
 This command specifies:

--- a/docs/canonicalk8s/snap/howto/install/snap.md
+++ b/docs/canonicalk8s/snap/howto/install/snap.md
@@ -13,7 +13,7 @@ This guide assumes the following:
 - You have an internet connection
 - The target machine has sufficient memory and disk space. To accommodate
   workloads, we recommend a system with ***at least*** 20G of disk space and
-  4G of memory.
+  8G of memory.
 
 ```{note}
 If you cannot meet these requirements, please see the [Installing][] page for

--- a/docs/canonicalk8s/snap/index.md
+++ b/docs/canonicalk8s/snap/index.md
@@ -19,8 +19,9 @@ The {{product}} snap is a performant, lightweight, secure and
 opinionated distribution of **Kubernetes** which includes everything needed to
 create and manage a scalable cluster suitable for all use cases.
 
-You can find out more about {{product}} on this [overview page] or
-see a more detailed explanation in our [architecture documentation].
+You can find out more about {{product}} on the 
+[what is Canonical Kubernetes page] or see a more detailed explanation in our
+[architecture documentation].
 
 For deployment at scale, {{product}} is also available as a
 [Juju charm][]
@@ -33,7 +34,7 @@ For deployment at scale, {{product}} is also available as a
 
 ````{grid} 1 1 2 2
 
-```{grid-item-card} [Tutorial](tutorial/index)
+```{grid-item-card} [Tutorial](tutorial/getting-started)
 
 **Start here!** A hands-on introduction to Canonical K8s for new users
 ```
@@ -47,15 +48,14 @@ For deployment at scale, {{product}} is also available as a
 
 ````{grid} 1 1 2 2
 
+```{grid-item-card} [Explanation](explanation/index)
+
+**Discussion and clarification** of key topics
+```
 
 ```{grid-item-card} [Reference](reference/index)
 
 **Technical information** - specifications, APIs, architecture
-```
-
-```{grid-item-card} [Explanation](explanation/index)
-
-**Discussion and clarification** of key topics
 ```
 
 ````
@@ -83,6 +83,6 @@ and constructive feedback.
 [community]: /snap/reference/community
 [contribute]: /snap/howto/contribute
 [releases]: /snap/reference/releases
-[overview page]: /snap/explanation/about
+[what is Canonical Kubernetes page]: /snap/explanation/about
 [architecture documentation]: /snap/explanation/architecture
 [Juju charm]: /charm/index

--- a/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
+++ b/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
@@ -25,11 +25,11 @@ worker node.
 The first step is creating the VMs.
 
 ```
-multipass launch 22.04 --name control-plane -m 4G -d 8G
+multipass launch 24.04 --name control-plane -m 8G -d 20G
 ```
 
 ```
-multipass launch 22.04 --name worker -m 4G -c 4 -d 8G
+multipass launch 24.04 --name worker -m 8G -c 4 -d 20G
 ```
 
 This step can take a few minutes as Multipass creates the new virtual machines.

--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -4,19 +4,20 @@
 the necessary tools and services needed to easily deploy and manage a cluster.
 As the upstream Kubernetes does not come with all that is required
 for a fully functional cluster by default, we have bundled everything into a
-snap that should only take a few minutes to install. This tutorial
-explains how to install the snap package and some typical operations.
+snap that should only take a few minutes to install. In this tutorial you will
+deploy a single node cluster by installing the snap package and execute some 
+typical cluster operations. 
 
 ## Prerequisites
 
-- System Requirements: Your machine should have at least **40G disk space**
-  and **4G of memory**
+- System Requirements: Your machine should have at least **20G disk space**
+  and **8G of memory**
 - An **Ubuntu** environment to run the commands (or
   another operating system which supports snapd - see the
   [snapd documentation](https://snapcraft.io/docs/installing-snapd))
 - A system with **no previous installations of containerd/docker** as this may
-cause conflicts. Consider using a [LXD virtual machine] if you would like an
-isolated working environment.
+cause conflicts. Consider using a [Multipass virtual machine] if you would like 
+an isolated working environment.
 
 ### Install {{product}}
 
@@ -36,8 +37,7 @@ The bootstrap command initializes your cluster and configures your host system
 as a Kubernetes node. Bootstrapping the cluster is only done once at cluster
 creation.
 
-If you would like to bootstrap a Kubernetes cluster with
-default configuration run:
+Bootstrap a Kubernetes cluster with default configuration:
 
 ```
 sudo k8s bootstrap
@@ -96,9 +96,11 @@ namespace:
 sudo k8s kubectl get pods -n kube-system
 ```
 
-You will observe at least four pods running. The status of the pods may be in
-`ContainerCreating` while they are being initialized. They should turn to
-`Running` after a few seconds.
+A [pod](https://kubernetes.io/docs/concepts/workloads/pods/) is the smallest
+deployable unit in Kubernetes.  You will observe at least four pods running. 
+The status of the pods may be in `ContainerCreating` while they are being 
+initialized. Run the command again after a few seconds and they should report 
+status as `Running`.
 
 The functions of these pods are:
 
@@ -118,15 +120,13 @@ Kubernetes is meant for deploying apps and services.
 You can use the `kubectl`
 command to do that as with any Kubernetes.
 
-Let's deploy a demo NGINX server:
+Let's deploy a demo web server (NGINX):
 
 ```
 sudo k8s kubectl create deployment nginx --image=nginx
 ```
 
-This command launches a
-[pod](https://kubernetes.io/docs/concepts/workloads/pods/), the smallest
-deployable unit in Kubernetes, running the NGINX application within a
+This command launches a pod running the NGINX application within a
 container.
 
 You can check the status of your pods by running:
@@ -213,13 +213,6 @@ sudo k8s disable local-storage
 
 ### Remove {{product}} (Optional)
 
-If you wish to remove the snap without saving a snapshot of its data execute:
-
-```
-sudo snap remove k8s --purge
-```
-
-The `--purge` flag ensures complete removal of the snap and its associated data.
 If you would like to maintain a snapshot of the `k8s` snap for future
 restoration, simply run :
 
@@ -230,15 +223,23 @@ sudo snap remove k8s
 The snapshot is a copy of the user, system and configuration data stored by
 snapd for the `k8s` snap. This data can be found in `/var/snap/k8s`.
 
+If you wish to remove the snap without saving any of its data execute:
+
+```
+sudo snap remove k8s --purge
+```
+
+The `--purge` flag ensures complete removal of the snap and its associated data.
+
 ## Next steps
 
-- Learn more about {{product}} with kubectl in our [How to use kubectl] tutorial
+- Learn more about {{product}} with kubectl in our [how to use kubectl] tutorial
 - Learn how to set up a multi-node environment by [adding and removing nodes]
 - Explore Kubernetes commands with our [command reference guide]
 
 <!-- LINKS -->
 
-[How to use kubectl]: kubectl
+[how to use kubectl]: kubectl
 [command reference guide]: /snap/reference/commands
 [adding and removing nodes]: add-remove-nodes
-[LXD virtual machine]: /snap/howto/install/lxd.md
+[Multipass virtual machine]: /snap/howto/install/multipass

--- a/docs/canonicalk8s/snap/tutorial/kubectl.md
+++ b/docs/canonicalk8s/snap/tutorial/kubectl.md
@@ -9,8 +9,8 @@ tool.
 
 Before you begin, make sure you have the following:
 
-- A bootstrapped {{product}} cluster (See
-  [Getting Started])
+- A bootstrapped {{product}} cluster (see
+  [getting started] tutorial)
 
 ### 1. The kubectl command
 
@@ -49,11 +49,11 @@ the configuration when you run `kubectl config view` lives at
 command.
 
 To find out more, you can visit
-[the official kubeconfig documentation][kubeconfig-doc]
+[the official kubeconfig documentation][kubeconfig-doc].
 
 ### 4. Viewing objects
 
-Let's review what was created in the [Getting Started]
+Let's review what was created in the [getting started]
 guide.
 
 To see what pods were created when we enabled the `network` and `dns`
@@ -127,12 +127,12 @@ pods will have a status of `ContainerCreating`.
 - Explore Kubernetes commands with our
   [Command Reference Guide]
 - See the official `kubectl` reference
-  [kubectl-reference][kubectl-reference]
+  [kubectl reference][kubectl-reference]
 
 <!-- LINKS -->
 
 [Command Reference Guide]: ../reference/commands
-[Getting Started]: getting-started
+[getting started]: getting-started
 [kubernetes-api-server]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
 [kubeconfig-doc]: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
 [kubectl-reference]: https://kubernetes.io/docs/reference/kubectl/


### PR DESCRIPTION
## Description

In the latest 2 user experience research sessions I noticed some common pain points. Manual back port to 1.33 due to some updated pages in the original PR not existing in 1.33.

## Solution

- It took too many clicks to get to the tutorial so I have changed the link to the tutorial tile on the index pages.
- Reference and Explanation tiles on index pages were also flipped.
- There was a memory issue with the recommended 4G of RAM so I have increased it across the docs.
- Some other misc updating of wording to address misunderstandings


## Issue

N/A

## Backport

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
