### PR TITLE
chore: update go compiler dynamically for runc and containerd (#2209)

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -4,9 +4,10 @@
 INITIAL_GO_REVISION=$(snap list go | grep -E '^go\s' | awk '{print $3}')
 echo "Current Go snap revision: ${INITIAL_GO_REVISION}"
 
-# Refresh to go 1.23-fips/stable channel
-echo "Refreshing to go 1.23-fips/stable channel..."
-snap refresh go --channel=1.23-fips/stable
+# Refresh to go fips stable channel
+maj_min=$(awk '/^go /{print $2}' go.mod | cut -d. -f1,2)
+echo "Refreshing to go ${maj_min}-fips/stable channel..."
+snap refresh go --channel=${maj_min}-fips/stable
 
 INSTALL="${1}/bin"
 mkdir -p "${INSTALL}"

--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -4,9 +4,10 @@
 INITIAL_GO_REVISION=$(snap list go | grep -E '^go\s' | awk '{print $3}')
 echo "Current Go snap revision: ${INITIAL_GO_REVISION}"
 
-# Refresh to go 1.23-fips/stable channel
-echo "Refreshing to go 1.23-fips/stable channel..."
-snap refresh go --channel=1.23-fips/stable
+# Refresh to go fips stable channel
+maj_min=$(awk '/^go /{print $2}' go.mod | cut -d. -f1,2)
+echo "Refreshing to go ${maj_min}-fips/stable channel..."
+snap refresh go --channel=${maj_min}-fips/stable
 
 VERSION="${2}"
 


### PR DESCRIPTION
Manual backport of #2209

(cherry picked from commit de5d8116fb2791cd4362b10b61c6bea8c1863874)
