### PR TITLE
docs: update networking explanation page

### DIFF
--- a/docs/canonicalk8s/snap/explanation/networking.md
+++ b/docs/canonicalk8s/snap/explanation/networking.md
@@ -1,8 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Overview of Canonical Kubernetes networking features 
-    including CNI, DNS, load balancing, Ingress, and Gateway API.
+    description: Overview of Canonical Kubernetes networking features including CNI, DNS, load balancing, Ingress, and Gateway API.
 ---
 
 # Networking


### PR DESCRIPTION
### Overview

This PR improves the networking explanation page to discuss the functionality of these features at a high-level while pointing to external resources for further info.