### PR TITLE
test: increase feature controller test retry window

### DIFF
--- a/tests/integration/tests/test_feature_controller.py
+++ b/tests/integration/tests/test_feature_controller.py
@@ -94,6 +94,6 @@ def test_feature_controller(instances: List[harness.Instance]):
         return True
 
     LOG.info("Verifying the output of `k8s status`")
-    util.stubbornly(retries=15, delay_s=10).on(instance).until(
+    util.stubbornly(retries=30, delay_s=20).on(instance).until(
         condition=status_output_matches,
     ).exec(["k8s", "status", "--wait-ready"])


### PR DESCRIPTION
## Summary

- Increase `test_feature_controller` retry window from 150s (15x10s) to 600s (30x20s)

## Root Cause

The `test_feature_controller` chaos test is a recurring nightly failure. The test kills `kube-apiserver` repeatedly while toggling features, then waits for recovery. Two failure patterns were observed:

**1. DNS ClusterIP allocator corruption:**
```
dns: Failed to deploy DNS: Service "coredns" is invalid: spec.clusterIPs:
  failed to allocate IP 10.152.183.216: provided IP is already allocated
```
Killing `kube-apiserver` mid-Helm-install can leave the ClusterIP allocator bitmap out of sync with actual Service objects. Kubernetes has a [repair controller](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/service/ipallocator/controller/repair.go#L49) that periodically reconciles orphaned allocations. It runs every ~3 minutes and requires 3 consecutive leak detections before cleanup, so worst case recovery is ~9 minutes.

**2. MetalLB webhook not ready:**
```
load-balancer: Failed to deploy MetalLB: failed calling webhook
  "l2advertisementvalidationwebhook.metallb.io": connection refused
```
The feature controller only waits for MetalLB CRDs to exist, not for webhook endpoints to be ready. The webhook pods need time to start after the chaos.

Both are transient and self-resolving, but the 150s retry window is too short given:
- Kubernetes repair controller needs up to ~9 minutes for ClusterIP reconciliation
- Feature controller exponential backoff (3s → 5min cap) slows retries after several failures
- Combined recovery can take 4-6 minutes