### PR TITLE
chore: update rawfile-localpv tag to include security patches [Backport release-1.33]

### DIFF
--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "0.8.2-ck1"
+	ImageTag = "0.8.3-ck0"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/k8s-snap/sig-storage/csi-node-driver-registrar:v2.10.1"


### PR DESCRIPTION
(cherry picked from commit 5ddfd0865060559d651a1ff8ccb381a38483a822)

Backports #2211 to `release-1.33`