### PR TITLE
chore: Add k8s-dqlite deprecation warning on bootstrap

### DIFF
--- a/src/k8s/cmd/k8s/k8s_bootstrap.go
+++ b/src/k8s/cmd/k8s/k8s_bootstrap.go
@@ -150,6 +150,11 @@ func newBootstrapCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				return
 			}
 
+			if bootstrapConfig.DatastoreType != nil && *bootstrapConfig.DatastoreType == "k8s-dqlite" {
+				cmd.PrintErrln("Warning: k8s-dqlite datastore is deprecated and will be removed in Canonical Kubernetes 1.36.",
+					"It is recommended to bootstrap new clusters with etcd instead.")
+			}
+
 			cmd.PrintErrln("Bootstrapping the cluster. This may take a few seconds, please wait.")
 
 			response, err := client.BootstrapCluster(cmd.Context(), apiv1.BootstrapClusterRequest{


### PR DESCRIPTION
Users should be warned if they try to bootstrap a new cluster with k8s-dqlite

See #2314 for more context

## Backport

1.32 - 1.34

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests (n/a)
- [ ] Covered by integration tests (n/a)
- [ ] Documentation updated (n/a)
- [x] CLA signed
- [x] Backport label added if necessary 
