### PR TITLE
ci: Re-add status write permissions for PR linter

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Validate PR title
     permissions:
       pull-requests: write # to comment
-      statuses: write # to set status
+      statuses: write # to set commit status checks for the PR title lint
     runs-on: ubuntu-latest
     steps:
       # no-semantic label is handled by the next step.


### PR DESCRIPTION
Looks like the PR linter action actually needs the permission that we stripped in #2242