### PR TITLE
chore: update go compiler dynamically for runc and containerd

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -4,9 +4,10 @@
 INITIAL_GO_REVISION=$(snap list go | grep -E '^go\s' | awk '{print $3}')
 echo "Current Go snap revision: ${INITIAL_GO_REVISION}"
 
-# Refresh to go 1.23-fips/stable channel
-echo "Refreshing to go 1.23-fips/stable channel..."
-snap refresh go --channel=1.23-fips/stable
+# Refresh to go fips stable channel
+maj_min=$(awk '/^go /{print $2}' go.mod | cut -d. -f1,2)
+echo "Refreshing to go ${maj_min}-fips/stable channel..."
+snap refresh go --channel=${maj_min}-fips/stable
 
 INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"

--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -4,9 +4,10 @@
 INITIAL_GO_REVISION=$(snap list go | grep -E '^go\s' | awk '{print $3}')
 echo "Current Go snap revision: ${INITIAL_GO_REVISION}"
 
-# Refresh to go 1.23-fips/stable channel
-echo "Refreshing to go 1.23-fips/stable channel..."
-snap refresh go --channel=1.23-fips/stable
+# Refresh to go fips stable channel
+maj_min=$(awk '/^go /{print $2}' go.mod | cut -d. -f1,2)
+echo "Refreshing to go ${maj_min}-fips/stable channel..."
+snap refresh go --channel=${maj_min}-fips/stable
 
 VERSION="${2}"
 


### PR DESCRIPTION
## Description

container and runc projects can swap which version of go is required to build their projects.  the build scripts should be able to snap install the correct one to build them.

## Solution
Read from the project's go.mod file looking for an appropriate go version to use

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
