### PR TITLE
docs: Drop in opentelemetry-collector as a replacement for grafana-agent

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -396,6 +396,7 @@ openssl
 OpenSSL's
 OpenStack
 openstack
+opentelemetry
 orchestrator
 OSD
 OSDs

--- a/docs/canonicalk8s/charm/howto/cos-lite.md
+++ b/docs/canonicalk8s/charm/howto/cos-lite.md
@@ -95,23 +95,23 @@ juju consume cos-lite.grafana
 juju consume cos-lite.prometheus
 ```
 
-Deploy the grafana-agent:
+Deploy the opentelemetry-collector:
 
 ```
-juju deploy grafana-agent
+juju deploy opentelemetry-collector --channel=2/stable
 ```
 
-Relate `grafana-agent` to `k8s`:
+Relate `opentelemetry-collector` to `k8s`:
 
 ```
-juju integrate grafana-agent:cos-agent k8s:cos-agent
+juju integrate opentelemetry-collector:cos-agent k8s:cos-agent
 ```
 
-Relate `grafana-agent` to the COS Lite offered interfaces:
+Relate `opentelemetry-collector` to the COS Lite offered interfaces:
 
 ```
-juju integrate grafana-agent grafana
-juju integrate grafana-agent prometheus
+juju integrate opentelemetry-collector grafana
+juju integrate opentelemetry-collector prometheus
 ```
 
 Get the credentials and login URL for Grafana:


### PR DESCRIPTION
## Description

Address a EOL of `grafana-agent` charm with its replacement `opentelemetry-collector`

## Solution

Adjust documentation to reference the replacement charm


## Backport

Selected the backport labels as this charm is a replacement for all releases

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

