### PR TITLE
test: increase feature controller test retry window [release-1.35]

### DIFF
--- a/tests/integration/tests/test_feature_controller.py
+++ b/tests/integration/tests/test_feature_controller.py
@@ -94,6 +94,6 @@ def test_feature_controller(instances: List[harness.Instance]):
         return True
 
     LOG.info("Verifying the output of `k8s status`")
-    util.stubbornly(retries=15, delay_s=10).on(instance).until(
+    util.stubbornly(retries=30, delay_s=20).on(instance).until(
         condition=status_output_matches,
     ).exec(["k8s", "status", "--wait-ready"])


### PR DESCRIPTION
## Summary

- Increase `test_feature_controller` retry window from 150s (15x10s) to 600s (30x20s)

Backport of #2524 to `release-1.35`.

## Root Cause

The `test_feature_controller` chaos test is a recurring nightly failure. The test kills `kube-apiserver` repeatedly while toggling features, then waits for recovery. Two failure patterns were observed:

**1. DNS ClusterIP allocator corruption:** Killing `kube-apiserver` mid-Helm-install can leave the ClusterIP allocator bitmap out of sync. Kubernetes has a [repair controller](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/service/ipallocator/controller/repair.go#L49) that periodically reconciles orphaned allocations. It runs every ~3 minutes and requires 3 consecutive leak detections before cleanup, so worst case recovery is ~9 minutes.

**2. MetalLB webhook not ready:** The feature controller only waits for CRDs, not webhook endpoint readiness.

Both are transient and self-resolving, but 150s is too short given Kubernetes repair time (up to ~9 min) + feature controller exponential backoff (3s to 5min cap).