### PR TITLE
fix: CNI is now built dynamically so the test should be changed to reflect that

### DIFF
--- a/tests/integration/tests/test_build.py
+++ b/tests/integration/tests/test_build.py
@@ -33,13 +33,13 @@ def test_build(instances: List[harness.Instance]):
         "kubectl",
         "k8s-apiserver-proxy",
         "containerd",
+        "cni",
     ]
 
     # These components should be statically built as they do not contain any crypto functions
     static_components = [
         "ctr",
         "runc",
-        "cni",
         "containerd-shim-runc-v2",
     ]
 


### PR DESCRIPTION
## Description

Nightly CI now fails because it tests that CNI is built statically. But CNI is now built dynamically so the test should change.

## Backport

This actually has already been [backported to 1.34](https://github.com/canonical/k8s-snap/blob/release-1.34/tests/integration/tests/test_build.py#L33) but I'm adding it now to main

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 