### PR TITLE
docs: Update snap tutorial [Backport release-1.32] 

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/multipass.md
+++ b/docs/canonicalk8s/snap/howto/install/multipass.md
@@ -112,7 +112,7 @@ multipass delete k8s-node --purge
 <!-- markdownlint-disable MD053 -->
 [Multipass]:https://multipass.run/
 [snap-support]: https://snapcraft.io/docs/installing-snapd
-[Multipass-options]: https://canonical.com/multipass/docs/tutorial/#create-a-customised-instance
+[Multipass-options]: https://documentation.ubuntu.com/multipass/latest/tutorial/#create-a-customised-instance
 [install instructions]: ./snap
 [Getting started]: ../../tutorial/getting-started
 [Multipass website]: https://multipass.run/docs

--- a/docs/canonicalk8s/snap/reference/community.md
+++ b/docs/canonicalk8s/snap/reference/community.md
@@ -2,7 +2,7 @@
 
 This rapidly growing community is a diverse bunch of people - developers,
 Kubernetes admins, inventors, researchers, students… and we all share the joy
-of a reliable, flexible, secure, timely version of upstream Kubernetes. The
+of a reliable, flexible and secure version of upstream Kubernetes. The
 team recognizes the important role each and every user plays in the success of
 the project as a whole and how valuable your contributions are.
 
@@ -25,8 +25,8 @@ but we promise to respond within three working days.
 
 ## Found a bug?
 
-You can always track what is going on with development by watching our GitHub
-repository. This is also the best place to file a bug if you find
+You can always track what is going on with development by watching our [GitHub
+repository]. This is also the best place to file a bug if you find
 one, or of course you are also welcome to contribute to the code.
 
 **Our commitment to you** - we monitor the issues on GitHub regularly and we
@@ -45,9 +45,9 @@ repository. We aim to respond to any PRs within three working days.
 
 Our documentation is extremely important to us and is actively maintained by
 the entire team. That doesn't mean that it can't be improved though. Every page
-in the documentation has an "Edit this page" link in the top right which takes
-you to GitHub to make small changes. For larger contributions, please see the
-[Contributing guide].
+in the documentation has an "Edit this page" link in the bottom right which 
+takes you to GitHub to make small changes. For larger contributions, please see 
+the [Contributing guide].
 
 **Our commitment to you**: Comments are usually read daily and we are really
 grateful for docs improvements.
@@ -70,3 +70,4 @@ the guidelines for participation.
 [Contributing guide]: /snap/howto/contribute.md
 [Developer guide]: /snap/howto/contribute.md
 [support]: https://ubuntu.com/support
+ [GitHub repository]: https://github.com/canonical/k8s-snap

--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -2,11 +2,13 @@
 
 {{product}} is a distribution of Kubernetes which includes all
 the necessary tools and services needed to easily deploy and manage a cluster.
-As the upstream Kubernetes does not come with all that is required
-for a fully functional cluster by default, we have bundled everything into a
-snap that should only take a few minutes to install. In this tutorial you will
-deploy a single node cluster by installing the snap package and execute some 
-typical cluster operations. 
+Upstream Kubernetes does not provide you with a fully functional cluster by 
+default, which is why we have bundled everything you need into a snap that 
+should only take a few minutes to install and deploy.
+
+In this tutorial you will deploy a single node cluster by installing the snap 
+package. You will also execute some typical cluster operations such as 
+deploying an NGINX server as a sample workload and configuring cluster storage.
 
 ## Prerequisites
 
@@ -19,7 +21,7 @@ typical cluster operations.
 cause conflicts. Consider using a [Multipass virtual machine] if you would like 
 an isolated working environment.
 
-### Install {{product}}
+## Install {{product}}
 
 Install the {{product}} `k8s` snap with:
 
@@ -31,7 +33,7 @@ Install the {{product}} `k8s` snap with:
 This may take a few moments as the snap installs all the necessary Kubernetes
 components for a fully functioning cluster such as the networking, storage, etc.
 
-### Bootstrap a Kubernetes cluster
+## Bootstrap a Kubernetes cluster
 
 The bootstrap command initializes your cluster and configures your host system
 as a Kubernetes node. Bootstrapping the cluster is only done once at cluster
@@ -52,7 +54,7 @@ sudo k8s bootstrap --help
 Once the bootstrap command has been successfully ran, the output should list the
 node address and confirm the CNI is being deployed.
 
-### Check cluster status
+## Check cluster status
 
 It may take a few minutes for the cluster to be ready. To confirm the
 installation was successful, use `k8s status` with the `wait-ready` flag
@@ -73,7 +75,10 @@ the  `--timeout`
 flag or re-run the command to continue waiting until the cluster is ready.
 ```
 
-### Access Kubernetes
+Congratulations, you have just deployed a single node cluster with {{product}}! 
+Now let's see what you can do with it.
+
+## Access Kubernetes
 
 The standard tool for deploying and managing workloads on Kubernetes
 is [kubectl](https://kubernetes.io/docs/reference/kubectl/).
@@ -116,7 +121,7 @@ life-cycle of the local storage solution.
 management.
 
 
-### Deploy an app
+## Deploy an app
 
 Kubernetes is meant for deploying apps and services.
 You can use the `kubectl`
@@ -140,7 +145,23 @@ sudo k8s kubectl get pods
 This command shows all pods in the default namespace.
 It may take a moment for the pod to be ready and running.
 
-### Remove an app
+Now to check the NGINX server in the pod is working correctly, get the IP 
+address of the pod by running the same command again but this time we will add 
+the `-owide` argument so we get more information about the pod: 
+
+ ```
+sudo k8s kubectl get pods -owide
+```
+
+Then query the NGINX IP address using `curl`:
+
+```
+curl <POD_IP>
+```
+
+The output should confirm NGINX was successfully installed and working.
+
+## Remove an app
 
 To remove the NGINX workload, execute the following command:
 
@@ -155,36 +176,36 @@ running:
 sudo k8s kubectl get pods
 ```
 
-### Enable local storage
+## Enable local storage
 
-In scenarios where you need to preserve application data beyond the
-life-cycle of the pod, Kubernetes provides persistent volumes.
+As we learned earlier, {{product}} comes with everything you need to run 
+and manage your cluster. Using the `enable` command you can easily turn on and 
+off the bundled services. 
 
-With {{product}}, you can enable local-storage to configure
-your storage solutions:
+For example, with {{product}} you can enable local storage:
 
 ```
 sudo k8s enable local-storage
 ```
 
-To verify that the local-storage is enabled, execute:
+To verify that the local storage is enabled, execute:
 
 ```
 sudo k8s status
 ```
 
-You should see `local-storage enabled` in the command output.
+You should see `local-storage: enabled` in the command output.
 
-Let's create a `PersistentVolumeClaim` and use it in a `Pod`.
-For example, we can deploy the following manifest:
+Enabling local storage allows you to create persistent volumes which is the 
+Kubernetes way to preserve application data beyond the life-cycle of a pod. 
+Let's create a `PersistentVolumeClaim` and use it in a `Pod`:
 
 ```
 sudo k8s kubectl apply -f https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/canonicalk8s/assets/tutorial-pod-with-pvc.yaml
 ```
 
-This command deploys a pod based on the YAML configuration of a
-storage writer pod and a persistent volume claim called `myclaim` with a
-capacity of 1G.
+This command deploys the YAML configuration of a pod called `storage-writer-pod`
+and a persistent volume claim called `myclaim` with a capacity of 1G.
 
 To confirm that the persistent volume is up and running:
 
@@ -198,7 +219,10 @@ You can inspect the storage-writer-pod with:
 sudo k8s kubectl describe pod storage-writer-pod
 ```
 
-### Disable local storage
+You should see `myclaim` listed under Volumes showing it has been 
+assigned correctly. 
+
+## Disable local storage
 
 Begin by removing the pod along with the persistent volume claim:
 
@@ -213,7 +237,7 @@ Next, disable the local storage:
 sudo k8s disable local-storage
 ```
 
-### Remove {{product}} (Optional)
+## Remove {{product}} (Optional)
 
 If you would like to maintain a snapshot of the `k8s` snap for future
 restoration, simply run :


### PR DESCRIPTION
Description

Manual backport of https://github.com/canonical/k8s-snap/pull/2320 to release-1.32.

(cherry picked from commit e6a68479113b27dbb0581fb39ced4cbbe9645ea6)
