### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/canonicalk8s/capi/explanation/in-place-upgrades.md
+++ b/docs/canonicalk8s/capi/explanation/in-place-upgrades.md
@@ -126,7 +126,7 @@ The illustrated flow of orchestrated in-place upgrades:
 [img-orchestrated]: https://assets.ubuntu.com/v1/8f302a00-orchestrated.png
 
 <!-- LINKS -->
-[1]: https://cluster-api.sigs.k8s.io/user/concepts#machine-immutability-in-place-upgrade-vs-replace
+[1]: https://cluster-api.sigs.k8s.io/user/concepts#machine-immutability-in-place-update-vs-replace
 [2]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [3]: https://kubernetes.io/docs/concepts/overview/working-with-objects/#object-spec-and-status
 [4]: ../reference/annotations.md

--- a/docs/canonicalk8s/charm/reference/versions/1.34.md
+++ b/docs/canonicalk8s/charm/reference/versions/1.34.md
@@ -59,7 +59,7 @@ Many thanks to [@addyess], [@mateoflorido], [@baycarbone], [@nhennigan],
 [@rapour]
 
 <!--     MISC       -->
-[upstream release]: https://kubernetes.io/blog/2025/12/17/kubernetes-v1-34-release/
+[upstream release]: https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/
 [snap release page]: /snap/reference/versions/1.34.md
 
 <!-- LINKS -->


### PR DESCRIPTION
## Description

Fix 2 broken links identified in linkcheck updates

## Solution
Drive by fix

## Issue

N/A

## Backport

1.35, 1.34 need to be updated with both files. 1.33, and 1.32 only need the capi explanation link update 

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.