### PR TITLE
chore: update `rawfile-localpv` image

### DIFF
--- a/src/k8s/pkg/k8sd/features/localpv/chart.go
+++ b/src/k8s/pkg/k8sd/features/localpv/chart.go
@@ -17,7 +17,7 @@ var (
 	// imageRepo is the repository to use for Rawfile LocalPV CSI.
 	imageRepo = "ghcr.io/canonical/rawfile-localpv"
 	// ImageTag is the image tag to use for Rawfile LocalPV CSI.
-	ImageTag = "0.8.3-ck0"
+	ImageTag = "0.8.3-ck2"
 
 	// csiNodeDriverImage is the image to use for the CSI node driver.
 	csiNodeDriverImage = "ghcr.io/canonical/csi-node-driver-registrar:2.15.0-ck0"


### PR DESCRIPTION
## Description

Update the `rawfile-localpv` image version to pick up the latest package updates.

## Solution

Use the latest patched image for `rawfile-localpv`. https://github.com/canonical/rawfile-localpv/pull/43

## Issue

N/A

## Backport

Yes, 1.32..1.35. A new PR will be raised in the k8sd repository.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
