### PR TITLE
test: increase pod readiness timeout for downgrade rollback test

### DIFF
--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -273,9 +273,13 @@ def test_version_downgrades_with_rollback(
 
             LOG.info("Rollback segment complete. Proceeding to next downgrade segment.")
 
-        LOG.info("Waiting for all pods to be ready after upgrade")
-        util.wait_for_pods_ready(cp)
-        LOG.info("All pods are ready after upgrade")
+        LOG.info("Waiting for all pods to be ready after downgrade segment")
+        # Use a generous timeout for pod readiness after downgrade segments.
+        # Multiple rapid version transitions (downgrade + rollback + final downgrade
+        # across all nodes) can leave pods in a degraded state that takes longer than
+        # the default 10 minutes to recover, especially on arm64.
+        util.wait_for_pods_ready(cp, retries=180, delay_s=5)
+        LOG.info("All pods are ready after downgrade segment")
 
     LOG.info("Rollback test complete. All downgrade segments verified.")
 


### PR DESCRIPTION
## Problem

The `test_version_downgrades_with_rollback` integration test has been failing in nightly CI (Ubuntu 24.04, arm64) with:

```
tenacity.RetryError  (at util.wait_for_pods_ready)
```

After completing the 1.34->1.33 downgrade segment, `coredns` and `ck-storage-rawfile-csi-node` pods were stuck not-ready and couldn't recover within the default 10-minute timeout (120 retries x 5s).

## Root Cause

The downgrade-with-rollback test puts significantly more stress on the cluster than a simple upgrade. Each downgrade segment performs 3 rolling operations across all nodes:

1. Downgrade all nodes to target channel
2. Roll back all nodes to previous channel
3. Final downgrade all nodes to target channel

That's 9+ snap refreshes across 3 nodes per segment, with `wait_until_k8s_ready` after each refresh (which only checks node readiness and snap services, not pod readiness). By the time `wait_for_pods_ready` is called at the end of the segment, pods may need more than 10 minutes to fully stabilize — especially on arm64 where everything runs slower.

## Changes

- Increase `wait_for_pods_ready` timeout from the default 10 minutes to 15 minutes (180 retries x 5s) specifically for the downgrade test.
- Fix log message to say "downgrade segment" instead of "upgrade".