### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
           zizmor-args: --pedantic
           advanced-security: "true"


### PR DESCRIPTION
Automated update of SHA-pinned GitHub Actions.

- `zizmorcore/zizmor-action`: `v0.5.2` -> `v0.5.3`