### PR TITLE
fix: some CI not being picked up by runners

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -48,20 +48,18 @@ on:
           This is useful if specific tests require more powerful/larger runners, e.g. for version upgrade tests.
           The amount of self-hosted runners is limited so we should selectively assign tests to them.
           The arch tag will automatically be assigned based on the 'arch' input, so don't use the full tags here.
-          (e.g. use ["self-hosted", "linux", "noble", "xlarge"] instead of ["self-hosted-linux-amd64-noble-xlarge"])
+          (e.g. use ["self-hosted", "noble", "xlarge"] instead of ["self-hosted-linux-amd64-noble-xlarge"])
         type: string
         required: false
         default: |
           {
             "tests/test_version_upgrades.py::test_version_upgrades": [
               "self-hosted",
-              "linux",
               "noble",
               "xlarge"
             ],
             "tests/test_version_upgrades.py::test_version_downgrades_with_rollback": [
               "self-hosted",
-              "linux",
               "noble",
               "xlarge"
             ]


### PR DESCRIPTION
## Description

Turns out arm64 noble xlarge runners don't have linux tag. We could revert back to jammy runners, but there are more noble runners, so it might be better to just drop "linux" tag.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 