### PR TITLE
docs: fix broken privileged container link in LXD install guide

### DIFF
--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -168,4 +168,4 @@ lxc delete k8s-vm
 [default-bridged-networking]: https://documentation.ubuntu.com/lxd/en/latest/reference/network_bridge/
 [Microbot]: https://github.com/dontrebootme/docker-microbot
 [channels]: ../../explanation/channels
-[privileged container]: https://documentation.ubuntu.com/lxd/explanation/security/#privileged-containers
+[privileged container]: https://documentation.ubuntu.com/lxd/en/latest/explanation/security/#privileged-containers


### PR DESCRIPTION
## Description

Fix broken link in `docs/canonicalk8s/snap/howto/install/lxd.md`.

The `documentation.ubuntu.com/server/...` URL now 301-redirects to `ubuntu.com/server/docs/...` which drops the anchor fragment, causing linkcheck CI to fail across all release branches.

## Solution

Updated the "privileged container" reference link to the current LXD security documentation URL, consistent with other LXD documentation links in the repo.

**Old URL:** `https://documentation.ubuntu.com/server/how-to/containers/lxd-containers/index.html#uid-mappings-and-privileged-containers`
**New URL:** `https://documentation.ubuntu.com/lxd/en/latest/explanation/security/#privileged-containers`

This fix resolves the linkcheck CI failures on PRs targeting main.

## Issue



## Backport



## Checklist

- [ ] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [ ] CLA signed
- [ ] Backport label added if necessary 
- [ ] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.

No unit or integration tests are applicable for a documentation link fix.