### PR TITLE
ci: Add automatic label to PR for release notes 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 ## Issue
 
-<!-- Include a link to the Github issue number if applicable. -->
+<!-- Include a link to the GitHub issue number if applicable. -->
 
 ## Backport
 
@@ -24,7 +24,7 @@
 - [ ] Documentation updated
 - [ ] CLA signed
 - [ ] Backport label added if necessary 
-- [ ] Release notes label applied if necessary
+- [ ] Confirm whether the `release-notes` label should be kept or removed
 
 If any item on the checklist is not complete, please provide justification why.
 

--- a/.github/workflows/auto-label-release-notes.yaml
+++ b/.github/workflows/auto-label-release-notes.yaml
@@ -1,7 +1,7 @@
 name: Auto label PRs with release notes 
 on:
-  pull_request:
-    types: [opened]
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Description

Currently when we generate our release notes we look at the git diff between the current release branch and the previous release branch. However, there can sometimes be a disconnect if the person preparing the release notes did not work on all aspects of the project. They may lack the context to be able to make the decision “is this change release notes worthy?”

The proposed process is that PRs will be labelled with a “release-notes” label automatically. Engineers will assess when drafting the PR if they deem the change worthy of being included in the release notes and decide to leave the label on or remove it. Then at release time, whoever is in charge of creating the release notes can use the PR labels as a guide. 

## Solution

- Added a new auto-label-release-notes.yaml workflow that will add release-notes to every opened PR 
- Updated the PR checklist to remind contributors to check if the release notes label is needed 
- Made the instructions on the PR template comments so they do not appear in the final PR 

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.