### PR TITLE
docs: Add redirects from read the docs

### DIFF
--- a/docs/canonicalk8s/redirects.txt
+++ b/docs/canonicalk8s/redirects.txt
@@ -15,7 +15,7 @@
 "reference/roadmap" "index"
 "snap/reference/roadmap" "index"
 
-# Condense referene files redirects
+# Condense reference files redirects
 "charm/reference/architecture" "charm/explanation/architecture"
 "snap/reference/architecture" "snap/explanation/architecture"
 "snap/reference/config-files/control-plane-join-config" "snap/reference/config-files/node-join-config"
@@ -37,7 +37,7 @@
 "snap/explanation/security/auth" "snap/explanation/security"
 "snap/howto/intermediate-ca" "snap/howto/security/intermediate-ca"
 "snap/howto/refresh-certs" "snap/howto/security/refresh-certs"
-# For GA, snap explanation secuirty pages were grouped under security 
+# For GA, snap explanation security pages were grouped under security 
 "snap/explanation/certificates" "snap/explanation/security/certificates"
 "snap/explanation/cis" "snap/explanation/security/cis"
 


### PR DESCRIPTION
## Description

Currently we have all redirects on Read the Docs. This is not ideal as it does not deal with versioning redirects as accurately and also you need admin permission to edit the redirects. 

## Solution

- Update the redirects.txt file will all redirects 
- Going forward, redirects.txt file will handle all redirects

## Issue

N/A

## Backport

I am not going to backport this PR. There are very few redirects that apply to 1.32, 1.33, 1.34 and 1.35, and for those, a redirect is already available in RTD. 

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 

If any item on the checklist is not complete, please provide justification why.