### PR TITLE
ci: remove stale src/k8s/go.mod reference from update scripts

### DIFF
--- a/build-scripts/hack/update_utils.py
+++ b/build-scripts/hack/update_utils.py
@@ -10,7 +10,6 @@ LOG = logging.getLogger(__name__)
 DIR = Path(__file__).absolute().parent
 SNAPCRAFT = DIR.parent.parent / "snap/snapcraft.yaml"
 COMPONENTS = DIR.parent / "components"
-GO_MOD = DIR.parent.parent / "src/k8s/go.mod"
 
 
 def update_go_version(dry_run: bool):
@@ -22,7 +21,6 @@ def update_go_version(dry_run: bool):
     LOG.info("Upstream go version is %s", go_version)
 
     _update_go_version_in_snapcraft(k8s_version, go_version, dry_run)
-    _update_go_version_in_go_mod(go_version, dry_run)
 
 
 def _update_go_version_in_snapcraft(k8s_version: str, go_version: str, dry_run: bool):
@@ -43,15 +41,3 @@ def _update_go_version_in_snapcraft(k8s_version: str, go_version: str, dry_run: 
             r"- go/\d+\.\d+(?:-fips)?/stable", f"- {go_snap}", snapcraft_yaml
         )
         SNAPCRAFT.write_text(updated)
-
-
-def _update_go_version_in_go_mod(go_version: str, dry_run: bool):
-    go_mod = GO_MOD.read_text()
-    if f"go {go_version}" in go_mod:
-        LOG.info("go.mod already contains go version %s", go_version)
-        return
-
-    LOG.info("Update go version to %s in %s", go_version, GO_MOD)
-    if not dry_run:
-        updated = re.sub(r"go \d+\.\d+\.\d+", f"go {go_version}", go_mod)
-        GO_MOD.write_text(updated)


### PR DESCRIPTION
## Summary

- Remove the `GO_MOD` constant, `_update_go_version_in_go_mod()` function, and its call from `update_utils.py`

## Root Cause

The `update-pre-release-branches` workflow runs `k8s_release.py` which calls `update_go_version()`. This function calls `_update_go_version_in_go_mod()` which tries to read `src/k8s/go.mod`. When the workflow checks out `main` (to prepare pre-release branches), `src/k8s/go.mod` no longer exists because k8sd was moved to the separate `canonical/k8sd` repository.

This causes `FileNotFoundError: No such file or directory: '.../src/k8s/go.mod'` on any PR that modifies `update-pre-release-branches.yaml` (triggering the workflow's `pull_request` path filter).

The fix aligns the release branch with `main`, which already removed this code.