### PR TITLE
docs: Update docs around using k8s kubectl on worker nodes

### DIFF
--- a/docs/canonicalk8s/snap/tutorial/kubectl.md
+++ b/docs/canonicalk8s/snap/tutorial/kubectl.md
@@ -47,9 +47,9 @@ sudo k8s kubectl <command>
 In {{product}}, the `kubeconfig` file that is being read to display
 the configuration when you run `kubectl config view` lives at
 `/etc/kubernetes/admin.conf` (for control plane nodes) and 
-`/etc/kubernetes/kubelet.conf` (for worker nodes). You can change this by setting a
-`KUBECONFIG` environment variable or passing the `--kubeconfig` flag to a
-command.
+`/etc/kubernetes/kubelet.conf` (for worker nodes). You can change this 
+by setting a `KUBECONFIG` environment variable or passing the 
+`--kubeconfig` flag to a command.
 
 To find out more, you can visit
 [the official kubeconfig documentation][kubeconfig-doc].


### PR DESCRIPTION
### Overview

This PR updates the docs around `k8s kubectl` on worker nodes. It is now possible to run this command on worker nodes after https://github.com/canonical/k8s-snap/pull/1978 tho with a different `KUBECONFIG`.