### PR TITLE
feat: [1.35 backport] add node join revert (k8sd#6)

### DIFF
--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"slices"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/canonical/k8s/pkg/utils/control"
 	"github.com/canonical/k8s/pkg/utils/experimental/snapdconfig"
 	"github.com/canonical/k8s/pkg/version"
+	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/microcluster/v2/state"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
@@ -203,6 +205,9 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to generate kubeconfigs: %w", err)
 	}
 
+	reverter := revert.New()
+	defer reverter.Fail()
+
 	// Configure datastore
 	switch cfg.Datastore.GetType() {
 	case "k8s-dqlite":
@@ -230,6 +235,10 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		if err := setup.K8sDqlite(snap, address, cluster, joinConfig.ExtraNodeK8sDqliteArgs); err != nil {
 			return fmt.Errorf("failed to configure k8s-dqlite with address=%s cluster=%v: %w", address, cluster, err)
 		}
+
+		// Register reverter for k8s-dqlite cleanup on join failure
+		registerK8sDqliteReverter(snap, reverter)
+
 	case "etcd":
 		leader, err := s.Leader()
 		if err != nil {
@@ -263,6 +272,9 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 			}
 			return fmt.Errorf("failed to add member %s to etcd cluster: %w", s.Name(), err)
 		}
+
+		// Register reverter for safe member removal on join failure
+		registerEtcdMemberReverter(snap, s.Name(), endpoints, reverter)
 
 		// Build initial cluster members map from etcd members
 		initialClusterMembers := make(map[string]string)
@@ -336,6 +348,9 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to get Kubernetes client: %w", err)
 	}
 
+	// Register reverter for Node deletion on join failure
+	registerK8sNodeDeletionReverter(k8sClient, s.Name(), reverter)
+
 	// This is required for backwards compatibility.
 	log.Info("Applying custom CRDs")
 	if err := k8sClient.ApplyCRDs(ctx); err != nil {
@@ -347,7 +362,75 @@ func (a *App) onPostJoin(ctx context.Context, s state.State, initConfig map[stri
 		return fmt.Errorf("failed to handle rollout-upgrade: %w", err)
 	}
 
+	reverter.Success()
+
 	return nil
+}
+
+// RegisterK8sDqliteReverter registers the reverter for k8s-dqlite cleanup on join failure.
+func registerK8sDqliteReverter(snap snap.Snap, reverter *revert.Reverter) {
+	reverter.Add(func() {
+		// Use an independent short-lived context for revert operations so
+		// they have a chance to complete even if the join hook's ctx has
+		// already been cancelled by a timeout.
+		rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		log := log.FromContext(rmCtx).WithValues("step", "k8s-dqlite-cleanup")
+
+		if err := os.RemoveAll(snap.K8sDqliteStateDir()); err != nil {
+			log.Error(err, "failed to cleanup k8s-dqlite state directory")
+		}
+	})
+}
+
+// RegisterEtcdMemberReverter registers the reverter for etcd member removal on join failure.
+// It safely removes the member only if there are >2 endpoints to avoid quorum loss.
+func registerEtcdMemberReverter(snap snap.Snap, nodeName string, endpoints []string, reverter *revert.Reverter) {
+	reverter.Add(func() {
+		// Use an independent short-lived context for revert operations so
+		// they have a chance to complete even if the join hook's ctx has
+		// already been cancelled by a timeout.
+		rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		log := log.FromContext(rmCtx).WithValues("step", "etcd-member-removal", "node", nodeName)
+		// Only remove the member if we have more than 2 endpoints,
+		// otherwise we lose quorum in etcd when removing a member.
+		// In such cases the join revert will be manual to avoid
+		// quorum loss.
+		if len(endpoints) > 2 {
+			etcdClient, err := snap.EtcdClient(endpoints)
+			if err != nil {
+				log.Error(err, "failed to create etcd client for member removal using peer endpoints")
+			} else {
+				defer etcdClient.Close()
+				if err := etcdClient.RemoveNodeByName(rmCtx, nodeName); err != nil {
+					log.Error(err, "failed to remove node from etcd cluster using peer endpoints")
+				} else {
+					if err := os.RemoveAll(snap.EtcdDir()); err != nil {
+						log.Error(err, "failed to cleanup etcd state directory")
+					}
+				}
+			}
+		}
+	})
+}
+
+// RegisterK8sNodeDeletionReverter registers the reverter for Kubernetes Node object deletion on join failure.
+// This ensures no orphaned PENDING nodes remain if the join fails after kubelet registration.
+func registerK8sNodeDeletionReverter(k8sClient *kubernetes.Client, nodeName string, reverter *revert.Reverter) {
+	reverter.Add(func() {
+		// Use an independent short-lived context for revert operations.
+		rmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		log := log.FromContext(rmCtx).WithValues("step", "k8s-node-deletion", "node", nodeName)
+
+		if err := k8sClient.DeleteNode(rmCtx, nodeName); err != nil {
+			log.Error(err, "failed to remove node from kubernetes during join revert")
+		}
+	})
 }
 
 func handleRollOutUpgrade(ctx context.Context, snap snap.Snap, s state.State, k8sClient *kubernetes.Client) error {

--- a/src/k8s/pkg/k8sd/app/hooks_join_test.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join_test.go
@@ -1,0 +1,190 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/client/kubernetes"
+	snapmock "github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/lxd/shared/revert"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestRegisterK8sDqliteReverter tests that the k8s-dqlite reverter properly cleans up state.
+func TestRegisterK8sDqliteReverter(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+	dqliteStateDir := filepath.Join(tmpDir, "dqlite")
+	g.Expect(os.MkdirAll(dqliteStateDir, 0o755)).To(Succeed())
+
+	// Create a test file in the state directory
+	testFile := filepath.Join(dqliteStateDir, "test.db")
+	g.Expect(os.WriteFile(testFile, []byte("test data"), 0o644)).To(Succeed())
+
+	// Verify file exists before cleanup
+	g.Expect(testFile).To(BeAnExistingFile())
+
+	// Create mock snap and reverter
+	mockSnap := &snapmock.Snap{
+		Mock: snapmock.Mock{
+			K8sDqliteStateDir: dqliteStateDir,
+		},
+	}
+	reverter := revert.New()
+
+	// Register the reverter
+	registerK8sDqliteReverter(mockSnap, reverter)
+
+	// Trigger the reverter (simulating join failure)
+	reverter.Fail()
+
+	// Verify the state directory was cleaned up
+	g.Expect(dqliteStateDir).NotTo(BeAnExistingFile())
+}
+
+// TestRegisterK8sDqliteReverter_Success tests that cleanup doesn't happen on success.
+func TestRegisterK8sDqliteReverter_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	tmpDir := t.TempDir()
+	dqliteStateDir := filepath.Join(tmpDir, "dqlite")
+	g.Expect(os.MkdirAll(dqliteStateDir, 0o755)).To(Succeed())
+
+	testFile := filepath.Join(dqliteStateDir, "test.db")
+	g.Expect(os.WriteFile(testFile, []byte("test data"), 0o644)).To(Succeed())
+
+	mockSnap := &snapmock.Snap{
+		Mock: snapmock.Mock{
+			K8sDqliteStateDir: dqliteStateDir,
+		},
+	}
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	// Register the reverter
+	registerK8sDqliteReverter(mockSnap, reverter)
+
+	// Mark as successful (no cleanup should happen)
+	reverter.Success()
+
+	// Verify directory still exists
+	g.Expect(testFile).To(BeAnExistingFile())
+}
+
+// TestRegisterEtcdMemberReverter_NotEnoughEndpoints tests that cleanup is skipped when <3 endpoints.
+func TestRegisterEtcdMemberReverter_NotEnoughEndpoints(t *testing.T) {
+	g := NewWithT(t)
+
+	tmpDir := t.TempDir()
+	etcdDir := filepath.Join(tmpDir, "etcd")
+	g.Expect(os.MkdirAll(etcdDir, 0o755)).To(Succeed())
+
+	testFile := filepath.Join(etcdDir, "member/snap/db")
+	g.Expect(os.MkdirAll(filepath.Dir(testFile), 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(testFile, []byte("etcd data"), 0o644)).To(Succeed())
+
+	// Only 2 endpoints - RegisterEtcdMemberReverter skips etcd operations when <3
+	endpoints := []string{"https://node1:2379", "https://node2:2379"}
+
+	mockSnap := &snapmock.Snap{
+		Mock: snapmock.Mock{
+			EtcdDir: etcdDir,
+			// No EtcdClient needed - reverter won't call snap.EtcdClient with <3 endpoints
+		},
+	}
+	reverter := revert.New()
+
+	registerEtcdMemberReverter(mockSnap, "node2", endpoints, reverter)
+
+	// Trigger reverter
+	reverter.Fail()
+
+	// Verify directory was NOT cleaned up (quorum protection)
+	g.Expect(etcdDir).To(BeAnExistingFile())
+}
+
+// TestRegisterEtcdMemberReverter_ClientCreationFailure tests error handling when EtcdClient creation fails.
+func TestRegisterEtcdMemberReverter_ClientCreationFailure(t *testing.T) {
+	g := NewWithT(t)
+
+	tmpDir := t.TempDir()
+	etcdDir := filepath.Join(tmpDir, "etcd")
+	g.Expect(os.MkdirAll(etcdDir, 0o755)).To(Succeed())
+
+	testFile := filepath.Join(etcdDir, "member/snap/db")
+	g.Expect(os.MkdirAll(filepath.Dir(testFile), 0o755)).To(Succeed())
+	g.Expect(os.WriteFile(testFile, []byte("etcd data"), 0o644)).To(Succeed())
+	// 3 endpoints - should attempt etcd operations but client creation fails
+	endpoints := []string{"https://node1:2379", "https://node2:2379", "https://node3:2379"}
+	nodeName := "node2"
+
+	// Mock snap that returns an error from EtcdClient
+	mockSnap := &snapmock.Snap{
+		Mock: snapmock.Mock{
+			EtcdDir:       etcdDir,
+			EtcdClientErr: fmt.Errorf("failed to create etcd client"),
+		},
+	}
+	reverter := revert.New()
+
+	registerEtcdMemberReverter(mockSnap, nodeName, endpoints, reverter)
+
+	// Trigger reverter
+	reverter.Fail()
+
+	// Verify directory was NOT cleaned up when client creation fails
+	g.Expect(etcdDir).To(BeAnExistingFile(), "etcd directory should NOT be removed when client creation fails")
+}
+
+// TestRegisterK8sNodeDeletionReverter_FailDeletesNode ensures a failed join triggers Node deletion.
+func TestRegisterK8sNodeDeletionReverter_FailDeletesNode(t *testing.T) {
+	g := NewWithT(t)
+
+	nodeName := "test-node"
+	clientset := fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	})
+	k8sClient := &kubernetes.Client{Interface: clientset}
+
+	reverter := revert.New()
+	registerK8sNodeDeletionReverter(k8sClient, nodeName, reverter)
+
+	// Simulate join failure
+	reverter.Fail()
+
+	// Node should be deleted
+	_, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "node should be removed on revert")
+}
+
+// TestRegisterK8sNodeDeletionReverter_Success ensures a successful join does not delete the Node.
+func TestRegisterK8sNodeDeletionReverter_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	nodeName := "test-node"
+	clientset := fake.NewClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+	})
+	k8sClient := &kubernetes.Client{Interface: clientset}
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	registerK8sNodeDeletionReverter(k8sClient, nodeName, reverter)
+
+	// Mark as successful join (reverts should not run)
+	reverter.Success()
+
+	// Node should still exist
+	_, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	g.Expect(err).NotTo(HaveOccurred(), "node should remain when join succeeds")
+}

--- a/src/k8s/pkg/snap/mock/mock.go
+++ b/src/k8s/pkg/snap/mock/mock.go
@@ -60,6 +60,7 @@ type Mock struct {
 	HelmClient                  helm.Client
 	K8sDqliteClient             *dqlite.Client
 	EtcdClient                  *etcd.Client
+	EtcdClientErr               error
 	K8sdClient                  k8sd.Client
 	SnapctlGet                  map[string][]byte
 }
@@ -305,7 +306,7 @@ func (s *Snap) K8sDqliteClient(context.Context) (*dqlite.Client, error) {
 }
 
 func (s *Snap) EtcdClient(endpoints []string) (*etcd.Client, error) {
-	return s.Mock.EtcdClient, nil
+	return s.Mock.EtcdClient, s.Mock.EtcdClientErr
 }
 
 func (s *Snap) K8sdClient(address string) (k8sd.Client, error) {


### PR DESCRIPTION
## Description

This PR backports https://github.com/canonical/k8sd/pull/6 manually.

## Backport

1.34,1.33,1.32

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
