### PR TITLE
feat: in-memory join membership reverter

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -24,9 +24,65 @@ import (
 	"github.com/canonical/k8s/pkg/version"
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/microcluster/v2/state"
+	"github.com/go-logr/logr"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 )
+
+// RegisterK8sDqliteReverter registers the reverter for k8s-dqlite cleanup on join failure.
+func RegisterK8sDqliteReverter(log logr.Logger, snap snap.Snap, reverter *revert.Reverter) {
+	reverter.Add(func() {
+		if err := os.RemoveAll(snap.K8sDqliteStateDir()); err != nil {
+			log.Error(err, "failed to cleanup k8s-dqlite state directory")
+		}
+	})
+}
+
+// RegisterEtcdMemberReverter registers the reverter for etcd member removal on join failure.
+// It safely removes the member only if there are >2 endpoints to avoid quorum loss.
+func RegisterEtcdMemberReverter(log logr.Logger, snap snap.Snap, nodeName string, endpoints []string, reverter *revert.Reverter) {
+	reverter.Add(func() {
+		// Use an independent short-lived context for revert operations so
+		// they have a chance to complete even if the join hook's ctx has
+		// already been cancelled by a timeout.
+		rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// Only remove the member if we have more than 2 endpoints,
+		// otherwise we lose quorum in etcd when removing a member.
+		// In such cases the join revert will be manual to avoid
+		// quorum loss.
+		if len(endpoints) > 2 {
+			etcdClient, err := snap.EtcdClient(endpoints)
+			if err != nil {
+				log.Error(err, "failed to create etcd client for member removal using peer endpoints")
+			} else {
+				defer etcdClient.Close()
+				if err := etcdClient.RemoveNodeByName(rmCtx, nodeName); err != nil {
+					log.Error(err, "failed to remove node from etcd cluster using peer endpoints")
+				} else {
+					if err := os.RemoveAll(snap.EtcdDir()); err != nil {
+						log.Error(err, "failed to cleanup etcd state directory")
+					}
+				}
+			}
+		}
+	})
+}
+
+// RegisterK8sNodeDeletionReverter registers the reverter for Kubernetes Node object deletion on join failure.
+// This ensures no orphaned PENDING nodes remain if the join fails after kubelet registration.
+func RegisterK8sNodeDeletionReverter(log logr.Logger, k8sClient *kubernetes.Client, nodeName string, reverter *revert.Reverter) {
+	reverter.Add(func() {
+		// Use an independent short-lived context for revert operations.
+		rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if err := k8sClient.DeleteNode(rmCtx, nodeName); err != nil {
+			log.Error(err, "failed to remove node from kubernetes during join revert")
+		}
+	})
+}
 
 // onPostJoin is called when a control plane node joins the cluster.
 // onPostJoin retrieves the cluster config from the database and configures local services.
@@ -236,11 +292,7 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 			return fmt.Errorf("failed to configure k8s-dqlite with address=%s cluster=%v: %w", address, cluster, err)
 		}
 
-		reverter.Add(func() {
-			if err := os.RemoveAll(snap.K8sDqliteStateDir()); err != nil {
-				log.Error(err, "failed to cleanup k8s-dqlite state directory")
-			}
-		})
+		RegisterK8sDqliteReverter(log, snap, reverter)
 
 	case "etcd":
 		leader, err := s.Leader()
@@ -276,33 +328,8 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 			return fmt.Errorf("failed to add member %s to etcd cluster: %w", s.Name(), err)
 		}
 
-		reverter.Add(func() {
-			// Use an independent short-lived context for revert operations so
-			// they have a chance to complete even if the join hook's ctx has
-			// already been cancelled by a timeout.
-			rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			// Only remove the member if we have more than 2 endpoints,
-			// otherwise we lose quorum in etcd when removing a member.
-			// In such cases the join revert will be manual to avoid
-			// quorum loss.
-			if len(endpoints) > 2 {
-				etcdClient, err := snap.EtcdClient(endpoints)
-				if err != nil {
-					log.Error(err, "failed to create etcd client for member removal using peer endpoints")
-				} else {
-					defer etcdClient.Close()
-					if err := etcdClient.RemoveNodeByName(rmCtx, s.Name()); err != nil {
-						log.Error(err, "failed to remove node from etcd cluster using peer endpoints")
-					} else {
-						if err := os.RemoveAll(snap.EtcdDir()); err != nil {
-							log.Error(err, "failed to cleanup etcd state directory")
-						}
-					}
-				}
-			}
-		})
+		// Register reverter for safe member removal on join failure
+		RegisterEtcdMemberReverter(log, snap, s.Name(), endpoints, reverter)
 
 		// Build initial cluster members map from etcd members
 		initialClusterMembers := make(map[string]string)
@@ -377,16 +404,8 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to get Kubernetes client: %w", err)
 	}
 
-	// Best-effort: if join fails after kubelet registers, remove the Node object to avoid orphans
-	reverter.Add(func() {
-		// Use an independent short-lived context for revert operations.
-		rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		if err := k8sClient.DeleteNode(rmCtx, s.Name()); err != nil {
-			log.Error(err, "failed to remove node from kubernetes during join revert")
-		}
-	})
+	// Register reverter for Node deletion on join failure
+	RegisterK8sNodeDeletionReverter(log, k8sClient, s.Name(), reverter)
 
 	// This is required for backwards compatibility.
 	log.Info("Applying custom CRDs")

--- a/src/k8s/pkg/k8sd/app/hooks_join_reverter_test.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join_reverter_test.go
@@ -1,0 +1,158 @@
+package app_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/client/kubernetes"
+	"github.com/canonical/k8s/pkg/k8sd/app"
+	snapmock "github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/lxd/shared/revert"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestRegisterK8sDqliteReverter tests that the k8s-dqlite reverter properly cleans up state.
+func TestRegisterK8sDqliteReverter(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+	dqliteStateDir := filepath.Join(tmpDir, "dqlite")
+	g.Expect(os.MkdirAll(dqliteStateDir, 0755)).To(Succeed())
+
+	// Create a test file in the state directory
+	testFile := filepath.Join(dqliteStateDir, "test.db")
+	g.Expect(os.WriteFile(testFile, []byte("test data"), 0644)).To(Succeed())
+
+	// Verify file exists before cleanup
+	g.Expect(testFile).To(BeAnExistingFile())
+
+	// Create mock snap and reverter
+	mockSnap := &snapmock.Snap{
+		Mock: snapmock.Mock{
+			K8sDqliteStateDir: dqliteStateDir,
+		},
+	}
+	reverter := revert.New()
+
+	// Register the reverter
+	app.RegisterK8sDqliteReverter(logr.Discard(), mockSnap, reverter)
+
+	// Trigger the reverter (simulating join failure)
+	reverter.Fail()
+
+	// Verify the state directory was cleaned up
+	g.Expect(dqliteStateDir).NotTo(BeAnExistingFile())
+}
+
+// TestRegisterK8sDqliteReverter_Success tests that cleanup doesn't happen on success.
+func TestRegisterK8sDqliteReverter_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	tmpDir := t.TempDir()
+	dqliteStateDir := filepath.Join(tmpDir, "dqlite")
+	g.Expect(os.MkdirAll(dqliteStateDir, 0755)).To(Succeed())
+
+	testFile := filepath.Join(dqliteStateDir, "test.db")
+	g.Expect(os.WriteFile(testFile, []byte("test data"), 0644)).To(Succeed())
+
+	mockSnap := &snapmock.Snap{
+		Mock: snapmock.Mock{
+			K8sDqliteStateDir: dqliteStateDir,
+		},
+	}
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	// Register the reverter
+	app.RegisterK8sDqliteReverter(logr.Discard(), mockSnap, reverter)
+
+	// Mark as successful (no cleanup should happen)
+	reverter.Success()
+
+	// Verify directory still exists
+	g.Expect(testFile).To(BeAnExistingFile())
+}
+
+// TestRegisterEtcdMemberReverter_NotEnoughEndpoints tests that cleanup is skipped when <3 endpoints.
+func TestRegisterEtcdMemberReverter_NotEnoughEndpoints(t *testing.T) {
+	g := NewWithT(t)
+
+	tmpDir := t.TempDir()
+	etcdDir := filepath.Join(tmpDir, "etcd")
+	g.Expect(os.MkdirAll(etcdDir, 0755)).To(Succeed())
+
+	testFile := filepath.Join(etcdDir, "member/snap/db")
+	g.Expect(os.MkdirAll(filepath.Dir(testFile), 0755)).To(Succeed())
+	g.Expect(os.WriteFile(testFile, []byte("etcd data"), 0644)).To(Succeed())
+
+	// Only 2 endpoints - RegisterEtcdMemberReverter skips etcd operations when <3
+	endpoints := []string{"https://node1:2379", "https://node2:2379"}
+
+	mockSnap := &snapmock.Snap{
+		Mock: snapmock.Mock{
+			EtcdDir: etcdDir,
+			// No EtcdClient needed - reverter won't call snap.EtcdClient with <3 endpoints
+		},
+	}
+	reverter := revert.New()
+
+	app.RegisterEtcdMemberReverter(logr.Discard(), mockSnap, "node2", endpoints, reverter)
+
+	// Trigger reverter
+	reverter.Fail()
+
+	// Verify directory was NOT cleaned up (quorum protection)
+	g.Expect(etcdDir).To(BeAnExistingFile())
+}
+
+// TestRegisterK8sNodeDeletionReverter_FailDeletesNode ensures a failed join triggers Node deletion.
+func TestRegisterK8sNodeDeletionReverter_FailDeletesNode(t *testing.T) {
+	g := NewWithT(t)
+
+	nodeName := "test-node"
+	clientset := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	})
+	k8sClient := &kubernetes.Client{Interface: clientset}
+
+	reverter := revert.New()
+	app.RegisterK8sNodeDeletionReverter(logr.Discard(), k8sClient, nodeName, reverter)
+
+	// Simulate join failure
+	reverter.Fail()
+
+	// Node should be deleted
+	_, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "node should be removed on revert")
+}
+
+// TestRegisterK8sNodeDeletionReverter_Success ensures a successful join does not delete the Node.
+func TestRegisterK8sNodeDeletionReverter_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	nodeName := "test-node"
+	clientset := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	})
+	k8sClient := &kubernetes.Client{Interface: clientset}
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	app.RegisterK8sNodeDeletionReverter(logr.Discard(), k8sClient, nodeName, reverter)
+
+	// Mark as successful join (reverts should not run)
+	reverter.Success()
+
+	// Node should still exist
+	_, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred(), "node should remain when join succeeds")
+}


### PR DESCRIPTION
## Description

This PR adds an in memory reverter for membership state.

If a node fails anywhere in the process membership get's reverted based on where we failed in the join process:
- any failure of the join logic triggers the microcluster's remove logic
- etcd membership
- Kubernetes membership

### Limitation:

Clean-up of etcd is only desirable if we have less than 3 nodes in the cluster. If we were to remove 1 etcd node from a 2 node configuration we would loose quorum. Admins will need to manually need to clean-up the broken configuration.

## Manual Testing

Inserted a fake error for the third joining node (see[ testing commit](https://github.com/canonical/k8s-snap/pull/2309/changes/a76851a874af09dc463f16799bd859d2db4802f8)). After the third node artificially fails to join, I verified the memberships of microcluster, etcd, k8s to ensure the reverter works as expected. 

## Backport

1.32, 1.33, 1.34, 1.35

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

