### PR TITLE
docs: Add metadata example 

### DIFF
--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -211,7 +211,7 @@ To confirm that the persistent volume is up and running:
 sudo k8s kubectl get pvc myclaim
 ```
 
-`myclaim` status should be Bound. Now let's inspect the 
+The persistent volume claim status should be Bound. Now let's inspect the 
 storage-writer-pod:
 
 ```
@@ -219,7 +219,7 @@ sudo k8s kubectl describe pod storage-writer-pod
 ```
 
 This output provides a detailed description of the storage-writer-pod. You 
-should see `myclaim` listed under Volumes showing it has been assigned 
+should see `myclaim` listed under Volumes showing that it has been assigned 
 correctly.
 
 ```


### PR DESCRIPTION
## Description

Adding metadata descriptions helps with SEO. From now on, as we update pages, we should add the metadata descriptions using this as an example. 

## Solution

- Added metadata description to the snap getting started tutorial 
- I also added a small clarification on the PVC expected output based on user feedback

## Issue

N/A

## Backport

1.32, 1.33, 1.34, 1.35

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.