### PR TITLE
docs: Rework the layout of the DISA STIG install page  [Backport release-1.35]

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/fips.md
+++ b/docs/canonicalk8s/snap/howto/install/fips.md
@@ -1,15 +1,13 @@
 # How to install a FIPS compliant Kubernetes cluster
 
+```{versionadded} release-1.34
+```
+
 The [Federal Information Processing Standard (FIPS) 140-3] is a US government
 security standard regulating the use of cryptography. Compliance is crucial for
 US government and regulated industries. This how-to guide provides the steps to
 set up a FIPS compliant Kubernetes cluster using the {{ product }} snap.
 
-```{note}
-FIPS is only available in the `k8s` snap release 1.34 and later. If you are
-using an earlier version, you will need to upgrade to a newer version of the
-snap to use FIPS mode.
-```
 
 ## Prerequisites
 

--- a/docs/canonicalk8s/snap/reference/config-files/disa-stig-config.md
+++ b/docs/canonicalk8s/snap/reference/config-files/disa-stig-config.md
@@ -1,0 +1,44 @@
+# DISA STIG example configuration files
+
+During the [installation of a DISA STIG hardened cluster], {{product}} provides
+default configuration files for cluster formation, control plane join and 
+worker join that automatically apply the following DISA STIG recommendations.  
+
+## Example control plane configuration files
+
+`/var/snap/k8s/common/etc/configurations/disa-stig/bootstrap.yaml` is the
+configuration file for bootstrapping the first node
+of a cluster. 
+
+`/var/snap/k8s/common/etc/configurations/disa-stig/control-plane.yaml` is the
+control plane node join configuration file for joining additional control plane
+nodes. 
+
+Both of these configuration files
+apply settings to align with the following recommendations:
+
+| STIG                                                                               | Summary                                                               |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| {ref}`242384`                                                                         | The Kubernetes Scheduler must have secure binding                     |
+| {ref}`242385`                                                                        | The Kubernetes Controller Manager must have secure binding            |
+| {ref}`242400`                                                                         | The Kubernetes API server must have Alpha APIs disabled               |
+| {ref}`242402`, {ref}`242403`, {ref}`242461`, {ref}`242462`, {ref}`242463`, {ref}`242464`, {ref}`242465` | The Kubernetes API Server must have an audit log configured           |
+| {ref}`242434`                                                                         | Kubernetes Kubelet must enable kernel protection                      |
+| {ref}`245541`                                                                         | Kubernetes Kubelet must not disable timeouts                          |
+| {ref}`254800`                                                                         | Kubernetes must have a Pod Security Admission control file configured |
+
+## Example worker node join configuration file
+
+`/var/snap/k8s/common/etc/configurations/disa-stig/worker.yaml` is the
+worker node join configuration file
+for joining worker nodes.
+
+It applies settings to align with the following recommendations:
+
+| STIG       | Summary                                          |
+| ---------- | ------------------------------------------------ |
+| {ref}`242434` | Kubernetes Kubelet must enable kernel protection |
+| {ref}`245541` | Kubernetes Kubelet must not disable timeouts     |
+
+<!-- LINKS -->
+[installation of a DISA STIG hardened cluster]: /snap/howto/install/disa-stig.md

--- a/docs/canonicalk8s/snap/reference/config-files/index.md
+++ b/docs/canonicalk8s/snap/reference/config-files/index.md
@@ -1,20 +1,23 @@
 # Configuration files
 
-```{toctree}
-:hidden:
-Configuration Files <self>
-```
-
 {{product}} uses several configuration files to control its behavior and
-settings. Links below provides detailed information about each configuration
-file.
+settings. 
+
+## Cluster initialization 
 
 ```{toctree}
 :glob:
 :titlesonly:
+Bootstrap <bootstrap-config.md>
+Worker node join <worker-join-config.md>
+Control plane node join <control-plane-join-config.md>
+DISA STIG <disa-stig-config.md>
+```
 
-bootstrap-config
-control-plane-join-config
-worker-join-config
-refresh-external-certs-config
+## Cluster certificates
+
+```{toctree}
+:glob:
+:titlesonly:
+Refresh certificates <refresh-external-certs-config.md>
 ```


### PR DESCRIPTION
## Description

Manual backport of DISA STIG rework to 1.35

## Solution

(cherry picked from commit a181dd449f80d385af95d30107ae76efd05dd7b6)

## Issue

N/A

## Backport

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.