### PR TITLE
fix: update metallb version in update component version CI

### DIFF
--- a/build-scripts/hack/update-component-versions.py
+++ b/build-scripts/hack/update-component-versions.py
@@ -47,7 +47,7 @@ HELM_BRANCH, HELM_RELEASE_SEMVER = "main", None
 
 # MetalLB Helm repository and chart version
 METALLB_REPO = "https://metallb.github.io/metallb"
-METALLB_CHART_VERSION = "0.14.8"
+METALLB_CHART_VERSION = "0.15.3"
 
 
 def is_valid_version(pinned_ver: None | Version) -> Callable[[None | Version], bool]:


### PR DESCRIPTION
## Description

Align MetalLB chart version in the component updater script to match the version currently deployed (0.15.3). Previously the script was pulling 0.14.8 while the runtime chart reference used 0.15.3.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
