### PR TITLE
ci: add Semgrep SAST scanning workflow

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -31,9 +31,7 @@ jobs:
                   python-version: "3.12"
 
             - name: Install Semgrep
-              run: |
-                  python -m pip install --upgrade pip setuptools
-                  python -m pip install semgrep==1.92.0
+              run: pip install semgrep==1.156.0
 
             - name: Run Semgrep scan
               run: |


### PR DESCRIPTION
## Summary

Add [Semgrep](https://semgrep.dev/) OSS SAST scanning for Python and GitHub Actions workflow files, as recommended by the security team.

Uses the fully open-source Semgrep CLI (`pip install semgrep`) — no account, token, or subscription required.

## What this PR does

Creates `.github/workflows/semgrep.yaml` that runs Semgrep with community rulesets:
- **`p/python`** — Python security rules
- **`p/github-actions`** — GitHub Actions security rules (e.g. shell injection detection)

Results are uploaded to the **GitHub Security tab** via SARIF.

## Triggers

- Push to `main` and `release-*` branches
- Pull requests (excluding docs-only changes)

## Blocking behavior

This scan is **advisory only** for now — findings appear in the Security tab but do not block PRs. There are 16 pre-existing shell injection findings in workflow files that need to be addressed in a follow-up PR before enabling blocking mode.

## Pre-existing findings

Semgrep identified 16 shell injection findings across 6 workflow files (all the same pattern — using `${{ inputs.* }}` directly in `run:` blocks instead of environment variables). See https://github.com/canonical/k8s-snap/security/code-scanning?query=pr%3A2468+is%3Aopen+tool%3A%22Semgrep+OSS%22. These will be fixed in a separate PR.

## Follow-up

- Fix pre-existing shell injection findings in workflow files (separate PR)
- Once fixed, enable `--error` flag to make Semgrep blocking