### PR TITLE
fix: test_wrong_token_race test

### DIFF
--- a/tests/integration/tests/test_clustering_race.py
+++ b/tests/integration/tests/test_clustering_race.py
@@ -24,9 +24,7 @@ def test_wrong_token_race(instances: List[harness.Instance]):
     # "No truststore entry found for node"
     # The heartbeat is every 2 seconds, so waiting for 3 seconds
     # should be sufficient.
-    util.stubbornly(retries=3, delay_s=1).on(cluster_node).cluster_node.exec(
-        ["k8s", "remove-node", instances[1].id]
-    )
+    util.remove_node_with_retry(cluster_node, instances[1].id, retries=3)
 
     another_join_token = util.get_join_token(cluster_node, instances[2])
 

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -635,6 +635,38 @@ def join_cluster(
         instance.exec(["k8s", "join-cluster", join_token])
 
 
+def remove_node_with_retry(
+    cluster_node: harness.Instance,
+    remove_node_id: str,
+    retries: int = 25,
+    delay_s: int = 1,
+    force: bool = False,
+):
+    """Remove node with retry.
+
+    Args:
+        cluster_node: The node from which to execute the remove command
+        remove_node_id: The ID of the node to remove
+        retries: Number of retry attempts (default: 25)
+        delay_s: Delay between retries in seconds (default: 1)
+        force: Whether to use --force flag (default: False)
+    """
+    for attempt in range(retries):
+        try:
+            cmd = ["k8s", "remove-node", remove_node_id]
+            if force:
+                cmd.append("--force")
+            cluster_node.exec(cmd)
+            break
+        except Exception as e:
+            if attempt == retries - 1:  # Last attempt
+                raise
+            LOG.info(
+                f"Remove attempt {attempt + 1} failed, retrying in {delay_s} second(s): {e}"
+            )
+            time.sleep(delay_s)
+
+
 def is_ipv6(ip: str) -> bool:
     addr = ipaddress.ip_address(ip)
     return isinstance(addr, ipaddress.IPv6Address)

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -558,7 +558,7 @@ def test_feature_upgrades_rollout_upgrade(
         ), f"Expected NodeUpgrade but got {crs[0]['status']['phase']}"
 
         # Remove old node from cluster
-        new_instance.exec(["k8s", "remove-node", cluster_node.id])
+        util.remove_node_with_retry(new_instance, cluster_node.id, retries=3)
 
     # After all nodes are upgraded, the phase should be FeatureUpgrade/Completed
     # and the helm releases should be updated.


### PR DESCRIPTION
## Description

fix flakey test: test_wrong_token_race by waiting for truststore entry to be populated.


## Backport

yes all the way back to 1.32

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
