### PR TITLE
revert: "chore: run tests on both datastores (#1721) [Backport release-1.34]"

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -33,10 +33,6 @@ on:
         description: Test flavor (e.g. strict), leave empty for classic
         default: ""
         type: string
-      datastore:
-        description: Datastore backend to use for the tests (e.g. etcd, k8s-dqlite)
-        default: ""
-        type: string
       extra-test-args:
         description: |
           Additional pytest arguments, use "-k <test_name>" to run a specific test
@@ -210,7 +206,6 @@ jobs:
           TEST_LXD_IMAGE: ${{ inputs.os }}
           TEST_MULTIPASS_IMAGE: ${{ inputs.os }}
           TEST_FLAVOR: ${{ inputs.flavor }}
-          TEST_DATASTORE: ${{ inputs.datastore }}
           TEST_INSPECTION_REPORTS_DIR: ${{ github.workspace }}/inspection-reports/${{ inputs.parallel && env.test_name || '' }}
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6"
           TEST_VERSION_DOWNGRADE_CHANNELS: "recent 6"

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -129,13 +129,11 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-        datastore: [etcd, k8s-dqlite]
     needs: [build-snap, get-e2e-tags, go-lint-and-unit, python-lint]
     uses: ./.github/workflows/e2e-tests.yaml
     with:
       arch: ${{ matrix.arch }}
       os: ubuntu:24.04
-      datastore: ${{ matrix.datastore }}
       test-tags: ${{ needs.get-e2e-tags.outputs.test-tags }}
       artifact: k8s-${{ matrix.arch }}.snap
       parallel: true

--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -31,25 +31,6 @@ jobs:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
       LAUNCHPAD_K8S_CI_BOT_PASSWORD: ${{ secrets.LAUNCHPAD_K8S_CI_BOT_PASSWORD }}
 
-  test-spread-datastore:
-    name: Spread tests across different datastores
-    strategy:
-      matrix:
-        arch: ["amd64", "arm64"]
-        datastore: ["etcd", "k8s-dqlite"]
-        channel: ["latest/edge"]
-      fail-fast: false
-    uses: ./.github/workflows/e2e-tests.yaml
-    with:
-      arch: ${{ matrix.arch }}
-      datastore: ${{ matrix.datastore }}
-      channel: ${{ matrix.channel }}
-      test-tags: "up_to_nightly"
-      parallel: true
-      # We need to reduce the max parallelism here to avoid occupying all runners.
-      # os * arch * channel * max-parallel = 160 jobs
-      max-parallel: 10
-
   Mattermost:
     name: Notify Mattermost
     # Notify on success or failure but only if the event is a scheduled run.

--- a/tests/integration/templates/bootstrap-k8s-dqlite.yaml
+++ b/tests/integration/templates/bootstrap-k8s-dqlite.yaml
@@ -1,11 +1,18 @@
 # Contains the bootstrap configuration for the session instance of the integration tests.
 # The session instance persists over test runs and is used to speed-up the integration tests.
+datastore-type: k8s-dqlite
 cluster-config:
   network:
     enabled: true
   dns:
     enabled: true
+  ingress:
+    enabled: true
+  load-balancer:
+    enabled: true
   local-storage:
     enabled: true
   gateway:
+    enabled: true
+  metrics-server:
     enabled: true

--- a/tests/integration/templates/bootstrap-smoke.yaml
+++ b/tests/integration/templates/bootstrap-smoke.yaml
@@ -28,7 +28,5 @@ extra-node-kubelet-args:
   --authentication-token-webhook-cache-ttl: 3m
 extra-node-containerd-args:
   --log-level: debug
-extra-node-k8s-dqlite-args:
-  --watch-storage-available-size-interval: 6s
 extra-node-etcd-args:
   --log-level: "info"

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -162,9 +162,7 @@ def pytest_configure(config):
             Only required for additional ports. k8s-snap default ports are expected to be open.\n"
         "no_setup: No setup steps (pushing snap, bootstrapping etc.) are performed on any node for this test.\n"
         "containerd_cfgdir: The instance containerd config directory, defaults to /etc/containerd."
-        "datastore_type: Specify the datastore type to use for the cluster (etcd or k8s-dqlite).\n"
-        "infra_network_type: Specify network type to use for the infrastructure (IPv4, Dualstack or IPv6).\n"
-        "cluster_network_type: Specify network type to use for the cluster (IPv4, Dualstack or IPv6).\n"
+        "network_type: Specify network type to use for the infrastructure (IPv4, Dualstack or IPv6).\n"
         "etcd_count: Mark a test to specify how many etcd instance nodes need to be created (None by default)\n"
         "node_count: Mark a test to specify how many instance nodes need to be created\n"
         "snap_versions: Mark a test to specify snap_versions for each node\n",
@@ -229,36 +227,12 @@ def bootstrap_config(request) -> Union[str, None]:
 
 
 @pytest.fixture(scope="function")
-def datastore_type(request) -> Union[str, None]:
-    datastore_type_marker = request.node.get_closest_marker("datastore_type")
-    if not datastore_type_marker:
-        return config.DATASTORE
-    datastore_type, *_ = datastore_type_marker.args
-    if datastore_type not in ("etcd", "k8s-dqlite"):
-        raise ValueError(
-            f"Invalid datastore_type marker value: {datastore_type}. Must be 'etcd' or 'k8s-dqlite'."
-        )
-    return datastore_type
-
-
-@pytest.fixture(scope="function")
-def infra_network_type(request) -> Union[str, None]:
-    infra_network_type_marker = request.node.get_closest_marker("infra_network_type")
-    if not infra_network_type_marker:
+def network_type(request) -> Union[str, None]:
+    bootstrap_config_marker = request.node.get_closest_marker("network_type")
+    if not bootstrap_config_marker:
         return "IPv4"
-    infra_network_type, *_ = infra_network_type_marker.args
-    return infra_network_type
-
-
-@pytest.fixture(scope="function")
-def cluster_network_type(request) -> Union[str, None]:
-    cluster_network_type_marker = request.node.get_closest_marker(
-        "cluster_network_type"
-    )
-    if not cluster_network_type_marker:
-        return "IPv4"
-    cluster_network_type, *_ = cluster_network_type_marker.args
-    return cluster_network_type
+    network_type, *_ = bootstrap_config_marker.args
+    return network_type
 
 
 @pytest.fixture(scope="function")
@@ -282,9 +256,7 @@ def instances(
     containerd_cfgdir: str,
     bootstrap_config: Union[str, None],
     request,
-    infra_network_type: str,
-    cluster_network_type: str,
-    datastore_type: str,
+    network_type: str,
 ) -> Generator[List[harness.Instance], None, None]:
     """Construct instances for a cluster.
 
@@ -298,7 +270,7 @@ def instances(
 
     for _, snap in zip(range(node_count), snap_versions(request)):
         # Create <node_count> instances and setup the k8s snap in each.
-        instance = h.new_instance(network_type=infra_network_type)
+        instance = h.new_instance(network_type=network_type)
         instances.append(instance)
 
         util.preload_snaps(instance)
@@ -318,16 +290,13 @@ def instances(
     if not disable_k8s_bootstrapping and not no_setup:
         first_node, *_ = instances
 
-        extra_args = []
-        if cluster_network_type == "IPv6":
-            extra_args.extend(["--address", "::/0"])
-
-        util.bootstrap(
-            first_node,
-            datastore_type=datastore_type,
-            bootstrap_config=bootstrap_config,
-            extra_args=extra_args,
-        )
+        if bootstrap_config:
+            first_node.exec(
+                ["k8s", "bootstrap", "--file", "-"],
+                input=str.encode(bootstrap_config),
+            )
+        else:
+            first_node.exec(["k8s", "bootstrap"])
 
     yield instances
 

--- a/tests/integration/tests/performance/test_perf_clustering.py
+++ b/tests/integration/tests/performance/test_perf_clustering.py
@@ -4,39 +4,23 @@
 from typing import List
 
 import pytest
-import yaml
-from test_util import config, harness, tags, util
+from test_util import harness, tags, util
 
 
 @pytest.mark.node_count(1)
 @pytest.mark.no_setup()
 @pytest.mark.tags(tags.PERFORMANCE)
-def test_perf_clustering_bootstrap_cli(
-    instances: List[harness.Instance], benchmark, datastore_type: str
-):
+def test_perf_clustering_bootstrap_cli(instances: List[harness.Instance], benchmark):
     node = instances[0]
-    bootstrap_yaml_bytes = None
 
     def setup():
-        nonlocal bootstrap_yaml_bytes
         # TODO(ben): benchmark `teardown` function is implemented but not yet released
         # in 5.1.0. Once released, we can move this teardown logic in a separate function.
         # See https://github.com/ionelmc/pytest-benchmark/issues/270
         node.exec(["snap", "remove", "k8s", "--purge"])
         util.setup_k8s_snap(node)
 
-        # Prepare bootstrap configuration (move YAML operations out of benchmark)
-        default_config_path = config.MANIFESTS_DIR / "bootstrap-default.yaml"
-        bootstrap_config = yaml.safe_load(default_config_path.read_text())
-        bootstrap_config["datastore-type"] = datastore_type
-        bootstrap_yaml = yaml.dump(bootstrap_config, default_flow_style=False)
-        bootstrap_yaml_bytes = str.encode(bootstrap_yaml)
-
     def run():
-        # Only run the actual bootstrap command
-        node.exec(
-            ["k8s", "bootstrap", "--file", "-"],
-            input=bootstrap_yaml_bytes,
-        )
+        node.exec(["k8s", "bootstrap"])
 
     benchmark.pedantic(run, setup=setup, rounds=20)

--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -73,7 +73,7 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="runner size too small on multipass"
 )
-def test_airgapped_with_proxy(instances: List[harness.Instance], datastore_type: str):
+def test_airgapped_with_proxy(instances: List[harness.Instance]):
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
     instance_ip = util.get_default_ip(instance)
@@ -110,7 +110,7 @@ def test_airgapped_with_proxy(instances: List[harness.Instance], datastore_type:
     # Install and configure Kubernetes snap
     util.setup_k8s_snap(instance)
     setup_containerd_proxy(instance, proxy_ip)
-    util.bootstrap(instance, datastore_type=datastore_type)
+    instance.exec("sudo k8s bootstrap".split())
     util.wait_until_k8s_ready(instance, [instance])
 
 
@@ -124,7 +124,6 @@ def test_airgapped_with_image_mirror(
     h: harness.Harness,
     instances: List[harness.Instance],
     function_scoped_registry: reg.Registry,
-    datastore_type: str,
 ):
     proxy, instance = instances
     proxy_ip = util.get_default_ip(proxy)
@@ -158,7 +157,7 @@ def test_airgapped_with_image_mirror(
     )
 
     setup_containerd_proxy(registry.instance, proxy_ip)
-    util.bootstrap(registry.instance, datastore_type=datastore_type)
+    registry.exec("sudo k8s bootstrap".split())
 
     # Mirror images
     out = registry.exec(["k8s", "list-images"], capture_output=True, text=True)
@@ -228,5 +227,5 @@ def test_airgapped_with_image_mirror(
     restrict_network(instance, allow_ports=[REGISTRY_PORT])
     util.setup_k8s_snap(instance)
     registry.apply_configuration(instance)
-    util.bootstrap(instance, datastore_type=datastore_type)
+    instance.exec("sudo k8s bootstrap".split())
     util.wait_until_k8s_ready(instance, [instance])

--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -105,7 +105,7 @@ def test_skip_services_stop_on_remove(instances: List[harness.Instance]):
 # Old versions still use k8s-dqlite
 @pytest.mark.required_ports(9000)
 def test_disable_separate_feature_upgrades(
-    instances: List[harness.Instance], tmp_path: Path, datastore_type: str
+    instances: List[harness.Instance], tmp_path: Path
 ):
     cluster_node = instances[0]
     joining_cp = instances[1]
@@ -114,11 +114,14 @@ def test_disable_separate_feature_upgrades(
     for instance in instances:
         instance.exec(f"snap install k8s --classic --channel={start_branch}".split())
 
-    bootstrap_config = (
-        config.MANIFESTS_DIR / "bootstrap-disable-separate-feature-upgrades.yaml"
-    ).read_text()
-    util.bootstrap(
-        cluster_node, datastore_type=datastore_type, bootstrap_config=bootstrap_config
+    cluster_node.exec(
+        "k8s bootstrap --file -".split(),
+        input=str.encode(
+            (
+                config.MANIFESTS_DIR
+                / "bootstrap-disable-separate-feature-upgrades.yaml"
+            ).read_text()
+        ),
     )
 
     util.wait_until_k8s_ready(cluster_node, [cluster_node])

--- a/tests/integration/tests/test_clustering_dqlite.py
+++ b/tests/integration/tests/test_clustering_dqlite.py
@@ -1,0 +1,94 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+import logging
+from typing import List
+
+import pytest
+from test_util import config, harness, tags, util
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.mark.node_count(4)
+@pytest.mark.tags(tags.PULL_REQUEST)
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-k8s-dqlite.yaml").read_text()
+)
+# For k8s-dqlite
+@pytest.mark.required_ports(9000)
+def test_control_plane_nodes_dqlite(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_node_1 = instances[1]
+    joining_node_2 = instances[2]
+    joining_node_3 = instances[3]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    join_token = util.get_join_token(cluster_node, joining_node_1)
+    util.join_cluster(joining_node_1, join_token)
+
+    join_token = util.get_join_token(cluster_node, joining_node_2)
+    util.join_cluster(joining_node_2, join_token)
+
+    join_token = util.get_join_token(cluster_node, joining_node_3)
+    util.join_cluster(joining_node_3, join_token)
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "control-plane" in util.get_local_node_status(joining_node_1)
+    assert "control-plane" in util.get_local_node_status(joining_node_2)
+    assert "control-plane" in util.get_local_node_status(joining_node_3)
+
+    # Verify that the initial node can be removed
+    joining_node_1.exec(["k8s", "remove-node", cluster_node.id])
+    util.stubbornly(retries=5, delay_s=3).until(
+        lambda _: not util.diverged_cluster_memberships(
+            joining_node_1, [joining_node_1, joining_node_2, joining_node_3]
+        )
+    )
+
+    # Verify that a node can remove itself
+    joining_node_2.exec(["k8s", "remove-node", joining_node_1.id])
+    util.stubbornly(retries=5, delay_s=3).until(
+        lambda _: not util.diverged_cluster_memberships(
+            joining_node_2, [joining_node_2, joining_node_3]
+        )
+    )
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.PULL_REQUEST)
+@pytest.mark.bootstrap_config(
+    (config.MANIFESTS_DIR / "bootstrap-k8s-dqlite.yaml").read_text()
+)
+def test_worker_nodes_dqlite(instances: List[harness.Instance]):
+    cluster_node = instances[0]
+    joining_node = instances[1]
+    other_joining_node = instances[2]
+
+    util.wait_until_k8s_ready(cluster_node, [cluster_node])
+
+    join_token = util.get_join_token(cluster_node, joining_node, "--worker")
+    join_token_2 = util.get_join_token(cluster_node, other_joining_node, "--worker")
+
+    assert join_token != join_token_2
+
+    util.join_cluster(joining_node, join_token)
+
+    util.join_cluster(other_joining_node, join_token_2)
+
+    util.wait_until_k8s_ready(cluster_node, instances)
+
+    assert "control-plane" in util.get_local_node_status(cluster_node)
+    assert "worker" in util.get_local_node_status(joining_node)
+    assert "worker" in util.get_local_node_status(other_joining_node)
+
+    cluster_node.exec(["k8s", "remove-node", joining_node.id])
+    nodes = util.ready_nodes(cluster_node)
+    assert len(nodes) == 2, "worker should have been removed from cluster"
+    assert cluster_node.id in [
+        node["metadata"]["name"] for node in nodes
+    ] and other_joining_node.id in [
+        node["metadata"]["name"] for node in nodes
+    ], f"only {cluster_node.id} should be left in cluster"

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -195,7 +195,7 @@ def delete_nginx_pod(instance: harness.Instance):
 @pytest.mark.tags(tags.NIGHTLY)
 # For communication with Vault
 @pytest.mark.required_ports(8200)
-def test_vault_intermediate_ca(instances: List[harness.Instance], datastore_type: str):
+def test_vault_intermediate_ca(instances: List[harness.Instance]):
     instance = instances[0]
     cp_node = instances[1]
     worker_node = instances[2]
@@ -231,8 +231,9 @@ def test_vault_intermediate_ca(instances: List[harness.Instance], datastore_type
         }
     )
 
-    util.bootstrap(
-        instance, datastore_type=datastore_type, bootstrap_config=bootstrap_config
+    instance.exec(
+        ["k8s", "bootstrap", "--file", "-"],
+        input=str.encode(yaml.dump(bootstrap_config)),
     )
 
     # Add a control plane node and a worker node.
@@ -254,7 +255,7 @@ def test_vault_intermediate_ca(instances: List[harness.Instance], datastore_type
 @pytest.mark.tags(tags.NIGHTLY)
 # For communication with Vault
 @pytest.mark.required_ports(8200)
-def test_vault_certificates(instances: List[harness.Instance], datastore_type: str):
+def test_vault_certificates(instances: List[harness.Instance]):
     instance = instances[0]
     bootstrap_node_ip = util.get_default_ip(instance)
     bootstrap_node_hostname = util.hostname(instance)
@@ -336,8 +337,9 @@ def test_vault_certificates(instances: List[harness.Instance], datastore_type: s
     bootstrap_config.pop("kube-controller-manager-client-key")
 
     LOG.info("Certificates are ready. Bootstrapping.")
-    util.bootstrap(
-        instance, datastore_type=datastore_type, bootstrap_config=bootstrap_config
+    instance.exec(
+        ["k8s", "bootstrap", "--file", "-"],
+        input=str.encode(yaml.dump(bootstrap_config)),
     )
 
     # Add a control plane node.
@@ -458,7 +460,7 @@ def test_vault_certificates(instances: List[harness.Instance], datastore_type: s
 @pytest.mark.tags(tags.NIGHTLY)
 # For communication with Vault
 @pytest.mark.required_ports(8200)
-def test_partial_refresh(instances: List[harness.Instance], datastore_type: str):
+def test_partial_refresh(instances: List[harness.Instance]):
     instance = instances[0]
     bootstrap_node_ip = util.get_default_ip(instance)
     bootstrap_node_hostname = util.hostname(instance)
@@ -510,8 +512,9 @@ def test_partial_refresh(instances: List[harness.Instance], datastore_type: str)
     create_and_assign_certs(client, bootstrap_certs.items(), bootstrap_config)
 
     LOG.info("Certificates are ready. Bootstrapping.")
-    util.bootstrap(
-        instance, datastore_type=datastore_type, bootstrap_config=bootstrap_config
+    instance.exec(
+        ["k8s", "bootstrap", "--file", "-"],
+        input=str.encode(yaml.dump(bootstrap_config)),
     )
 
     # Add a control plane node.

--- a/tests/integration/tests/test_external_etcd.py
+++ b/tests/integration/tests/test_external_etcd.py
@@ -6,6 +6,7 @@ import logging
 from typing import List
 
 import pytest
+import yaml
 from test_util import harness, tags, util
 from test_util.etcd import EtcdCluster
 
@@ -19,17 +20,23 @@ LOG = logging.getLogger(__name__)
 def test_external_etcd(instances: List[harness.Instance], etcd_cluster: EtcdCluster):
     k8s_instance = instances[0]
 
-    bootstrap_conf = {
-        "cluster-config": {"network": {"enabled": True}, "dns": {"enabled": True}},
-        "datastore-servers": etcd_cluster.client_urls,
-        "datastore-ca-crt": etcd_cluster.ca_cert,
-        "datastore-client-crt": etcd_cluster.cert,
-        "datastore-client-key": etcd_cluster.key,
-    }
-
-    util.bootstrap(
-        k8s_instance, datastore_type="external", bootstrap_config=bootstrap_conf
+    bootstrap_conf = yaml.safe_dump(
+        {
+            "cluster-config": {"network": {"enabled": True}, "dns": {"enabled": True}},
+            "datastore-type": "external",
+            "datastore-servers": etcd_cluster.client_urls,
+            "datastore-ca-crt": etcd_cluster.ca_cert,
+            "datastore-client-crt": etcd_cluster.cert,
+            "datastore-client-key": etcd_cluster.key,
+        }
     )
+
+    k8s_instance.exec(
+        ["dd", "of=/root/config.yaml"],
+        input=str.encode(bootstrap_conf),
+    )
+
+    k8s_instance.exec(["k8s", "bootstrap", "--file", "/root/config.yaml"])
     util.wait_for_dns(k8s_instance)
     util.wait_for_network(k8s_instance)
 

--- a/tests/integration/tests/test_feature_controller.py
+++ b/tests/integration/tests/test_feature_controller.py
@@ -15,6 +15,7 @@ STATUS_PATTERNS = [
     r"cluster status:\s*ready",
     r"control plane nodes:\s*(\d{1,3}(?:\.\d{1,3}){3}:\d{1,5})\s\(voter\)",
     r"high availability:\s*no",
+    r"datastore:\s*etcd",
     r"network:\s*enabled",
     r"dns:\s*enabled at (\d{1,3}(?:\.\d{1,3}){3})",
     r"ingress:\s*enabled",
@@ -25,12 +26,10 @@ STATUS_PATTERNS = [
 
 
 @pytest.mark.tags(tags.PULL_REQUEST)
-def test_feature_controller(instances: List[harness.Instance], datastore_type: str):
+def test_feature_controller(instances: List[harness.Instance]):
     """
     Verifies that the feature controller won't get stuck in a chaotic situation.
     """
-    status_patterns = STATUS_PATTERNS.copy()
-    status_patterns.insert(3, r"datastore:\s*{}".format(datastore_type))
 
     instance = instances[0]
 
@@ -80,14 +79,14 @@ def test_feature_controller(instances: List[harness.Instance], datastore_type: s
 
     def status_output_matches(p: subprocess.CompletedProcess) -> bool:
         result_lines = p.stdout.decode().strip().split("\n")
-        if len(result_lines) != len(status_patterns):
+        if len(result_lines) != len(STATUS_PATTERNS):
             LOG.info(
-                f"wrong number of results lines, expected {len(status_patterns)}, got {len(result_lines)}"
+                f"wrong number of results lines, expected {len(STATUS_PATTERNS)}, got {len(result_lines)}"
             )
             return False
 
         for i in range(len(result_lines)):
-            line, pattern = result_lines[i], status_patterns[i]
+            line, pattern = result_lines[i], STATUS_PATTERNS[i]
             if not re.search(pattern, line):
                 LOG.info(f"could not match `{line.strip()}` with `{pattern}`")
                 return False

--- a/tests/integration/tests/test_loadbalancer.py
+++ b/tests/integration/tests/test_loadbalancer.py
@@ -2,61 +2,72 @@
 # Copyright 2025 Canonical, Ltd.
 #
 import logging
+from enum import Enum
 from pathlib import Path
 from typing import List
 
 import pytest
-from test_util import config, harness, tags, util
+from test_util import harness, tags, util
 from test_util.config import MANIFESTS_DIR, SUBSTRATE
 
 LOG = logging.getLogger(__name__)
 
 
+class K8sNetType(Enum):
+    ipv4 = "ipv4"
+    ipv6 = "ipv6"
+    dualstack = "dualstack"
+
+
 @pytest.mark.node_count(2)
 @pytest.mark.tags(tags.PULL_REQUEST)
+@pytest.mark.disable_k8s_bootstrapping()
 # For loadbalancer communication
 @pytest.mark.required_ports(80)
-def test_loadbalancer_ipv4(
-    instances: List[harness.Instance], cluster_network_type: str
-):
-    _test_loadbalancer(instances, cluster_network_type)
+def test_loadbalancer_ipv4(instances: List[harness.Instance]):
+    _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv4)
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.tags(tags.PULL_REQUEST)
+@pytest.mark.skipif(
+    SUBSTRATE == "multipass", reason="QUEMU does not properly support IPv6"
+)
+def test_loadbalancer_ipv6_only(instances: List[harness.Instance]):
+    _test_loadbalancer(instances, k8s_net_type=K8sNetType.ipv6)
 
 
 @pytest.mark.node_count(2)
 @pytest.mark.tags(tags.PULL_REQUEST)
-@pytest.mark.bootstrap_config(
-    (config.MANIFESTS_DIR / "bootstrap-ipv6-only.yaml").read_text()
-)
-@pytest.mark.infra_network_type("Dualstack")
-@pytest.mark.cluster_network_type("IPv6")
+@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.dualstack()
+@pytest.mark.network_type("dualstack")
 @pytest.mark.skipif(
     SUBSTRATE == "multipass", reason="QUEMU does not properly support IPv6"
 )
-def test_loadbalancer_ipv6_only(
-    instances: List[harness.Instance], cluster_network_type: str
-):
-    _test_loadbalancer(instances, cluster_network_type)
+def test_loadbalancer_ipv6_dualstack(instances: List[harness.Instance]):
+    _test_loadbalancer(instances, k8s_net_type=K8sNetType.dualstack)
 
 
-@pytest.mark.node_count(2)
-@pytest.mark.tags(tags.PULL_REQUEST)
-@pytest.mark.bootstrap_config(
-    (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
-)
-@pytest.mark.infra_network_type("Dualstack")
-@pytest.mark.cluster_network_type("Dualstack")
-@pytest.mark.skipif(
-    SUBSTRATE == "multipass", reason="QUEMU does not properly support IPv6"
-)
-def test_loadbalancer_ipv6_dualstack(
-    instances: List[harness.Instance], cluster_network_type: str
-):
-    _test_loadbalancer(instances, cluster_network_type)
-
-
-def _test_loadbalancer(instances: List[harness.Instance], network_type: str):
+def _test_loadbalancer(instances: List[harness.Instance], k8s_net_type: K8sNetType):
     instance = instances[0]
     tester_instance = instances[1]
+
+    if k8s_net_type == K8sNetType.ipv6:
+        bootstrap_config = (MANIFESTS_DIR / "bootstrap-ipv6-only.yaml").read_text()
+        instance.exec(
+            ["k8s", "bootstrap", "--file", "-", "--address", "::/0"],
+            input=str.encode(bootstrap_config),
+        )
+    elif k8s_net_type == K8sNetType.dualstack:
+        bootstrap_config = (MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
+        instance.exec(
+            ["k8s", "bootstrap", "--file", "-"],
+            input=str.encode(bootstrap_config),
+        )
+    else:
+        instance.exec(["k8s", "bootstrap"])
 
     lb_cidrs = []
 
@@ -72,9 +83,9 @@ def _test_loadbalancer(instances: List[harness.Instance], network_type: str):
         )
         return lb_cidr
 
-    if network_type in ("IPv4", "Dualstack"):
+    if k8s_net_type in (K8sNetType.ipv4, K8sNetType.dualstack):
         lb_cidrs.append(get_lb_cidr(ipv6_cidr=False))
-    if network_type in ("IPv6", "Dualstack"):
+    if k8s_net_type in (K8sNetType.ipv6, K8sNetType.dualstack):
         lb_cidrs.append(get_lb_cidr(ipv6_cidr=True))
     lb_cidr_str = ",".join(lb_cidrs)
 

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -16,8 +16,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.bootstrap_config(
     (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
 )
-@pytest.mark.infra_network_type("Dualstack")
-@pytest.mark.cluster_network_type("Dualstack")
+@pytest.mark.dualstack()
 @pytest.mark.tags(tags.NIGHTLY)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="QUEMU does not properly support IPv6"
@@ -110,11 +109,8 @@ def test_dualstack(instances: List[harness.Instance]):
 
 
 @pytest.mark.node_count(3)
-@pytest.mark.bootstrap_config(
-    (config.MANIFESTS_DIR / "bootstrap-ipv6-only.yaml").read_text()
-)
-@pytest.mark.infra_network_type("Dualstack")
-@pytest.mark.cluster_network_type("IPv6")
+@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.network_type("dualstack")
 @pytest.mark.tags(tags.NIGHTLY)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="QUEMU does not properly support IPv6"
@@ -123,6 +119,15 @@ def test_ipv6_only_on_dualstack_infra(instances: List[harness.Instance]):
     main = instances[0]
     joining_cp = instances[1]
     joining_worker = instances[2]
+
+    ipv6_bootstrap_config = (
+        config.MANIFESTS_DIR / "bootstrap-ipv6-only.yaml"
+    ).read_text()
+
+    main.exec(
+        ["k8s", "bootstrap", "--file", "-", "--address", "::/0"],
+        input=str.encode(ipv6_bootstrap_config),
+    )
 
     join_token = util.get_join_token(main, joining_cp)
     joining_cp.exec(["k8s", "join-cluster", join_token, "--address", "::/0"])

--- a/tests/integration/tests/test_node_availability_zone.py
+++ b/tests/integration/tests/test_node_availability_zone.py
@@ -7,7 +7,7 @@ import struct
 from typing import List
 
 import pytest
-from test_util import harness, tags, util
+from test_util import config, harness, tags, util
 
 LOG = logging.getLogger(__name__)
 
@@ -21,13 +21,15 @@ def _get_failure_domain(availability_zone: str) -> int:
 
 @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.parametrize("same_az", (False, True))
+@pytest.mark.parametrize("datastore", ("k8s-dqlite", "etcd"))
 # For k8s-dqlite
 @pytest.mark.required_ports(9000)
 def test_node_availability_zone(
     instances: List[harness.Instance],
     same_az: bool,
-    datastore_type: str,
+    datastore: str,
 ):
     # Steps:
     # * create a three-node cluster
@@ -39,6 +41,18 @@ def test_node_availability_zone(
     #     domain changes to be applied. We need to make sure that this doesn't
     #     lead to a quorum loss.
     initial_node = instances[0]
+
+    if datastore == "k8s-dqlite":
+        bootstrap_config = (
+            config.MANIFESTS_DIR / "bootstrap-k8s-dqlite.yaml"
+        ).read_text()
+    else:
+        bootstrap_config = (config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text()
+
+    initial_node.exec(
+        ["k8s", "bootstrap", "--file", "-"],
+        input=str.encode(bootstrap_config),
+    )
 
     util.wait_until_k8s_ready(initial_node, [initial_node])
 
@@ -103,7 +117,7 @@ def test_node_availability_zone(
                 ]
             )
 
-            if datastore_type == "k8s-dqlite":
+            if datastore == "k8s-dqlite":
                 # Check k8s-dqlite.
                 util.stubbornly(retries=5, delay_s=10).on(instance).until(
                     lambda p: str(failure_domain) in p.stdout.decode()

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -39,10 +39,6 @@ REGISTRY_VERSION = os.getenv("REGISTRY_VERSION") or "v2.8.3"
 # FLAVOR is the flavor of the snap to use.
 FLAVOR = os.getenv("TEST_FLAVOR") or "classic"
 
-# DATASTORE is the datastore backend to use for the tests.
-# One of 'etcd' (default), or 'k8s-dqlite'.
-DATASTORE = os.getenv("TEST_DATASTORE") or "etcd"
-
 # SNAP is the absolute path to the snap against which we run the integration tests.
 SNAP = os.getenv("TEST_SNAP")
 

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -13,7 +13,7 @@ import urllib.request
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Union
+from typing import Any, Callable, List, Mapping, Optional, Union
 
 import pytest
 import yaml
@@ -498,37 +498,6 @@ def ready_nodes(control_node: harness.Instance) -> List[Any]:
         for node in get_nodes(control_node)
         if is_node_ready(control_node, node_dict=node)
     ]
-
-
-# Bootstrap the instance
-def bootstrap(
-    instance: harness.Instance,
-    datastore_type: str,
-    bootstrap_config: Optional[Union[Dict[str, Any], str]] = None,
-    extra_args: Optional[List[str]] = None,
-    **kwargs,
-):
-    if bootstrap_config:
-        if isinstance(bootstrap_config, str):
-            # If bootstrap_config is a string, assume it's a YAML string
-            bootstrap_config = yaml.safe_load(bootstrap_config)
-    else:
-        # Use bootstrap-default.yaml as the base config
-        default_config_path = config.MANIFESTS_DIR / "bootstrap-default.yaml"
-        bootstrap_config = yaml.safe_load(default_config_path.read_text())
-
-    if not extra_args:
-        extra_args = []
-
-    # Add/update datastore-type and convert to YAML
-    bootstrap_config["datastore-type"] = datastore_type
-    modified_config = yaml.dump(bootstrap_config, default_flow_style=False)
-
-    return instance.exec(
-        ["k8s", "bootstrap", "--file", "-", *extra_args],
-        input=str.encode(modified_config),
-        **kwargs,
-    )
 
 
 # Create a token to join a node to an existing cluster

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -28,7 +28,6 @@ def test_version_upgrades(
     tmp_path,
     containerd_cfgdir: str,
     registry: Registry,
-    datastore_type: str,
 ):
     channels = config.VERSION_UPGRADE_CHANNELS
     cp = instances[0]
@@ -100,7 +99,7 @@ def test_version_upgrades(
         if config.USE_LOCAL_MIRROR:
             registry.apply_configuration(instance, containerd_cfgdir)
 
-    util.bootstrap(cp, datastore_type=datastore_type)
+    cp.exec(["k8s", "bootstrap"])
 
     join_token_cp1 = util.get_join_token(cp, cp1)
     join_token_cp2 = util.get_join_token(cp, cp2)
@@ -155,7 +154,6 @@ def test_version_downgrades_with_rollback(
     tmp_path,
     containerd_cfgdir: str,
     registry: Registry,
-    datastore_type: str,
 ):
     """
     This test will downgrade the snap through the channels, and at each downgrade, attempt a rollback.
@@ -212,7 +210,7 @@ def test_version_downgrades_with_rollback(
         if config.USE_LOCAL_MIRROR:
             registry.apply_configuration(instance, containerd_cfgdir)
 
-    util.bootstrap(cp, datastore_type=datastore_type)
+    cp.exec(["k8s", "bootstrap"])
 
     join_token_cp1 = util.get_join_token(cp, cp1)
     join_token_cp2 = util.get_join_token(cp, cp2)
@@ -297,9 +295,7 @@ def test_version_downgrades_with_rollback(
     not config.SNAP,
     reason="Feature upgrades require a local snap file",
 )
-def test_feature_upgrades_inplace(
-    instances: List[harness.Instance], tmp_path: Path, datastore_type: str
-):
+def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: Path):
     """Verify that feature upgrades function correctly.
 
     Note: This is an interim test that will be expanded as feature upgrades mature.
@@ -326,7 +322,7 @@ def test_feature_upgrades_inplace(
             ]
         )
 
-    util.bootstrap(bootstrap_cp, datastore_type=datastore_type)
+    bootstrap_cp.exec(["k8s", "bootstrap"])
     for instance in instances:
         if instance.id in [bootstrap_cp.id, worker.id]:
             continue
@@ -486,7 +482,7 @@ def _get_upgrade_crs(instance: harness.Instance) -> List[dict]:
     reason="The node removal does not work consistently due to a microcluster bug."
 )
 def test_feature_upgrades_rollout_upgrade(
-    instances: List[harness.Instance], tmp_path: Path, datastore_type: str
+    instances: List[harness.Instance], tmp_path: Path
 ):
     """ """
     # TODO: Ensure that this test only runs on different k8s versions.
@@ -504,7 +500,7 @@ def test_feature_upgrades_rollout_upgrade(
         ["snap", "install", "k8s", "--classic", *util.snap_channel_args(start_snap)]
     )
 
-    util.bootstrap(main_old, datastore_type=datastore_type)
+    main_old.exec(["k8s", "bootstrap"])
     for instance in instances[1:3]:
         token = util.get_join_token(main_old, instance)
         instance.exec(["k8s", "join-cluster", token])


### PR DESCRIPTION
Reverts canonical/k8s-snap#2103

The k8s-dqlite test introduce a lot of friction/issues in the CI without much use given the new etcd direction.