### PR TITLE
build: Don't fail if snap tries to revert to same version

### DIFF
--- a/build-scripts/components/containerd/build.sh
+++ b/build-scripts/components/containerd/build.sh
@@ -32,5 +32,5 @@ done
 # Restore the initial Go snap revision
 echo "Restoring Go snap to initial revision: ${INITIAL_GO_REVISION}"
 
-# Snap revert fails if the revision  is already the current one, so we ignore errors
+# Snap revert fails if the revision is already the current one, so we ignore errors
 snap revert go --revision="${INITIAL_GO_REVISION}" || true

--- a/build-scripts/components/runc/build.sh
+++ b/build-scripts/components/runc/build.sh
@@ -22,4 +22,6 @@ cp runc "${INSTALL}/runc"
 
 # Restore the initial Go snap revision
 echo "Restoring Go snap to initial revision: ${INITIAL_GO_REVISION}"
-snap revert go --revision="${INITIAL_GO_REVISION}"
+
+# Snap revert fails if the revision is already the current one, so we ignore errors
+snap revert go --revision="${INITIAL_GO_REVISION}" || true


### PR DESCRIPTION
`snap revert` fails if it tries to revert to the current running version.
This means that the containerd build script fails in cases where the snapcraft go revision is the same as the one required for containerd.

See e.g. https://github.com/canonical/k8s-snap/actions/runs/20992418274/job/60340929434?pr=2245#step:6:1597