### PR TITLE
docs: Update broken links in 1.34

### DIFF
--- a/docs/canonicalk8s/conf.py
+++ b/docs/canonicalk8s/conf.py
@@ -240,6 +240,8 @@ linkcheck_ignore = [
     'https://www.esd.whs.mil/portals/54/documents/dd/issuances/dodi/855101p.pdf',
     r'https://stigviewer.com/stigs/kubernetes/2024-06-10/finding/V-24',
     'https://developer.hashicorp.com/vault/docs',
+    'https://kubernetes.io/docs/setup/release/version-skew-policy',
+    'https://kubernetes.io/docs/reference/config-api/',
     ]
 
 
@@ -264,7 +266,7 @@ linkcheck_anchors_ignore_for_url = [
     ]
 
 # give linkcheck multiple tries on failure
-# linkcheck_timeout = 30
+linkcheck_timeout = 30
 linkcheck_retries = 3
 
 ########################

--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -332,7 +332,7 @@ to the cluster.
 [proxy]: /snap/howto/networking/proxy.md
 [regsync]: https://github.com/regclient/regclient/blob/main/docs/regsync.md
 [regctl]: https://github.com/regclient/regclient/blob/main/docs/regctl.md
-[regctl.sh]: https://github.com/canonical/k8s-snap/blob/main/src/k8s/tools/regctl.sh
+[regctl.sh]: https://github.com/canonical/k8s-snap/blob/release-1.34/src/k8s/tools/regctl.sh
 [nodes]: /snap/tutorial/add-remove-nodes.md
 [squid]: https://www.squid-cache.org/
 [generate a join token]: /snap/reference/commands/#k8s-get-join-token


### PR DESCRIPTION
## Description

During the addition of the weekly linkcheck, these links were identified as either broken, or rate limited.

## Solution

- The regctl was removed from main, but not 1.34 so I updated that link 
- Kubernetes site was being rate limited so I skipped that site
- I also re added the linkcheck timeout between unsuccessful retries 

## Issue

Related to PR#2394

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 