### PR TITLE
feat(k8sd): [backport 1.34] coredns changes and service args improvements

### DIFF
--- a/build-scripts/build-component.sh
+++ b/build-scripts/build-component.sh
@@ -31,6 +31,7 @@ if [ ! -d "${COMPONENT_BUILD_DIRECTORY}" ]; then
 fi
 
 cd "${COMPONENT_BUILD_DIRECTORY}"
+echo "Building ${COMPONENT_NAME} at commit $(git rev-parse HEAD)"
 git config user.name "K8s builder bot"
 git config user.email "k8s-bot@canonical.com"
 

--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -44,6 +44,7 @@ asn
 auth
 autocompletion
 automountServiceAccountToken
+Autoscaler
 autostart
 autosuspend
 aws
@@ -230,6 +231,7 @@ HostPath
 HostPorts
 HostProcess
 howto
+HPA
 HPC
 html
 http
@@ -402,6 +404,7 @@ passthrough
 passwordless
 pathto
 pci
+PDB
 pdf
 PEM
 performant

--- a/docs/canonicalk8s/snap/explanation/default-dns.md
+++ b/docs/canonicalk8s/snap/explanation/default-dns.md
@@ -1,0 +1,33 @@
+# Default DNS
+
+{{product}} includes a default DNS (Domain Name System) solution which is
+essential for internal cluster communication. When enabled, the DNS facilitates
+service discovery by assigning each service a DNS name.
+
+## Scaling DNS
+
+Default DNS is scaled automatically through a Horizontal Pod Autoscaler ([HPA])
+which monitors DNS pods' CPU and memory resource usage and adjusts the number of
+replicas accordingly.
+
+## DNS scheduling
+
+DNS pods are scheduled with [topology spread constraints] to spread them across
+the cluster nodes and zones when applicable.
+When {{ product }} detects that all pods are scheduled on the same node, it
+will restart the DNS pods to re-balance their distribution.
+
+A [priority class] is assigned to DNS pods to ensure their scheduling
+before pods which are not node critical.
+
+## DNS maintenance
+
+When performing maintenance operations on the cluster, please be aware that
+the pod disruption budget ([PDB]) will only allow one DNS pod to be taken down
+at a time.
+
+<!--LINKS -->
+[PDB]: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+[HPA]: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+[topology spread constraints]: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+[priority class]: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

--- a/docs/canonicalk8s/snap/explanation/index.md
+++ b/docs/canonicalk8s/snap/explanation/index.md
@@ -53,6 +53,7 @@ Understand the networking capabilities in {{product}}.
 :titlesonly:
 ingress
 load-balancer
+default-dns
 ```
 
 ## Security and compliance

--- a/docs/canonicalk8s/snap/howto/networking/default-dns.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-dns.md
@@ -3,7 +3,8 @@
 {{product}} includes a default DNS (Domain Name System) which is
 essential for internal cluster communication. When enabled, the DNS facilitates
 service discovery by assigning each service a DNS name. When disabled, you can
-integrate a custom DNS solution into your cluster.
+integrate a custom DNS solution into your cluster. Learn more about the
+default DNS in the [reference documentation].
 
 ## Prerequisites
 
@@ -95,3 +96,4 @@ sudo k8s help disable
 <!-- LINKS -->
 
 [getting-started-guide]: ../../tutorial/getting-started
+[reference documentation]: ../../explanation/default-dns.md

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -19,6 +19,7 @@ var rootCmdOpts struct {
 	disableNodeLabelController          bool
 	disableControlPlaneConfigController bool
 	disableFeatureController            bool
+	disableDNSRebalancerController      bool
 	disableUpdateNodeConfigController   bool
 	disableCSRSigningController         bool
 	disableUpgradeController            bool
@@ -59,6 +60,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				DisableControlPlaneConfigController: rootCmdOpts.disableControlPlaneConfigController,
 				DisableUpdateNodeConfigController:   rootCmdOpts.disableUpdateNodeConfigController,
 				DisableFeatureController:            rootCmdOpts.disableFeatureController,
+				DisableDNSRebalancerController:      rootCmdOpts.disableDNSRebalancerController,
 				DisableCSRSigningController:         rootCmdOpts.disableCSRSigningController,
 				DisableUpgradeController:            rootCmdOpts.disableUpgradeController,
 				DrainConnectionsTimeout:             rootCmdOpts.drainConnectionsTimeout,
@@ -92,6 +94,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableControlPlaneConfigController, "disable-control-plane-config-controller", false, "Disable the Control Plane Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableUpdateNodeConfigController, "disable-update-node-config-controller", false, "Disable the Update Node Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableFeatureController, "disable-feature-controller", false, "Disable the Feature Controller")
+	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableDNSRebalancerController, "disable-dns-rebalancer-controller", false, "Disable the DNS Rebalancer Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableCSRSigningController, "disable-csrsigning-controller", false, "Disable the CSR signing controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableUpgradeController, "disable-upgrade-controller", false, "Disable the upgrade controller")
 

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -26,6 +26,8 @@ var rootCmdOpts struct {
 	disableUpgradeController            bool
 	drainConnectionsTimeout             time.Duration
 	featureControllerMaxRetryAttempts   int
+	disableServiceArgsController        bool
+	serviceArgsControllerCheckInterval  time.Duration
 }
 
 func addCommands(root *cobra.Command, group *cobra.Group, commands ...*cobra.Command) {
@@ -67,6 +69,8 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				DisableUpgradeController:            rootCmdOpts.disableUpgradeController,
 				DrainConnectionsTimeout:             rootCmdOpts.drainConnectionsTimeout,
 				FeatureControllerMaxRetryAttempts:   rootCmdOpts.featureControllerMaxRetryAttempts,
+				DisableServiceArgsController:        rootCmdOpts.disableServiceArgsController,
+				ServiceArgsControllerCheckInterval:  rootCmdOpts.serviceArgsControllerCheckInterval,
 			})
 			if err != nil {
 				cmd.PrintErrf("Error: Failed to initialize k8sd: %v", err)
@@ -105,6 +109,8 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.Flags().MarkDeprecated("port", "this flag does not have any effect, and will be removed in a future version")
 	cmd.Flags().DurationVar(&rootCmdOpts.drainConnectionsTimeout, "drain-connection-timeout", 10*time.Second, "amount of time to allow for all connections to drain when shutting down")
 	cmd.Flags().IntVar(&rootCmdOpts.featureControllerMaxRetryAttempts, "feature-controller-max-retry-attempts", 64, "Maximum number of retry attempts for the feature controller before giving up. Zero or negative values mean no limit.")
+	cmd.Flags().BoolVar(&rootCmdOpts.disableServiceArgsController, "disable-service-args-controller", false, "Disable the Service Args Controller")
+	cmd.Flags().DurationVar(&rootCmdOpts.serviceArgsControllerCheckInterval, "service-args-controller-check-interval", 2*time.Minute, "Interval at which the service args controller checks for changes. Should be greater than 30 seconds.")
 
 	cmd.AddCommand(newSqlCmd(env))
 

--- a/src/k8s/cmd/k8sd/k8sd.go
+++ b/src/k8s/cmd/k8sd/k8sd.go
@@ -16,6 +16,7 @@ var rootCmdOpts struct {
 	stateDir                            string
 	pprofAddress                        string
 	disableNodeConfigController         bool
+	nodeConfigControllerWatchDuration   time.Duration
 	disableNodeLabelController          bool
 	disableControlPlaneConfigController bool
 	disableFeatureController            bool
@@ -56,6 +57,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 				Snap:                                env.Snap,
 				PprofAddress:                        rootCmdOpts.pprofAddress,
 				DisableNodeConfigController:         rootCmdOpts.disableNodeConfigController,
+				NodeConfigControllerWatchDuration:   rootCmdOpts.nodeConfigControllerWatchDuration,
 				DisableNodeLabelController:          rootCmdOpts.disableNodeLabelController,
 				DisableControlPlaneConfigController: rootCmdOpts.disableControlPlaneConfigController,
 				DisableUpdateNodeConfigController:   rootCmdOpts.disableUpdateNodeConfigController,
@@ -90,6 +92,7 @@ func NewRootCmd(env cmdutil.ExecutionEnvironment) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.stateDir, "state-dir", "", "Directory with the dqlite datastore")
 	cmd.PersistentFlags().StringVar(&rootCmdOpts.pprofAddress, "pprof-address", "", "Listen address for pprof endpoints, e.g. \"127.0.0.1:4217\"")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeConfigController, "disable-node-config-controller", false, "Disable the Node Config Controller")
+	cmd.Flags().DurationVar(&rootCmdOpts.nodeConfigControllerWatchDuration, "node-config-controller-watch-duration", 5*time.Minute, "The duration that node config controller watches k8sd-config map before restarting and triggering a fresh GET/WATCH. Should be greater than 30 seconds.")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableNodeLabelController, "disable-node-label-controller", false, "Disable the Node Label Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableControlPlaneConfigController, "disable-control-plane-config-controller", false, "Disable the Control Plane Config Controller")
 	cmd.PersistentFlags().BoolVar(&rootCmdOpts.disableUpdateNodeConfigController, "disable-update-node-config-controller", false, "Disable the Update Node Config Controller")

--- a/src/k8s/pkg/client/kubernetes/configmap.go
+++ b/src/k8s/pkg/client/kubernetes/configmap.go
@@ -6,13 +6,29 @@ import (
 
 	"github.com/canonical/k8s/pkg/log"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	applyv1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 func (c *Client) WatchConfigMap(ctx context.Context, namespace string, name string, reconcile func(configMap *v1.ConfigMap) error) error {
 	log := log.FromContext(ctx).WithValues("namespace", namespace, "name", name)
-	w, err := c.CoreV1().ConfigMaps(namespace).Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{Name: name}))
+
+	cm, err := c.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get configmap namespace=%s name=%s: %w", namespace, name, err)
+	}
+
+	log.V(1).Info("Seeding reconcile from existing ConfigMap", "resourceVersion", cm.ResourceVersion)
+	if err := reconcile(cm); err != nil {
+		return fmt.Errorf("initial reconcile failed: %w", err)
+	}
+
+	w, err := c.CoreV1().ConfigMaps(namespace).Watch(ctx, metav1.SingleObject(metav1.ObjectMeta{
+		Name:            name,
+		ResourceVersion: cm.ResourceVersion,
+	}))
 	if err != nil {
 		return fmt.Errorf("failed to watch configmap namespace=%s name=%s: %w", namespace, name, err)
 	}
@@ -24,6 +40,9 @@ func (c *Client) WatchConfigMap(ctx context.Context, namespace string, name stri
 		case evt, ok := <-w.ResultChan():
 			if !ok {
 				return fmt.Errorf("watch closed")
+			}
+			if evt.Type == watch.Error {
+				return fmt.Errorf("watch error event: %w", apierrors.FromObject(evt.Object))
 			}
 			configMap, ok := evt.Object.(*v1.ConfigMap)
 			if !ok {

--- a/src/k8s/pkg/client/kubernetes/configmap_test.go
+++ b/src/k8s/pkg/client/kubernetes/configmap_test.go
@@ -23,10 +23,6 @@ func TestWatchConfigMap(t *testing.T) {
 		configmap *corev1.ConfigMap
 	}{
 		{
-			name:      "pass nil object",
-			configmap: nil,
-		},
-		{
 			name: "example configmap with values",
 			configmap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-config", Namespace: "kube-system"},
@@ -46,7 +42,11 @@ func TestWatchConfigMap(t *testing.T) {
 		},
 	}
 
-	clientset := fake.NewSimpleClientset()
+	clientset := fake.NewSimpleClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-config", Namespace: "kube-system"},
+		},
+	)
 	watcher := watch.NewFake()
 	clientset.PrependWatchReactor("configmaps", k8stesting.DefaultWatchReactor(watcher, nil))
 
@@ -56,13 +56,17 @@ func TestWatchConfigMap(t *testing.T) {
 
 	go client.WatchConfigMap(ctx, "kube-system", "test-config", func(configMap *corev1.ConfigMap) error {
 		doneCh <- configMap
-		if configMap == nil {
-			return fmt.Errorf("unexpected nil map test case error")
-		}
 		return nil
 	})
 
 	defer watcher.Stop()
+
+	// WatchConfigMap seeds the reconcile from the initial Get; drain it before the watch-event loop.
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for seed reconcile")
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -71,15 +75,81 @@ func TestWatchConfigMap(t *testing.T) {
 			watcher.Add(tc.configmap)
 			select {
 			case recv := <-doneCh:
-				if tc.configmap != nil {
-					g.Expect(recv.Data).To(Equal(tc.configmap.Data))
-					g.Expect(recv.Name).To(Equal(tc.configmap.Name))
-					g.Expect(recv.Namespace).To(Equal(tc.configmap.Namespace))
-				}
+				g.Expect(recv.Data).To(Equal(tc.configmap.Data))
+				g.Expect(recv.Name).To(Equal(tc.configmap.Name))
+				g.Expect(recv.Namespace).To(Equal(tc.configmap.Namespace))
 			case <-time.After(time.Second):
 				t.Fatal("Timed out waiting for watch to complete")
 			}
 		})
+	}
+}
+
+func TestWatchConfigMap_SeedsExistingObject(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g := NewWithT(t)
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+		Data: map[string]string{
+			"cluster-dns":    "10.152.183.10",
+			"cluster-domain": "cluster.local",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(existing)
+	client := &Client{Interface: clientset}
+
+	doneCh := make(chan *corev1.ConfigMap, 1)
+	go func() {
+		_ = client.WatchConfigMap(ctx, "kube-system", "k8sd-config", func(cm *corev1.ConfigMap) error {
+			doneCh <- cm
+			return nil
+		})
+	}()
+
+	select {
+	case recv := <-doneCh:
+		g.Expect(recv).ToNot(BeNil())
+		g.Expect(recv.Name).To(Equal(existing.Name))
+		g.Expect(recv.Namespace).To(Equal(existing.Namespace))
+		g.Expect(recv.Data).To(Equal(existing.Data))
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconcile was not invoked for the pre-existing ConfigMap; WatchConfigMap missed the initial state")
+	}
+}
+
+func TestWatchConfigMap_SeedErrorPropagates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g := NewWithT(t)
+
+	existing := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+		Data:       map[string]string{"cluster-dns": "10.152.183.10"},
+	}
+
+	clientset := fake.NewSimpleClientset(existing)
+	client := &Client{Interface: clientset}
+
+	seedErr := fmt.Errorf("transient reconcile failure")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.WatchConfigMap(ctx, "kube-system", "k8sd-config", func(*corev1.ConfigMap) error {
+			return seedErr
+		})
+	}()
+
+	select {
+	case err := <-errCh:
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring(seedErr.Error()))
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchConfigMap did not return after seed reconcile failure")
 	}
 }
 

--- a/src/k8s/pkg/k8sd/api/cluster.go
+++ b/src/k8s/pkg/k8sd/api/cluster.go
@@ -3,20 +3,26 @@ package api
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
+	"github.com/canonical/k8s/pkg/client/kubernetes"
 	"github.com/canonical/k8s/pkg/k8sd/api/impl"
 	"github.com/canonical/k8s/pkg/k8sd/database"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/features"
 	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/utils"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/v2/state"
 )
 
 func (e *Endpoints) getClusterStatus(s state.State, r *http.Request) response.Response {
+	log := log.FromContext(r.Context()).WithValues("endpoint", "getClusterStatus")
+
 	// fail if node is not initialized yet
 	if err := s.Database().IsOpen(r.Context()); err != nil {
 		return response.Unavailable(fmt.Errorf("daemon not yet initialized"))
@@ -39,6 +45,14 @@ func (e *Endpoints) getClusterStatus(s state.State, r *http.Request) response.Re
 	ready, err := client.HasReadyNodes(r.Context())
 	if err != nil {
 		return response.InternalError(fmt.Errorf("failed to check if cluster has ready nodes: %w", err))
+	}
+
+	// If dns is enabled, we also check for the coredns service clusterIP before reporting cluster as "ready"
+	if config.DNS.Enabled != nil && *config.DNS.Enabled {
+		if err := e.checkKubeletClusterDNS(r.Context(), client); err != nil {
+			log.Error(err, "kubelet does not have correct --cluster-dns arg")
+			ready = false
+		}
 	}
 
 	var statuses map[types.FeatureName]types.FeatureStatus
@@ -71,4 +85,32 @@ func (e *Endpoints) getClusterStatus(s state.State, r *http.Request) response.Re
 			LocalStorage:  statuses[features.LocalStorage].ToAPI(),
 		},
 	})
+}
+
+// checkKubeletClusterDNS checks if --cluster-dns argument of the running kubelet service
+// matches the coredns service clusterIP.
+func (e *Endpoints) checkKubeletClusterDNS(ctx context.Context, client *kubernetes.Client) error {
+	// this is similar to what we do in the coredns feature to get the cluster IP and update kubelet.
+	// note that this is a bit brittle and might break if we change e.g. the coredns service name or namespace.
+	corednsClusterIP, err := client.GetServiceClusterIP(ctx, "coredns", "kube-system")
+	if err != nil {
+		return fmt.Errorf("failed to get coredns service cluster IP: %w", err)
+	}
+
+	if corednsClusterIP == "" {
+		return errors.New("coredns does not have a cluster IP yet")
+	}
+
+	serviceArgs, err := utils.RunningServiceArgs(ctx, "kubelet")
+	if err != nil {
+		return fmt.Errorf("failed to get args for kubelet: %w", err)
+	}
+
+	argsDNS := serviceArgs["--cluster-dns"]
+
+	if argsDNS != corednsClusterIP {
+		return fmt.Errorf("kubelet --cluster-dns %q does not match coredns service clusterIP %q", argsDNS, corednsClusterIP)
+	}
+
+	return nil
 }

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -45,6 +45,8 @@ type Config struct {
 	DisableUpdateNodeConfigController bool
 	// DisableFeatureController is a bool flag to disable feature controller
 	DisableFeatureController bool
+	// DisableDNSRebalancerController is a bool flag to disable dns rebalancer controller
+	DisableDNSRebalancerController bool
 	// DisableCSRSigningController is a bool flag to disable csrsigning controller.
 	DisableCSRSigningController bool
 	// DisableUpgradeController is a bool flag to disable upgrade controller.
@@ -212,6 +214,7 @@ func New(cfg Config) (*App, error) {
 			FeatureControllerReconcileTimeout: 2 * time.Minute,
 		},
 		cfg.DisableCSRSigningController,
+		cfg.DisableDNSRebalancerController,
 	)
 
 	return app, nil

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -37,6 +37,10 @@ type Config struct {
 	PprofAddress string
 	// DisableNodeConfigController is a bool flag to disable node config controller
 	DisableNodeConfigController bool
+	// NodeConfigControllerWatchDuration specifies how long watch is in progress before getting
+	// cancelled and restarts. The restart is meant to trigger a fresh guaranteed reconciliation
+	// of the k8sd-config configmap. Should be greater than 30 seconds.
+	NodeConfigControllerWatchDuration time.Duration
 	// DisableNodeLabelController is a bool flag to disable node label controller
 	DisableNodeLabelController bool
 	// DisableControlPlaneConfigController is a bool flag to disable control-plane config controller
@@ -120,6 +124,7 @@ func New(cfg Config) (*App, error) {
 		app.nodeConfigController = controllers.NewNodeConfigurationController(
 			cfg.Snap,
 			app.readyWg.Wait,
+			max(cfg.NodeConfigControllerWatchDuration, 30*time.Second),
 		)
 	} else {
 		log.L().Info("node-config-controller disabled via config")

--- a/src/k8s/pkg/k8sd/app/app.go
+++ b/src/k8s/pkg/k8sd/app/app.go
@@ -60,6 +60,11 @@ type Config struct {
 	// FeatureControllerMaxRetryAttempts is the maximum number of retry attempts for the reconcile loop
 	// of the feature controller. Zero or negative values mean no limit.
 	FeatureControllerMaxRetryAttempts int
+	// DisableServiceArgsController is a bool flag to disable the service args controller.
+	DisableServiceArgsController bool
+	// ServiceArgsControllerCheckInterval is the interval at which the service args controller checks for
+	// argument drift between the args file and the running process. Should be greater than 30 seconds.
+	ServiceArgsControllerCheckInterval time.Duration
 }
 
 // App is the k8sd microcluster instance.
@@ -78,6 +83,7 @@ type App struct {
 	nodeConfigController         *controllers.NodeConfigurationController
 	nodeLabelController          *controllers.NodeLabelController
 	controlPlaneConfigController *controllers.ControlPlaneConfigurationController
+	serviceArgsController        *controllers.ServiceArgsController
 	controllerCoordinator        *controllers.Coordinator
 
 	// updateNodeConfigController
@@ -154,6 +160,15 @@ func New(cfg Config) (*App, error) {
 		)
 	} else {
 		log.L().Info("control-plane-config-controller disabled via config")
+	}
+
+	if !cfg.DisableServiceArgsController {
+		app.serviceArgsController = controllers.NewServiceArgsController(controllers.ServiceArgsControllerOpts{
+			Snap:      cfg.Snap,
+			TriggerCh: time.NewTicker(max(cfg.ServiceArgsControllerCheckInterval, 30*time.Second)).C,
+		})
+	} else {
+		log.L().Info("service-args-controller disabled via config")
 	}
 
 	app.triggerUpdateNodeConfigControllerCh = make(chan struct{}, 1)

--- a/src/k8s/pkg/k8sd/app/hooks_start.go
+++ b/src/k8s/pkg/k8sd/app/hooks_start.go
@@ -146,6 +146,10 @@ func (a *App) onStart(ctx context.Context, s state.State) error {
 	// when k8sd gets restarted before getting the chance to reconcile features.
 	a.NotifyFeatureController(true, true, true, true, true, true, true)
 
+	if a.serviceArgsController != nil {
+		go a.serviceArgsController.Run(ctx)
+	}
+
 	return nil
 }
 

--- a/src/k8s/pkg/k8sd/controllers/dnsrebalancer/controller.go
+++ b/src/k8s/pkg/k8sd/controllers/dnsrebalancer/controller.go
@@ -1,0 +1,55 @@
+package dnsrebalancer
+
+import (
+	"context"
+
+	"github.com/canonical/k8s/pkg/k8sd/types"
+	"github.com/canonical/k8s/pkg/snap"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type controller struct {
+	logger           logr.Logger
+	client           client.Client
+	getClusterConfig func(context.Context) (types.ClusterConfig, error)
+	snap             snap.Snap
+}
+
+func NewController(
+	logger logr.Logger,
+	client client.Client,
+	getClusterConfig func(context.Context) (types.ClusterConfig, error),
+	snap snap.Snap,
+) *controller {
+	return &controller{
+		logger:           logger,
+		client:           client,
+		getClusterConfig: getClusterConfig,
+		snap:             snap,
+	}
+}
+
+// SetupWithManager sets up the controller with the manager.
+func (r *controller) SetupWithManager(mgr ctrl.Manager) error {
+	// Watch Node resources, trigger reconciliation when node status changes
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			// Only trigger reconciliation when a node becomes Ready
+			node, ok := object.(*corev1.Node)
+			if !ok {
+				return false
+			}
+			for _, condition := range node.Status.Conditions {
+				if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		})).
+		Complete(r)
+}

--- a/src/k8s/pkg/k8sd/controllers/dnsrebalancer/reconcile.go
+++ b/src/k8s/pkg/k8sd/controllers/dnsrebalancer/reconcile.go
@@ -1,0 +1,123 @@
+package dnsrebalancer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/canonical/k8s/pkg/log"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Reconcile implements the reconciliation loop.
+func (r *controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx).WithValues("node", req.Name)
+
+	if r.getClusterConfig == nil {
+		log.Info("getClusterConfig is nil")
+		return ctrl.Result{}, nil
+	}
+
+	// skip reconcile if dns is disabled
+	config, err := r.getClusterConfig(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get cluster config: %w", err)
+	}
+	if !config.DNS.GetEnabled() {
+		return ctrl.Result{}, nil
+	}
+
+	// Count ready nodes
+	nodeList := &corev1.NodeList{}
+	if err := r.client.List(ctx, nodeList); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	readyCount := countReadyNodes(nodeList)
+	if readyCount < 2 {
+		log.V(1).Info("Less than 2 nodes ready, skipping rebalancing check", "readyCount", readyCount)
+		return ctrl.Result{}, nil
+	}
+
+	log.V(1).Info("Sufficient nodes ready, checking CoreDNS distribution", "readyCount", readyCount)
+
+	// Check if rebalancing is needed
+	needsRebalancing, err := r.coreDNSNeedsRebalancing(ctx)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, fmt.Errorf("failed to check CoreDNS pods distribution: %w", err)
+	}
+
+	if !needsRebalancing {
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("CoreDNS pods need rebalancing, triggering deployment rollout restart")
+
+	// Get kubernetes client to restart deployment
+	k8sClient, err := r.snap.KubernetesClient("")
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := k8sClient.RestartDeployment(ctx, "coredns", "kube-system"); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to restart CoreDNS deployment: %w", err)
+	}
+
+	log.Info("Successfully triggered CoreDNS deployment restart")
+	return ctrl.Result{}, nil
+}
+
+// coreDNSNeedsRebalancing checks if CoreDNS pods need rebalancing.
+func (r *controller) coreDNSNeedsRebalancing(ctx context.Context) (bool, error) {
+	pods := &corev1.PodList{}
+	if err := r.client.List(ctx, pods, client.InNamespace("kube-system"), client.MatchingLabels{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"}); err != nil {
+		return false, err
+	}
+
+	if len(pods.Items) == 0 {
+		return false, fmt.Errorf("no CoreDNS pods found")
+	}
+
+	// Filter scheduled pods (NodeName != ""). Pending pods can cause false positives.
+	scheduled := make([]corev1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName != "" {
+			scheduled = append(scheduled, pod)
+		}
+	}
+
+	if len(scheduled) < 2 {
+		return false, fmt.Errorf("less than 2 pods are scheduled")
+	}
+
+	// Check if all scheduled pods are on the same node
+	firstNodeName := scheduled[0].Spec.NodeName
+	for _, pod := range scheduled[1:] {
+		if pod.Spec.NodeName != firstNodeName {
+			// Pods are on different nodes - no rebalancing needed
+			return false, nil
+		}
+	}
+	// All scheduled pods are on the same node - rebalancing needed
+	return true, nil
+}
+
+// countReadyNodes counts the number of nodes with Ready condition.
+func countReadyNodes(nodeList *corev1.NodeList) int {
+	readyCount := 0
+	for _, node := range nodeList.Items {
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
+				readyCount++
+				break
+			}
+		}
+	}
+	return readyCount
+}

--- a/src/k8s/pkg/k8sd/controllers/dnsrebalancer/reconcile_test.go
+++ b/src/k8s/pkg/k8sd/controllers/dnsrebalancer/reconcile_test.go
@@ -1,0 +1,296 @@
+package dnsrebalancer
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcile_LessThanTwoNodesReady(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Only one node ready
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(node).
+		Build()
+
+	reconciler := &controller{
+		logger: ctrl.Log.WithName("test"),
+		client: fakeClient,
+		snap:   nil,
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{})
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestReconcile_CoreDNSAlreadyBalanced(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Two nodes ready
+	nodes := []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-2"},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	// Pods already distributed
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-1",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-2",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-2"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&nodes[0], &nodes[1], &pods[0], &pods[1]).
+		Build()
+
+	reconciler := &controller{
+		logger: ctrl.Log.WithName("test"),
+		client: fakeClient,
+		snap:   nil,
+	}
+
+	result, err := reconciler.Reconcile(ctx, ctrl.Request{})
+
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func TestCoreDNSNeedsRebalancing_AllPodsSameNode(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-1",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-a"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-2",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-a"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&pods[0], &pods[1]).
+		Build()
+
+	reconciler := &controller{
+		logger: ctrl.Log.WithName("test"),
+		client: fakeClient,
+		snap:   nil,
+	}
+
+	needsRebalancing, err := reconciler.coreDNSNeedsRebalancing(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(needsRebalancing).To(BeTrue(), "should need rebalancing when all pods on same node")
+}
+
+func TestCoreDNSNeedsRebalancing_Distributed(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-1",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-a"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-2",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-b"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&pods[0], &pods[1]).
+		Build()
+
+	reconciler := &controller{
+		logger: ctrl.Log.WithName("test"),
+		client: fakeClient,
+		snap:   nil,
+	}
+
+	needsRebalancing, err := reconciler.coreDNSNeedsRebalancing(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(needsRebalancing).To(BeFalse(), "should not need rebalancing when pods distributed")
+}
+
+func TestCoreDNSNeedsRebalancing_IgnoresUnscheduledPods(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// One scheduled, one pending (no NodeName)
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-1",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{NodeName: "node-a"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-2",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&pods[0], &pods[1]).
+		Build()
+
+	reconciler := &controller{
+		logger: ctrl.Log.WithName("test"),
+		client: fakeClient,
+		snap:   nil,
+	}
+
+	needsRebalancing, err := reconciler.coreDNSNeedsRebalancing(ctx)
+
+	g.Expect(err.Error()).To(Equal("less than 2 pods are scheduled"))
+	g.Expect(needsRebalancing).To(BeFalse(), "should not need rebalancing with unscheduled pods")
+}
+
+func TestCoreDNSNeedsRebalancing_AllPodsPending(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	// Both pods pending (no NodeName)
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-1",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "coredns-2",
+				Labels:    map[string]string{"k8s-app": "coredns", "app.kubernetes.io/instance": "ck-dns"},
+			},
+			Spec: corev1.PodSpec{},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&pods[0], &pods[1]).
+		Build()
+
+	reconciler := &controller{
+		logger: ctrl.Log.WithName("test"),
+		client: fakeClient,
+		snap:   nil,
+	}
+
+	needsRebalancing, err := reconciler.coreDNSNeedsRebalancing(ctx)
+
+	g.Expect(err.Error()).To(Equal("less than 2 pods are scheduled"))
+	g.Expect(needsRebalancing).To(BeFalse(), "should not need rebalancing when no pods scheduled")
+}
+
+func TestCoreDNSNeedsRebalancing_NoPods(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		Build()
+
+	reconciler := &controller{
+		logger: ctrl.Log.WithName("test"),
+		client: fakeClient,
+		snap:   nil,
+	}
+
+	needsRebalancing, err := reconciler.coreDNSNeedsRebalancing(ctx)
+
+	g.Expect(err.Error()).To(Equal("no CoreDNS pods found"))
+	g.Expect(needsRebalancing).To(BeFalse())
+}

--- a/src/k8s/pkg/k8sd/controllers/node_configuration.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration.go
@@ -18,14 +18,18 @@ type NodeConfigurationController struct {
 	snap      snap.Snap
 	waitReady func()
 	// reconciledCh is used to notify that the controller has finished its reconciliation loop.
-	reconciledCh chan struct{}
+	reconciledCh  chan struct{}
+	watchDuration time.Duration
 }
 
-func NewNodeConfigurationController(snap snap.Snap, waitReady func()) *NodeConfigurationController {
+func NewNodeConfigurationController(snap snap.Snap, waitReady func(),
+	watchDuration time.Duration,
+) *NodeConfigurationController {
 	return &NodeConfigurationController{
-		snap:         snap,
-		waitReady:    waitReady,
-		reconciledCh: make(chan struct{}, 1),
+		snap:          snap,
+		waitReady:     waitReady,
+		reconciledCh:  make(chan struct{}, 1),
+		watchDuration: watchDuration,
 	}
 }
 
@@ -43,16 +47,20 @@ func (c *NodeConfigurationController) Run(ctx context.Context, getRSAKey func(co
 		client, err := getNewK8sClientWithRetries(ctx, c.snap, false)
 		if err != nil {
 			log.Error(err, "Failed to create a Kubernetes client")
-		}
-
-		if err := client.WatchConfigMap(ctx, "kube-system", "k8sd-config", func(configMap *v1.ConfigMap) error {
-			err := c.reconcile(ctx, configMap, getRSAKey)
-			c.notifyReconciled()
-			return err
-		}); err != nil {
-			// This also can fail during bootstrapping/start up when api-server is not ready
-			// So the watch requests get connection refused replies
-			log.WithValues("name", "k8sd-config", "namespace", "kube-system").Error(err, "Failed to watch configmap")
+		} else {
+			// Bound each watch iteration so the seed Get re-runs periodically even
+			// when the ConfigMap is in steady state and no watch events arrive.
+			watchCtx, cancel := context.WithTimeout(ctx, c.watchDuration)
+			if err := client.WatchConfigMap(watchCtx, "kube-system", "k8sd-config", func(configMap *v1.ConfigMap) error {
+				err := c.reconcile(ctx, configMap, getRSAKey)
+				c.notifyReconciled()
+				return err
+			}); err != nil {
+				// This also can fail during bootstrapping/start up when api-server is not ready
+				// So the watch requests get connection refused replies
+				log.WithValues("name", "k8sd-config", "namespace", "kube-system").Error(err, "Failed to watch configmap")
+			}
+			cancel()
 		}
 
 		select {
@@ -69,6 +77,8 @@ func (c *NodeConfigurationController) Run(ctx context.Context, getRSAKey func(co
 }
 
 func (c *NodeConfigurationController) reconcile(ctx context.Context, configMap *v1.ConfigMap, getRSAKey func(context.Context) (*rsa.PublicKey, error)) error {
+	log := log.FromContext(ctx)
+
 	key, err := getRSAKey(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load the RSA public key: %w", err)
@@ -107,6 +117,7 @@ func (c *NodeConfigurationController) reconcile(ctx context.Context, configMap *
 	}
 
 	if mustRestartKubelet {
+		log.Info("Kubelet arguments changed, restarting kubelet", "updateArgs", updateArgs, "deleteArgs", deleteArgs)
 		// This may fail if other controllers try to restart the services at the same time, hence the retry.
 		if err := control.RetryFor(ctx, 5, 5*time.Second, func() error {
 			if err := c.snap.RestartServices(ctx, []string{"kubelet"}); err != nil {

--- a/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
+++ b/src/k8s/pkg/k8sd/controllers/node_configuration_test.go
@@ -179,7 +179,11 @@ func TestConfigPropagation(t *testing.T) {
 		},
 	}
 
-	clientset := fake.NewSimpleClientset()
+	clientset := fake.NewSimpleClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "k8sd-config", Namespace: "kube-system"},
+		},
+	)
 	watcher := watch.NewFake()
 	clientset.PrependWatchReactor("configmaps", k8stesting.DefaultWatchReactor(watcher, nil))
 
@@ -194,12 +198,21 @@ func TestConfigPropagation(t *testing.T) {
 
 	g.Expect(setup.EnsureAllDirectories(s)).To(Succeed())
 
-	ctrl := controllers.NewNodeConfigurationController(s, func() {})
+	ctrl := controllers.NewNodeConfigurationController(s, func() {}, 2*time.Minute)
 
 	keyCh := make(chan *rsa.PublicKey)
 
 	go ctrl.Run(ctx, func(ctx context.Context) (*rsa.PublicKey, error) { return <-keyCh, nil })
 	defer watcher.Stop()
+
+	// WatchConfigMap now does an initial Get to seed the reconcile. Drain that
+	// seed reconcile (empty configmap, nil key → no-op) before the test loop.
+	keyCh <- nil
+	select {
+	case <-ctrl.ReconciledCh():
+	case <-time.After(channelSendTimeout):
+		g.Fail("Timed out waiting for seed reconcile to complete")
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/src/k8s/pkg/k8sd/controllers/node_label.go
+++ b/src/k8s/pkg/k8sd/controllers/node_label.go
@@ -34,7 +34,7 @@ func NewNodeLabelController(snap snap.Snap, waitReady func(), getNodeName func(c
 }
 
 func (c *NodeLabelController) Run(ctx context.Context, getDatastoreType func(ctx context.Context) (string, error)) {
-	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "node-configuration"))
+	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "node-label"))
 	log := log.FromContext(ctx)
 
 	log.Info("Waiting for node to be ready")

--- a/src/k8s/pkg/k8sd/controllers/service_args.go
+++ b/src/k8s/pkg/k8sd/controllers/service_args.go
@@ -1,0 +1,152 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/canonical/k8s/pkg/log"
+	"github.com/canonical/k8s/pkg/snap"
+	snaputil "github.com/canonical/k8s/pkg/snap/util"
+	"github.com/canonical/k8s/pkg/utils"
+)
+
+// ServiceArgsControllerOpts holds configuration for ServiceArgsController.
+type ServiceArgsControllerOpts struct {
+	// Snap is the snap interface.
+	Snap snap.Snap
+	// Services is an optional override for the list of service names to watch.
+	// When nil, the list is determined dynamically each reconcile cycle based on
+	// whether the node is a worker or control-plane.
+	Services []string
+	// TriggerCh drives the reconciliation loop. Typically time.NewTicker(<interval>).C.
+	TriggerCh <-chan time.Time
+	// GetRunningArgs returns the parsed command-line arguments of the running process
+	// for the named service. Returns nil, nil when the process is not running.
+	// Defaults to a systemd-based implementation when nil.
+	GetRunningArgs func(ctx context.Context, serviceName string) (map[string]string, error)
+}
+
+// ServiceArgsController periodically compares each service's args file against the
+// arguments of the running process and restarts any service whose arguments have drifted.
+type ServiceArgsController struct {
+	snap           snap.Snap
+	services       []string
+	triggerCh      <-chan time.Time
+	reconciledCh   chan struct{}
+	getRunningArgs func(ctx context.Context, serviceName string) (map[string]string, error)
+}
+
+// NewServiceArgsController creates a new ServiceArgsController.
+func NewServiceArgsController(opts ServiceArgsControllerOpts) *ServiceArgsController {
+	if opts.GetRunningArgs == nil {
+		opts.GetRunningArgs = utils.RunningServiceArgs
+	}
+	return &ServiceArgsController{
+		snap:           opts.Snap,
+		services:       opts.Services,
+		triggerCh:      opts.TriggerCh,
+		reconciledCh:   make(chan struct{}, 1),
+		getRunningArgs: opts.GetRunningArgs,
+	}
+}
+
+// Run starts the controller and blocks until ctx is cancelled.
+func (c *ServiceArgsController) Run(ctx context.Context) {
+	ctx = log.NewContext(ctx, log.FromContext(ctx).WithValues("controller", "service-args"))
+	log := log.FromContext(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.triggerCh:
+		}
+
+		log.Info("checking service arguments for drift")
+		if err := c.reconcile(ctx); err != nil {
+			log.Error(err, "failed to reconcile service arguments")
+		}
+
+		select {
+		case c.reconciledCh <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (c *ServiceArgsController) reconcile(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	services := c.services
+	if services == nil {
+		isWorker, err := snaputil.IsWorker(c.snap)
+		if err != nil {
+			return fmt.Errorf("failed to determine node type: %w", err)
+		}
+		if isWorker {
+			services = snaputil.WorkerServices()
+		} else {
+			services = snaputil.ControlPlaneServices()
+		}
+	}
+
+	for _, svc := range services {
+		differs, err := c.serviceArgsDiffer(ctx, svc)
+		if err != nil {
+			log.Error(err, "failed to compare arguments", "service", svc)
+			continue
+		}
+		if !differs {
+			continue
+		}
+
+		log.Info("service arguments have drifted from args file, restarting", "service", svc)
+		if err := c.snap.RestartServices(ctx, []string{svc}); err != nil {
+			log.Error(err, "failed to restart service", "service", svc)
+		}
+	}
+
+	return nil
+}
+
+// serviceArgsDiffer returns true if the desired args (from the args file) differ
+// from the arguments the running service was started with.
+// Returns false if the args file does not exist or the process is not running.
+func (c *ServiceArgsController) serviceArgsDiffer(ctx context.Context, serviceName string) (bool, error) {
+	argsFilePath := filepath.Join(c.snap.ServiceArgumentsDir(), serviceName)
+	desiredArgs, err := utils.ParseArgumentFile(argsFilePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read args file for %q: %w", serviceName, err)
+	}
+
+	actualArgs, err := c.getRunningArgs(ctx, serviceName)
+	if err != nil {
+		if errors.Is(err, utils.ErrUnitNotRunning) {
+			// service is not running, args don't differ technically
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get running args for %q: %w", serviceName, err)
+	}
+
+	if len(desiredArgs) != len(actualArgs) {
+		return true, nil
+	}
+	for key, desiredVal := range desiredArgs {
+		if actualArgs[key] != desiredVal {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ReconciledCh returns the channel that receives a value after each reconciliation loop.
+func (c *ServiceArgsController) ReconciledCh() <-chan struct{} {
+	return c.reconciledCh
+}

--- a/src/k8s/pkg/k8sd/controllers/service_args_test.go
+++ b/src/k8s/pkg/k8sd/controllers/service_args_test.go
@@ -1,0 +1,255 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/canonical/k8s/pkg/k8sd/controllers"
+	"github.com/canonical/k8s/pkg/snap/mock"
+	"github.com/canonical/k8s/pkg/utils"
+	. "github.com/onsi/gomega"
+)
+
+func TestServiceArgsController(t *testing.T) {
+	newCtrl := func(s *mock.Snap, services []string, getRunningArgs func(context.Context, string) (map[string]string, error)) (*controllers.ServiceArgsController, chan time.Time) {
+		triggerCh := make(chan time.Time)
+		ctrl := controllers.NewServiceArgsController(controllers.ServiceArgsControllerOpts{
+			Snap:           s,
+			Services:       services,
+			TriggerCh:      triggerCh,
+			GetRunningArgs: getRunningArgs,
+		})
+		return ctrl, triggerCh
+	}
+
+	t.Run("NoRestartWhenArgsMatch", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dir := t.TempDir()
+		g.Expect(os.WriteFile(filepath.Join(dir, "kubelet"), []byte("--foo=\"bar\"\n"), 0o600)).To(Succeed())
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: dir}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet"}, func(_ context.Context, _ string) (map[string]string, error) {
+			return map[string]string{"--foo": "bar"}, nil
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
+	})
+
+	t.Run("RestartsWhenArgValueDiffers", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dir := t.TempDir()
+		g.Expect(os.WriteFile(filepath.Join(dir, "kubelet"), []byte("--foo=\"new-val\"\n"), 0o600)).To(Succeed())
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: dir}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet"}, func(_ context.Context, _ string) (map[string]string, error) {
+			return map[string]string{"--foo": "old-val"}, nil
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		g.Expect(s.RestartServicesCalledWith).To(HaveLen(1))
+		g.Expect(s.RestartServicesCalledWith[0]).To(ConsistOf("kubelet"))
+	})
+
+	t.Run("RestartsWhenArgMissingFromRunningProcess", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dir := t.TempDir()
+		g.Expect(os.WriteFile(filepath.Join(dir, "kubelet"), []byte("--foo=\"bar\"\n"), 0o600)).To(Succeed())
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: dir}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet"}, func(_ context.Context, _ string) (map[string]string, error) {
+			return map[string]string{}, nil // process has no args
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		g.Expect(s.RestartServicesCalledWith).To(HaveLen(1))
+		g.Expect(s.RestartServicesCalledWith[0]).To(ConsistOf("kubelet"))
+	})
+
+	t.Run("RestartsWhenRunningProcessHasExtraArg", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dir := t.TempDir()
+		// args file has only --foo; running process still has stale --removed arg
+		g.Expect(os.WriteFile(filepath.Join(dir, "kubelet"), []byte("--foo=\"bar\"\n"), 0o600)).To(Succeed())
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: dir}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet"}, func(_ context.Context, _ string) (map[string]string, error) {
+			return map[string]string{"--foo": "bar", "--removed": "old"}, nil
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		g.Expect(s.RestartServicesCalledWith).To(HaveLen(1))
+		g.Expect(s.RestartServicesCalledWith[0]).To(ConsistOf("kubelet"))
+	})
+
+	t.Run("NoRestartWhenProcessNotRunning", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dir := t.TempDir()
+		g.Expect(os.WriteFile(filepath.Join(dir, "kubelet"), []byte("--foo=\"bar\"\n"), 0o600)).To(Succeed())
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: dir}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet"}, func(_ context.Context, _ string) (map[string]string, error) {
+			return nil, utils.ErrUnitNotRunning
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
+	})
+
+	t.Run("NoRestartWhenArgsFileMissing", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: t.TempDir()}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet"}, func(_ context.Context, _ string) (map[string]string, error) {
+			return map[string]string{"--foo": "bar"}, nil
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		g.Expect(s.RestartServicesCalledWith).To(BeEmpty())
+	})
+
+	t.Run("ContinuesAfterGetRunningArgsError", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dir := t.TempDir()
+		for _, svc := range []string{"kubelet", "containerd"} {
+			g.Expect(os.WriteFile(filepath.Join(dir, svc), []byte("--foo=\"bar\"\n"), 0o600)).To(Succeed())
+		}
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: dir}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet", "containerd"}, func(_ context.Context, svc string) (map[string]string, error) {
+			if svc == "kubelet" {
+				return nil, fmt.Errorf("proc read error")
+			}
+			return map[string]string{"--foo": "old-val"}, nil // differs → should restart
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		// kubelet error was swallowed, containerd should be restarted
+		g.Expect(s.RestartServicesCalledWith).To(HaveLen(1))
+		g.Expect(s.RestartServicesCalledWith[0]).To(ConsistOf("containerd"))
+	})
+
+	t.Run("OnlyDriftingServicesRestarted", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		dir := t.TempDir()
+		for _, svc := range []string{"kubelet", "containerd"} {
+			g.Expect(os.WriteFile(filepath.Join(dir, svc), []byte("--foo=\"bar\"\n"), 0o600)).To(Succeed())
+		}
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: dir}}
+		ctrl, triggerCh := newCtrl(s, []string{"kubelet", "containerd"}, func(_ context.Context, svc string) (map[string]string, error) {
+			if svc == "kubelet" {
+				return map[string]string{"--foo": "bar"}, nil // matches
+			}
+			return map[string]string{"--foo": "old-val"}, nil // drifted
+		})
+		go ctrl.Run(ctx)
+
+		triggerCh <- time.Now()
+		select {
+		case <-ctrl.ReconciledCh():
+		case <-time.After(channelSendTimeout):
+			g.Fail("timed out waiting for reconciliation")
+		}
+
+		g.Expect(s.RestartServicesCalledWith).To(HaveLen(1))
+		g.Expect(s.RestartServicesCalledWith[0]).To(ConsistOf("containerd"))
+	})
+
+	t.Run("StopsOnContextCancellation", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		s := &mock.Snap{Mock: mock.Mock{ServiceArgumentsDir: t.TempDir()}}
+		ctrl, _ := newCtrl(s, nil, nil)
+
+		done := make(chan struct{})
+		go func() {
+			ctrl.Run(ctx)
+			close(done)
+		}()
+
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(channelSendTimeout):
+			g.Fail("controller did not stop after context cancellation")
+		}
+	})
+}

--- a/src/k8s/pkg/k8sd/features/coredns/coredns.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns.go
@@ -123,7 +123,7 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 			{
 				"maxSkew":           1,
 				"topologyKey":       "kubernetes.io/hostname",
-				"whenUnsatisfiable": "DoNotSchedule",
+				"whenUnsatisfiable": "ScheduleAnyway",
 				"labelSelector": map[string]any{
 					"matchLabels": map[string]any{
 						"app.kubernetes.io/name":     "coredns",

--- a/src/k8s/pkg/k8sd/features/coredns/coredns.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns.go
@@ -95,7 +95,8 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 							"labelSelector": map[string]any{
 								"matchLabels": map[string]any{
 									"app.kubernetes.io/name":     "coredns",
-									"app.kubernetes.io/instance": "coredns",
+									"app.kubernetes.io/instance": "ck-dns",
+									"k8s-app":                    "coredns",
 								},
 							},
 							"topologyKey": "kubernetes.io/hostname",
@@ -113,20 +114,24 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 				"labelSelector": map[string]any{
 					"matchLabels": map[string]any{
 						"app.kubernetes.io/name":     "coredns",
-						"app.kubernetes.io/instance": "coredns",
+						"app.kubernetes.io/instance": "ck-dns",
+						"k8s-app":                    "coredns",
 					},
 				},
+				"matchLabelKeys": []string{"pod-template-hash"},
 			},
 			{
 				"maxSkew":           1,
 				"topologyKey":       "kubernetes.io/hostname",
-				"whenUnsatisfiable": "ScheduleAnyway",
+				"whenUnsatisfiable": "DoNotSchedule",
 				"labelSelector": map[string]any{
 					"matchLabels": map[string]any{
 						"app.kubernetes.io/name":     "coredns",
-						"app.kubernetes.io/instance": "coredns",
+						"app.kubernetes.io/instance": "ck-dns",
+						"k8s-app":                    "coredns",
 					},
 				},
+				"matchLabelKeys": []string{"pod-template-hash"},
 			},
 		},
 		// PDB: Ensure availability of CoreDNS during maintenance.

--- a/src/k8s/pkg/k8sd/features/coredns/coredns.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns.go
@@ -57,6 +57,7 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 			"create": true,
 			"name":   "coredns",
 		},
+		"priorityClassName": "system-node-critical",
 		"deployment": map[string]any{
 			"name": "coredns",
 		},
@@ -81,6 +82,82 @@ func ApplyDNS(ctx context.Context, snap snap.Snap, dns types.DNS, kubelet types.
 					{"name": "loop"},
 					{"name": "reload"},
 					{"name": "loadbalance"},
+				},
+			},
+		},
+		// PodAntiAffinity: Preferably schedule CoreDNS pods on separate nodes.
+		"affinity": map[string]any{
+			"podAntiAffinity": map[string]any{
+				"preferredDuringSchedulingIgnoredDuringExecution": []map[string]any{
+					{
+						"weight": 100,
+						"podAffinityTerm": map[string]any{
+							"labelSelector": map[string]any{
+								"matchLabels": map[string]any{
+									"app.kubernetes.io/name":     "coredns",
+									"app.kubernetes.io/instance": "coredns",
+								},
+							},
+							"topologyKey": "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
+		},
+		// TopologySpreadConstraints: Evenly distribute CoreDNS pods across zones and nodes.
+		"topologySpreadConstraints": []map[string]any{
+			{
+				"maxSkew":           1,
+				"topologyKey":       "topology.kubernetes.io/zone",
+				"whenUnsatisfiable": "ScheduleAnyway",
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
+						"app.kubernetes.io/name":     "coredns",
+						"app.kubernetes.io/instance": "coredns",
+					},
+				},
+			},
+			{
+				"maxSkew":           1,
+				"topologyKey":       "kubernetes.io/hostname",
+				"whenUnsatisfiable": "ScheduleAnyway",
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
+						"app.kubernetes.io/name":     "coredns",
+						"app.kubernetes.io/instance": "coredns",
+					},
+				},
+			},
+		},
+		// PDB: Ensure availability of CoreDNS during maintenance.
+		"podDisruptionBudget": map[string]any{
+			"minAvailable": 1,
+		},
+		// HPA: Scale pods based on CPU+memory utilization.
+		"hpa": map[string]any{
+			"enabled":     true,
+			"minReplicas": 2,
+			"maxReplicas": 100,
+			"metrics": []map[string]any{
+				{
+					"type": "Resource",
+					"resource": map[string]any{
+						"name": "cpu",
+						"target": map[string]any{
+							"type":               "Utilization",
+							"averageUtilization": 80,
+						},
+					},
+				},
+				{
+					"type": "Resource",
+					"resource": map[string]any{
+						"name": "memory",
+						"target": map[string]any{
+							"type":               "Utilization",
+							"averageUtilization": 70,
+						},
+					},
 				},
 			},
 		},

--- a/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
@@ -238,7 +238,7 @@ func validateValues(g Gomega, values map[string]any, dns types.DNS, kubelet type
 	labelSelector := podAffinityTerm["labelSelector"].(map[string]any)
 	matchLabels := labelSelector["matchLabels"].(map[string]any)
 	g.Expect(matchLabels["app.kubernetes.io/name"]).To(Equal("coredns"))
-	g.Expect(matchLabels["app.kubernetes.io/instance"]).To(Equal("coredns"))
+	g.Expect(matchLabels["app.kubernetes.io/instance"]).To(Equal("ck-dns"))
 
 	// Validate TopologySpreadConstraints
 	topologySpread := values["topologySpreadConstraints"].([]map[string]any)
@@ -247,21 +247,29 @@ func validateValues(g Gomega, values map[string]any, dns types.DNS, kubelet type
 	zoneSelector := topologySpread[0]["labelSelector"].(map[string]any)
 	zoneMatchLabels := zoneSelector["matchLabels"].(map[string]any)
 	g.Expect(zoneMatchLabels["app.kubernetes.io/name"]).To(Equal("coredns"))
-	g.Expect(zoneMatchLabels["app.kubernetes.io/instance"]).To(Equal("coredns"))
+	g.Expect(zoneMatchLabels["app.kubernetes.io/instance"]).To(Equal("ck-dns"))
+	g.Expect(zoneMatchLabels["k8s-app"]).To(Equal("coredns"))
 
 	// Hostname constraint
 	hostnameSelector := topologySpread[1]["labelSelector"].(map[string]any)
 	hostnameMatchLabels := hostnameSelector["matchLabels"].(map[string]any)
 	g.Expect(hostnameMatchLabels["app.kubernetes.io/name"]).To(Equal("coredns"))
-	g.Expect(hostnameMatchLabels["app.kubernetes.io/instance"]).To(Equal("coredns"))
+	g.Expect(hostnameMatchLabels["app.kubernetes.io/instance"]).To(Equal("ck-dns"))
+	g.Expect(hostnameMatchLabels["k8s-app"]).To(Equal("coredns"))
 
 	// Zone constraint
 	g.Expect(topologySpread[0]["maxSkew"]).To(Equal(1))
 	g.Expect(topologySpread[0]["topologyKey"]).To(Equal("topology.kubernetes.io/zone"))
 	g.Expect(topologySpread[0]["whenUnsatisfiable"]).To(Equal("ScheduleAnyway"))
+	zoneMatchLabelKeys, ok := topologySpread[0]["matchLabelKeys"].([]string)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(zoneMatchLabelKeys).To(Equal([]string{"pod-template-hash"}))
 
 	// Hostname constraint
 	g.Expect(topologySpread[1]["maxSkew"]).To(Equal(1))
 	g.Expect(topologySpread[1]["topologyKey"]).To(Equal("kubernetes.io/hostname"))
-	g.Expect(topologySpread[1]["whenUnsatisfiable"]).To(Equal("ScheduleAnyway"))
+	g.Expect(topologySpread[1]["whenUnsatisfiable"]).To(Equal("DoNotSchedule"))
+	hostnameMatchLabelKeys, ok := topologySpread[1]["matchLabelKeys"].([]string)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(hostnameMatchLabelKeys).To(Equal([]string{"pod-template-hash"}))
 }

--- a/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
@@ -193,4 +193,75 @@ func validateValues(g Gomega, values map[string]any, dns types.DNS, kubelet type
 	plugins := servers[0]["plugins"].([]map[string]any)
 	g.Expect(plugins[3]["parameters"]).To(ContainSubstring(kubelet.GetClusterDomain()))
 	g.Expect(plugins[5]["parameters"]).To(ContainSubstring(strings.Join(dns.GetUpstreamNameservers(), " ")))
+
+	// Validate PriorityClass
+	g.Expect(values["priorityClassName"]).To(Equal("system-node-critical"))
+
+	// Validate HPA configuration
+	hpa := values["hpa"].(map[string]any)
+	g.Expect(hpa["enabled"]).To(BeTrue())
+	g.Expect(hpa["minReplicas"]).To(Equal(2))
+	g.Expect(hpa["maxReplicas"]).To(Equal(100))
+
+	metrics := hpa["metrics"].([]map[string]any)
+	g.Expect(metrics).To(HaveLen(2))
+
+	// CPU metric
+	g.Expect(metrics[0]["type"]).To(Equal("Resource"))
+	cpuResource := metrics[0]["resource"].(map[string]any)
+	g.Expect(cpuResource["name"]).To(Equal("cpu"))
+	cpuTarget := cpuResource["target"].(map[string]any)
+	g.Expect(cpuTarget["type"]).To(Equal("Utilization"))
+	g.Expect(cpuTarget["averageUtilization"]).To(Equal(80))
+
+	// Memory metric
+	g.Expect(metrics[1]["type"]).To(Equal("Resource"))
+	memResource := metrics[1]["resource"].(map[string]any)
+	g.Expect(memResource["name"]).To(Equal("memory"))
+	memTarget := memResource["target"].(map[string]any)
+	g.Expect(memTarget["type"]).To(Equal("Utilization"))
+	g.Expect(memTarget["averageUtilization"]).To(Equal(70))
+
+	// Validate PDB configuration
+	pdb := values["podDisruptionBudget"].(map[string]any)
+	g.Expect(pdb["minAvailable"]).To(Equal(1))
+
+	// Validate PodAntiAffinity
+	affinity := values["affinity"].(map[string]any)
+	podAntiAffinity := affinity["podAntiAffinity"].(map[string]any)
+	preferred := podAntiAffinity["preferredDuringSchedulingIgnoredDuringExecution"].([]map[string]any)
+	g.Expect(preferred).To(HaveLen(1))
+	g.Expect(preferred[0]["weight"]).To(Equal(100))
+
+	podAffinityTerm := preferred[0]["podAffinityTerm"].(map[string]any)
+	g.Expect(podAffinityTerm["topologyKey"]).To(Equal("kubernetes.io/hostname"))
+	labelSelector := podAffinityTerm["labelSelector"].(map[string]any)
+	matchLabels := labelSelector["matchLabels"].(map[string]any)
+	g.Expect(matchLabels["app.kubernetes.io/name"]).To(Equal("coredns"))
+	g.Expect(matchLabels["app.kubernetes.io/instance"]).To(Equal("coredns"))
+
+	// Validate TopologySpreadConstraints
+	topologySpread := values["topologySpreadConstraints"].([]map[string]any)
+	g.Expect(topologySpread).To(HaveLen(2))
+	// Zone constraint
+	zoneSelector := topologySpread[0]["labelSelector"].(map[string]any)
+	zoneMatchLabels := zoneSelector["matchLabels"].(map[string]any)
+	g.Expect(zoneMatchLabels["app.kubernetes.io/name"]).To(Equal("coredns"))
+	g.Expect(zoneMatchLabels["app.kubernetes.io/instance"]).To(Equal("coredns"))
+
+	// Hostname constraint
+	hostnameSelector := topologySpread[1]["labelSelector"].(map[string]any)
+	hostnameMatchLabels := hostnameSelector["matchLabels"].(map[string]any)
+	g.Expect(hostnameMatchLabels["app.kubernetes.io/name"]).To(Equal("coredns"))
+	g.Expect(hostnameMatchLabels["app.kubernetes.io/instance"]).To(Equal("coredns"))
+
+	// Zone constraint
+	g.Expect(topologySpread[0]["maxSkew"]).To(Equal(1))
+	g.Expect(topologySpread[0]["topologyKey"]).To(Equal("topology.kubernetes.io/zone"))
+	g.Expect(topologySpread[0]["whenUnsatisfiable"]).To(Equal("ScheduleAnyway"))
+
+	// Hostname constraint
+	g.Expect(topologySpread[1]["maxSkew"]).To(Equal(1))
+	g.Expect(topologySpread[1]["topologyKey"]).To(Equal("kubernetes.io/hostname"))
+	g.Expect(topologySpread[1]["whenUnsatisfiable"]).To(Equal("ScheduleAnyway"))
 }

--- a/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
+++ b/src/k8s/pkg/k8sd/features/coredns/coredns_test.go
@@ -268,7 +268,7 @@ func validateValues(g Gomega, values map[string]any, dns types.DNS, kubelet type
 	// Hostname constraint
 	g.Expect(topologySpread[1]["maxSkew"]).To(Equal(1))
 	g.Expect(topologySpread[1]["topologyKey"]).To(Equal("kubernetes.io/hostname"))
-	g.Expect(topologySpread[1]["whenUnsatisfiable"]).To(Equal("DoNotSchedule"))
+	g.Expect(topologySpread[1]["whenUnsatisfiable"]).To(Equal("ScheduleAnyway"))
 	hostnameMatchLabelKeys, ok := topologySpread[1]["matchLabelKeys"].([]string)
 	g.Expect(ok).To(BeTrue())
 	g.Expect(hostnameMatchLabelKeys).To(Equal([]string{"pod-template-hash"}))

--- a/src/k8s/pkg/snap/util/services.go
+++ b/src/k8s/pkg/snap/util/services.go
@@ -39,6 +39,12 @@ var (
 	}
 )
 
+// WorkerServices returns the list of k8s services that run on a worker node.
+func WorkerServices() []string { return append([]string(nil), workerK8sServices...) }
+
+// ControlPlaneServices returns the list of k8s services that run on a control-plane node.
+func ControlPlaneServices() []string { return append([]string(nil), controlPlaneK8sServices...) }
+
 // RestartControlPlaneServices restarts the control plane services.
 // RestartControlPlaneServices will return on the first failing service.
 func RestartControlPlaneServices(ctx context.Context, snap snap.Snap, extraSnapArgs ...string) error {

--- a/src/k8s/pkg/utils/services.go
+++ b/src/k8s/pkg/utils/services.go
@@ -1,5 +1,16 @@
 package utils
 
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
 // ServiceArgsFromMap processes a map of string pointers and categorizes them into update and delete lists.
 // - If the value pointer is nil, it adds the argument name to the delete list.
 // - If the value pointer is not nil, it adds the argument and its value to the update map.
@@ -15,4 +26,143 @@ func ServiceArgsFromMap(args map[string]*string) (map[string]string, []string) {
 		}
 	}
 	return updateArgs, deleteArgs
+}
+
+var ErrUnitNotRunning = errors.New("unit is not running")
+
+// RunningServiceArgs queries systemd for the MainPID of the snap service unit
+// and returns its parsed command-line arguments from /proc/<pid>/cmdline.
+// Returns nil, nil when the service is not running.
+func RunningServiceArgs(ctx context.Context, serviceName string) (map[string]string, error) {
+	unitName := fmt.Sprintf("snap.k8s.%s.service", serviceName)
+
+	// unit not found:
+	// LoadState=not-found
+	// ActiveState=inactive
+
+	// unit not running
+	// LoadState=loaded
+	// ActiveState=inactive
+
+	// unit running
+	// LoadState=loaded
+	// ActiveState=active
+
+	loadState, err := getUnitLoadState(ctx, unitName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get unit %q LoadState: %w", unitName, err)
+	}
+
+	if loadState == LoadStateNotFound {
+		return nil, fmt.Errorf("unit %q was not found", unitName)
+	}
+
+	// unit is loaded, let's see if it's running
+
+	activeState, err := getUnitActiveState(ctx, unitName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get unit %q ActiveState: %w", unitName, err)
+	}
+
+	if activeState == ActiveStateInactive {
+		return nil, fmt.Errorf("%q: %w", unitName, ErrUnitNotRunning)
+	}
+
+	// unit is loaded and running, let's get its pid
+
+	pid, err := getUnitMainPID(ctx, unitName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get unit %q MainPID: %w", unitName, err)
+	}
+
+	if pid == 0 {
+		// this should only happen in case of a race condition.
+		// for snap services with Type=simple or Type=notify (containerd),
+		//  MainPID is only 0 if the unit is either inactive or not-found.
+		// since we're making sure the service is loaded and active before getting the PID,
+		// the only possible explanation for this branch is that the service was stopped right after
+		// we checked the load and active states.
+		return nil, fmt.Errorf("pid is 0 for unit %q: %w", unitName, ErrUnitNotRunning)
+	}
+
+	cmdlineData, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// this branch is the similar to pid == 0. it shouldn't really happen, unless due to a race condition.
+			return nil, fmt.Errorf("cmdline file doesn't exist for unit %q (pid %d): %w", unitName, pid, ErrUnitNotRunning)
+		}
+		return nil, fmt.Errorf("failed to read cmdline for pid %d (unit %q): %w", pid, unitName, err)
+	}
+
+	args := make(map[string]string)
+	for _, part := range bytes.Split(cmdlineData, []byte{0})[1:] { // skip argv[0] (binary path)
+		if len(part) == 0 {
+			continue
+		}
+		key, value := ParseArgumentLine(string(part))
+		if key != "" {
+			args[key] = value
+		}
+	}
+	return args, nil
+}
+
+type LoadState string
+
+const (
+	LoadStateLoaded   = "loaded"
+	LoadStateNotFound = "not-found"
+)
+
+func getUnitLoadState(ctx context.Context, unit string) (LoadState, error) {
+	out, err := exec.CommandContext(ctx, "systemctl", "show", unit, "--property=LoadState", "--value").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to query LoadState for unit %q: %w", unit, err)
+	}
+
+	switch st := strings.TrimSpace(string(out)); st {
+	case "loaded":
+		return LoadStateLoaded, nil
+	case "not-found":
+		return LoadStateNotFound, nil
+	default:
+		return "", fmt.Errorf("invalid LoadState %q for unit %q", st, unit)
+	}
+}
+
+type ActiveState string
+
+const (
+	ActiveStateActive   ActiveState = "active"
+	ActiveStateInactive ActiveState = "inactive"
+)
+
+func getUnitActiveState(ctx context.Context, unit string) (ActiveState, error) {
+	out, err := exec.CommandContext(ctx, "systemctl", "show", unit, "--property=ActiveState", "--value").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to query ActiveState for unit %q: %w", unit, err)
+	}
+
+	switch st := strings.TrimSpace(string(out)); st {
+	case "active":
+		return ActiveStateActive, nil
+	case "inactive":
+		return ActiveStateInactive, nil
+	default:
+		return "", fmt.Errorf("invalid ActiveState %q for unit %q", st, unit)
+	}
+}
+
+func getUnitMainPID(ctx context.Context, unit string) (int, error) {
+	out, err := exec.CommandContext(ctx, "systemctl", "show", unit, "--property=MainPID", "--value").Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to query MainPID for unit %q: %w", unit, err)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert unit %q pid %q to int: %w", unit, string(out), err)
+	}
+
+	return pid, nil
 }

--- a/src/k8s/pkg/utils/services_test.go
+++ b/src/k8s/pkg/utils/services_test.go
@@ -1,10 +1,20 @@
 package utils
 
 import (
+	"context"
+	"errors"
+	"os/exec"
 	"testing"
 
 	. "github.com/onsi/gomega"
 )
+
+func skipIfNoSystemctl(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		t.Skip("systemctl not available")
+	}
+}
 
 func TestServiceArgsFromMap(t *testing.T) {
 	tests := []struct {
@@ -74,4 +84,84 @@ func TestServiceArgsFromMap(t *testing.T) {
 			g.Expect(deleteArgs).To(Equal(tt.expected.deleteArgs))
 		})
 	}
+}
+
+func TestGetUnitLoadState(t *testing.T) {
+	skipIfNoSystemctl(t)
+	ctx := context.Background()
+
+	t.Run("NotFound", func(t *testing.T) {
+		g := NewWithT(t)
+		state, err := getUnitLoadState(ctx, "snap.k8s.definitely-nonexistent-k8sd-test.service")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal(LoadState(LoadStateNotFound)))
+	})
+
+	t.Run("Loaded", func(t *testing.T) {
+		// init.scope is always loaded and active on any systemd system.
+		g := NewWithT(t)
+		state, err := getUnitLoadState(ctx, "init.scope")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal(LoadState(LoadStateLoaded)))
+	})
+}
+
+func TestGetUnitActiveState(t *testing.T) {
+	skipIfNoSystemctl(t)
+	ctx := context.Background()
+
+	t.Run("Active", func(t *testing.T) {
+		// init.scope is always loaded and active on any systemd system.
+		g := NewWithT(t)
+		state, err := getUnitActiveState(ctx, "init.scope")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal(ActiveStateActive))
+	})
+
+	t.Run("Inactive", func(t *testing.T) {
+		// A loaded-but-inactive unit: systemd ships plymouth-quit.service which
+		// is loaded but finishes quickly and stays inactive afterward.
+		// Use a unit that is guaranteed to be loaded but not running:
+		// systemd-ask-password-console.service is loaded but inactive on headless systems.
+		// Fall back to checking any not-found unit — systemctl returns "inactive" for those too.
+		g := NewWithT(t)
+		state, err := getUnitActiveState(ctx, "snap.k8s.definitely-nonexistent-k8sd-test.service")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(state).To(Equal(ActiveStateInactive))
+	})
+}
+
+func TestGetUnitMainPID(t *testing.T) {
+	skipIfNoSystemctl(t)
+	ctx := context.Background()
+
+	t.Run("ActiveUnitHasNonZeroPID", func(t *testing.T) {
+		// systemd-journald is always running on any systemd system.
+		g := NewWithT(t)
+		pid, err := getUnitMainPID(ctx, "systemd-journald.service")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(pid).To(BeNumerically(">", 0))
+	})
+
+	t.Run("InactiveUnitHasZeroPID", func(t *testing.T) {
+		g := NewWithT(t)
+		pid, err := getUnitMainPID(ctx, "snap.k8s.definitely-nonexistent-k8sd-test.service")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(pid).To(Equal(0))
+	})
+}
+
+func TestRunningServiceArgs(t *testing.T) {
+	skipIfNoSystemctl(t)
+	ctx := context.Background()
+
+	t.Run("UnitNotFound", func(t *testing.T) {
+		// A completely unknown service name: LoadState=not-found.
+		// This is NOT wrapped in ErrUnitNotRunning — it's a different error class.
+		g := NewWithT(t)
+		_, err := RunningServiceArgs(ctx, "definitely-nonexistent-k8sd-test-unit")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(errors.Is(err, ErrUnitNotRunning)).To(BeFalse())
+		g.Expect(err.Error()).To(ContainSubstring("was not found"))
+	})
 }

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -79,3 +79,84 @@ def test_dns(instances: List[harness.Instance]):
     assert (
         "'coredns'" == result.stdout
     ), "Expected coredns serviceaccount to be 'coredns', not {result.stdout}"
+
+
+@pytest.mark.node_count(2)
+@pytest.mark.tags(tags.PULL_REQUEST)
+def test_dns_ha_rebalancing(instances: List[harness.Instance]):
+    initial_node = instances[0]
+    joining_cplane_node = instances[1]
+
+    # Wait for initial cluster to be ready
+    util.wait_until_k8s_ready(initial_node, [initial_node])
+
+    # Verify initial state: all CoreDNS pods should be on the first node
+    result = initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "pods",
+            "-n",
+            "kube-system",
+            "-l",
+            "k8s-app=coredns",
+            "-o",
+            "jsonpath='{.items[*].spec.nodeName}'",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    initial_nodes = set(result.stdout.replace("'", "").split())
+    LOG.info(f"Initial CoreDNS pod distribution: {initial_nodes}")
+    assert (
+        len(initial_nodes) == 1
+    ), f"Expected all CoreDNS pods on one node initially, got {initial_nodes}"
+
+    # Join additional control plane nodes
+    join_token = util.get_join_token(initial_node, joining_cplane_node)
+
+    util.join_cluster(joining_cplane_node, join_token)
+
+    util.wait_until_k8s_ready(initial_node, instances)
+
+    # Wait for the DNS rebalancer controller to trigger and complete the rollout
+    # Allow more time for image pulls/scheduling across new nodes.
+    util.stubbornly(retries=60, delay_s=2).on(initial_node).exec(
+        [
+            "k8s",
+            "kubectl",
+            "rollout",
+            "status",
+            "-n",
+            "kube-system",
+            "deployment/coredns",
+            "--timeout=10s",
+        ]
+    )
+
+    # Get the actual nodes where CoreDNS pods are now running
+    result = initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "pods",
+            "-n",
+            "kube-system",
+            "-l",
+            "k8s-app=coredns",
+            "-o",
+            "jsonpath='{.items[*].spec.nodeName}'",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+    # Verify CoreDNS pods are now distributed across multiple nodes
+    node_names = set(result.stdout.replace("'", "").split())
+    LOG.info(f"Final CoreDNS pod distribution: {node_names}")
+
+    assert (
+        len(node_names) > 1
+    ), f"CoreDNS pods not distributed after rebalancing: {node_names}"

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -89,6 +89,7 @@ def test_dns_ha_rebalancing(instances: List[harness.Instance]):
 
     # Wait for initial cluster to be ready
     util.wait_until_k8s_ready(initial_node, [initial_node])
+    util.wait_for_dns(initial_node)
 
     # Verify initial state: all CoreDNS pods should be on the first node
     result = initial_node.exec(
@@ -102,13 +103,16 @@ def test_dns_ha_rebalancing(instances: List[harness.Instance]):
             "-l",
             "k8s-app=coredns",
             "-o",
-            "jsonpath='{.items[*].spec.nodeName}'",
+            "jsonpath='{.items[*].spec.nodeName} {.items[0].metadata.labels.pod-template-hash}'",
         ],
         text=True,
         capture_output=True,
     )
-    initial_nodes = set(result.stdout.replace("'", "").split())
-    LOG.info(f"Initial CoreDNS pod distribution: {initial_nodes}")
+    output = result.stdout.replace("'", "").split()
+    initial_nodes = output[0].split()
+    initial_pod_template_hash = output[1]
+    LOG.info(f"pod-template-hash: {initial_pod_template_hash}")
+    # Verify all pods are on the same node initially
     assert (
         len(initial_nodes) == 1
     ), f"Expected all CoreDNS pods on one node initially, got {initial_nodes}"
@@ -120,23 +124,19 @@ def test_dns_ha_rebalancing(instances: List[harness.Instance]):
 
     util.wait_until_k8s_ready(initial_node, instances)
 
-    # Wait for the DNS rebalancer controller to trigger and complete the rollout
-    # Allow more time for image pulls/scheduling across new nodes.
-    util.stubbornly(retries=60, delay_s=2).on(initial_node).exec(
-        [
-            "k8s",
-            "kubectl",
-            "rollout",
-            "status",
-            "-n",
-            "kube-system",
-            "deployment/coredns",
-            "--timeout=10s",
-        ]
-    )
+    # Wait for the DNS rebalancer controller to trigger and distribute CoreDNS pods across nodes
+    # Check until we have new pods (without the old template hash) on different nodes
+    def pods_distributed(result):
+        node_names = set(result.stdout.replace("'", "").split())
+        if len(node_names) > 1:
+            LOG.info(f"CoreDNS pods distributed across nodes: {node_names}")
+            return True
+        LOG.debug(f"CoreDNS pods still on {len(node_names)} node(s), waiting...")
+        return False
 
-    # Get the actual nodes where CoreDNS pods are now running
-    result = initial_node.exec(
+    util.stubbornly(retries=60, delay_s=2).on(initial_node).until(
+        pods_distributed
+    ).exec(
         [
             "k8s",
             "kubectl",
@@ -145,18 +145,9 @@ def test_dns_ha_rebalancing(instances: List[harness.Instance]):
             "-n",
             "kube-system",
             "-l",
-            "k8s-app=coredns",
+            f"k8s-app=coredns,pod-template-hash!={initial_pod_template_hash}",
             "-o",
             "jsonpath='{.items[*].spec.nodeName}'",
         ],
         text=True,
-        capture_output=True,
     )
-
-    # Verify CoreDNS pods are now distributed across multiple nodes
-    node_names = set(result.stdout.replace("'", "").split())
-    LOG.info(f"Final CoreDNS pod distribution: {node_names}")
-
-    assert (
-        len(node_names) > 1
-    ), f"CoreDNS pods not distributed after rebalancing: {node_names}"

--- a/tests/integration/tests/test_dns.py
+++ b/tests/integration/tests/test_dns.py
@@ -151,3 +151,120 @@ def test_dns_ha_rebalancing(instances: List[harness.Instance]):
         ],
         text=True,
     )
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.tags(tags.PULL_REQUEST)
+def test_dns_cluster_dns_propagates_to_late_joiners(
+    instances: List[harness.Instance],
+):
+    """
+    Regression test for issue #2516.
+
+    When a node joins after CoreDNS has already been reconciled, the
+    kube-system/k8sd-config ConfigMap is already at its steady-state contents
+    including cluster-dns=<CoreDNS ClusterIP>. A bare Watch established *after*
+    the ConfigMap was created does not synthesise an ADDED event for the
+    pre-existing object, so on the joining node NodeConfigurationController
+    would never reconcile kubelet with --cluster-dns. The fix seeds WatchConfigMap
+    with a Get before starting the Watch, and additionally writes kubelet args +
+    restarts kubelet locally on the node that reconciles CoreDNS. This test joins
+    a control-plane and a worker node *after* DNS is ready and asserts every node
+    ends up with --cluster-dns pointing at the CoreDNS service IP.
+    """
+    initial_node = instances[0]
+    joining_cplane_node = instances[1]
+    joining_worker_node = instances[2]
+
+    # Bring up the initial control plane and wait for CoreDNS to converge so
+    # the k8sd-config ConfigMap is already in its steady state with
+    # cluster-dns=<IP> before either other node joins.
+    util.wait_until_k8s_ready(initial_node, [initial_node])
+    util.wait_for_dns(initial_node)
+
+    # Discover the CoreDNS service ClusterIP instead of hard-coding it so the
+    # assertion survives CIDR changes.
+    result = initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "get",
+            "service",
+            "-n",
+            "kube-system",
+            "coredns",
+            "-o",
+            "jsonpath={.spec.clusterIP}",
+        ],
+        capture_output=True,
+    )
+    coredns_ip = result.stdout.decode().strip()
+    assert coredns_ip, "CoreDNS service should have a ClusterIP"
+    LOG.info("CoreDNS ClusterIP: %s", coredns_ip)
+
+    cplane_token = util.get_join_token(initial_node, joining_cplane_node)
+    worker_token = util.get_join_token(initial_node, joining_worker_node, "--worker")
+    util.join_cluster(joining_cplane_node, cplane_token)
+    util.join_cluster(joining_worker_node, worker_token)
+
+    util.wait_until_k8s_ready(initial_node, instances)
+
+    # Every node's kubelet args file must end up with --cluster-dns set to the
+    # CoreDNS ClusterIP. Before the fix, the joining nodes'
+    # NodeConfigurationController would miss the pre-existing ConfigMap's
+    # initial state and this arg would never be written.
+    expected_arg = f'--cluster-dns="{coredns_ip}"'
+    for instance in instances:
+        LOG.info("Asserting --cluster-dns on node %s", instance.id)
+        util.stubbornly(retries=12, delay_s=5).on(instance).until(
+            lambda p: expected_arg in p.stdout.decode()
+        ).exec(["cat", "/var/snap/k8s/common/args/kubelet"])
+
+    # End-to-end sanity: schedule a pod on the late-joined worker and verify
+    # its /etc/resolv.conf points at the CoreDNS ClusterIP. This is the actual
+    # user-visible symptom from the issue.
+    worker_name = util.hostname(joining_worker_node)
+    initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "run",
+            "busybox-late",
+            "--image=ghcr.io/containerd/busybox:1.28",
+            "--restart=Never",
+            "--overrides",
+            f'{{"spec": {{"nodeName": "{worker_name}"}}}}',
+            "--",
+            "sleep",
+            "3600",
+        ],
+    )
+
+    util.stubbornly(retries=3, delay_s=1).on(initial_node).exec(
+        [
+            "k8s",
+            "kubectl",
+            "wait",
+            "--for=condition=ready",
+            "pod",
+            "busybox-late",
+            "--timeout",
+            "180s",
+        ]
+    )
+
+    resolv = initial_node.exec(
+        [
+            "k8s",
+            "kubectl",
+            "exec",
+            "busybox-late",
+            "--",
+            "cat",
+            "/etc/resolv.conf",
+        ],
+        capture_output=True,
+    ).stdout.decode()
+    assert (
+        f"nameserver {coredns_ip}" in resolv
+    ), f"expected CoreDNS ClusterIP in pod resolv.conf, got: {resolv}"


### PR DESCRIPTION
### Overview

This PR backports the following changes:
- https://github.com/canonical/k8s-snap/pull/2098
- https://github.com/canonical/k8s-snap/pull/2102
- https://github.com/canonical/k8s-snap/pull/2131
- https://github.com/canonical/k8s-snap/pull/2132
- https://github.com/canonical/k8sd/pull/41
- https://github.com/canonical/k8s-snap/pull/2536