### PR TITLE
fix: attribute Trivy SARIF results to the scanned branch

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -71,7 +71,7 @@ jobs:
           # not the branch that triggered the workflow. Without this,
           # scheduled scans of release branches get attributed to main
           # and create alerts that can never be resolved.
-          ref: ${{ inputs.checkout-ref && format('refs/heads/{0}', inputs.checkout-ref) || github.ref }}
+          ref: ${{ inputs.checkout-ref && (startsWith(inputs.checkout-ref, 'refs/') && inputs.checkout-ref || format('refs/heads/{0}', inputs.checkout-ref)) || github.ref }}
           sha: ${{ inputs.checkout-ref && steps.scan-ref.outputs.sha || github.sha }}
           category: trivy-repo-scan/${{ inputs.checkout-ref || github.ref_name }}
       - name: Send vulnerability records


### PR DESCRIPTION
## Summary

Fixes stale Trivy code scanning alerts on `main` (CVE-2026-33186 and CVE-2026-3351) that can never be resolved.

**Root cause**: The scheduled Trivy scan (`trivy.yaml`) scans multiple branches (main, release-1.32 through release-1.35). The `security-scan.yaml` workflow checks out the target branch via `checkout-ref` but the `upload-sarif` step did not specify `ref` or `sha`. This caused **all** SARIF results to be attributed to `refs/heads/main` (the cron trigger ref), even when a release branch was actually scanned.

Since `src/k8s/go.mod` was removed from `main` (moved to the [k8sd repo](https://github.com/canonical/k8sd)), vulnerabilities found in that file on release branches created alerts on `main` that could never be resolved — the file doesn't exist on `main` so GitHub cannot determine the alert is fixed.

**Fix**: Pass `ref`, `sha`, and `category` to `github/codeql-action/upload-sarif` so that results are correctly attributed to the branch that was actually scanned. When `checkout-ref` is provided (scheduled scans), results go to that branch. When it's not provided (PR scans via `lint_and_integration.yaml`), the existing default behavior (`github.ref`/`github.sha`) is preserved.