### PR TITLE
fix: update trivy to a known-safe version

### DIFF
--- a/tests/trivy-scan.sh
+++ b/tests/trivy-scan.sh
@@ -12,11 +12,11 @@ if [[ ! -f $SNAP_PATH ]]; then
 fi
 
 # Setup Trivy vulnerability scanner
+TRIVY_VERSION="v0.69.3"
 mkdir -p .trivy/sarifs
 pushd .trivy
-VER=$(curl --silent -qI https://github.com/aquasecurity/trivy/releases/latest | awk -F '/' '/^location/ {print  substr($NF, 1, length($NF)-1)}');
-wget https://github.com/aquasecurity/trivy/releases/download/${VER}/trivy_${VER#v}_Linux-64bit.tar.gz
-tar -zxvf ./trivy_${VER#v}_Linux-64bit.tar.gz
+wget https://github.com/aquasecurity/trivy/releases/download/${TRIVY_VERSION}/trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz
+tar -zxvf ./trivy_${TRIVY_VERSION#v}_Linux-64bit.tar.gz
 popd
 
 # Run Trivy vulnerability scanner in repo mode.


### PR DESCRIPTION
Update trivy to a known-safe version