### PR TITLE
fix(deps): bump vulnerable Python dependencies in test/CI files

### DIFF
--- a/build-scripts/hack/requirements.txt
+++ b/build-scripts/hack/requirements.txt
@@ -1,4 +1,4 @@
-lief==0.16.6
+lief==0.17.6
 packaging==24.2
 pyyaml==6.0.1
 tenacity==9.0.0

--- a/ci/requirements-ci.txt
+++ b/ci/requirements-ci.txt
@@ -1,7 +1,7 @@
 bandit[toml]==1.7.10
-black==24.3.0
+black==26.3.1
 codespell==2.2.4
 flake8==6.0.0
 isort==5.12.0
 licenseheaders==0.8.8
-requests==2.32.5
+requests==2.33.1

--- a/tests/branch_management/requirements-dev.txt
+++ b/tests/branch_management/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==24.3.0
+black==26.3.1
 codespell==2.2.4
 flake8==6.0.0
 isort==5.12.0

--- a/tests/branch_management/requirements-test.txt
+++ b/tests/branch_management/requirements-test.txt
@@ -3,5 +3,5 @@ pytest==7.3.1
 PyYAML==6.0.1
 tenacity==8.2.3
 pylint==3.2.5
-requests==2.32.3
+requests==2.33.1
 semver==3.0.2

--- a/tests/integration/requirements-dev.txt
+++ b/tests/integration/requirements-dev.txt
@@ -1,5 +1,5 @@
 bandit[toml]==1.7.10
-black==24.3.0
+black==26.3.1
 codespell==2.2.4
 flake8==6.0.0
 isort==5.12.0

--- a/tests/integration/requirements-test.txt
+++ b/tests/integration/requirements-test.txt
@@ -5,7 +5,7 @@ pytest-benchmark==5.0.0
 PyYAML==6.0.1
 tenacity==8.2.3
 pylint==3.2.5
-cryptography==44.0.1
+cryptography==46.0.6
 hvac==2.3.0
 python-subunit>=1.2
 os-testr


### PR DESCRIPTION
## Summary

Bump vulnerable Python dependencies in test and CI requirement files.

### CVEs Fixed

| CVE | Severity | Package | Old Version | Fixed Version | Files |
|-----|----------|---------|-------------|---------------|-------|
| CVE-2026-32274 | **HIGH** | black | 24.3.0 | 26.3.1 | ci/, tests/branch_management/, tests/integration/ |
| CVE-2026-26007 | **HIGH** | cryptography | 44.0.1 | 46.0.6 | tests/integration/ |
| CVE-2026-25645 | MEDIUM | requests | 2.32.3-2.32.5 | 2.33.1 | ci/, tests/branch_management/ |
| CVE-2024-47081 | MEDIUM | requests | 2.32.3 | 2.33.1 | tests/branch_management/ |
| CVE-2026-34073 | LOW | cryptography | 44.0.1 | 46.0.6 | tests/integration/ |
| CVE-2025-15504 | LOW | lief | 0.16.6 | 0.17.6 | build-scripts/hack/ |

All affected packages are dev/test/CI tooling only, not production dependencies.