### PR TITLE
test: Adjust e2e tests to support pulls from forks

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -62,6 +62,13 @@ on:
               "xlarge"
             ]
           }
+      test-collection-repo:
+        description: |
+          Repository to use for collecting tests. Can be used to override the default behavior of
+          collecting tests from the same repository as the workflow is running in.
+        type: string
+        required: false
+        default: ${{ github.repository }}
       test-collection-branch:
         description: |
           Branch to use for collecting tests. Can be used to override the default behavior of
@@ -121,6 +128,7 @@ jobs:
     outputs:
       tests: ${{ steps.collect-tests.outputs.tests }}
       test-runners: ${{ steps.compute-test-runners.outputs.test_runners }}
+      repo: ${{ steps.compute-ref.outputs.repo }}
       ref: ${{ steps.compute-ref.outputs.ref }}
     steps:
       - name: Compute ref for test collection
@@ -145,10 +153,12 @@ jobs:
           fi
 
           echo "Using git ref $REF for channel: $CHANNEL"
+          echo "repo=${{ inputs.test-collection-repo }}" >> $GITHUB_OUTPUT
           echo "ref=$REF" >> $GITHUB_OUTPUT
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          repository: ${{ steps.compute-ref.outputs.repo }}
           ref: ${{ steps.compute-ref.outputs.ref }}
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -200,6 +210,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          repository: ${{ needs.prepare.outputs.repo }}
           ref: ${{ needs.prepare.outputs.ref }}
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -138,6 +138,7 @@ jobs:
       os: ubuntu:24.04
       test-tags: ${{ needs.get-e2e-tags.outputs.test-tags }}
       artifact: k8s-${{ matrix.arch }}.snap
+      test-collection-repo: ${{github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       test-collection-branch: ${{ github.head_ref }}
       parallel: true
 


### PR DESCRIPTION
# DO NOT MERGE

This just tests if the same commit when raised from a repo/BRANCH works as well as a FORK/BRANCH
See instead 
* https://github.com/canonical/k8s-snap/pull/2282

When it is successful, this branch and PR can be deleted and closed