### PR TITLE
feat(tests): add regression test for late-joining nodes' DNS configuration

### DIFF
--- a/build-scripts/build-component.sh
+++ b/build-scripts/build-component.sh
@@ -31,6 +31,7 @@ if [ ! -d "${COMPONENT_BUILD_DIRECTORY}" ]; then
 fi
 
 cd "${COMPONENT_BUILD_DIRECTORY}"
+echo "Building ${COMPONENT_NAME} at commit $(git rev-parse HEAD)"
 git config user.name "K8s builder bot"
 git config user.email "k8s-bot@canonical.com"
 

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -151,3 +151,120 @@ def test_dns_ha_rebalancing(instances: List[harness.Instance]):
         ],
         text=True,
     )
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.PULL_REQUEST)
+def test_dns_cluster_dns_propagates_to_late_joiners(
+    instances: List[harness.Instance],
+):
+    """
+    Regression test for issue #2516.
+
+    When a node joins after CoreDNS has already been reconciled, the
+    kube-system/k8sd-config ConfigMap is already at its steady-state contents
+    including cluster-dns=<CoreDNS ClusterIP>. A bare Watch established *after*
+    the ConfigMap was created does not synthesise an ADDED event for the
+    pre-existing object, so on the joining node NodeConfigurationController
+    would never reconcile kubelet with --cluster-dns. The fix seeds WatchConfigMap
+    with a Get before starting the Watch, and additionally writes kubelet args +
+    restarts kubelet locally on the node that reconciles CoreDNS. This test joins
+    a control-plane and a worker node *after* DNS is ready and asserts every node
+    ends up with --cluster-dns pointing at the CoreDNS service IP.
+    """
+    initial_node = instances[0]
+    joining_cplane_node = instances[1]
+    joining_worker_node = instances[2]
+
+    # Bring up the initial control plane and wait for CoreDNS to converge so
+    # the k8sd-config ConfigMap is already in its steady state with
+    # cluster-dns=<IP> before either other node joins.
+    util.wait_until_k8s_ready(initial_node, [initial_node])
+    util.wait_for_dns(initial_node)
+
+    # Discover the CoreDNS service ClusterIP instead of hard-coding it so the
+    # assertion survives CIDR changes.
+    result = initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "service",
+            "-n",
+            "kube-system",
+            "coredns",
+            "-o",
+            "jsonpath={.spec.clusterIP}",
+        ],
+        capture_output=True,
+    )
+    coredns_ip = result.stdout.decode().strip()
+    assert coredns_ip, "CoreDNS service should have a ClusterIP"
+    LOG.info("CoreDNS ClusterIP: %s", coredns_ip)
+
+    cplane_token = util.get_join_token(initial_node, joining_cplane_node)
+    worker_token = util.get_join_token(initial_node, joining_worker_node, "--worker")
+    util.join_cluster(joining_cplane_node, cplane_token)
+    util.join_cluster(joining_worker_node, worker_token)
+
+    util.wait_until_k8s_ready(initial_node, instances)
+
+    # Every node's kubelet args file must end up with --cluster-dns set to the
+    # CoreDNS ClusterIP. Before the fix, the joining nodes'
+    # NodeConfigurationController would miss the pre-existing ConfigMap's
+    # initial state and this arg would never be written.
+    expected_arg = f'--cluster-dns="{coredns_ip}"'
+    for instance in instances:
+        LOG.info("Asserting --cluster-dns on node %s", instance.id)
+        util.stubbornly(retries=12, delay_s=5).on(instance).until(
+            lambda p: expected_arg in p.stdout.decode()
+        ).exec(["cat", "/var/snap/k8s/common/args/kubelet"])
+
+    # End-to-end sanity: schedule a pod on the late-joined worker and verify
+    # its /etc/resolv.conf points at the CoreDNS ClusterIP. This is the actual
+    # user-visible symptom from the issue.
+    worker_name = util.hostname(joining_worker_node)
+    initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "run",
+            "busybox-late",
+            "--image=ghcr.io/containerd/busybox:1.28",
+            "--restart=Never",
+            "--overrides",
+            f'{{"spec": {{"nodeName": "{worker_name}"}}}}',
+            "--",
+            "sleep",
+            "3600",
+        ],
+    )
+
+    util.stubbornly(retries=3, delay_s=1).on(initial_node).exec(
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "busybox-late",
+            "--timeout",
+            "180s",
+        ]
+    )
+
+    resolv = initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "exec",
+            "busybox-late",
+            "--",
+            "cat",
+            "/etc/resolv.conf",
+        ],
+        capture_output=True,
+    ).stdout.decode()
+    assert (
+        f"nameserver {coredns_ip}" in resolv
+    ), f"expected CoreDNS ClusterIP in pod resolv.conf, got: {resolv}"


### PR DESCRIPTION
This pull request introduces a regression test to ensure that the CoreDNS ClusterIP is correctly propagated to nodes that join a Kubernetes cluster after CoreDNS has already been reconciled. This addresses a previous issue where late-joining nodes would not receive the correct `--cluster-dns` configuration, potentially breaking DNS resolution for workloads scheduled on those nodes. Additionally, the pull request updates the `k8sd` component version to track the relevant work.

**Testing and validation improvements:**

* Added a new regression test `test_dns_cluster_dns_propagates_to_late_joiners` in `test_dns.py` to verify that nodes joining after CoreDNS reconciliation receive the correct `--cluster-dns` kubelet argument and that pods scheduled on those nodes use the correct DNS configuration.

Needs: https://github.com/canonical/k8sd/pull/34