### PR TITLE
docs: added hw requirements page

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -211,6 +211,7 @@ GCM
 GCP
 ghcr
 Gi
+GiB
 github
 GitPython
 golang
@@ -512,6 +513,7 @@ SR-IOV
 src
 SRG
 SRGID
+SSD
 sshd
 SSL
 SSLv

--- a/docs/canonicalk8s/snap/reference/hw-requirements.md
+++ b/docs/canonicalk8s/snap/reference/hw-requirements.md
@@ -1,10 +1,13 @@
 # Hardware Requirements
 
-The following are the suggested minimum hardware requirements for running Canonical's 
-various Kubernetes products. Note that running with these resources will only allow
-for basic usage, and extra resource allotment is expected for complex use cases.
+The following are the suggested minimum hardware requirements 
+for running Canonical's various Kubernetes products. Note 
+that running with these resources will only allow for 
+basic usage, and extra resource allotment is expected for 
+complex use cases.
 
 ## Canonical Kubernetes (Snap)
+
 | Component | Specification | Notes |
 | --- | --- | --- |
 | CPU | 2 core | amd64/arm64 only |

--- a/docs/canonicalk8s/snap/reference/hw-requirements.md
+++ b/docs/canonicalk8s/snap/reference/hw-requirements.md
@@ -1,0 +1,36 @@
+# Hardware Requirements
+
+The following are the suggested minimum hardware requirements for running Canonical's 
+various Kubernetes products. Note that running with these resources will only allow
+for basic usage, and extra resource allotment is expected for complex use cases.
+
+## Canonical Kubernetes (Snap)
+| Component | Specification | Notes |
+| --- | --- | --- |
+| CPU | 2 core | amd64/arm64 only |
+| RAM | 8 GiB | |
+| Root Disk | 20 GiB of free space | SSD |
+
+## Canonical Kubernetes (Charm)
+
+| Component | Specification | Notes |
+| --- | --- | --- |
+| CPU | 2 core | amd64/arm64 only |
+| RAM | 16 GiB | |
+| Root Disk | 40 GiB of free space | SSD |
+
+## Charmed Kubernetes
+
+| Component | Specification | Notes |
+| --- | --- | --- |
+| CPU | 4 core | amd64/arm64 only |
+| RAM | 32 GiB | |
+| Root Disk | 128 GiB of free space | SSD |
+
+## MicroK8s
+
+| Component | Specification | Notes |
+| --- | --- | --- |
+| CPU | 2 core | amd64/arm64 only |
+| RAM | 4 GiB | |
+| Root Disk | 20 GiB of free space | SSD |

--- a/docs/canonicalk8s/snap/reference/hw-requirements.md
+++ b/docs/canonicalk8s/snap/reference/hw-requirements.md
@@ -1,4 +1,4 @@
-# Hardware Requirements
+# Hardware requirements
 
 The following are the suggested minimum hardware requirements 
 for running Canonical's various Kubernetes products. Note 
@@ -10,7 +10,7 @@ complex use cases.
 
 | Component | Specification | Notes |
 | --- | --- | --- |
-| CPU | 2 core | amd64/arm64 only |
+| CPU | 2 cores | amd64/arm64 only |
 | RAM | 8 GiB | |
 | Root Disk | 20 GiB of free space | SSD |
 
@@ -18,7 +18,7 @@ complex use cases.
 
 | Component | Specification | Notes |
 | --- | --- | --- |
-| CPU | 2 core | amd64/arm64 only |
+| CPU | 2 cores | amd64/arm64 only |
 | RAM | 16 GiB | |
 | Root Disk | 40 GiB of free space | SSD |
 
@@ -26,7 +26,7 @@ complex use cases.
 
 | Component | Specification | Notes |
 | --- | --- | --- |
-| CPU | 4 core | amd64/arm64 only |
+| CPU | 4 cores | amd64/arm64 only |
 | RAM | 32 GiB | |
 | Root Disk | 128 GiB of free space | SSD |
 
@@ -34,6 +34,6 @@ complex use cases.
 
 | Component | Specification | Notes |
 | --- | --- | --- |
-| CPU | 2 core | amd64/arm64 only |
+| CPU | 2 cores | amd64/arm64 only |
 | RAM | 4 GiB | |
 | Root Disk | 20 GiB of free space | SSD |

--- a/docs/canonicalk8s/snap/reference/hw-requirements.md
+++ b/docs/canonicalk8s/snap/reference/hw-requirements.md
@@ -21,19 +21,3 @@ complex use cases.
 | CPU | 2 cores | amd64/arm64 only |
 | RAM | 16 GiB | |
 | Root Disk | 40 GiB of free space | SSD |
-
-## Charmed Kubernetes
-
-| Component | Specification | Notes |
-| --- | --- | --- |
-| CPU | 4 cores | amd64/arm64 only |
-| RAM | 32 GiB | |
-| Root Disk | 128 GiB of free space | SSD |
-
-## MicroK8s
-
-| Component | Specification | Notes |
-| --- | --- | --- |
-| CPU | 2 cores | amd64/arm64 only |
-| RAM | 4 GiB | |
-| Root Disk | 20 GiB of free space | SSD |

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -87,6 +87,7 @@ Suggested minimum hardware requirements to run Kubernetes.
 :titlesonly:
 hw-requirements
 ```
+
 ---
 
 ## Other documentation types

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -79,6 +79,13 @@ troubleshooting
 inspection-reports
 ```
 
+## Hardware Requirements
+
+Suggested minimum hardware requirements to run Kubernetes.
+```{toctree}
+:titlesonly:
+hw-requirements
+```
 ---
 
 ## Other documentation types

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -82,6 +82,7 @@ inspection-reports
 ## Hardware Requirements
 
 Suggested minimum hardware requirements to run Kubernetes.
+
 ```{toctree}
 :titlesonly:
 hw-requirements


### PR DESCRIPTION
This PR adds a consolidated reference page in the docs to see the minimum hardware requirements for all of our Kubernetes products.