### PR TITLE
fix: add retry logic for snap install/refresh in integration tests

### DIFF
--- a/tests/integration/tests/test_annotations.py
+++ b/tests/integration/tests/test_annotations.py
@@ -106,7 +106,9 @@ def test_disable_separate_feature_upgrades(
 
     start_branch = util.previous_track(config.SNAP)
     for instance in instances:
-        instance.exec(f"snap install k8s --classic --channel={start_branch}".split())
+        util.stubbornly(retries=3, delay_s=30).on(instance).exec(
+            ["snap", "install", "k8s", "--classic", f"--channel={start_branch}"]
+        )
 
     cluster_node.exec(
         "k8s bootstrap --file -".split(),

--- a/tests/integration/tests/test_bootstrap.py
+++ b/tests/integration/tests/test_bootstrap.py
@@ -4,7 +4,7 @@
 from typing import List
 
 import pytest
-from test_util import harness, tags
+from test_util import harness, tags, util
 
 
 @pytest.mark.node_count(1)
@@ -12,7 +12,9 @@ from test_util import harness, tags
 @pytest.mark.tags(tags.NIGHTLY)
 def test_microk8s_installed(instances: List[harness.Instance]):
     instance = instances[0]
-    instance.exec("snap install microk8s --classic".split())
+    util.stubbornly(retries=3, delay_s=30).on(instance).exec(
+        "snap install microk8s --classic".split()
+    )
     result = instance.exec("k8s bootstrap".split(), capture_output=True, check=False)
     assert "Error: microk8s snap is installed" in result.stderr.decode()
 

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -85,7 +85,9 @@ def setup_vault(instance: harness.Instance, instance_ip: str):
     """Install and initialize Vault."""
 
     LOG.info("Installing Vault.")
-    instance.exec(["snap", "install", "vault"])
+    util.stubbornly(retries=3, delay_s=30).on(instance).exec(
+        ["snap", "install", "vault"]
+    )
     instance.exec(["snap", "start", "vault"])
 
     LOG.info("Waiting for Vault to become available.")

--- a/tests/integration/tests/test_snap_services.py
+++ b/tests/integration/tests/test_snap_services.py
@@ -28,8 +28,8 @@ def test_snap_services(instances: List[harness.Instance]):
     refresh_track = util.previous_track(config.SNAP)
 
     LOG.info(f"Refreshing the snap to {refresh_track}")
-    cp.exec(f"snap refresh k8s --channel={refresh_track} --amend".split())
-    worker.exec(f"snap refresh k8s --channel={refresh_track} --amend".split())
+    util.snap_refresh(cp, refresh_track, "--amend")
+    util.snap_refresh(worker, refresh_track, "--amend")
 
     LOG.info("Waiting for k8s to be ready")
     util.wait_until_k8s_ready(cp, instances)

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -271,7 +271,7 @@ def setup_k8s_snap(
         LOG.info("Install k8s snap by least risky channel: %s", channel)
         cmd += [config.SNAP_NAME, "--channel", channel]
 
-    instance.exec(cmd)
+    stubbornly(retries=3, delay_s=30).on(instance).exec(cmd)
     if connect_interfaces:
         LOG.info("Ensure k8s interfaces and network requirements")
         instance.exec(["/snap/k8s/current/k8s/hack/init.sh"], stdout=subprocess.DEVNULL)
@@ -290,6 +290,41 @@ def snap_channel_args(channel: str) -> List[str]:
         return ["--channel", chan, "--revision", revision]
     else:
         return ["--channel", channel]
+
+
+def snap_refresh(
+    instance: harness.Instance,
+    channel: str,
+    *extra_args: str,
+    retries: int = 3,
+    delay_s: int = 30,
+):
+    """Refresh the k8s snap on an instance with retry logic.
+
+    Snap refresh operations can fail transiently due to snap store issues,
+    network timeouts, or snapd being busy. This function wraps the refresh
+    command with retries to handle these cases.
+
+    Args:
+        instance:   instance on which to refresh the snap
+        channel:    snap channel to refresh to
+        *extra_args: additional arguments to pass to snap refresh (e.g. "--amend")
+        retries:    number of retry attempts (default: 3)
+        delay_s:    delay in seconds between retries (default: 30)
+    """
+    cmd = [
+        "snap",
+        "refresh",
+        config.SNAP_NAME,
+        *snap_channel_args(channel),
+        # note: the `--classic` flag will be ignored by snapd for strict snaps.
+        "--classic",
+        *extra_args,
+    ]
+    LOG.info(
+        "Refreshing %s to channel %s on %s", config.SNAP_NAME, channel, instance.id
+    )
+    stubbornly(retries=retries, delay_s=delay_s).on(instance).exec(cmd)
 
 
 def remove_k8s_snap(instance: harness.Instance):

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -124,15 +124,13 @@ def test_version_upgrades(
             latest_version = out.stdout.decode().strip().split("\n")[-1]
             LOG.info(f"Current snap version: {latest_version}")
 
-            # note: the `--classic` flag will be ignored by snapd for strict snaps.
             if channel.startswith("/"):
                 LOG.info("Refreshing k8s snap by path")
-                cmd = ["snap", "install", "--classic", "--dangerous", snap_path]
+                instance.exec(
+                    ["snap", "install", "--classic", "--dangerous", snap_path]
+                )
             else:
-                cmd = ["snap", "refresh", "--classic", config.SNAP_NAME]
-                cmd += [*util.snap_channel_args(channel), "--amend"]
-
-            instance.exec(cmd)
+                util.snap_refresh(instance, channel, "--amend")
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance)
@@ -243,16 +241,7 @@ def test_version_downgrades_with_rollback(
             LOG.debug(
                 f"Step 1. Downgrade {instance.id} from {current_channel} → {channel}"
             )
-            # note: the `--classic` flag will be ignored by snapd for strict snaps.
-            instance.exec(
-                [
-                    "snap",
-                    "refresh",
-                    config.SNAP_NAME,
-                    *util.snap_channel_args(channel),
-                    "--classic",
-                ]
-            )
+            util.snap_refresh(instance, channel)
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance)
@@ -264,16 +253,7 @@ def test_version_downgrades_with_rollback(
 
         for instance in instances:
             LOG.debug(f"Step 2. Roll back from {current_channel} → {last_channel}")
-            # note: the `--classic` flag will be ignored by snapd for strict snaps.
-            instance.exec(
-                [
-                    "snap",
-                    "refresh",
-                    config.SNAP_NAME,
-                    *util.snap_channel_args(last_channel),
-                    "--classic",
-                ]
-            )
+            util.snap_refresh(instance, last_channel)
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance)
@@ -284,15 +264,7 @@ def test_version_downgrades_with_rollback(
             LOG.debug(
                 f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
             )
-            instance.exec(
-                [
-                    "snap",
-                    "refresh",
-                    config.SNAP_NAME,
-                    *util.snap_channel_args(current_channel),
-                    "--classic",
-                ]
-            )
+            util.snap_refresh(instance, current_channel)
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance)
@@ -336,7 +308,7 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
     worker = instances[-1]
 
     for instance in instances:
-        instance.exec(
+        util.stubbornly(retries=3, delay_s=30).on(instance).exec(
             [
                 "snap",
                 "install",
@@ -520,11 +492,11 @@ def test_feature_upgrades_rollout_upgrade(
 
     # Setup the first half of nodes up on the old version.
     for instance in instances[:3]:
-        instance.exec(
+        util.stubbornly(retries=3, delay_s=30).on(instance).exec(
             ["snap", "install", "k8s", "--classic", *util.snap_channel_args(start_snap)]
         )
 
-    instance.exec(
+    util.stubbornly(retries=3, delay_s=30).on(instance).exec(
         ["snap", "install", "k8s", "--classic", *util.snap_channel_args(start_snap)]
     )
 


### PR DESCRIPTION
## Summary

Adds retry logic to all bare `snap install` and `snap refresh` calls in integration tests. These operations can fail transiently due to network timeouts, snapd being busy, or snap store availability issues, causing nightly CI flakes.

Analysis of recent nightly runs shows `test_version_upgrades` and `test_version_downgrades_with_rollback` are the most frequent failures, consistently caused by `snap refresh` returning exit status 1 transiently.

## Changes

- **`tests/integration/tests/test_util/util.py`** — Added `snap_refresh()` utility function that wraps `snap refresh` with retry logic (3 attempts, 30s delay). Added retry to `setup_k8s_snap()` for `snap install` operations.
- **`tests/integration/tests/test_version_upgrades.py`** — All `snap refresh` and `snap install` calls now use retrying wrappers (`snap_refresh()` or `stubbornly()`). This covers `test_version_upgrades`, `test_version_downgrades_with_rollback`, `test_feature_upgrades_inplace`, and `test_feature_upgrades_rollout_upgrade`.
- **`tests/integration/tests/test_snap_services.py`** — `snap refresh` calls now use `snap_refresh()`.
- **`tests/integration/tests/test_external_certificates.py`** — `snap install vault` now uses `stubbornly()` retry.
- **`tests/integration/tests/test_annotations.py`** — `snap install k8s` now uses `stubbornly()` retry.
