### PR TITLE
test: Fix flaky restart test

### DIFF
--- a/tests/integration/tests/test_restart.py
+++ b/tests/integration/tests/test_restart.py
@@ -42,11 +42,10 @@ def test_restart(instances: List[harness.Instance]):
         util.stubbornly(retries=15, delay_s=10).on(instance).until(
             condition=lambda p: util.status_output_matches(p, STATUS_PATTERNS),
         ).exec(["k8s", "status", "--wait-ready"])
+        5
 
-    # Verify all nodes are ready in Kubernetes
-    util.stubbornly(retries=15, delay_s=5).until(
-        lambda: len(util.ready_nodes(main)) == 3
-    ).exec()
+    # Verify all nodes are ready, not just k8s status
+    util.wait_until_k8s_ready(main, instances)
 
     for instance in instances:
         LOG.info("Restart the instance %s", instance.id)
@@ -61,6 +60,4 @@ def test_restart(instances: List[harness.Instance]):
         ).exec(["k8s", "status", "--wait-ready"])
 
     # Verify all nodes are ready in Kubernetes after restart
-    util.stubbornly(retries=15, delay_s=5).until(
-        lambda: len(util.ready_nodes(main)) == 3
-    ).exec()
+    util.wait_until_k8s_ready(main, instances)


### PR DESCRIPTION
The test did only wait until `k8s status` reports ready. This is already the case if at least one Kubernetes node is ready. Then, the test checked if all nodes are ready and failed right away if this is not the case.

With this fix, the test waits until all nodes are ready and not instantly fails.

## Backport

Yes, we introduced this test in 1.34
