### PR TITLE
feat: Reject k8s-dqlite upgrades to 1.36+

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -6,7 +6,7 @@ k8s::common::setup_env
 # Reject upgrade if deprecated k8s-dqlite datastore is used.
 if [ -d "$SNAP_COMMON/var/lib/k8s-dqlite" ]; then
   echo "ERROR: upgrade blocked: k8s-dqlite is no longer supported in version 1.36 and later."
-  echo "Either stay on version 1.35 or deploy a new cluster with etcd as the datastore."
+  echo "Remain on version 1.35 or deploy a new cluster with etcd."
   exit 1
 fi
 


### PR DESCRIPTION
k8s-dqlite is not supported for 1.36+, see #2314 

The output for the user looks like this:
```
ubuntu@noble:~/k8s-snap$ sudo snap install k8s.snap --classic --dangerous
2026-02-02T11:30:40+01:00 INFO Waiting for "snap.k8s.kube-scheduler.service" to stop.
2026-02-02T11:30:48+01:00 INFO Waiting for "snap.k8s.kube-apiserver.service" to stop.
error: cannot perform the following tasks:
- Run post-refresh hook of "k8s" snap if present (run hook "post-refresh": 
-----
ERROR: k8s-dqlite is not supported anymore in version 1.36 and later.
Either stay on version 1.35 or deploy a new cluster with etcd as the datastore.
-----)
```

## Backport

No, this is for 1.36+

