### PR TITLE
test: fix network type issue from revert

### DIFF
--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -382,7 +382,7 @@ def test_dual_nic(instances: List[harness.Instance]):
 
 @pytest.mark.node_count(1)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.infra_network_type("fan")
+@pytest.mark.network_type("fan")
 @pytest.mark.tags(tags.NIGHTLY)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="Not implemented for multipass"


### PR DESCRIPTION
## Description

Fixes left over test fixture from #2232 

## Backport

`release-1.35`

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
