### PR TITLE
ci: Add linkcheck to our weekly tests

### DIFF
--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -76,6 +76,7 @@ jobs:
     name: Docs linkcheck (${{ matrix.ref }})
     strategy:
       fail-fast: false
+      # Update when new release branches are created
       matrix:
         ref:
           [


### PR DESCRIPTION
## Description

This is a follow up PR from #2276. Originally I had this file in that PR, but the weekly test are not being backported. Separating the PRs will make it clearer if the tests are passing. 2276 should be merged and backported and then this PR can be evaluated. 

## Solution

 Here we add the linkchecker to the weekly test and run on all release branches

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.