### PR TITLE
fix: add TEST_ prefix to LXD_DUAL_NIC env vars for consistency

### DIFF
--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -126,12 +126,12 @@ LXD_DUAL_NIC_NETWORK = os.getenv("TEST_LXD_DUAL_NIC_NETWORK") or "dual-nic-br0"
 
 # LXD_DUAL_NIC_PROFILE_NAME is the profile name to use for LXD containers with dual NIC setup.
 LXD_DUAL_NIC_PROFILE_NAME = (
-    os.getenv("LXD_DUAL_NIC_PROFILE_NAME") or "k8s-integration-dual-nic"
+    os.getenv("TEST_LXD_DUAL_NIC_PROFILE_NAME") or "k8s-integration-dual-nic"
 )
 
 # LXD_DUAL_NIC_PROFILE is the profile to use for LXD containers with dual NIC setup.
 LXD_DUAL_NIC_PROFILE = (
-    os.getenv("LXD_DUAL_NIC_PROFILE")
+    os.getenv("TEST_LXD_DUAL_NIC_PROFILE")
     or (DIR / ".." / ".." / "lxd-dual-nic-profile.yaml").read_text()
 )
 


### PR DESCRIPTION
## Summary

- Renames `LXD_DUAL_NIC_PROFILE_NAME` → `TEST_LXD_DUAL_NIC_PROFILE_NAME` and `LXD_DUAL_NIC_PROFILE` → `TEST_LXD_DUAL_NIC_PROFILE` in the test config environment variable lookups.
- All other LXD-related env vars in `tests/integration/tests/test_util/config.py` already use the `TEST_` prefix (e.g. `TEST_LXD_PROFILE_NAME`, `TEST_LXD_FAN_PROFILE_NAME`, `TEST_LXD_DUALSTACK_PROFILE_NAME`, etc.). These two were the only exceptions.
- No CI workflows reference these env vars, so this is a safe rename.

**Note:** This is a breaking change for anyone who has `LXD_DUAL_NIC_PROFILE_NAME` or `LXD_DUAL_NIC_PROFILE` set in their local test environment. They would need to rename to `TEST_LXD_DUAL_NIC_PROFILE_NAME` / `TEST_LXD_DUAL_NIC_PROFILE`.