### PR TITLE
test: fix flaky test_gateway by waiting for Gateway controller readiness

### DIFF
--- a/tests/integration/tests/test_gateway.py
+++ b/tests/integration/tests/test_gateway.py
@@ -22,7 +22,7 @@ def get_gateway_service_node_port(p):
     gateway_services = [
         svc
         for svc in services["items"]
-        if svc["metadata"].get("labels").get("io.cilium.gateway/owning-gateway")
+        if svc["metadata"].get("labels", {}).get("io.cilium.gateway/owning-gateway")
         == "my-gateway"
     ]
 
@@ -40,7 +40,7 @@ def get_external_service_ip(instance: harness.Instance) -> str:
     LOG.info("Waiting for gateway IP to be available...")
     try_count = 0
     gateway_ip = None
-    while not gateway_ip and try_count < 30:
+    while not gateway_ip and try_count < 60:
         LOG.info(f"Attempt {try_count + 1} to get gateway IP...")
         try_count += 1
         try:
@@ -83,10 +83,44 @@ def test_gateway(instances: List[harness.Instance]):
     util.wait_for_network(instance)
     util.wait_for_dns(instance)
 
+    # Wait for the GatewayClass to be accepted by Cilium before applying
+    # gateway resources. Without this, the Gateway controller may not be
+    # ready to reconcile the Gateway and HTTPRoute resources.
+    LOG.info("Waiting for GatewayClass ck-gateway to be accepted...")
+    util.stubbornly(retries=30, delay_s=10).on(instance).until(
+        lambda p: "True" in p.stdout.decode()
+    ).exec(
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "gatewayclass",
+            "ck-gateway",
+            "-o=jsonpath={.status.conditions[?(@.type=='Accepted')].status}",
+        ]
+    )
+
     manifest = MANIFESTS_DIR / "gateway-test.yaml"
     instance.exec(
         ["k8s", "kubectl", "apply", "-f", "-"],
         input=Path(manifest).read_bytes(),
+    )
+
+    # Wait for the Gateway to be programmed. The Cilium gateway controller
+    # needs time to reconcile the Gateway resource, create the underlying
+    # service/endpoints, and set status conditions.
+    LOG.info("Waiting for Gateway my-gateway to be programmed...")
+    util.stubbornly(retries=30, delay_s=10).on(instance).until(
+        lambda p: "True" in p.stdout.decode()
+    ).exec(
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "gateway",
+            "my-gateway",
+            "-o=jsonpath={.status.conditions[?(@.type=='Programmed')].status}",
+        ]
     )
 
     LOG.info("Waiting for nginx pod to show up...")
@@ -112,7 +146,7 @@ def test_gateway(instances: List[harness.Instance]):
     # Get gateway node port
     gateway_http_port = None
     result = (
-        util.stubbornly(retries=10, delay_s=3)
+        util.stubbornly(retries=20, delay_s=5)
         .on(instance)
         .until(lambda p: get_gateway_service_node_port(p))
         .exec(["k8s", "kubectl", "get", "service", "-o", "json"])
@@ -121,13 +155,13 @@ def test_gateway(instances: List[harness.Instance]):
 
     assert gateway_http_port, "No Gateway nodePort found."
 
-    # Test the Gateway service via loadbalancer IP.
-    util.stubbornly(retries=10, delay_s=5).on(instance).until(
+    # Test the Gateway service via nodePort.
+    util.stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"localhost:{gateway_http_port}"])
 
     gateway_ip = get_external_service_ip(instance)
     assert gateway_ip, "No Gateway IP found."
-    util.stubbornly(retries=10, delay_s=5).on(instance).until(
+    util.stubbornly(retries=15, delay_s=5).on(instance).until(
         lambda p: "Welcome to nginx!" in p.stdout.decode()
     ).exec(["curl", f"{gateway_ip}", "-H", "Host: foo.bar.com"])


### PR DESCRIPTION
## Summary

`test_gateway` has been intermittently failing in the nightly run (e.g. [run #23966847062](https://github.com/canonical/k8s-snap/actions/runs/23966847062)) on `1.33-classic/edge` / `amd64`. The test races against the Cilium Gateway controller — it applies a Gateway manifest and immediately starts probing for the gateway service nodePort without ever confirming the Gateway has been programmed.

## Root Cause

After applying the gateway-test.yaml manifest, the test jumps straight to looking for the gateway service (`retries=10, delay=3s` = 30s max). The Cilium gateway controller needs time to:
1. Accept the GatewayClass
2. Reconcile the Gateway resource
3. Create the underlying Service/Endpoints
4. Set status conditions (Accepted, Programmed)

On slower CI runners this chain easily exceeds 30s, causing a flaky failure.

By comparison, `test_ingress.py` uses `retries=20, delay=3s` (60s) for its equivalent check, and `test_loadbalancer.py` explicitly calls `wait_for_load_balancer()` before proceeding.

## Changes

1. **Wait for GatewayClass to be Accepted** (300s budget) — confirms the Cilium gateway controller is ready before applying resources
2. **Wait for Gateway to be Programmed** (300s budget) — confirms the Gateway has been fully reconciled before probing services
3. **Increase nodePort retry budget** — from `retries=10, delay=3s` (30s) to `retries=20, delay=5s` (100s), matching `test_ingress.py`
4. **Increase external IP retry attempts** — from 30 to 60, matching `test_ingress.py`
5. **Increase curl retry budgets** — from `retries=10` to `retries=15` for both nodePort and LB IP tests
6. **Fix potential AttributeError** — `.get('labels').get()` → `.get('labels', {}).get()` to handle services with no labels

## Testing

These are integration test changes — the fix is verified by the nightly run itself. The added waits are generous but bounded, so they won't slow down passing runs (stubbornly returns as soon as the condition is met).