### PR TITLE
fix: Use noble for 2xlarge runners as there is no jammy ones

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -48,7 +48,7 @@ on:
           This is useful if specific tests require more powerful/larger runners, e.g. for version upgrade tests.
           The amount of self-hosted runners is limited so we should selectively assign tests to them.
           The arch tag will automatically be assigned based on the 'arch' input, so don't use the full tags here.
-          (e.g. use ["self-hosted", "linux", "noble", "2xlarge"] instead of ["self-hosted-linux-amd64-noble-2xlarge"])
+          (e.g. use ["self-hosted", "linux", "noble", "xlarge"] instead of ["self-hosted-linux-amd64-noble-xlarge"])
         type: string
         required: false
         default: |
@@ -57,13 +57,13 @@ on:
               "self-hosted",
               "linux",
               "noble",
-              "2xlarge-extra"
+              "xlarge"
             ],
             "tests/test_version_upgrades.py::test_version_downgrades_with_rollback": [
               "self-hosted",
               "linux",
               "noble",
-              "2xlarge-extra"
+              "xlarge"
             ]
           }
       test-collection-branch:


### PR DESCRIPTION
## Description

I inadvertently approved and merged a [PR](https://github.com/canonical/k8s-snap/pull/2198) that increases the size of runners to help pass tests. But there are no 2xlarge jammy runners. So this PR fixes that.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

