### PR TITLE
fix(ci): use BOT_TOKEN for auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-successful-prs.yaml
+++ b/.github/workflows/auto-merge-successful-prs.yaml
@@ -20,6 +20,6 @@ jobs:
           python-version: '3.12'
       - name: Auto-merge pull requests if all status checks pass
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
             build-scripts/hack/auto-merge-successful-pr.py


### PR DESCRIPTION
The auto-merge workflow uses `gh pr review --approve` and `gh pr merge --admin`, which require pull request write permissions. The default `github.token` only has `contents: read` (set at the workflow level), causing recurring `Resource not accessible by integration` errors every 4 hours.

Switch to `BOT_TOKEN` which has the necessary permissions, matching the pattern already used in `update-ci-dependencies.yaml`.