### PR TITLE
fix: k8s-dqlite upgrade rejection

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -4,7 +4,10 @@
 k8s::common::setup_env
 
 # Reject upgrade if deprecated k8s-dqlite datastore is used.
-if [ -d "$SNAP_COMMON/var/lib/k8s-dqlite" ]; then
+# In older releases, the k8s-dqlite directory is created regardless
+# of whether k8s-dqlite is used or not. Therefore, we also check
+# that the directory is not empty.
+if [ -d "$SNAP_COMMON/var/lib/k8s-dqlite" ] && [ -n "$(ls -A "$SNAP_COMMON/var/lib/k8s-dqlite" 2>/dev/null)" ]; then
   echo "ERROR: upgrade blocked: k8s-dqlite is no longer supported in version 1.36 and later."
   echo "Remain on version 1.35 or deploy a new cluster with etcd."
   exit 1


### PR DESCRIPTION
Follow-up fix for #2351

The k8s-dqlite directory existence check is not enough as older CK8s releases will create this folder regardless if the datastore option is used or not.

We now also check if this directory is actually populated.

## Backport

Not required

