### PR TITLE
docs: fix occured typo in k8s-status proposal

### DIFF
--- a/docs/proposals/001-k8s-status.md
+++ b/docs/proposals/001-k8s-status.md
@@ -27,7 +27,7 @@ Kubernetes features.
 This can be used to allow users to verify that all built-in features of
 Canonical Kubernetes (e.g. `network`, `dns`, etc) are deployed on the cluster.
 
-Otherwise, if an error has occured (e.g. configuration is not valid, or some
+Otherwise, if an error has occurred (e.g. configuration is not valid, or some
 resource could not be deployed), this error will be raised to the user as well.
 
 ## Rationale


### PR DESCRIPTION
## Description

Fixes 'occured' -> 'occurred' typo in `docs/proposals/001-k8s-status.md`.

## Solution

One-character documentation typo fix.

## Issue

N/A.

## Backport

Not needed (docs only).

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary
- [ ] Confirm whether the `release-notes` label should be kept or removed

Documentation-only typo fix, no tests required.
