### PR TITLE
feat: [backport 1.35] bump metallb rock to v0.15.3-ck2

### DIFF
--- a/src/k8s/pkg/k8sd/features/metallb/chart.go
+++ b/src/k8s/pkg/k8sd/features/metallb/chart.go
@@ -25,13 +25,13 @@ var (
 	controllerImageRepo = "ghcr.io/canonical/metallb-controller"
 
 	// ControllerImageTag is the tag to use for metallb-controller.
-	ControllerImageTag = "v0.15.3-ck0"
+	ControllerImageTag = "v0.15.3-ck2"
 
 	// speakerImageRepo is the image to use for metallb-speaker.
 	speakerImageRepo = "ghcr.io/canonical/metallb-speaker"
 
 	// speakerImageTag is the tag to use for metallb-speaker.
-	speakerImageTag = "v0.15.3-ck0"
+	speakerImageTag = "v0.15.3-ck2"
 
 	// frrImageRepo is the image to use for frrouting.
 	frrImageRepo = "ghcr.io/canonical/frr"


### PR DESCRIPTION
### Overview

This PR bumps metallb controller and speaker rocks to v0.15.3-ck2 to incorporate the patches from https://github.com/canonical/metallb-rocks/pull/33