### PR TITLE
docs: change CA rotation warning to reflect upstream state

### DIFF
--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -10,10 +10,10 @@ nodes in your {{product}} cluster.
 
 ```{warning}
 Only Kubernetes component certificates refreshes are supported with the
- `k8s refresh-certs` command. Microcluster and etcd certificates' expiration
- is set to 20 years, so renewal is not typically necessary. They are not automatically
- renewed by the command and currently cannot be refreshed manually.
- Additionally, like upstream Kubernetes, rotating the Certificate Authority (CA) is not supported.
+ `k8s refresh-certs` command. Microcluster and etcd certificates are set to
+ expire after 20 years, are not automatically renewed by this command, and
+ cannot currently be refreshed manually. CA rotation is not currently supported
+ in Canonical Kubernetes.
 ```
 
 ## Prerequisites

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -11,7 +11,7 @@ nodes in your {{product}} cluster.
 ```{warning}
 Only Kubernetes component certificates refreshes are supported with the
  `k8s refresh-certs` command. Microcluster and etcd certificates are set to
- expire after 20 years, are not automatically renewed by this command, and
+ expire after 20 years. They are not automatically renewed by this command and
  cannot currently be refreshed manually. CA rotation is not currently supported
  in Canonical Kubernetes.
 ```


### PR DESCRIPTION
## Description

Update the documentation to clarify the behavior of certificate refresh and rotation in Canonical Kubernetes. 

## Solution

The main change is to make it clearer which certificates are affected by the `k8s refresh-certs` command and the current limitations around certificate and CA rotation.

## Issue

fixes #2560 

## Backport

Yes, to all the releases that support certificates refresh (i.e., `release-1.33..latest`)

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [ ] Confirm whether the `release-notes` label should be kept or removed