### PR TITLE
fix: containerd plugin initialization race

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Get e2e test tags
         id: get-e2e-tags
         run: |
-          tags="up_to_nightly"
+          tags="pull_request"
           if ${{ github.event_name == 'pull_request' }}; then
             # Run all tests if there are test changes. In case of a PR, we'll
             # get a merge commit that includes all changes.


### PR DESCRIPTION
* Retry plugin initialization because it can collide with containerd setup
* Avoid variable capturing by renaming "c" to "config"

This issue was introduced with the bump to containerd 2.6 in 1.35

See the following CI failures:
* https://github.com/canonical/k8s-snap/actions/runs/21133279201/job/60771361127?pr=2292#step:12:1805
* https://github.com/canonical/k8s-snap/actions/runs/21132623821/job/60777938745#step:11:1569

## Backport

1.35

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
