### PR TITLE
build: Dynamically infer Go version for containerd

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -6,6 +6,10 @@ echo "Current Go snap revision: ${INITIAL_GO_REVISION}"
 
 # Extract Go version from go.mod (normalize to major.minor for snap channel)
 GO_VERSION=$(grep -E '^go ' go.mod | awk '{print $2}' | cut -d. -f1-2)
+if [ -z "${GO_VERSION}" ]; then
+  echo "Error: Could not extract Go version from go.mod"
+  exit 1
+fi
 echo "Go version from go.mod: ${GO_VERSION}"
 
 # Refresh to go ${GO_VERSION}-fips/stable channel


### PR DESCRIPTION
## Description

The containerd build script currently hardcodes the Go version, which breaks if the version is bumped as it happened on 1.34 [here](https://github.com/canonical/k8s-snap/actions/runs/20333205622/job/58413262584?pr=2206)

## Solution

The script now dynamically infers the Go version from the containerd `go.mod` file which will avoid breaking it in the future again.

## Backport

Up to 1.34 for FIPS
