### PR TITLE
fix: expand test matrix to include release 1.35

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -14,24 +14,24 @@ permissions:
 
 jobs:
   Trivy:
-   permissions:
-     contents: read # for actions/checkout to fetch code
-     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-   strategy:
-     matrix:
-       include:
-         # Latest branches
-         - { branch: main, channel: latest/edge }
-         # Stable branches
-         # Add branches to test here
-         # TODO: automatically retrieve the list of channels.
-         - { branch: release-1.32, channel: 1.32-classic/edge }
-         - { branch: release-1.33, channel: 1.33-classic/edge }
-         - { branch: release-1.34, channel: 1.34-classic/edge }
-   uses: ./.github/workflows/security-scan.yaml
-   with:
-     channel: ${{ matrix.channel }}
-     checkout-ref: ${{ matrix.branch }}
-     upload-reports-to-jira: true
-   secrets: inherit
-
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    strategy:
+      matrix:
+        include:
+          # Latest branches
+          - { branch: main, channel: latest/edge }
+          # Stable branches
+          # Add branches to test here
+          # TODO: automatically retrieve the list of channels.
+          - { branch: release-1.32, channel: 1.32-classic/edge }
+          - { branch: release-1.33, channel: 1.33-classic/edge }
+          - { branch: release-1.34, channel: 1.34-classic/edge }
+          - { branch: release-1.35, channel: 1.35-classic/edge }
+    uses: ./.github/workflows/security-scan.yaml
+    with:
+      channel: ${{ matrix.channel }}
+      checkout-ref: ${{ matrix.branch }}
+      upload-reports-to-jira: true
+    secrets: inherit

--- a/.github/workflows/update-components.yaml
+++ b/.github/workflows/update-components.yaml
@@ -25,6 +25,7 @@ jobs:
           # Keep main branch up to date
           - main
           # Supported release branches
+          - release-1.35
           - release-1.34
           - release-1.33
           - release-1.32
@@ -39,7 +40,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Description

Two of our workflows (trivy, update component version) do not include the release-1.35 (yet).

## Backport

1.35

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.
