### PR TITLE
fix: Included packaging to component updater (backport #1271)

### DIFF
--- a/build-scripts/hack/requirements.txt
+++ b/build-scripts/hack/requirements.txt
@@ -1,1 +1,2 @@
+packaging==24.2
 pyyaml==6.0.1


### PR DESCRIPTION
Backports #1271 to `release-1.32`