### PR TITLE
docs: add a revert section for failed upgrade

### DIFF
--- a/docs/canonicalk8s/snap/howto/upgrades.md
+++ b/docs/canonicalk8s/snap/howto/upgrades.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Learn how to upgrade the Canonical Kubernetes snap, revert a failed upgrade, and freeze automatic updates.
+---
+
 # How to upgrade the snap
 
 Upgrading the Kubernetes version of a node is a critical operation that


### PR DESCRIPTION
## Description

This pull request adds new documentation to help users handle failed upgrades by reverting the `k8s` snap to a previous version. The update provides clear instructions and important warnings to ensure cluster safety during the revert process.

Revert upgrade documentation:

* Added a new section titled "Revert a failed upgrade" to `docs/canonicalk8s/snap/howto/upgrades.md`, including step-by-step instructions for reverting the `k8s` snap, warnings about backup requirements, and guidance for multi-node clusters.

## Backport

Should this PR be backported? If so, to which release?

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 