### PR TITLE
test: Increase runner sizes for the version upgrade tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -48,7 +48,7 @@ on:
           This is useful if specific tests require more powerful/larger runners, e.g. for version upgrade tests.
           The amount of self-hosted runners is limited so we should selectively assign tests to them.
           The arch tag will automatically be assigned based on the 'arch' input, so don't use the full tags here.
-          (e.g. use ["self-hosted", "linux", "jammy", "xlarge"] instead of ["self-hosted-linux-amd64-noble-2xlarge"])
+          (e.g. use ["self-hosted", "linux", "jammy", "2xlarge"] instead of ["self-hosted-linux-amd64-noble-2xlarge"])
         type: string
         required: false
         default: |
@@ -57,13 +57,13 @@ on:
               "self-hosted",
               "linux",
               "jammy",
-              "large"
+              "2xlarge-extra"
             ],
             "tests/test_version_upgrades.py::test_version_downgrades_with_rollback": [
               "self-hosted",
               "linux",
               "jammy",
-              "large"
+              "2xlarge-extra"
             ]
           }
       test-collection-branch:


### PR DESCRIPTION
## Description

We run into memory pressure with the existing configuration. Let's give the upgrade tests beefier machines.

## Backport

No, the old tests seem to be fine. We just ran into this with 1.35+ since the amount of releases increased.