### PR TITLE
fix: test_build error message differ in different OpenSSL versions [Backport to release-1.35]

### DIFF
--- a/tests/integration/tests/test_build.py
+++ b/tests/integration/tests/test_build.py
@@ -95,7 +95,7 @@ def test_build(instances: List[harness.Instance]):
         )
         LOG.info(result.stderr)
         assert result.stderr.startswith(
-            "panic: opensslcrypto: FIPS mode requested (environment variable GOFIPS) but not available in OpenSSL"
+            "panic: opensslcrypto: FIPS mode requested (environment variable GOFIPS) but not available"
         ) or result.stderr.startswith(
             "panic: opensslcrypto: can't enable FIPS mode for OpenSSL"
         ), f"{component} should fail with FIPS enabled on non-compliant system"


### PR DESCRIPTION
## Description

Backports #2208 to `release-1.35`