### PR TITLE
fix: init client outside of go routine, replicate built-in plugin behaviors

### DIFF
--- a/build-scripts/components/containerd/patches/v2.1.3/0001-side-load-images-plugin.patch
+++ b/build-scripts/components/containerd/patches/v2.1.3/0001-side-load-images-plugin.patch
@@ -1,12 +1,12 @@
-From f445271144cb0d880a290424badb40ea7db268d9 Mon Sep 17 00:00:00 2001
+From 5894b02d173f83ee07cac29841e59533a30aa76a Mon Sep 17 00:00:00 2001
 From: Angelos Kolaitis <angelos.kolaitis@canonical.com>
 Date: Sun, 16 Jun 2024 16:58:03 +0300
 Subject: [PATCH] side-load images plugin
 
 ---
  cmd/containerd/builtins_custom.go |   6 ++
- custom_plugins/sideload.go        | 143 ++++++++++++++++++++++++++++++
- 2 files changed, 149 insertions(+)
+ custom_plugins/sideload.go        | 144 ++++++++++++++++++++++++++++++
+ 2 files changed, 150 insertions(+)
  create mode 100644 cmd/containerd/builtins_custom.go
  create mode 100644 custom_plugins/sideload.go
 
@@ -24,10 +24,10 @@ index 000000000..d4bfd80c5
 +)
 diff --git a/custom_plugins/sideload.go b/custom_plugins/sideload.go
 new file mode 100644
-index 000000000..f661a8d4e
+index 000000000..05b480b65
 --- /dev/null
 +++ b/custom_plugins/sideload.go
-@@ -0,0 +1,155 @@
+@@ -0,0 +1,144 @@
 +package custom_plugins
 +
 +import (
@@ -84,6 +84,13 @@ index 000000000..f661a8d4e
 +		Type:   plugins.ServicePlugin,
 +		ID:     pluginName,
 +		Config: c,
++		Requires: []plugin.Type{
++			plugins.EventPlugin,
++			plugins.LeasePlugin,
++			plugins.SandboxStorePlugin,
++			plugins.TransferPlugin,
++			plugins.ServicePlugin,
++		},
 +		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 +			config := ic.Config.(*Config)
 +			config.SetDefaults()
@@ -97,42 +104,24 @@ index 000000000..f661a8d4e
 +				return nil, fmt.Errorf("no sources configured: %w", plugin.ErrSkipPlugin)
 +			}
 +
++			cl, err := containerd.New(
++				"",
++				containerd.WithDefaultNamespace(config.Namespace),
++				containerd.WithDefaultPlatform(platforms.Default()),
++				containerd.WithInMemoryServices(ic),
++				containerd.WithTimeout(2*time.Second),
++			)
++			if err != nil {
++				return nil, fmt.Errorf("sideload: failed to create containerd client: %w", err)
++			}
++
++			ctx := ic.Context
 +			go func() {
-+				// get a containerd client
-+				var (
-+					cl  *containerd.Client
-+					err error
-+				)
-+
-+				// Retry with exponential backoff to avoid race conditions during plugin initialization
-+				retries := 0
-+				maxRetries := 10
-+				for cl == nil && retries < maxRetries {
-+					select {
-+					case <-ic.Context.Done():
-+						return
-+					default:
++				defer func() {
++					if err := cl.Close(); err != nil {
++						logger.WithError(err).Warn("Failed to close containerd client")
 +					}
-+
-+					cl, err = containerd.New(
-+						"",
-+						containerd.WithDefaultNamespace(config.Namespace),
-+						containerd.WithDefaultPlatform(platforms.Default()),
-+						containerd.WithInMemoryServices(ic),
-+						containerd.WithTimeout(2*time.Second))
-+					if err != nil {
-+						retries++
-+						backoff := time.Duration(retries*retries) * 100 * time.Millisecond
-+						logger.WithError(err).Debugf("Failed to create containerd client (attempt %d/%d), retrying in %v", retries, maxRetries, backoff)
-+						time.Sleep(backoff)
-+					}
-+				}
-+
-+				if cl == nil {
-+					logger.Error("Failed to create containerd client after retries, plugin will not load images")
-+					return
-+				}
-+
++				}()
 +				for {
 +				nextDir:
 +					for _, dir := range config.Sources {
@@ -152,8 +141,8 @@ index 000000000..f661a8d4e
 +								logger.WithError(err).Warn("Failed to open file")
 +								continue nextFile
 +							}
-+							ctx := namespaces.WithNamespace(ic.Context, config.Namespace)
-+							images, err := cl.Import(ctx, r, containerd.WithImportPlatform(platforms.DefaultStrict()))
++							nsCtx := namespaces.WithNamespace(ctx, config.Namespace)
++							images, err := cl.Import(nsCtx, r, containerd.WithImportPlatform(platforms.DefaultStrict()))
 +							if err != nil {
 +								logger.WithError(err).Error("Failed to import images")
 +							} else {
@@ -172,7 +161,7 @@ index 000000000..f661a8d4e
 +						return
 +					}
 +					select {
-+					case <-ic.Context.Done():
++					case <-ctx.Done():
 +						return
 +					case <-time.After(config.Interval):
 +					}
@@ -183,5 +172,5 @@ index 000000000..f661a8d4e
 +		},
 +	})
 +}
---
-2.34.1
+-- 
+2.43.0


### PR DESCRIPTION
## Description

Containerd sometimes panics at the plugin init phase with the following message 
```
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: fatal error: concurrent map read and map write
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: goroutine 132 gp=0xc0005cc1c0 m=12 mp=0xc000601008 [running]:
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: runtime.fatal({0x5be244318cb3, 0x21})
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /snap/go/11053/src/runtime/panic.go:1123 +0x5e fp=0xc00003a6e0 sp=0xc00003a6b0 pc=0x5be2430dfabe
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: internal/runtime/maps.fatal({0x5be244318cb3?, 0x2e72656e6961746e?})
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /snap/go/11053/src/runtime/panic.go:1058 +0x18 fp=0xc00003a700 sp=0xc00003a6e0 pc=0x5be243118918
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: runtime.mapaccess1_faststr(0x2b?, 0x72672e6472656e69?, {0x5be244301c49?, 0x6365686368746c61?})
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /snap/go/11053/src/internal/runtime/maps/runtime_faststr_swiss.go:115 +0x110 fp=0xc00003a780 sp=0xc00003a700 pc=0x5be2430a9b10
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: github.com/containerd/plugin.(*InitContext).GetSingle(0x5be2447a7660?, {0x5be244301c49, 0x19})
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /build/k8s/parts/containerd/build/containerd/vendor/github.com/containerd/plugin/context.go:142 +0x47 fp=0xc00003a870 sp=0xc00003a780 pc=0x5be243801ae7
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: github.com/containerd/containerd/v2/custom_plugins.init.0.func1.1.WithInMemoryServices.3(0xc0002342d0)
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /build/k8s/parts/containerd/build/containerd/client/services.go:194 +0x27c fp=0xc00003abb8 sp=0xc00003a870 pc=0x5be24387967c
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: github.com/containerd/containerd/v2/client.New({0x0, 0x0}, {0xc00003af58, 0x4, 0x0?})
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /build/k8s/parts/containerd/build/containerd/client/client.go:104 +0x8e fp=0xc00003add8 sp=0xc00003abb8 pc=0x5be24384bf4e
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: github.com/containerd/containerd/v2/custom_plugins.init.0.func1.1()
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /build/k8s/parts/containerd/build/containerd/custom_plugins/sideload.go:87 +0x167 fp=0xc00003afe0 sp=0xc00003add8 pc=0x5be243878c87
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: runtime.goexit({})
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /snap/go/11053/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc00003afe8 sp=0xc00003afe0 pc=0x5be243120fa1
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]: created by github.com/containerd/containerd/v2/custom_plugins.init.0.func1 in goroutine 15
Feb 19 01:07:17 k8s-integration-5-977437 k8s.containerd[16274]:         /build/k8s/parts/containerd/build/containerd/custom_plugins/sideload.go:70 +0x187
```

## Solution

We move containerd client initialization outside of the go routine so that it runs synchronously in `InitFN`
My suspicion is since we run this in a go routine, `InitFN` returns early and containerd moves onto another plugin. Based on timing/race condition, both plugins access the underlying resources at the same time and we end up with the error.

## Backport

`release-1.35`

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 