### PR TITLE
fix: (release-1.32) use self-hosted runners for `20.04`

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -92,7 +92,7 @@ jobs:
   run-tests:
     name: ${{ matrix.test }}
     needs: prepare
-    runs-on: ${{ fromJson(needs.prepare.outputs.test-runners)[matrix.test] || (inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04') }}
+    runs-on: ${{ fromJson(needs.prepare.outputs.test-runners)[matrix.test] || (inputs.os == 'ubuntu:20.04' && fromJson(format('["self-hosted", "linux", "jammy", "large", "{0}"]', inputs.arch))) || (inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

The latest version of the Linux kernel in `24.04` creates some issues with LXD containers.

## Solution

Our self-hosted runners have moved to the previous version of the kernel in order to mitigate this impact. We are moving the affected instances (i.e., those using `20.04`) for now.

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 