### PR TITLE
fix: covdata tool missing in go 1.25

### DIFF
--- a/src/k8s/hack/static-go-test.sh
+++ b/src/k8s/hack/static-go-test.sh
@@ -4,6 +4,7 @@ DIR="$(realpath `dirname "${0}"`)"
 
 . "${DIR}/static-dqlite.sh"
 
+# Workaround for issue in Go 1.25 https://github.com/golang/go/issues/75031
 go env -w GOTOOLCHAIN="go$(grep ^go go.mod | awk '{print $2;}')+auto"
 
 go test \


### PR DESCRIPTION
## Description

Running `go test` [fails in CI](https://github.com/canonical/k8s-snap/actions/runs/20260642205/job/58179889046?pr=2167#step:9:248) with Go 1.25 because of a [known issue](https://github.com/golang/go/issues/75031) in Go 1.25.

## Solution

Apply a workaround that sets the go tool chain version to match the go version.

## Backport

Since this only occurs in Go 1.25. There's no need to backport it.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
