### PR TITLE
ci: add CodeQL SAST analysis workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+    branches:
+      - main
+      - 'release-[0-9]+.[0-9]+'
+
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Add CodeQL SAST (Static Application Security Testing) analysis for Python code, as recommended by the security team.

## What this PR does

Creates a new `.github/workflows/codeql.yaml` workflow that runs GitHub's CodeQL analysis on the repository's Python code.

## Triggers

- **Push** to `main` and `release-*` branches
- **Pull requests** (excluding docs-only changes)
- **Weekly schedule** (Monday 06:00 UTC) to catch newly disclosed vulnerability patterns

## How it works

- CodeQL automatically analyzes all Python code in the repository
- Results appear in the **GitHub Security tab** under Code scanning alerts
- No build configuration needed — Python is an interpreted language, so CodeQL handles it automatically
- Uses the same `security-events: write` permission pattern as the existing Trivy SARIF upload

## Permissions

- `contents: read` — checkout code
- `security-events: write` — upload analysis results to GitHub Security tab

## Follow-up

- opengrep workflow for shell/YAML coverage (separate PR)