### PR TITLE
ci: Move linkcheck logic out for weekly tests [backport release-1.34]

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -10,20 +10,16 @@ permissions:
   contents: read
 
 jobs:
-  documentation-checks:
-    #    uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
-    #    with:
-      #   working-directory: "docs/canonicalk8s"
-      #  fetch-depth: 0
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      file_list: ${{ steps.changes.outputs.changed_files }}
+      repo: ${{ steps.changes.outputs.repo }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
 
       - name: Get changed files list with git diff
         id: changes
@@ -36,36 +32,46 @@ jobs:
             sed 's|^docs/canonicalk8s/||' | \
             xargs)
 
+          REPO=${{github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+
           # Pass the space-delimited list to the step output
           echo "Changed files: $FILE_LIST"
+          echo "Repo for tests: $REPO"
           echo "changed_files=$FILE_LIST" >> $GITHUB_OUTPUT
+          echo "repo=$REPO" >> $GITHUB_OUTPUT
 
-      - name: linkcheck 
-        run: |
-          CHANGED_FILES="${{ steps.changes.outputs.changed_files }}" 
+  linkcheck:
+    needs: prepare 
+    uses: ./.github/workflows/linkcheck.yaml
+    with:
+      changed_files: ${{ needs.prepare.outputs.file_list }}
+      repo: ${{ needs.prepare.outputs.repo }}
+      ref: ${{ github.head_ref }}
 
-          echo "Running linkcheck with files: $CHANGED_FILES"
+  spellcheck-and-inclusive-language:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-          python3 docs/canonicalk8s/.sphinx/linkcheck.py docs/canonicalk8s \
-          --install_target install \
-          --linkcheck_target linkcheck \
-          --makefile Makefile \
-          "$CHANGED_FILES"
-        shell: bash
+    - name: Set up Python
+      uses: actions/setup-python@v5
 
-      - id: spell-check
-        name: Spell Check
-        if: success() || failure()
-        uses: canonical/documentation-workflows/spellcheck@main
-        with:
-          working-directory: docs/canonicalk8s
+    - id: spell-check
+      name: Spell Check
+      if: success() || failure()
+      uses: canonical/documentation-workflows/spellcheck@main
+      with:
+        working-directory: docs/canonicalk8s
 
-      - name: Inclusive Language Check
-        id: woke-step
-        if: success() || failure()
-        uses: canonical/documentation-workflows/inclusive-language@main
-        with:
-          working-directory: docs/canonicalk8s
+    - name: Inclusive Language Check
+      id: woke-step
+      if: success() || failure()
+      uses: canonical/documentation-workflows/inclusive-language@main
+      with:
+        working-directory: docs/canonicalk8s
 
 
 

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,0 +1,71 @@
+name: Linkcheck 
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      ref: 
+        description: 'Branch to run the tests on'
+        type: string
+        required: false
+      repo:
+        description: 'Repo to run the tests on'
+        type: string
+        required: false
+        default: ${{ github.repository }}
+      changed_files:
+        type: string
+        default: ''
+
+jobs:
+  prepare:
+    name: Prepare Environment
+    runs-on: ubuntu-latest
+    outputs:
+      repo: ${{ steps.compute-ref.outputs.repo }}
+      ref: ${{ steps.compute-ref.outputs.ref }}
+    steps:
+      - name: Compute ref for test collection
+        id: compute-ref
+        shell: bash
+        run: |
+          # Determine from which rev to collect the tests, resolved in order:
+          # 1. inputs.ref if set
+          # 2. main branch
+
+          REF="main"
+          
+          if [ -n "${{ inputs.ref }}" ]; then
+            REF="${{ inputs.ref }}"
+          fi
+
+          echo "Using git ref $REF"
+          echo "repo=${{ inputs.repo }}" >> $GITHUB_OUTPUT
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+  linkcheck: 
+    name: Run linkchecker 
+    runs-on: ubuntu-latest 
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{ needs.prepare.outputs.repo }}
+          ref: ${{ needs.prepare.outputs.ref }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+      - name: Run linkcheck 
+        run: |
+          CHANGED_FILES="${{ inputs.changed_files }}"
+          echo "Running linkcheck with files: $CHANGED_FILES"
+
+          # echo "Changed files: ${{ inputs.changed_files }}"
+          python3 docs/canonicalk8s/.sphinx/linkcheck.py docs/canonicalk8s \
+            --install_target install \
+            --linkcheck_target linkcheck \
+            --makefile Makefile \
+            "$CHANGED_FILES"
+        shell: bash  

--- a/docs/canonicalk8s/.sphinx/linkcheck.py
+++ b/docs/canonicalk8s/.sphinx/linkcheck.py
@@ -48,8 +48,13 @@ def main():
             "-f",
             makefile,
             linkcheck_target,
-            f"FILES={args.changed_files}",
         ]
+
+        # Only add the FILES variable if changed_files is not empty
+        if args.changed_files and args.changed_files.strip():
+            linkcheck_cmd.append(f"FILES={args.changed_files}")
+
+        print(f"Executing: {' '.join(linkcheck_cmd)} in {args.working_dir}")
         run_command(linkcheck_cmd, args.working_dir)
 
     except subprocess.CalledProcessError as e:

--- a/docs/canonicalk8s/charm/howto/contribute.md
+++ b/docs/canonicalk8s/charm/howto/contribute.md
@@ -135,7 +135,7 @@ press `F5` in your browser to reload the page without caching)!
 <!-- LINKS -->
 
 [install lxd]: https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/
-[Snapcraft documentation]: https://snapcraft.io/docs/snapcraft-setup
+[Snapcraft documentation]: https://documentation.ubuntu.com/snapcraft/stable/how-to/set-up-snapcraft/
 [code repo]: https://github.com/canonical/k8s-snap
 [Diátaxis website]: https://diataxis.fr/
 [_parts]: https://github.com/canonical/k8s-snap/blob/main/docs/canonicalk8s/_parts/doc-cheat-sheet-myst.md

--- a/docs/canonicalk8s/charm/howto/install/charm.md
+++ b/docs/canonicalk8s/charm/howto/install/charm.md
@@ -92,5 +92,5 @@ Use `juju status` to watch these units approach the active/idle state.
 [channels]:      ../../explanation/channels
 [credentials]:   https://documentation.ubuntu.com/juju/3.6/reference/credential/
 [juju]:          https://juju.is/docs/juju/install-juju
-[charm]:         https://juju.is/docs/juju/charmed-operator
+[charm]:         https://documentation.ubuntu.com/juju/3.6/reference/charm/
 [localhost]:     install-lxd

--- a/docs/canonicalk8s/conf.py
+++ b/docs/canonicalk8s/conf.py
@@ -239,6 +239,7 @@ linkcheck_ignore = [
     'https://www.squid-cache.org/',
     'https://www.esd.whs.mil/portals/54/documents/dd/issuances/dodi/855101p.pdf',
     r'https://stigviewer.com/stigs/kubernetes/2024-06-10/finding/V-24',
+    'https://developer.hashicorp.com/vault/docs',
     ]
 
 

--- a/docs/canonicalk8s/snap/howto/contribute.md
+++ b/docs/canonicalk8s/snap/howto/contribute.md
@@ -200,7 +200,7 @@ press `F5` in your browser to reload the page without caching)!
 <!-- LINKS -->
 
 [install lxd]: https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/
-[Snapcraft documentation]: https://snapcraft.io/docs/snapcraft-setup
+[Snapcraft documentation]: https://documentation.ubuntu.com/snapcraft/stable/how-to/set-up-snapcraft/
 [code repo]: https://github.com/canonical/k8s-snap
 [Diátaxis website]: https://diataxis.fr/
 [_parts]: https://github.com/canonical/k8s-snap/blob/main/docs/canonicalk8s/_parts/doc-cheat-sheet-myst.md


### PR DESCRIPTION
# Description 

Manual backport of https://github.com/canonical/k8s-snap/pull/2276
(cherry picked from commit https://github.com/canonical/k8s-snap/commit/43b06ad424d5d494976756c584b18c7b442197df)