### PR TITLE
docs(troubleshooting): Update Cilium direct routing device instructions for bridge interfaces

### DIFF
--- a/docs/canonicalk8s/snap/reference/troubleshooting.md
+++ b/docs/canonicalk8s/snap/reference/troubleshooting.md
@@ -248,9 +248,12 @@ device with the k8s InternalIP/ExternalIP or the device with a default route.
 However, bridge type devices are ignored in this automatic selection. In this
 case, a bridge interface is used as the default route and
 therefore Cilium enters a failed state being unable to find the direct routing
-device. The bridge interface must be added to the list of `devices` using
-cluster annotations so that `direct-routing-device` will not skip the bridge
-interface.
+device.
+
+The solution is to add the bridge interface to the list of `devices` using
+cluster annotations. Once the bridge interface is included in `devices`,
+Cilium will automatically populate `direct-routing-device` when the pod
+restarts—there is no need to set `direct-routing-device` manually.
 ````
 
 ````{dropdown} Solution


### PR DESCRIPTION
### Overview

Updates the docs around Cilium direct routing device. Follow up on https://github.com/canonical/k8s-snap/pull/2353.