### PR TITLE
docs: Bump k8sd API for docs updates

### DIFF
--- a/docs/canonicalk8s/_parts/bootstrap_config.md
+++ b/docs/canonicalk8s/_parts/bootstrap_config.md
@@ -237,6 +237,9 @@ If omitted defaults to `6443`.
 ### k8s-dqlite-port
 **Type:** `int`<br>
 
+Deprecated: k8s-dqlite is being deprecated and will be removed in Canonical Kubernetes 1.36 without an upgrade path.
+We recommend against bootstrapping new clusters with k8s-dqlite.
+
 The port number for k8s-dqlite to use.
 If omitted defaults to `9000`.
 
@@ -249,6 +252,8 @@ If omitted defaults to `etcd`.
 Can be used to point to an external datastore like etcd.
 
 Possible Values: `k8s-dqlite | etcd | external`.
+Deprecated: k8s-dqlite is being deprecated and will be removed in Canonical Kubernetes 1.36 without an upgrade path.
+We recommend against bootstrapping new clusters with k8s-dqlite.
 
 ### datastore-servers
 **Type:** `[]string`<br>
@@ -529,6 +534,9 @@ The format is `map[<--flag-name>]<value>`.
 
 ### extra-node-k8s-dqlite-args
 **Type:** `map[string]string`<br>
+
+Deprecated: k8s-dqlite is being deprecated and will be removed in Canonical Kubernetes 1.36 without an upgrade path.
+We recommend against bootstrapping new clusters with k8s-dqlite.
 
 Additional arguments that are passed to `k8s-dqlite` only for that specific node.
 A parameter that is explicitly set to `null` is deleted.

--- a/docs/canonicalk8s/_parts/control_plane_join_config.md
+++ b/docs/canonicalk8s/_parts/control_plane_join_config.md
@@ -179,6 +179,9 @@ The format is `map[<--flag-name>]<value>`.
 ### extra-node-k8s-dqlite-args
 **Type:** `map[string]string`<br>
 
+Deprecated: k8s-dqlite is being deprecated and will be removed in Canonical Kubernetes 1.36 without an upgrade path.
+We recommend against bootstrapping new clusters with k8s-dqlite.
+
 Additional arguments that are passed to `k8s-dqlite` only for that specific node.
 A parameter that is explicitly set to `null` is deleted.
 The format is `map[<--flag-name>]<value>`.

--- a/src/k8s/go.mod
+++ b/src/k8s/go.mod
@@ -5,7 +5,7 @@ go 1.24.11
 require (
 	dario.cat/mergo v1.0.1
 	github.com/canonical/go-dqlite/v2 v2.0.1
-	github.com/canonical/k8s-snap-api v1.1.0
+	github.com/canonical/k8s-snap-api v1.1.1
 	github.com/canonical/lxd v0.0.0-20251020131551-7c883edf07bb
 	github.com/canonical/microcluster/v2 v2.2.1
 	github.com/go-logr/logr v1.4.3

--- a/src/k8s/go.sum
+++ b/src/k8s/go.sum
@@ -38,8 +38,8 @@ github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuP
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/canonical/go-dqlite/v2 v2.0.1 h1:C5A+MioYkjew5rG8apjVYwGYIpKKkkC1FlnL4cBLGaE=
 github.com/canonical/go-dqlite/v2 v2.0.1/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/k8s-snap-api v1.1.0 h1:RME41bv1t8TY4IIEoVs8JOqJO5C9UW+CC/TEPvWKXnA=
-github.com/canonical/k8s-snap-api v1.1.0/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.1.1 h1:4qrM1Y864b+13fXgsih3jjejGQ/jJdc3Xq+lRzwZNqw=
+github.com/canonical/k8s-snap-api v1.1.1/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/canonical/lxd v0.0.0-20251020131551-7c883edf07bb h1:U4W81ayFsS2Ubs5ED1lffkiREcJXgNJCen7M+Uznup0=
 github.com/canonical/lxd v0.0.0-20251020131551-7c883edf07bb/go.mod h1:5fDWM2hwEeJGmTdpnz53YG/DGbuPX5nxmbDh7joYRlM=
 github.com/canonical/microcluster/v2 v2.2.1 h1:3XM5zU1MbMrZJewHwtSXzMYUoxOLVHXU96eSLAjSmxI=


### PR DESCRIPTION
Bump the API patch version to include the docs changes for k8s-dqlite deprecation.

See related PR: #2314 

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests (n/a)
- [ ] Covered by integration tests (n/a)
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary (n/a)