### PR TITLE
test: add tags for promotion testing

### DIFF
--- a/tests/integration/tests/test_airgapped.py
+++ b/tests/integration/tests/test_airgapped.py
@@ -69,7 +69,7 @@ Environment="NO_PROXY=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.1
 
 @pytest.mark.node_count(2)
 @pytest.mark.no_setup()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_STABLE)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="runner size too small on multipass"
 )
@@ -116,7 +116,7 @@ def test_airgapped_with_proxy(instances: List[harness.Instance]):
 
 @pytest.mark.node_count(2)
 @pytest.mark.no_setup()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_STABLE)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="runner size too small on multipass"
 )

--- a/tests/integration/tests/test_config_propagation.py
+++ b/tests/integration/tests/test_config_propagation.py
@@ -11,7 +11,7 @@ LOG = logging.getLogger(__name__)
 
 
 @pytest.mark.node_count(3)
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_CANDIDATE)
 def test_config_propagation(instances: List[harness.Instance]):
     initial_node = instances[0]
     joining_cplane_node = instances[1]

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -192,7 +192,7 @@ def delete_nginx_pod(instance: harness.Instance):
 
 @pytest.mark.node_count(3)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_STABLE)
 # For communication with Vault
 @pytest.mark.required_ports(8200)
 def test_vault_intermediate_ca(instances: List[harness.Instance]):
@@ -252,7 +252,7 @@ def test_vault_intermediate_ca(instances: List[harness.Instance]):
 
 @pytest.mark.node_count(3)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_STABLE)
 # For communication with Vault
 @pytest.mark.required_ports(8200)
 def test_vault_certificates(instances: List[harness.Instance]):
@@ -451,7 +451,7 @@ def test_vault_certificates(instances: List[harness.Instance]):
 
 @pytest.mark.node_count(2)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_STABLE)
 # For communication with Vault
 @pytest.mark.required_ports(8200)
 def test_partial_refresh(instances: List[harness.Instance]):

--- a/tests/integration/tests/test_external_etcd.py
+++ b/tests/integration/tests/test_external_etcd.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.node_count(1)
 @pytest.mark.etcd_count(1)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_STABLE)
 def test_external_etcd(instances: List[harness.Instance], etcd_cluster: EtcdCluster):
     k8s_instance = instances[0]
 

--- a/tests/integration/tests/test_networking.py
+++ b/tests/integration/tests/test_networking.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
     (config.MANIFESTS_DIR / "bootstrap-dualstack.yaml").read_text()
 )
 @pytest.mark.dualstack()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_CANDIDATE)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="QUEMU does not properly support IPv6"
 )
@@ -113,7 +113,7 @@ def test_dualstack(instances: List[harness.Instance]):
 @pytest.mark.node_count(3)
 @pytest.mark.disable_k8s_bootstrapping()
 @pytest.mark.network_type("dualstack")
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_CANDIDATE)
 @pytest.mark.skipif(
     config.SUBSTRATE == "multipass", reason="QUEMU does not properly support IPv6"
 )

--- a/tests/integration/tests/test_node_taints.py
+++ b/tests/integration/tests/test_node_taints.py
@@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
 @pytest.mark.bootstrap_config(
     (config.MANIFESTS_DIR / "bootstrap-node-taints.yaml").read_text()
 )
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_CANDIDATE)
 def test_node_taints(instances: List[harness.Instance]):
     """Test node taints are returned by the GetNodeStatus RPC."""
     cp_node = instances[0]

--- a/tests/integration/tests/test_user_config.py
+++ b/tests/integration/tests/test_user_config.py
@@ -15,7 +15,7 @@ LOG = logging.getLogger(__name__)
 
 @pytest.mark.node_count(1)
 @pytest.mark.disable_k8s_bootstrapping()
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_CANDIDATE)
 def test_user_config(instances: List[harness.Instance]):
     """Verifies that the snap and services environment variables set by the user are loaded correctly.
 
@@ -71,7 +71,7 @@ def test_user_config(instances: List[harness.Instance]):
 
 @pytest.mark.node_count(1)
 @pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
-@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_CANDIDATE)
 def test_no_unnecessary_helm_revisions(instances: List[harness.Instance]):
     """Verifies that calling 'k8s set' with the same configuration multiple times
     does not create new helm chart revisions.

--- a/tests/integration/tests/test_util/tags.py
+++ b/tests/integration/tests/test_util/tags.py
@@ -9,11 +9,23 @@ WEEKLY = "weekly"
 GPU = "gpu"
 CONFORMANCE = "conformance_tests"
 PERFORMANCE = "performance"
+PROMOTE_CANDIDATE = "beta_to_candidate"
+PROMOTE_STABLE = "candidate_to_stable"
 
 # Each test needs to be tagged with at least one of the following tags.
 # This is enforced by conftest.
-TEST_TAGS = [PULL_REQUEST, NIGHTLY, WEEKLY, CONFORMANCE, PERFORMANCE, GPU]
+TEST_TAGS = [
+    PULL_REQUEST,
+    NIGHTLY,
+    WEEKLY,
+    CONFORMANCE,
+    PERFORMANCE,
+    GPU,
+    PROMOTE_CANDIDATE,
+    PROMOTE_STABLE,
+]
 
 # Those tags can be used for a convenient way to run multiple test levels.
 combine_tags("up_to_nightly", PULL_REQUEST, NIGHTLY)
 combine_tags("up_to_weekly", PULL_REQUEST, NIGHTLY, WEEKLY)
+combine_tags("edge_to_beta", PULL_REQUEST)


### PR DESCRIPTION
## Description

Adds tags to specify which tests should be ran on which risk testing on promotion pipeline.

For edge to beta, we will be running the full PR suite which takes around an hour.
Beta to candidate and candidate to stable runs extra tests from nightly that are not flaky and valuable.

## Backport

`release-1.32`
`release-1.33`
`release-1.34`
`release-1.35`

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 