### PR TITLE
fix(ci): bump pip-tools to 8.3.0

### DIFF
--- a/.github/workflows/update-ci-dependencies.yaml
+++ b/.github/workflows/update-ci-dependencies.yaml
@@ -59,7 +59,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install pip-tools
-        run: pip install "pip-tools==7.4.1" "requests==2.33.1"
+        run: pip install "pip-tools==8.3.0" "requests==2.33.1"
 
       - name: Update pip lock files
         id: check


### PR DESCRIPTION
pip-tools 7.4.1 is incompatible with pip >= 25.x — `pip-compile` crashes with:

```
AttributeError: 'PackageFinder' object has no attribute 'allow_all_prereleases'
```

This breaks the daily `Update CI dependencies` workflow. pip-tools 8.x uses the updated pip API.