### PR TITLE
docs: rollout docs spread testing to snap how to guides

### DIFF
--- a/.github/workflows/docs-spread-tests.yaml
+++ b/.github/workflows/docs-spread-tests.yaml
@@ -171,4 +171,4 @@ jobs:
           sudo adduser --gecos "" --disabled-password ubuntu || true
           echo "ubuntu:ubuntu" | sudo chpasswd || true
           cd docs
-          spread -vv "github-ci:ubuntu-24.04-64:tests/spread_generated/${{ matrix.suite }}/"
+          spread -vv -repeat 0 "github-ci:ubuntu-24.04-64:tests/spread_generated/${{ matrix.suite }}/"

--- a/.github/workflows/docs-spread-tests.yaml
+++ b/.github/workflows/docs-spread-tests.yaml
@@ -88,7 +88,7 @@ jobs:
 
             rel="${file#docs/canonicalk8s/}"
             rel="${rel%.*}"
-            task_name="$(echo "$rel" | sed 's|/|-|g')"
+            task_name="$(echo "$rel" | sed 's|/|_|g')"
             out_dir="tests/spread_generated/${suite_marker}/${task_name}"
 
             # Generate the task.yaml for this file using the upstream script

--- a/.github/workflows/docs-spread-tests.yaml
+++ b/.github/workflows/docs-spread-tests.yaml
@@ -58,13 +58,21 @@ jobs:
           if [[ -z "$changed_files_input" ]]; then
             echo "no_suites=true" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
+          fi 
 
+          # Append the docs/canonicalk8s/ prefix to each changed file and store in an array
           mapfile -t changed_files < <(
             printf '%s\n' "$changed_files_input" \
             | tr ' ' '\n' \
+            | grep -v '^$' \
             | sed 's|^|docs/canonicalk8s/|'
           )
+
+          if [[ ${#changed_files[@]} -eq 0 ]]; then
+            echo "No docs files needing spread tests changed in this PR."
+            echo "no_suites=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           generated_any=false
 

--- a/.github/workflows/docs-spread-tests.yaml
+++ b/.github/workflows/docs-spread-tests.yaml
@@ -12,8 +12,10 @@ permissions:
   contents: read
 
 jobs:
-  docs-spread-tests:
+  prepare-docs-spread:
     runs-on: ubuntu-latest
+    outputs:
+      no_suites: ${{ steps.generate.outputs.no_suites }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -37,12 +39,8 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version: "1.23"
-
-      - name: Generate tasks.yaml for changed docs
+      - id: generate
+        name: Generate tasks.yaml for changed docs
         shell: bash
         env:
           CHANGED_FILES_INPUT: ${{ inputs.changed_files }}
@@ -57,54 +55,41 @@ jobs:
 
           changed_files_input="${CHANGED_FILES_INPUT:-}"
 
-          # Append the docs/canonicalk8s/ prefix to each changed file and store in an array
-          if [[ -n "$changed_files_input" ]]; then
-            mapfile -t changed_files < <(
-              printf '%s\n' "$changed_files_input" \
-              | tr ' ' '\n' \
-              | sed 's|^|docs/canonicalk8s/|' \
-              || true
-            )
-          else
-            echo "No changed_files input provided; skipping docs spread generation."
-            echo "NO_SUITES=true" >> "$GITHUB_ENV"
+          if [[ -z "$changed_files_input" ]]; then
+            echo "no_suites=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [[ ${#changed_files[@]} -eq 0 ]]; then
-            echo "No docs files needing spread tests changed in this PR."
-            echo "NO_SUITES=true" >> "$GITHUB_ENV"
-            exit 0
-          fi
+          mapfile -t changed_files < <(
+            printf '%s\n' "$changed_files_input" \
+            | tr ' ' '\n' \
+            | sed 's|^|docs/canonicalk8s/|'
+          )
 
-          declare -A suites_seen=()
           generated_any=false
 
           for file in "${changed_files[@]}"; do
             # Look for suite marker in the file like "SPREAD SUITE: snap_clean" to determine which suite to place it in
-            marker_suite="$(grep -Eo 'SPREAD SUITE:\s*[a-z_]+' "$file" | head -n1 | sed -E 's/.*:\s*//' || true)"
+            suite_marker="$(grep -Eo 'SPREAD SUITE:\s*[a-z_]+' "$file" | head -n1 | sed -E 's/.*:\s*//' || true)"
 
-            if [[ -z "$marker_suite" ]]; then
+            if [[ -z "$suite_marker" ]]; then
               echo "Skipping $file (no SPREAD SUITE marker)"
               continue
             fi
 
-            suite="$marker_suite"
-
             # Validate suite value against allowed list
-            case "$suite" in
+            case "$suite_marker" in
               snap_clean|snap_bootstrapped) ;;
               *)
-                echo "Unsupported SPREAD SUITE marker '$suite' in $file"
+                echo "Unsupported SPREAD SUITE marker '$suite_marker' in $file"
                 exit 1
                 ;;
             esac
 
             rel="${file#docs/canonicalk8s/}"
             rel="${rel%.*}"
-            # Flatten: use sanitized path with slashes replaced to avoid intermediate dirs
-            task_name=$(echo "$rel" | sed 's|/|-|g')
-            out_dir="tests/spread-generated/${suite}/${task_name}"
+            task_name="$(echo "$rel" | sed 's|/|-|g')"
+            out_dir="tests/spread-generated/${suite_marker}/${task_name}"
 
             # Generate the task.yaml for this file using the upstream script
             mkdir -p "$out_dir"
@@ -112,55 +97,78 @@ jobs:
               "$file" \
               "$out_dir/task.yaml"
 
-            suites_seen["$suite"]=1
             generated_any=true
           done
 
           if [[ "$generated_any" != true ]]; then
-            echo "No docs files with SPREAD SUITE markers changed in this PR."
-            echo "NO_SUITES=true" >> "$GITHUB_ENV"
+            echo "no_suites=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          printf "%s\n" "${!suites_seen[@]}" | sort > /tmp/spread_suites.txt
+          echo "no_suites=false" >> "$GITHUB_OUTPUT"
 
-          {
-            echo "SPREAD_SUITES<<EOF"
-            cat /tmp/spread_suites.txt
-            echo "EOF"
-          } >> "$GITHUB_ENV"
+      - name: Upload generated spread tasks
+        if: steps.generate.outputs.no_suites != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: spread-generated
+          path: tests/spread-generated
+
+  docs-spread-tests:
+    needs: prepare-docs-spread
+    if: needs.prepare-docs-spread.outputs.no_suites != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - snap_bootstrapped
+          - snap_clean
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download generated spread tasks
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: spread-generated
+          path: tests/spread-generated
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.23"
 
       - name: Install spread
-        if: env.NO_SUITES != 'true'
         shell: bash
         run: |
           set -euo pipefail
           go install github.com/canonical/spread/cmd/spread@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-      - name: Run spread suites
-        if: env.NO_SUITES != 'true'
+      - name: Skip empty suite
+        id: suite-check
+        shell: bash
+        run: |
+          set -euo pipefail
+          suite_dir="tests/spread-generated/${{ matrix.suite }}"
+          if [[ ! -d "$suite_dir" ]] || [[ -z "$(find "$suite_dir" -name task.yaml -print -quit)" ]]; then
+            echo "Suite ${{ matrix.suite }} has no generated tasks; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run spread suite
+        if: steps.suite-check.outputs.skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
           sudo adduser --gecos "" --disabled-password ubuntu || true
           echo "ubuntu:ubuntu" | sudo chpasswd || true
-
-          ANY_SUITE_FAILED=0
-
-          while IFS= read -r suite; do
-            [[ -z "$suite" ]] && continue
-            echo "Running docs suite: $suite"
-            if !(
-              cd docs
-              spread -vv "github-ci:ubuntu-24.04-64:tests/spread-generated/${suite}/"
-            ); then
-              echo "Suite '$suite' encountered errors, but continuing pipeline..."
-              ANY_SUITE_FAILED=1
-            fi
-          done <<< "$SPREAD_SUITES"
-
-          if [[ "$ANY_SUITE_FAILED" -ne 0 ]]; then
-            echo "GitHub Action failing because one or more documentation suites failed."
-            exit 1
-          fi
+          cd docs
+          spread -vv "github-ci:ubuntu-24.04-64:tests/spread-generated/${{ matrix.suite }}/"

--- a/.github/workflows/docs-spread-tests.yaml
+++ b/.github/workflows/docs-spread-tests.yaml
@@ -146,11 +146,21 @@ jobs:
           sudo adduser --gecos "" --disabled-password ubuntu || true
           echo "ubuntu:ubuntu" | sudo chpasswd || true
 
+          ANY_SUITE_FAILED=0
+
           while IFS= read -r suite; do
             [[ -z "$suite" ]] && continue
             echo "Running docs suite: $suite"
-            (
+            if !(
               cd docs
               spread -vv "github-ci:ubuntu-24.04-64:tests/spread-generated/${suite}/"
-            )
+            ); then
+              echo "Suite '$suite' encountered errors, but continuing pipeline..."
+              ANY_SUITE_FAILED=1
+            fi
           done <<< "$SPREAD_SUITES"
+
+          if [[ "$ANY_SUITE_FAILED" -ne 0 ]]; then
+            echo "GitHub Action failing because one or more documentation suites failed."
+            exit 1
+          fi

--- a/.github/workflows/docs-spread-tests.yaml
+++ b/.github/workflows/docs-spread-tests.yaml
@@ -47,11 +47,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          rm -rf tests/spread-generated
-          mkdir -p tests/spread-generated
+          rm -rf tests/spread_generated
+          mkdir -p tests/spread_generated
           
           # Create all suite directories so spread doesn't fail reading spread.yaml
-          mkdir -p tests/spread-generated/{snap_clean,snap_bootstrapped}
+          mkdir -p tests/spread_generated/{snap_clean,snap_bootstrapped}
 
           changed_files_input="${CHANGED_FILES_INPUT:-}"
 
@@ -89,7 +89,7 @@ jobs:
             rel="${file#docs/canonicalk8s/}"
             rel="${rel%.*}"
             task_name="$(echo "$rel" | sed 's|/|-|g')"
-            out_dir="tests/spread-generated/${suite_marker}/${task_name}"
+            out_dir="tests/spread_generated/${suite_marker}/${task_name}"
 
             # Generate the task.yaml for this file using the upstream script
             mkdir -p "$out_dir"
@@ -109,10 +109,10 @@ jobs:
 
       - name: Upload generated spread tasks
         if: steps.generate.outputs.no_suites != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: spread-generated
-          path: tests/spread-generated
+          name: spread_generated
+          path: tests/spread_generated
 
   docs-spread-tests:
     needs: prepare-docs-spread
@@ -135,8 +135,8 @@ jobs:
       - name: Download generated spread tasks
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: spread-generated
-          path: tests/spread-generated
+          name: spread_generated
+          path: tests/spread_generated
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -155,7 +155,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          suite_dir="tests/spread-generated/${{ matrix.suite }}"
+          suite_dir="tests/spread_generated/${{ matrix.suite }}"
           if [[ ! -d "$suite_dir" ]] || [[ -z "$(find "$suite_dir" -name task.yaml -print -quit)" ]]; then
             echo "Suite ${{ matrix.suite }} has no generated tasks; skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -171,4 +171,4 @@ jobs:
           sudo adduser --gecos "" --disabled-password ubuntu || true
           echo "ubuntu:ubuntu" | sudo chpasswd || true
           cd docs
-          spread -vv "github-ci:ubuntu-24.04-64:tests/spread-generated/${{ matrix.suite }}/"
+          spread -vv "github-ci:ubuntu-24.04-64:tests/spread_generated/${{ matrix.suite }}/"

--- a/docs/canonicalk8s/releases/snap/upgrading.md
+++ b/docs/canonicalk8s/releases/snap/upgrading.md
@@ -10,7 +10,7 @@ before refreshing.
 
 Simply run:
 
-```bash
+```
 sudo snap refresh k8s --channel=1.35-classic/stable
 ```
 

--- a/docs/canonicalk8s/snap/howto/image-management.md
+++ b/docs/canonicalk8s/snap/howto/image-management.md
@@ -79,10 +79,6 @@ docker.io/library/hello-world:latest
 ```
 <!-- SPREAD SKIP END -->
 
-<!-- SPREAD 
-sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q | grep docker.io/library/hello-world:latest
--->
-
 <!-- LINKS -->
 
 [snap-install-howto]: ./install/snap

--- a/docs/canonicalk8s/snap/howto/image-management.md
+++ b/docs/canonicalk8s/snap/howto/image-management.md
@@ -56,7 +56,9 @@ sha256:873ed75102791e5b0b8a7fcd41606c92fcec98d56d05ead4ac5131650004c136
 
 <!-- SPREAD 
 # Ensure all pods are up and images pulled before query
-sudo k8s kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=300s
+sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m
+sudo k8s kubectl rollout status deployment/cilium-operator -n kube-system --timeout=10m
+sudo k8s kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=10m
 sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q | grep "ghcr.io"
 -->
 

--- a/docs/canonicalk8s/snap/howto/image-management.md
+++ b/docs/canonicalk8s/snap/howto/image-management.md
@@ -1,5 +1,7 @@
 # How to manage images
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} uses the containerd runtime to manage images, which in turn uses
 runc to run containers. Some users may need to use containerd's capabilities
 directly. For example, if they do not have access to our default image
@@ -39,6 +41,7 @@ sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --names
 
 You should see:
 
+<!-- SPREAD SKIP -->
 ```
 ghcr.io/canonical/cilium-operator-generic:1.17.1-ck0
 ghcr.io/canonical/cilium-operator-generic@sha256:e02dcce1e175312bf4dc2da6a97df49456a8eef6b2a1a9f2d68d4342dc0d3664
@@ -47,6 +50,12 @@ ghcr.io/canonical/k8s-snap/pause@sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f5
 sha256:27e1954b8e6cbf80ddccbb54f1b0cb78111c3cafe28d742044ecb6cbb22f9d1c
 sha256:873ed75102791e5b0b8a7fcd41606c92fcec98d56d05ead4ac5131650004c136
 ```
+
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD 
+sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q | grep "ghcr.io"
+-->
 
 ## Pulling images
 
@@ -64,9 +73,15 @@ sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --names
 
 You should see:
 
+<!-- SPREAD SKIP -->
 ```
 docker.io/library/hello-world:latest
 ```
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD 
+sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q | grep docker.io/library/hello-world:latest
+-->
 
 <!-- LINKS -->
 

--- a/docs/canonicalk8s/snap/howto/image-management.md
+++ b/docs/canonicalk8s/snap/howto/image-management.md
@@ -42,6 +42,7 @@ sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --names
 You should see:
 
 <!-- SPREAD SKIP -->
+
 ```
 ghcr.io/canonical/cilium-operator-generic:1.17.1-ck0
 ghcr.io/canonical/cilium-operator-generic@sha256:e02dcce1e175312bf4dc2da6a97df49456a8eef6b2a1a9f2d68d4342dc0d3664
@@ -76,9 +77,11 @@ sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --names
 You should see:
 
 <!-- SPREAD SKIP -->
+
 ```
 docker.io/library/hello-world:latest
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- LINKS -->

--- a/docs/canonicalk8s/snap/howto/image-management.md
+++ b/docs/canonicalk8s/snap/howto/image-management.md
@@ -54,6 +54,8 @@ sha256:873ed75102791e5b0b8a7fcd41606c92fcec98d56d05ead4ac5131650004c136
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD 
+# Ensure all pods are up and images pulled before query
+sudo k8s kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=300s
 sudo /snap/k8s/current/bin/ctr --address /run/containerd/containerd.sock --namespace k8s.io images list -q | grep "ghcr.io"
 -->
 

--- a/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
@@ -1,5 +1,11 @@
 # How to install with a custom bootstrap configuration
 
+<!-- SPREAD SUITE: snap_clean -->
+
+<!-- SPREAD
+sudo snap install k8s --classic --channel=1.35-classic/stable
+-->
+
 When creating a {{ product }} cluster that differs from the default
 configuration you can choose to use a custom bootstrap configuration.
 The CLI interactive mode or a custom bootstrap configuration file allow you
@@ -24,6 +30,7 @@ CIDR and the Service CIDR.
 
 To bootstrap interactively, run:
 
+<!-- SPREAD SKIP -->
 ```
 sudo k8s bootstrap --timeout 10m --interactive
 ```
@@ -43,6 +50,7 @@ Bootstrapping the cluster. This may take a few seconds, please wait.
 Bootstrapped a new Kubernetes cluster with node address "192.122.3.111:6400".
 The node will be 'Ready' to host workloads after the CNI is deployed successfully.
 ```
+<!-- SPREAD SKIP END -->
 
 ## Bootstrap configuration file
 
@@ -68,9 +76,16 @@ EOF
 
 Then, apply the bootstrap configuration file:
 
+<!-- SPREAD SKIP -->
 ```
 sudo k8s bootstrap --file /path/to/bootstrap.yaml
 ```
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+sudo k8s bootstrap --file bootstrap.yaml
+sudo k8s status --wait-ready
+-->
 
 To verify any changes to the built-in features run:
 

--- a/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
@@ -31,6 +31,7 @@ CIDR and the Service CIDR.
 To bootstrap interactively, run:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo k8s bootstrap --timeout 10m --interactive
 ```
@@ -50,6 +51,7 @@ Bootstrapping the cluster. This may take a few seconds, please wait.
 Bootstrapped a new Kubernetes cluster with node address "192.122.3.111:6400".
 The node will be 'Ready' to host workloads after the CNI is deployed successfully.
 ```
+
 <!-- SPREAD SKIP END -->
 
 ## Bootstrap configuration file
@@ -77,9 +79,11 @@ EOF
 Then, apply the bootstrap configuration file:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo k8s bootstrap --file /path/to/bootstrap.yaml
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD

--- a/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
@@ -88,7 +88,7 @@ sudo k8s bootstrap --file /path/to/bootstrap.yaml
 
 <!-- SPREAD
 sudo k8s bootstrap --file bootstrap.yaml
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 sudo k8s get network | grep "enabled: true"
 -->
 

--- a/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
@@ -85,6 +85,7 @@ sudo k8s bootstrap --file /path/to/bootstrap.yaml
 <!-- SPREAD
 sudo k8s bootstrap --file bootstrap.yaml
 sudo k8s status --wait-ready
+sudo k8s get network | grep "enabled: true"
 -->
 
 To verify any changes to the built-in features run:

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -55,7 +55,7 @@ containerd-related files (e.g.: `/ck8s/etc/containerd`,
 `/ck8s/var/run/containerd/containerd.sock`, etc.).
 
 <!-- SPREAD
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 ps -ef | grep kubelet | grep container-runtime-endpoint=/ck8s/etc/containerd/k8s-containerd
 -->
 

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -5,6 +5,9 @@
 <!-- SPREAD
 sudo snap install docker
 sudo snap install k8s --classic --channel=1.35-classic/stable
+# Tear down docker on exit
+trap 'sudo snap remove docker --purge' EXIT
+# Start doc test
 -->
 
 We recommend testing {{product}} in an isolated environment such as a clean

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -68,6 +68,7 @@ space for operations like image layer unpacking. Insufficient space can cause:
 To check the available space on the tmpfs:
 
 <!-- SPREAD SKIP -->
+
 ```
 df -h /run
 ```
@@ -78,6 +79,7 @@ increase the size of the tmpfs mount to see if it resolves the problem:
 ```
 sudo mount -o remount,size=10G /run
 ```
+
 <!-- SPREAD SKIP END -->
 
 ```{note}

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -1,5 +1,12 @@
 # Install {{product}} in development environments
 
+<!-- SPREAD SUITE: snap_clean -->
+
+<!-- SPREAD
+sudo snap install docker
+sudo snap install k8s --classic --channel=1.35-classic/stable
+-->
+
 We recommend testing {{product}} in an isolated environment such as a clean
 virtual machine.
 
@@ -22,7 +29,11 @@ with {{product}}.
 But, if necessary, {{product}} can be configured to use a custom containerd
 path, like so:
 
-```bash
+<!-- SPREAD
+export containerdBaseDir=/ck8s/etc/containerd
+-->
+
+```
 cat <<EOF | sudo k8s bootstrap --file -
 containerd-base-dir: $containerdBaseDir
 cluster-config:
@@ -40,6 +51,15 @@ Any non-temporary directory can be chosen for `containerd-base-dir`
 containerd-related files (e.g.: `/ck8s/etc/containerd`,
 `/ck8s/var/run/containerd/containerd.sock`, etc.).
 
+<!-- SPREAD
+sudo k8s status --wait-ready
+source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
+ps -ef | grep kubelet | grep container-runtime-endpoint=/ck8s/etc/containerd/k8s-containerd
+-->
+
+
+<!-- repeat_checks "ps -ef | grep kubelet | grep container-runtime-endpoint" "--container-runtime-endpoint=/ck8s/etc/containerd/k8s-containerd" -->
+
 ### State Directory on tmpfs — Disk Pressure & ErrImagePull
 
 When using a custom containerd, if it is configured to use a state directory on
@@ -51,16 +71,18 @@ space for operations like image layer unpacking. Insufficient space can cause:
 
 To check the available space on the tmpfs:
 
-```bash
+<!-- SPREAD SKIP -->
+```
 df -h /run
 ```
 
 If the space is low and you're experiencing these issues, you can temporarily 
 increase the size of the tmpfs mount to see if it resolves the problem:
 
-```bash
+```
 sudo mount -o remount,size=10G /run
 ```
+<!-- SPREAD SKIP END -->
 
 ```{note}
 This change is not persistent and will reset on reboot.
@@ -73,9 +95,13 @@ for example after joining a different Wi-Fi network.
 
 In this case, you may configure {{product}} to use the ``localhost`` address:
 
+<!-- SPREAD SKIP -->
+
 ```bash
 sudo k8s bootstrap --address=127.0.0.1
 ```
+
+<!-- SPREAD SKIP END -->
 
 ## Conflicting Docker iptables rules
 

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -53,12 +53,8 @@ containerd-related files (e.g.: `/ck8s/etc/containerd`,
 
 <!-- SPREAD
 sudo k8s status --wait-ready
-source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
 ps -ef | grep kubelet | grep container-runtime-endpoint=/ck8s/etc/containerd/k8s-containerd
 -->
-
-
-<!-- repeat_checks "ps -ef | grep kubelet | grep container-runtime-endpoint" "--container-runtime-endpoint=/ck8s/etc/containerd/k8s-containerd" -->
 
 ### State Directory on tmpfs — Disk Pressure & ErrImagePull
 

--- a/docs/canonicalk8s/snap/howto/install/snap.md
+++ b/docs/canonicalk8s/snap/howto/install/snap.md
@@ -82,7 +82,7 @@ It is recommended to ensure that the cluster initializes properly and is
 running with no issues. Run the command:
 
 ```
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 ```
 
 This command will wait until the cluster indicates it is ready and then display

--- a/docs/canonicalk8s/snap/howto/install/snap.md
+++ b/docs/canonicalk8s/snap/howto/install/snap.md
@@ -1,5 +1,7 @@
 # How to install {{product}} from a snap
 
+<!-- SPREAD SUITE: snap_clean -->
+
 {{product}} is packaged as a [snap], available from the
 snap store for all supported platforms.
 
@@ -44,10 +46,16 @@ page] for an explanation of the different types of channel.
 
 The snap can be installed with the snap command:
 
+<!-- SPREAD SKIP -->
 ```{literalinclude} ../../../_parts/install.md
 :start-after: <!-- snap start -->
 :end-before: <!-- snap end -->
 ```
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+sudo snap install k8s --classic --channel=1.35-classic/stable
+-->
 
 ## Bootstrap the cluster
 

--- a/docs/canonicalk8s/snap/howto/install/snap.md
+++ b/docs/canonicalk8s/snap/howto/install/snap.md
@@ -47,10 +47,12 @@ page] for an explanation of the different types of channel.
 The snap can be installed with the snap command:
 
 <!-- SPREAD SKIP -->
+
 ```{literalinclude} ../../../_parts/install.md
 :start-after: <!-- snap start -->
 :end-before: <!-- snap end -->
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD

--- a/docs/canonicalk8s/snap/howto/install/uninstall.md
+++ b/docs/canonicalk8s/snap/howto/install/uninstall.md
@@ -34,6 +34,7 @@ sudo k8s kubectl get nodes
 Uninstall the `k8s` snap:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo snap remove k8s
 ```
@@ -53,6 +54,7 @@ To confirm the snap is successfully removed, check the list of installed
 snaps:
 
 <!-- SPREAD SKIP -->
+
 ```
 snap list k8s
 ```
@@ -62,6 +64,7 @@ This command should produce an output similar to:
 ```
 error: no matching snaps installed
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD 

--- a/docs/canonicalk8s/snap/howto/install/uninstall.md
+++ b/docs/canonicalk8s/snap/howto/install/uninstall.md
@@ -1,5 +1,7 @@
 # How to uninstall the {{product}} snap
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 This guide provides step-by-step instructions for removing the {{ product }}
 snap from your system.
 
@@ -13,6 +15,8 @@ In this case, the node needs to be removed with the `--force` flag as explained 
 
 From any control plane node:
 
+<!-- SPREAD SKIP -->
+
 ```
 sudo k8s remove-node <NODE_NAME>
 ```
@@ -23,10 +27,13 @@ Ensure the node has been removed from the cluster:
 sudo k8s kubectl get nodes
 ```
 
+<!-- SPREAD SKIP END -->
+
 ## Remove the k8s snap
 
 Uninstall the `k8s` snap:
 
+<!-- SPREAD SKIP -->
 ```
 sudo snap remove k8s
 ```
@@ -34,6 +41,7 @@ sudo snap remove k8s
 This command uninstalls the snap but may leave some configurations and data
 files on the system.
 For a complete removal, including all cluster data, use the `--purge` option:
+<!-- SPREAD SKIP END -->
 
 ```
 sudo snap remove k8s --purge
@@ -44,6 +52,7 @@ sudo snap remove k8s --purge
 To confirm the snap is successfully removed, check the list of installed
 snaps:
 
+<!-- SPREAD SKIP -->
 ```
 snap list k8s
 ```
@@ -53,3 +62,4 @@ This command should produce an output similar to:
 ```
 error: no matching snaps installed
 ```
+<!-- SPREAD SKIP END -->

--- a/docs/canonicalk8s/snap/howto/install/uninstall.md
+++ b/docs/canonicalk8s/snap/howto/install/uninstall.md
@@ -63,3 +63,7 @@ This command should produce an output similar to:
 error: no matching snaps installed
 ```
 <!-- SPREAD SKIP END -->
+
+<!-- SPREAD 
+! snap list k8s >/dev/null 2>&1
+-->

--- a/docs/canonicalk8s/snap/howto/networking/default-dns.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-dns.md
@@ -75,9 +75,11 @@ You should see three options:
 Set a new DNS server IP for forwarding known entries:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo k8s set dns.upstream-nameservers=<new-ips>
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD 
@@ -88,9 +90,11 @@ sudo k8s get dns | grep "8.8.8.8"
 Change the cluster domain name:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo k8s set dns.cluster-domain=<new-domain-name>
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD 
@@ -106,6 +110,7 @@ do this):
 ```
 sudo k8s set dns.service-ip=<new-cluster-ip>
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD 

--- a/docs/canonicalk8s/snap/howto/networking/default-dns.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-dns.md
@@ -25,7 +25,7 @@ sudo k8s status
 ```
 
 <!-- SPREAD
-sudo k8s get dns | grep "enabled: true"
+sudo k8s status | grep "dns:                      enabled at"
 -->
 
 The default state for the cluster is `dns enabled`.
@@ -61,7 +61,9 @@ sudo k8s get dns
 ```
 
 <!-- SPREAD
-sudo k8s get dns | grep "enabled: true"
+sudo k8s get dns | grep "upstream-nameservers"
+sudo k8s get dns | grep "cluster-domain"
+sudo k8s get dns | grep "service-ip"
 -->
 
 You should see three options:
@@ -76,22 +78,45 @@ Set a new DNS server IP for forwarding known entries:
 ```
 sudo k8s set dns.upstream-nameservers=<new-ips>
 ```
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD 
+sudo k8s set dns.upstream-nameservers=8.8.8.8
+sudo k8s get dns | grep "8.8.8.8"
+-->
 
 Change the cluster domain name:
 
+<!-- SPREAD SKIP -->
 ```
 sudo k8s set dns.cluster-domain=<new-domain-name>
 ```
+<!-- SPREAD SKIP END -->
 
-Assign a new cluster IP to the DNS service:
+<!-- SPREAD 
+sudo k8s set dns.cluster-domain=k8s.testing
+sudo k8s get dns | grep "cluster-domain: k8s.testing"
+-->
+
+Assign a new cluster IP to the DNS service (DNS must be disabled in order to 
+do this):
+
+<!-- SPREAD SKIP -->
 
 ```
 sudo k8s set dns.service-ip=<new-cluster-ip>
 ```
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD 
+sudo k8s disable dns
+sudo k8s set dns.service-ip="10.152.183.254"
+sudo k8s enable dns
+sudo k8s get dns | grep "service-ip: 10.152.183.254"
+-->
 
 Replace `<new-ip>`, `<new-domain-name>`, and `<new-cluster-ip>` with the
 desired values for your DNS configuration.
-<!-- SPREAD SKIP END -->
 
 ## Disable DNS
 

--- a/docs/canonicalk8s/snap/howto/networking/default-dns.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-dns.md
@@ -1,5 +1,7 @@
 # How to use default DNS
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} includes a default DNS (Domain Name System) which is
 essential for internal cluster communication. When enabled, the DNS facilitates
 service discovery by assigning each service a DNS name. When disabled, you can
@@ -22,6 +24,10 @@ Find out whether DNS is enabled or disabled with the following command:
 sudo k8s status
 ```
 
+<!-- SPREAD
+sudo k8s get dns | grep "enabled: true"
+-->
+
 The default state for the cluster is `dns enabled`.
 
 ## Enable DNS
@@ -32,11 +38,19 @@ To enable DNS, run:
 sudo k8s enable dns
 ```
 
+<!-- SPREAD
+sudo k8s get dns | grep "enabled: true"
+-->
+
 For more information on this command, run:
 
 ```
 sudo k8s help enable
 ```
+
+<!-- SPREAD
+sudo k8s help enable | grep "Enable one of network, dns"
+-->
 
 ## Configure DNS
 
@@ -46,6 +60,10 @@ Discover your configuration options by running:
 sudo k8s get dns
 ```
 
+<!-- SPREAD
+sudo k8s get dns | grep "enabled: true"
+-->
+
 You should see three options:
 
 - `upstream-nameservers`: DNS servers used to forward known entries
@@ -54,6 +72,7 @@ You should see three options:
 
 Set a new DNS server IP for forwarding known entries:
 
+<!-- SPREAD SKIP -->
 ```
 sudo k8s set dns.upstream-nameservers=<new-ips>
 ```
@@ -72,6 +91,7 @@ sudo k8s set dns.service-ip=<new-cluster-ip>
 
 Replace `<new-ip>`, `<new-domain-name>`, and `<new-cluster-ip>` with the
 desired values for your DNS configuration.
+<!-- SPREAD SKIP END -->
 
 ## Disable DNS
 
@@ -87,11 +107,19 @@ DNS at any point, and your cluster will return to normal functionality.
 sudo k8s disable dns
 ```
 
+<!-- SPREAD
+sudo k8s get dns | grep "enabled: false"
+-->
+
 For more information on this command, execute:
 
 ```
 sudo k8s help disable
 ```
+
+<!-- SPREAD
+sudo k8s help disable | grep "Disable one of network, dns"
+-->
 
 <!-- LINKS -->
 

--- a/docs/canonicalk8s/snap/howto/networking/default-gateway.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-gateway.md
@@ -1,7 +1,9 @@
 # How to use the default Gateway
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} enables you to configure advanced networking of your cluster using
-[gateway API]. When enabled, the necessary CRDs and GatewayClass are generated
+[gateway API](https://gateway-api.sigs.k8s.io/). When enabled, the necessary CRDs and GatewayClass are generated
 to enable the CNI controllers configure traffic and provision infrastructure to
 the cluster.
 
@@ -11,7 +13,7 @@ This guide assumes the following:
 
 - You have root or sudo access to the machine
 - You have a bootstrapped {{product}} cluster (see the
-[Getting Started][getting-started-guide] guide).
+   [Getting Started](/snap/tutorial/getting-started) guide).
 
 ## Check Gateway status
 
@@ -21,6 +23,11 @@ disabled with the following command:
 ```
 sudo k8s status
 ```
+
+<!-- SPREAD
+source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
+sudo k8s get gateway | grep "enabled: true"
+-->
 
 Please ensure that Gateway is enabled on your cluster.
 
@@ -32,6 +39,10 @@ To enable Gateway, run:
 sudo k8s enable gateway
 ```
 
+<!-- SPREAD
+sudo k8s get gateway | grep "enabled: true"
+--> 
+
 ## Deploy sample workload
 
 As Gateway is enabled, the GatewayClass called `ck-gateway` is already
@@ -41,7 +52,11 @@ deployed. View the default GatewayClass:
 sudo k8s kubectl get GatewayClass
 ```
 
-A [sample workload] is available as part of our integration test
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get GatewayClass" "ck-gateway"
+--> 
+
+A [sample workload](https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/main/tests/integration/templates/gateway-test.yaml) is available as part of our integration test
 suite. This deploys a standard Nginx server with a Service to expose the
 ClusterIP. A Gateway that points to our GatewayClass and a HTTPRoute that
 specifies routing of HTTP requests from our Gateway to the Nginx Service
@@ -53,6 +68,10 @@ Deploy the sample workload:
 sudo k8s kubectl apply -f https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/main/tests/integration/templates/gateway-test.yaml
 ```
 
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get pods" "Running"
+--> 
+
 View the workload and service deployed:
 
 ```
@@ -60,6 +79,8 @@ sudo k8s kubectl get all -owide
 ```
 
 The output should look similar to below:
+
+<!-- SPREAD SKIP -->
 
 ```
 NAME                            READY   STATUS    RESTARTS   AGE     IP
@@ -70,23 +91,38 @@ service/cilium-gateway-my-gateway   LoadBalancer   10.152.183.189   <pending>   
 service/my-nginx                    ClusterIP      10.152.183.37    <none>        80/TCP         4m19s   run=my-nginx
 ```
 
-Curling the ClusterIP of `cilium-gateway-my-gateway` or `my-nginx` 
-should return the welcome to Nginx message. This means the Nginx 
+<!-- SPREAD SKIP END -->
+
+Curling the ClusterIP of `cilium-gateway-my-gateway` or `my-nginx`
+should return the welcome to Nginx message. This means the Nginx
 server is accessible from within the cluster. In this example
 the IP address is 10.152.183.189:80:
+
+<!-- SPREAD SKIP -->
 
 ```
 curl 10.152.183.189:80
 ```
 
-To gain access from outside of the cluster, the Gateway needs an 
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+GATEWAY_IP=$(sudo k8s kubectl get service cilium-gateway-my-gateway -o jsonpath='{.spec.clusterIP}')
+repeat_checks "curl $GATEWAY_IP:80" "Welcome to nginx"
+--> 
+
+To gain access from outside of the cluster, the Gateway needs an
 external IP address which will be provided with the load balancer.
 
 ```
 sudo k8s enable load-balancer
 ```
 
-Configure the load balancer CIDR. Choose an appropriate value 
+<!-- SPREAD
+sudo k8s get load-balancer | grep "enabled: true"
+--> 
+
+Configure the load balancer CIDR. Choose an appropriate value
 depending on your cluster.
 This will assign an external IP to `cilium-gateway-my-gateway`.
 
@@ -95,7 +131,14 @@ sudo k8s set load-balancer.cidrs=10.0.1.0/28 load-balancer.l2-mode=true
 sudo k8s kubectl get service cilium-gateway-my-gateway
 ```
 
+<!-- SPREAD
+sudo k8s get load-balancer | grep "10.0.1.0/28"
+sudo k8s get load-balancer | grep "l2-mode: true"
+--> 
+
 Get the external IP of the Gateway from the output.
+
+<!-- SPREAD SKIP -->
 
 ```
 NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)        AGE
@@ -108,13 +151,21 @@ Verify access from the external IP with the target port.
 curl 10.0.1.0:80
 ```
 
+<!-- SPREAD SKIP END -->
+
 The output should display a welcome to Nginx message.
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get service cilium-gateway-my-gateway" "10.0.1."
+LOADBALANCER_IP=$(sudo k8s kubectl get service cilium-gateway-my-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+repeat_checks "curl $LOADBALANCER_IP:80" "Welcome to nginx"
+--> 
 
 ## Disable gateway
 
 You can `disable` the built-in Gateway:
 
-``` {warning}
+```{warning}
 If you have an active cluster, disabling Gateway may impact external access to services within your cluster. Ensure that you have alternative configurations in place before disabling Gateway.
 ```
 
@@ -122,8 +173,6 @@ If you have an active cluster, disabling Gateway may impact external access to s
 sudo k8s disable gateway
 ```
 
-<!-- LINKS -->
-[gateway API]:https://gateway-api.sigs.k8s.io/
-[getting-started-guide]: ../../tutorial/getting-started
-[kubectl-guide]: ../../tutorial/kubectl
-[sample workload]: https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/main/tests/integration/templates/gateway-test.yaml
+<!-- SPREAD
+sudo k8s get gateway | grep "enabled: false"
+--> 

--- a/docs/canonicalk8s/snap/howto/networking/default-gateway.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-gateway.md
@@ -165,6 +165,8 @@ curl 10.0.1.0:80
 The output should display a welcome to Nginx message.
 
 <!-- SPREAD
+# Ensure my-gateway is ready
+sudo k8s kubectl wait --for=condition=Programmed gateway/my-gateway --timeout=5m
 repeat_checks "sudo k8s kubectl get service cilium-gateway-my-gateway" "10.0.1." 30
 LOADBALANCER_IP=$(sudo k8s kubectl get service cilium-gateway-my-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 repeat_checks "curl --connect-timeout 2 --max-time 4 $LOADBALANCER_IP:80" "Welcome to nginx"

--- a/docs/canonicalk8s/snap/howto/networking/default-gateway.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-gateway.md
@@ -42,7 +42,10 @@ sudo k8s enable gateway
 <!-- SPREAD
 sudo k8s get gateway | grep "enabled: true"
 # Ensure all pods are up before continuing 
-sudo k8s kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=300s
+sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m
+sudo k8s kubectl rollout status deployment/cilium-operator -n kube-system --timeout=10m
+sudo k8s kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=10m
+sudo k8s kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="Accepted")].status}'=True gatewayclass/ck-gateway --timeout=10m
 --> 
 
 ## Deploy sample workload

--- a/docs/canonicalk8s/snap/howto/networking/default-gateway.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-gateway.md
@@ -41,6 +41,8 @@ sudo k8s enable gateway
 
 <!-- SPREAD
 sudo k8s get gateway | grep "enabled: true"
+# Ensure all pods are up before continuing 
+sudo k8s kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=300s
 --> 
 
 ## Deploy sample workload
@@ -160,7 +162,7 @@ curl 10.0.1.0:80
 The output should display a welcome to Nginx message.
 
 <!-- SPREAD
-repeat_checks "sudo k8s kubectl get service cilium-gateway-my-gateway" "10.0.1."
+repeat_checks "sudo k8s kubectl get service cilium-gateway-my-gateway" "10.0.1." 30
 LOADBALANCER_IP=$(sudo k8s kubectl get service cilium-gateway-my-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 repeat_checks "curl --connect-timeout 2 --max-time 4 $LOADBALANCER_IP:80" "Welcome to nginx"
 --> 

--- a/docs/canonicalk8s/snap/howto/networking/default-gateway.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-gateway.md
@@ -26,7 +26,7 @@ sudo k8s status
 
 <!-- SPREAD
 source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
-sudo k8s get gateway | grep "enabled: true"
+sudo k8s status | grep "gateway                   enabled"
 -->
 
 Please ensure that Gateway is enabled on your cluster.
@@ -78,6 +78,10 @@ View the workload and service deployed:
 sudo k8s kubectl get all -owide
 ```
 
+<!-- SPREAD 
+sudo k8s kubectl get service -owide | grep "my-nginx"
+-->
+
 The output should look similar to below:
 
 <!-- SPREAD SKIP -->
@@ -108,7 +112,7 @@ curl 10.152.183.189:80
 
 <!-- SPREAD
 GATEWAY_IP=$(sudo k8s kubectl get service cilium-gateway-my-gateway -o jsonpath='{.spec.clusterIP}')
-repeat_checks "curl $GATEWAY_IP:80" "Welcome to nginx"
+repeat_checks "curl --connect-timeout 2 --max-time 4 $GATEWAY_IP:80" "Welcome to nginx"
 --> 
 
 To gain access from outside of the cluster, the Gateway needs an
@@ -158,7 +162,7 @@ The output should display a welcome to Nginx message.
 <!-- SPREAD
 repeat_checks "sudo k8s kubectl get service cilium-gateway-my-gateway" "10.0.1."
 LOADBALANCER_IP=$(sudo k8s kubectl get service cilium-gateway-my-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-repeat_checks "curl $LOADBALANCER_IP:80" "Welcome to nginx"
+repeat_checks "curl --connect-timeout 2 --max-time 4 $LOADBALANCER_IP:80" "Welcome to nginx"
 --> 
 
 ## Disable gateway

--- a/docs/canonicalk8s/snap/howto/networking/default-ingress.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-ingress.md
@@ -1,5 +1,7 @@
 # How to use default Ingress
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} enables you to configure Ingress for your cluster. When enabled, it
 directs external HTTP and HTTPS traffic to the appropriate services within the
 cluster.
@@ -10,7 +12,7 @@ This guide assumes the following:
 
 - You have root or sudo access to the machine
 - You have a bootstrapped {{product}} cluster (see the [Getting
-  Started][getting-started-guide] guide).
+   Started](/snap/tutorial/getting-started) guide).
 
 ## Check Ingress status
 
@@ -19,6 +21,10 @@ Find out whether Ingress is enabled or disabled with the following command:
 ```
 sudo k8s status
 ```
+
+<!-- SPREAD
+sudo k8s get ingress | grep "enabled: false"
+-->
 
 Please ensure that Ingress is enabled on your cluster.
 
@@ -30,11 +36,19 @@ To enable Ingress, run:
 sudo k8s enable ingress
 ```
 
+<!-- SPREAD
+sudo k8s get ingress | grep "enabled: true"
+--> 
+
 For more information on the command, execute:
 
 ```
 sudo k8s help enable
 ```
+
+<!-- SPREAD
+sudo k8s help enable | grep "Enable one of network, dns"
+-->
 
 ```{warning}
 The Kubernetes Service created for the ingress controller is set to single
@@ -50,22 +64,28 @@ Discover your configuration options by running:
 sudo k8s get ingress
 ```
 
+<!-- SPREAD
+sudo k8s get ingress | grep "enabled: true"
+-->
+
 You should see three options:
 
 - `enabled`: If set to true, Ingress is enabled
 - `default-tls-secret`: Name of the TLS (Transport Layer Security) Secret in
-  the kube-system namespace that will be used as the default Ingress
-  certificate
+   the kube-system namespace that will be used as the default Ingress
+   certificate
 - `enable-proxy-protocol`: If set, proxy protocol will be enabled for the
-  Ingress
+   Ingress
 
 ### TLS secret
 
 You can create a TLS secret by following the official
-[Kubernetes documentation][kubectl-create-secret-TLS/].
-Please remember to use `sudo k8s kubectl` (See the [kubectl-guide]).
+[Kubernetes documentation](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_tls/).
+Please remember to use `sudo k8s kubectl` (See the [kubectl-guide](/snap/tutorial/kubectl)).
 
 Tell Ingress to use your new Ingress certificate:
+
+<!-- SPREAD SKIP -->
 
 ```
 sudo k8s set ingress.default-tls-secret=<new-default-tls-secret>
@@ -74,22 +94,30 @@ sudo k8s set ingress.default-tls-secret=<new-default-tls-secret>
 Replace `<new-default-tls-secret>` with the desired value for your Ingress
 configuration.
 
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD 
+sudo k8s set ingress.default-tls-secret=new-default-tls-secret
+sudo k8s get ingress | grep "default-tls-secret: new-default-tls-secret"
+-->
+
 ### Proxy protocol
 
 Enabling the proxy protocol allows passing client connection information to the
 backend service.
 
 Consult the official
-[Kubernetes documentation on the proxy protocol][proxy-protocol].
+[Kubernetes documentation on the proxy protocol](https://kubernetes.io/docs/reference/networking/service-protocols/#protocol-proxy-special).
 
 Use the following command to enable the proxy protocol:
 
 ```
-sudo k8s set ingress.enable-proxy-protocol=<new-enable-proxy-protocol>
+sudo k8s set ingress.enable-proxy-protocol=true
 ```
 
-Adjust the value of `<new-enable-proxy-protocol>` with your proxy protocol
-requirements.
+<!-- SPREAD 
+sudo k8s get ingress | grep "enable-proxy-protocol: true"
+-->
 
 ## Disable Ingress
 
@@ -104,11 +132,19 @@ Ensure that you have alternative configurations in place before disabling Ingres
 sudo k8s disable ingress
 ```
 
+<!-- SPREAD
+sudo k8s get ingress | grep "enabled: false"
+-->
+
 For more information on this command, run:
 
 ```
 sudo k8s help disable
 ```
+
+<!-- SPREAD
+sudo k8s help disable | grep "Disable one of network, dns"
+--> 
 
 ## Next Step
 

--- a/docs/canonicalk8s/snap/howto/networking/default-ingress.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-ingress.md
@@ -23,7 +23,7 @@ sudo k8s status
 ```
 
 <!-- SPREAD
-sudo k8s get ingress | grep "enabled: false"
+sudo k8s status | grep "ingress:                  disabled"
 -->
 
 Please ensure that Ingress is enabled on your cluster.
@@ -65,7 +65,8 @@ sudo k8s get ingress
 ```
 
 <!-- SPREAD
-sudo k8s get ingress | grep "enabled: true"
+sudo k8s get ingress | grep "default-tls-secret"
+sudo k8s get ingress | grep "enable-proxy-protocol"
 -->
 
 You should see three options:

--- a/docs/canonicalk8s/snap/howto/networking/default-ingress.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-ingress.md
@@ -38,6 +38,10 @@ sudo k8s enable ingress
 
 <!-- SPREAD
 sudo k8s get ingress | grep "enabled: true"
+# Ensure all pods are up and ready before continuing
+sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m
+sudo k8s kubectl rollout status deployment/cilium-operator -n kube-system --timeout=10m
+sudo k8s kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=10m
 --> 
 
 For more information on the command, execute:

--- a/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
@@ -1,5 +1,7 @@
 # How to use the default load balancer
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} includes a default load balancer. As this is not an
 essential service for all deployments, it is not enabled by default. This guide
 explains how to configure and enable the `load-balancer`.
@@ -21,14 +23,21 @@ command:
 sudo k8s status
 ```
 
-The load balancer is not enabled by default, it won't be listed on the status
-output unless it has been subsequently enabled.
+<!-- SPREAD
+sudo k8s get load-balancer | grep "enabled: false"
+-->
+
+The load balancer is not enabled by default.
 
 To check the current configuration of the `load-balancer`, run the following:
 
 ```
 sudo k8s get load-balancer
 ```
+
+<!-- SPREAD
+sudo k8s get load-balancer | grep "enabled: false"
+-->
 
 This should output a list of values like this:
 
@@ -50,12 +59,24 @@ These values are configured using the `k8s set` command, e.g.:
 sudo k8s set load-balancer.l2-mode=true
 ```
 
+<!-- SPREAD
+sudo k8s get load-balancer | grep "l2-mode: true"
+-->
+
 Note that for the BGP mode, it is necessary to set ***all*** the values
 simultaneously. E.g.
 
 ```
 sudo k8s set load-balancer.bgp-mode=true load-balancer.bgp-local-asn=64512 load-balancer.bgp-peer-address=10.0.10.63 load-balancer.bgp-peer-asn=64512 load-balancer.bgp-peer-port=7012
 ```
+
+<!-- SPREAD
+sudo k8s get load-balancer | grep "bgp-mode: true"
+sudo k8s get load-balancer | grep "bgp-local-asn: 64512"
+sudo k8s get load-balancer | grep "bgp-peer-address: 10.0.10.63"
+sudo k8s get load-balancer | grep "bgp-peer-asn: 64512"
+sudo k8s get load-balancer | grep "bgp-peer-port: 7012"
+-->
 
 ## Enable the load balancer
 
@@ -65,11 +86,19 @@ To enable the load balancer, run:
 sudo k8s enable load-balancer
 ```
 
+<!-- SPREAD
+sudo k8s get load-balancer | grep "enabled: true"
+-->
+
 You can now confirm it is working by running:
 
 ```
 sudo k8s status
 ```
+
+<!-- SPREAD
+sudo k8s get load-balancer | grep "enabled: true"
+-->
 
 ```{important}
 If you run `k8s status` soon after enabling the load balancer in BGP mode,
@@ -83,6 +112,10 @@ The default load balancer can be disabled again with:
 ```
 sudo k8s disable load-balancer
 ```
+
+<!-- SPREAD
+sudo k8s get load-balancer | grep "enabled: false"
+-->
 
 ## Next Step
 

--- a/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
@@ -24,7 +24,7 @@ sudo k8s status
 ```
 
 <!-- SPREAD
-sudo k8s get load-balancer | grep "enabled: false"
+sudo k8s status | grep "load-balancer:            disabled"
 -->
 
 The load balancer is not enabled by default.
@@ -37,6 +37,14 @@ sudo k8s get load-balancer
 
 <!-- SPREAD
 sudo k8s get load-balancer | grep "enabled: false"
+sudo k8s get load-balancer | grep "cidrs"
+sudo k8s get load-balancer | grep "l2-mode"
+sudo k8s get load-balancer | grep "l2-interfaces"
+sudo k8s get load-balancer | grep "bgp-mode"
+sudo k8s get load-balancer | grep "bgp-local-asn"
+sudo k8s get load-balancer | grep "bgp-peer-address"
+sudo k8s get load-balancer | grep "bgp-peer-asn"
+sudo k8s get load-balancer | grep "bgp-peer-port"
 -->
 
 This should output a list of values like this:

--- a/docs/canonicalk8s/snap/howto/networking/default-network.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-network.md
@@ -39,6 +39,11 @@ sudo k8s enable network
 
 <!-- SPREAD
 sudo k8s get network | grep "enabled: true"
+# Make sure cluster is fully up before continuing 
+sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m
+sudo k8s kubectl rollout status deployment/cilium-operator -n kube-system --timeout=10m
+sudo k8s kubectl rollout status deployment/coredns -n kube-system --timeout=10m
+sudo k8s kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=10m
 -->
 
 For more information on the command, execute:
@@ -79,8 +84,6 @@ sudo k8s kubectl exec -it cilium-97vcw -n kube-system -c cilium-agent \
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD
-# Ensure all pods are up before query
-sudo k8s kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=300s
 CILIUM_POD=$(sudo k8s kubectl get pod -n kube-system -l k8s-app=cilium -o jsonpath='{.items[0].metadata.name}')
 sudo k8s kubectl exec "$CILIUM_POD" -n kube-system -c cilium-agent -- cilium status
 -->

--- a/docs/canonicalk8s/snap/howto/networking/default-network.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-network.md
@@ -24,7 +24,7 @@ sudo k8s status
 ```
 
 <!-- SPREAD
-sudo k8s get network | grep "enabled: true"
+sudo k8s status | grep "network:                  enabled"
 -->
 
 The default state for the cluster is `network enabled`.

--- a/docs/canonicalk8s/snap/howto/networking/default-network.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-network.md
@@ -1,5 +1,7 @@
 # How to use the default Network
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} includes a high-performance, advanced network plugin
 called Cilium. The network component allows cluster administrators to leverage
 software-defined networking to automatically scale and secure network policies
@@ -21,7 +23,11 @@ Find out whether Network is enabled or disabled with the following command:
 sudo k8s status
 ```
 
-The default state for the cluster is `network disabled`.
+<!-- SPREAD
+sudo k8s get network | grep "enabled: true"
+-->
+
+The default state for the cluster is `network enabled`.
 
 ## Enable Network
 
@@ -31,11 +37,19 @@ To enable Network, run:
 sudo k8s enable network
 ```
 
+<!-- SPREAD
+sudo k8s get network | grep "enabled: true"
+-->
+
 For more information on the command, execute:
 
 ```
 sudo k8s enable --help
 ```
+
+<!-- SPREAD
+sudo k8s enable --help | grep "Enable one of network, dns"
+-->
 
 ## Configure Network
 
@@ -50,17 +64,24 @@ Let's look at the detailed status of the network as reported by Cilium.
 
 First, find the name of the Cilium pod:
 
-```sh
+```
 sudo k8s kubectl get pod -n kube-system -l k8s-app=cilium
 ```
 
 Once you have the name of the pod, run the following command to see Cilium's
 status:
 
-```sh
+<!-- SPREAD SKIP -->
+```
 sudo k8s kubectl exec -it cilium-97vcw -n kube-system -c cilium-agent \
   -- cilium status
 ```
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+CILIUM_POD=$(sudo k8s kubectl get pod -n kube-system -l k8s-app=cilium -o jsonpath='{.items[0].metadata.name}')
+sudo k8s kubectl exec "$CILIUM_POD" -n kube-system -c cilium-agent -- cilium status
+-->
 
 You should see a wide range of metrics and configuration values for your
 cluster.
@@ -79,15 +100,26 @@ You can `disable` the built-in network:
 If your underlying network is Cilium you will have to run
 `sudo k8s disable gateway` before disabling network.
 
+<!-- SPREAD 
+sudo k8s disable gateway
+-->
+
 ```
 sudo k8s disable network
 ```
+<!-- SPREAD 
+sudo k8s get network | grep "enabled: false"
+-->
 
 For more information on this command, run:
 
 ```
 sudo k8s disable --help
 ```
+
+<!-- SPREAD
+sudo k8s disable --help | grep "Disable one of network, dns"
+-->
 
 <!-- LINKS -->
 

--- a/docs/canonicalk8s/snap/howto/networking/default-network.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-network.md
@@ -77,10 +77,12 @@ Once you have the name of the pod, run the following command to see Cilium's
 status:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo k8s kubectl exec -it cilium-97vcw -n kube-system -c cilium-agent \
   -- cilium status
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD
@@ -112,6 +114,7 @@ sudo k8s disable gateway
 ```
 sudo k8s disable network
 ```
+
 <!-- SPREAD 
 sudo k8s get network | grep "enabled: false"
 -->

--- a/docs/canonicalk8s/snap/howto/networking/default-network.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-network.md
@@ -79,6 +79,8 @@ sudo k8s kubectl exec -it cilium-97vcw -n kube-system -c cilium-agent \
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD
+# Ensure all pods are up before query
+sudo k8s kubectl wait --namespace kube-system --for=condition=Ready pods --all --timeout=300s
 CILIUM_POD=$(sudo k8s kubectl get pod -n kube-system -l k8s-app=cilium -o jsonpath='{.items[0].metadata.name}')
 sudo k8s kubectl exec "$CILIUM_POD" -n kube-system -c cilium-agent -- cilium status
 -->

--- a/docs/canonicalk8s/snap/howto/networking/proxy.md
+++ b/docs/canonicalk8s/snap/howto/networking/proxy.md
@@ -29,6 +29,7 @@ We would add the configuration to the
 <!-- SPREAD
   sudo tee /etc/systemd/system/snap.k8s.containerd.service.d/http-proxy.conf <<'EOF'  
 -->
+
 ```
 [Service]
 Environment="HTTPS_PROXY=http://squid.internal:3128"
@@ -38,9 +39,11 @@ Environment="https_proxy=http://squid.internal:3128"
 Environment="http_proxy=http://squid.internal:3128"
 Environment="no_proxy=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.16.0.0/12"
 ```
+
 <!-- SPREAD
 EOF
 -->
+
 Note that you may need to restart for these settings to take effect.
 You can restart with the following commands:
 

--- a/docs/canonicalk8s/snap/howto/networking/proxy.md
+++ b/docs/canonicalk8s/snap/howto/networking/proxy.md
@@ -1,5 +1,7 @@
 # How to configure proxy settings for {{product}}
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} packages a number of utilities (for example curl, Helm) which need
 to fetch resources they expect to find on the internet. In a restricted
 network environment, such access is usually controlled through proxies.
@@ -11,7 +13,7 @@ To set up a proxy using Squid follow the
 
 If necessary, create the `snap.k8s.containerd.service.d` directory:
 
-```bash
+```
 sudo mkdir -p /etc/systemd/system/snap.k8s.containerd.service.d
 ```
 
@@ -24,8 +26,10 @@ we are using the networks `10.0.0.0/8`,`192.168.0.0/16` and `172.16.0.0/12`.
 We would add the configuration to the
 (`/etc/systemd/system/snap.k8s.containerd.service.d/http-proxy.conf`) file:
 
-```bash
-# /etc/systemd/system/snap.k8s.containerd.service.d/http-proxy.conf
+<!-- SPREAD
+  sudo tee /etc/systemd/system/snap.k8s.containerd.service.d/http-proxy.conf <<'EOF'  
+-->
+```
 [Service]
 Environment="HTTPS_PROXY=http://squid.internal:3128"
 Environment="HTTP_PROXY=http://squid.internal:3128"
@@ -34,7 +38,9 @@ Environment="https_proxy=http://squid.internal:3128"
 Environment="http_proxy=http://squid.internal:3128"
 Environment="no_proxy=10.1.0.0/16,10.152.183.0/24,192.168.0.0/16,127.0.0.1,172.16.0.0/12"
 ```
-
+<!-- SPREAD
+EOF
+-->
 Note that you may need to restart for these settings to take effect.
 You can restart with the following commands:
 
@@ -43,6 +49,10 @@ sudo systemctl daemon-reload
 sudo systemctl restart snap.k8s.containerd.service
 ```
 
+<!-- SPREAD 
+source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
+repeat_checks "sudo k8s kubectl get node" "Ready"
+-->
 
 ```{note}
 Include the CIDRs **10.152.183.0/24** and **10.1.0.0/16** in both the

--- a/docs/canonicalk8s/snap/howto/networking/proxy.md
+++ b/docs/canonicalk8s/snap/howto/networking/proxy.md
@@ -2,6 +2,12 @@
 
 <!-- SPREAD SUITE: snap_bootstrapped -->
 
+<!-- SPREAD 
+# Tear down proxy settings on exit
+trap 'sudo rm -rf /etc/systemd/system/snap.k8s.containerd.service.d; sudo systemctl daemon-reload' EXIT
+# Start doc test
+-->
+
 {{product}} packages a number of utilities (for example curl, Helm) which need
 to fetch resources they expect to find on the internet. In a restricted
 network environment, such access is usually controlled through proxies.

--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -1,5 +1,7 @@
 # How to configure Uncomplicated Firewall (UFW)
 
+<!-- SPREAD SUITE: snap_clean -->
+
 This how-to presents a set of firewall rules/guidelines that should be
 considered when setting up {{product}}. These rules may be incompatible
 with some network setups, so we recommend you review and tune them to
@@ -16,21 +18,25 @@ This guide assumes the following:
 
 Install Uncomplicated Firewall:
 
-```sh
+```
 sudo apt update
 sudo apt install ufw
 ```
 
 Verify that UFW is installed:
 
-```sh
+```
 sudo ufw status verbose
 ```
+
+<!-- SPREAD
+sudo ufw status verbose | grep "Status: inactive"
+-->
 
 To maintain SSH access to the machine, allow `OpenSSH` through UFW
 before enabling the firewall:
 
-```sh
+```
 sudo ufw allow OpenSSH
 ```
 
@@ -46,14 +52,20 @@ internal network and the outside world.
 
 To enable IP forwarding:
 
-```sh
+```
 sudo sed -i 's|^.*net.ipv4.ip_forward.*$|net.ipv4.ip_forward=1|' /etc/sysctl.conf
 sudo sysctl -p
 ```
 
+<!-- SPREAD 
+sudo sysctl -p | grep "net.ipv4.ip_forward = 1"
+-->
+
 ### Set forwarding rules
 
 Set UFW forwarding rules using one of the following methods.
+
+<!-- SPREAD SKIP -->
 
 `````{tab-set}
 ````{tab-item} Allow system wide
@@ -78,9 +90,17 @@ sudo ufw route allow from 10.1.0.0/16 to 10.1.0.0/16
 ````
 `````
 
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+sudo grep -qE '^\s*#?\s*DEFAULT_FORWARD_POLICY=' /etc/default/ufw \
+  && sudo sed -i -E 's|^\s*#?\s*DEFAULT_FORWARD_POLICY=.*|DEFAULT_FORWARD_POLICY="ACCEPT"|' /etc/default/ufw \
+  || echo 'DEFAULT_FORWARD_POLICY="ACCEPT"' | sudo tee -a /etc/default/ufw
+-->
+
 ### Allow access to kubelet
 
-```sh
+```
 sudo ufw allow 10250/tcp
 ```
 
@@ -89,7 +109,7 @@ sudo ufw allow 10250/tcp
 Allow access to the {{product}} daemon (required for
 cluster formation):
 
-```sh
+```
 sudo ufw allow 6400/tcp
 ```
 
@@ -98,7 +118,7 @@ sudo ufw allow 6400/tcp
 Allow the cluster-wide Cilium agent health checks and VXLAN traffic on
 all nodes:
 
-```sh
+```
 sudo ufw allow 4240/tcp
 sudo ufw allow 8472/udp
 ```
@@ -111,14 +131,14 @@ Apply the following rules on all control plane nodes.
 
 Allow access to the API server:
 
-```sh
+```
 sudo ufw allow 6443/tcp
 ```
 
 Allow access to kube-controller-manager and kube-scheduler
 (e.g. for metrics gathering):
 
-```sh
+```
 sudo ufw allow 10257/tcp
 sudo ufw allow 10259/tcp
 ```
@@ -129,7 +149,7 @@ To form a High Availability (HA) cluster, etcd
 needs to establish direct connections among control plane nodes.
 Allow access to the etcd peer and client port:
 
-```sh
+```
 sudo ufw allow 2380/tcp
 sudo ufw allow 2379/tcp
 ```
@@ -138,9 +158,27 @@ sudo ufw allow 2379/tcp
 
 Now enable UFW:
 
+<!-- SPREAD SKIP -->
 ```sh
 sudo ufw enable
 ```
+<!-- SPREAD SKIP END -->
+<!-- SPREAD
+echo "y" | sudo ufw enable
+# Confirm all settings are correct
+sudo ufw status verbose | grep "Status: active"
+sysctl net.ipv4.ip_forward | grep "net.ipv4.ip_forward = 1"
+sudo ufw status | grep "OpenSSH"
+sudo ufw status | grep "10250/tcp"
+sudo ufw status | grep "6400/tcp"
+sudo ufw status | grep "4240/tcp"
+sudo ufw status | grep "8472/udp"
+sudo ufw status | grep "6443/tcp"
+sudo ufw status | grep "10257/tcp"
+sudo ufw status | grep "10259/tcp"
+sudo ufw status | grep "2380/tcp"
+sudo ufw status | grep "2379/tcp"
+-->
 
 ## UFW troubleshooting
 
@@ -148,15 +186,18 @@ The [ports-and-services] page has a list of all ports {{product}} uses.
 
 To inspect a failing service you can enable logging:
 
-```sh
+```
 sudo ufw logging on
 ```
 
 Monitor the firewall logs with:
 
-```sh
+<!-- SPREAD SKIP -->
+```
 tail -f /var/log/ufw.log
 ```
+
+<!-- SPREAD SKIP END -->
 
 The logs will show you which packets are dropped, their destination and
 source as well as the protocol used and the destination port. This
@@ -166,7 +207,7 @@ enable within UFW.
 After troubleshooting, keep the resources used by UFW to a minimum by
 disabling logging:
 
-```sh
+```
 sudo ufw logging off
 ```
 

--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -1,10 +1,10 @@
 # How to configure Uncomplicated Firewall (UFW)
 
-<!-- SPREAD SUITE: snap_clean -->
+<!-- SPREAD SUITE: snap_bootstrapped -->
 
 <!-- SPREAD 
 # Tear down UFW settings on exit
-trap 'sudo ufw reset; sudo ufw disable; sudo sed -i '/net.ipv4.ip_forward/d' /etc/sysctl.conf; sudo sed -i 's/DEFAULT_FORWARD_POLICY="ACCEPT"/DEFAULT_FORWARD_POLICY="DROP"/' /etc/default/ufw; sudo sysctl -p' EXIT
+trap 'echo "y" | sudo ufw reset; sudo ufw disable; sudo sed -i '/net.ipv4.ip_forward/d' /etc/sysctl.conf; sudo sed -i 's/DEFAULT_FORWARD_POLICY="ACCEPT"/DEFAULT_FORWARD_POLICY="DROP"/' /etc/default/ufw; sudo sysctl -p' EXIT
 # Start doc test
 -->
 

--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -2,6 +2,12 @@
 
 <!-- SPREAD SUITE: snap_clean -->
 
+<!-- SPREAD 
+# Tear down UFW settings on exit
+trap 'sudo ufw reset; sudo ufw disable; sudo sed -i '/net.ipv4.ip_forward/d' /etc/sysctl.conf; sudo sed -i 's/DEFAULT_FORWARD_POLICY="ACCEPT"/DEFAULT_FORWARD_POLICY="DROP"/' /etc/default/ufw; sudo sysctl -p' EXIT
+# Start doc test
+-->
+
 This how-to presents a set of firewall rules/guidelines that should be
 considered when setting up {{product}}. These rules may be incompatible
 with some network setups, so we recommend you review and tune them to

--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -72,7 +72,7 @@ Set UFW forwarding rules using one of the following methods.
 Packet forwarding can be allowed system wide by editing `/etc/default/ufw`
 and changing `DEFAULT_FORWARD_POLICY` to:
 
-```sh
+```
 DEFAULT_FORWARD_POLICY="ACCEPT"
 ```
 ````
@@ -83,7 +83,7 @@ between the subnets of the pods and the hosts. For example, assuming the
 pods CIDR is `10.1.0.0/16` and the cluster nodes are in `10.0.20/24`, you
 could:
 
-```sh
+```
 sudo ufw route allow from 10.1.0.0/16 to 10.0.20.0/24
 sudo ufw route allow from 10.1.0.0/16 to 10.1.0.0/16
 ```
@@ -159,7 +159,7 @@ sudo ufw allow 2379/tcp
 Now enable UFW:
 
 <!-- SPREAD SKIP -->
-```sh
+```
 sudo ufw enable
 ```
 <!-- SPREAD SKIP END -->

--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -159,9 +159,11 @@ sudo ufw allow 2379/tcp
 Now enable UFW:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo ufw enable
 ```
+
 <!-- SPREAD SKIP END -->
 <!-- SPREAD
 echo "y" | sudo ufw enable
@@ -193,6 +195,7 @@ sudo ufw logging on
 Monitor the firewall logs with:
 
 <!-- SPREAD SKIP -->
+
 ```
 tail -f /var/log/ufw.log
 ```

--- a/docs/canonicalk8s/snap/howto/observability.md
+++ b/docs/canonicalk8s/snap/howto/observability.md
@@ -1,5 +1,7 @@
 # How to use Prometheus with {{product}}
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 Observability is an essential component in any system for understanding,
 managing, and improving its performance and reliability. The main pillars of
 observability are metrics, logs and traces.
@@ -22,6 +24,16 @@ This guide assumes the following:
 - You have [installed Helm][install-helm].
 - You have enabled a persistent storage solution in your cluster
   (see How-to [Enable persistent storage][enable-storage]).
+
+<!-- SPREAD
+sudo snap install helm --classic
+sudo k8s enable local-storage
+source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
+sudo k8s get local-storage | grep "enabled: true"
+mkdir -p ~/.kube
+sudo k8s config > ~/.kube/config
+chmod 600 ~/.kube/config
+-->
 
 ## Install Prometheus
 
@@ -55,10 +67,20 @@ sudo k8s kubectl get storageclass
 After the Prometheus deployment has been customized with the
 `values.yaml` file, run the following command:
 
+<!-- SPREAD SKIP -->
 ```
 sudo helm install prometheus prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace observability -f values.yaml
 ```
+
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+sudo helm install prometheus prometheus-community/kube-prometheus-stack \
+  --create-namespace --namespace observability -f values.yaml \
+  --kubeconfig /root/.kube/config
+sudo k8s kubectl wait --for=condition=Ready pods --all -n observability --timeout=300s
+-->
 
 Note that this Helm chart installs a few dependent charts:
 
@@ -75,6 +97,10 @@ without issues. Check that the Prometheus pods are running:
 sudo k8s kubectl get pods -n observability -l "app.kubernetes.io/name=prometheus"
 ```
 
+<!-- SPREAD 
+repeat_checks 'sudo k8s kubectl get pods -n observability -l "app.kubernetes.io/name=prometheus"' 'Running'
+-->
+
 Next, connect to the Prometheus dashboard through its Kubernetes Service:
 
 ```
@@ -89,6 +115,7 @@ If you do not have access to the cluster network, or if the Prometheus
 Kubernetes service is not exposed externally, you can instead create a
 temporary local port-forward to the Prometheus dashboard:
 
+<!-- SPREAD SKIP -->
 ```
 export POD_NAME=$(sudo k8s kubectl get pods --namespace observability -l "app.kubernetes.io/name=prometheus" -o jsonpath="{.items[0].metadata.name}")
 sudo k8s kubectl --namespace observability port-forward $POD_NAME 9090
@@ -99,6 +126,7 @@ You can check the metrics that have been scraped so far by running:
 ```
 curl -s http://${CLUSTER_IP}:${CLUSTER_IP_PORT}/metrics
 ```
+<!-- SPREAD SKIP END -->
 
 ## Accessing Grafana
 
@@ -112,6 +140,10 @@ have Grafana deployed in your cluster:
 ```
 sudo k8s kubectl get pods -n observability -l "app.kubernetes.io/name=grafana"
 ```
+
+<!-- SPREAD 
+repeat_checks 'sudo k8s kubectl get pods -n observability -l "app.kubernetes.io/name=grafana"' 'Running'
+-->
 
 Next, connect to the Grafana dashboard through its Kubernetes service:
 
@@ -127,10 +159,12 @@ If you do not have access to the cluster network, or if the Grafana Kubernetes
 service is not exposed externally, you can instead create a temporary local
 port-forward to the Grafana dashboard:
 
+<!-- SPREAD SKIP -->
 ```
 export POD_NAME=$(sudo k8s kubectl get pods --namespace observability -l "app.kubernetes.io/name=grafana" -o jsonpath="{.items[0].metadata.name}")
 sudo k8s kubectl --namespace observability port-forward $POD_NAME 3000
 ```
+<!-- SPREAD SKIP END -->
 
 The default username/password for Grafana are: `admin`/`prom-operator`
 
@@ -151,6 +185,10 @@ sudo helm delete prometheus -n observability
 sudo k8s kubectl get -n observability pvc
 sudo k8s kubectl get pv
 ```
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get all -n observability" "No resources found"
+-->
 
 <!-- LINKS -->
 

--- a/docs/canonicalk8s/snap/howto/observability.md
+++ b/docs/canonicalk8s/snap/howto/observability.md
@@ -78,7 +78,7 @@ sudo helm install prometheus prometheus-community/kube-prometheus-stack \
 <!-- SPREAD
 sudo helm install prometheus prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace observability -f values.yaml \
-  --kubeconfig /root/.kube/config
+  --kubeconfig ~/.kube/config
 sudo k8s kubectl wait --for=condition=Ready pods --all -n observability --timeout=300s
 -->
 

--- a/docs/canonicalk8s/snap/howto/observability.md
+++ b/docs/canonicalk8s/snap/howto/observability.md
@@ -68,6 +68,7 @@ After the Prometheus deployment has been customized with the
 `values.yaml` file, run the following command:
 
 <!-- SPREAD SKIP -->
+
 ```
 sudo helm install prometheus prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace observability -f values.yaml
@@ -116,6 +117,7 @@ Kubernetes service is not exposed externally, you can instead create a
 temporary local port-forward to the Prometheus dashboard:
 
 <!-- SPREAD SKIP -->
+
 ```
 export POD_NAME=$(sudo k8s kubectl get pods --namespace observability -l "app.kubernetes.io/name=prometheus" -o jsonpath="{.items[0].metadata.name}")
 sudo k8s kubectl --namespace observability port-forward $POD_NAME 9090
@@ -126,6 +128,7 @@ You can check the metrics that have been scraped so far by running:
 ```
 curl -s http://${CLUSTER_IP}:${CLUSTER_IP_PORT}/metrics
 ```
+
 <!-- SPREAD SKIP END -->
 
 ## Accessing Grafana
@@ -160,10 +163,12 @@ service is not exposed externally, you can instead create a temporary local
 port-forward to the Grafana dashboard:
 
 <!-- SPREAD SKIP -->
+
 ```
 export POD_NAME=$(sudo k8s kubectl get pods --namespace observability -l "app.kubernetes.io/name=grafana" -o jsonpath="{.items[0].metadata.name}")
 sudo k8s kubectl --namespace observability port-forward $POD_NAME 3000
 ```
+
 <!-- SPREAD SKIP END -->
 
 The default username/password for Grafana are: `admin`/`prom-operator`

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -131,7 +131,7 @@ Review the warnings detected and address any failing checks you see fit.
 
 ```
 
-<!-- TODO: This test will fail without hardening applied. When pages are testing with each other, test 0 checks FAIL -- >
+<!-- TODO: This test will fail without hardening applied. When pages are testing with each other, test 0 checks FAIL -->
 
 <!-- SPREAD SKIP END -->
 

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -1,5 +1,7 @@
 # How to assess CIS compliance
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 CIS Hardening refers to the process of implementing security configurations that
 align with the benchmarks set by the [Center for Internet Security (CIS)].
 Out of the box {{product}} complies with the majority of the recommended
@@ -47,6 +49,10 @@ Verify kube-bench installation:
 kube-bench version
 ```
 
+<!-- SPREAD 
+kube-bench version | grep 0.8.0
+-->
+
 The output should list the version installed.
 
 Install `kubectl` and configure it to interact with the cluster:
@@ -75,6 +81,8 @@ sudo -E kube-bench --version ck8s-cis-1.24 --config-dir ./kube-bench-ck8s-cfg/cf
 ```
 
 Review the warnings detected and address any failing checks you see fit.
+
+<!-- SPREAD SKIP -->
 
 ```
 [INFO] 1 Control Plane Security Configuration
@@ -122,6 +130,10 @@ Review the warnings detected and address any failing checks you see fit.
 0 checks INFO
 
 ```
+
+<!-- TODO: This test will fail without hardening applied. When pages are testing with each other, test 0 checks FAIL -- >
+
+<!-- SPREAD SKIP END -->
 
 <!-- LINKS -->
 [Center for Internet Security (CIS)]:https://www.cisecurity.org/

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -2,6 +2,12 @@
 
 <!-- SPREAD SUITE: snap_bootstrapped -->
 
+<!-- SPREAD 
+# Tear down kube bench settings on exit
+trap 'sudo rm -f /usr/local/bin/kube-bench; sudo snap remove kubectl --purge; rm -f ~/.kube/config; rm -rf ~/kube-bench ~/kube-bench-ck8s-cfg' EXIT
+# Start doc test
+-->
+
 CIS Hardening refers to the process of implementing security configurations that
 align with the benchmarks set by the [Center for Internet Security (CIS)].
 Out of the box {{product}} complies with the majority of the recommended

--- a/docs/canonicalk8s/snap/howto/security/hardening.md
+++ b/docs/canonicalk8s/snap/howto/security/hardening.md
@@ -1,5 +1,7 @@
 # How to harden your {{product}} cluster
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 The {{product}} hardening guide provides actionable steps to enhance the
 security posture of your deployment. These steps are designed to help you align
 with industry-standard frameworks such as CIS.
@@ -32,15 +34,18 @@ costs for the benefit of an increased security posture.
 
 Encrypt key-value store secrets rather than leaving it as base64 encoded values
 as described in the upstream Kubernetes documentation on
-[encrypting secrets][encryption_at_rest].
+[encrypting secrets](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 
 Create the `EncryptionConfiguration` file under
 `/var/snap/k8s/common/etc/encryption/`.
 
+<!-- SPREAD
+export BASE_64_ENCODED_SECRET=$(head -c 32 /dev/urandom | base64)
+-->
+
 ```
-sudo sh -c '
-mkdir -p /var/snap/k8s/common/etc/encryption/
-cat >/var/snap/k8s/common/etc/encryption/enc.yaml << EOL
+sudo mkdir -p /var/snap/k8s/common/etc/encryption/
+cat << EOL | sudo tee /var/snap/k8s/common/etc/encryption/enc.yaml > /dev/null
 kind: "EncryptionConfiguration"
 apiVersion: apiserver.config.k8s.io/v1
 resources:
@@ -49,11 +54,17 @@ resources:
   - aesgcm:
       keys:
       - name: key1
-        secret: ${BASE 64 ENCODED SECRET}
+        secret: ${BASE_64_ENCODED_SECRET}
   - identity: {}
 EOL
-chmod 600 /var/snap/k8s/common/etc/encryption/enc.yaml
+sudo chmod 600 /var/snap/k8s/common/etc/encryption/enc.yaml
 ```
+
+<!-- SPREAD
+source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
+sudo test -s /var/snap/k8s/common/etc/encryption/enc.yaml
+sudo stat -c '%a' /var/snap/k8s/common/etc/encryption/enc.yaml | grep "600"
+-->
 
 Set the `--encryption-provider-config` file as an argument to the kubernetes
 apiserver.
@@ -65,12 +76,16 @@ cat >>/var/snap/k8s/common/args/kube-apiserver <<EOL
 EOL'
 ```
 
+<!-- SPREAD
+sudo cat /var/snap/k8s/common/args/kube-apiserver | grep -e "--encryption-provider-config=/var/snap/k8s/common/etc/encryption/enc.yaml"
+-->
+
 Securing the contents of this key file is left as a separate exercise.
 
 #### Configure authorization modes
 
 Enforce RBAC (Role-Based Access Control) policies and confirm the value of the
-apiserver [`authorization-mode`][authorization_mode]:
+apiserver [`authorization-mode`](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#authorization-modules):
 
 * includes `RBAC`
 * doesn't include `AlwaysAllow`
@@ -82,14 +97,21 @@ sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
     grep -q "AlwaysAllow" && echo "Remove AlwaysAllow" || echo "okay"
 ```
 
+<!-- SPREAD
+sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
+    grep -q "RBAC" && echo "okay" || echo "missing" | grep "okay"
+sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
+    grep -q "AlwaysAllow" && echo "Remove AlwaysAllow" || echo "okay" | grep "okay"
+-->
+
 By default, the value is `Node,RBAC`
 
 * `Node`:
-  A special-purpose authorization mode that grants permissions
-  to kubelets based on the pods they are scheduled to run.
+   A special-purpose authorization mode that grants permissions
+   to kubelets based on the pods they are scheduled to run.
 
- To apply RBAC to other cluster resources, see the upstream Kubernetes
- [RBAC guide].
+To apply RBAC to other cluster resources, see the upstream Kubernetes
+[RBAC guide](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
 #### Configure log auditing
 
@@ -99,7 +121,7 @@ may incur performance penalties in the form of disk I/O.
 ```
 
 Create an audit-policy.yaml file under `/var/snap/k8s/common/etc/` and specify
-the level of auditing you desire based on the [upstream instructions].
+the level of auditing you desire based on the [upstream instructions](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/).
 Here is a minimal example of such a policy file.
 
 ```
@@ -113,6 +135,10 @@ rules:
 EOL'
 ```
 
+<!-- SPREAD 
+sudo test -s /var/snap/k8s/common/etc/audit-policy.yaml
+-->
+
 Enable auditing at the API server level by adding the following arguments.
 
 ```
@@ -125,11 +151,20 @@ sudo sh -c 'cat >>/var/snap/k8s/common/args/kube-apiserver <<EOL
 EOL'
 ```
 
+<!-- SPREAD
+sudo cat /var/snap/k8s/common/args/kube-apiserver | grep -e "--audit-log-path=/var/log/kubernetes/audit.log"
+-->
+
 Restart the API server:
 
 ```
 sudo systemctl restart snap.k8s.kube-apiserver
 ```
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get nodes" "Ready"
+sudo test -f /var/log/kubernetes/audit.log
+-->
 
 #### Set event rate limits
 
@@ -138,8 +173,7 @@ Configuring event rate limits requires the cluster administrator's input
 in assessing the hardware and workload specifications/requirements.
 ```
 
-
-Create a configuration file with the [rate limits] and place it under
+Create a configuration file with the [rate limits](https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1) and place it under
 `/var/snap/k8s/common/etc/`.
 For example:
 
@@ -155,6 +189,10 @@ limits:
 EOL'
 ```
 
+<!-- SPREAD
+sudo test -s /var/snap/k8s/common/etc/eventconfig.yaml
+-->
+
 Create an admissions control config file under `/var/k8s/snap/common/etc/` .
 
 ```
@@ -168,12 +206,25 @@ plugins:
 EOL'
 ```
 
+<!-- SPREAD
+sudo test -s /var/snap/k8s/common/etc/admission-control-config-file.yaml
+-->
+
 Make sure the EventRateLimit admission plugin is loaded in the
 `/var/snap/k8s/common/args/kube-apiserver` .
+
+<!-- SPREAD SKIP -->
 
 ```
 --enable-admission-plugins=...,EventRateLimit,...
 ```
+
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD 
+sudo sed -i 's/\(--enable-admission-plugins="[^"]*\)"/\1,EventRateLimit"/' /var/snap/k8s/common/args/kube-apiserver
+sudo cat /var/snap/k8s/common/args/kube-apiserver | grep "EventRateLimit"
+-->
 
 Load the admission control config file.
 
@@ -183,11 +234,19 @@ sudo sh -c 'cat >>/var/snap/k8s/common/args/kube-apiserver <<EOL
 EOL'
 ```
 
+<!-- SPREAD
+sudo cat /var/snap/k8s/common/args/kube-apiserver | grep -e "--admission-control-config-file=/var/snap/k8s/common/etc/admission-control-config-file.yaml"
+-->
+
 Restart the API server.
 
 ```
 sudo systemctl restart snap.k8s.kube-apiserver
 ```
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get nodes" "Ready"
+-->
 
 #### Enable AlwaysPullImages admission control plugin
 
@@ -200,15 +259,28 @@ that use image sideloading.
 Make sure the AlwaysPullImages admission plugin is loaded in the
 `/var/snap/k8s/common/args/kube-apiserver`
 
-```
+<!-- SPREAD SKIP -->
+
+```sh
 --enable-admission-plugins=...,AlwaysPullImages,...
 ```
+
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+sudo sed -i 's/\(--enable-admission-plugins="[^"]*\)"/\1,AlwaysPullImages"/' /var/snap/k8s/common/args/kube-apiserver
+sudo cat /var/snap/k8s/common/args/kube-apiserver | grep "AlwaysPullImages"
+-->
 
 Restart the API server.
 
 ```
 sudo systemctl restart snap.k8s.kube-apiserver
 ```
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get nodes" "Ready"
+-->
 
 #### Set the Kubernetes scheduler and controller manager bind address
 
@@ -227,6 +299,10 @@ sudo sh -c 'cat >>/var/snap/k8s/common/args/kube-scheduler <<EOL
 EOL'
 ```
 
+<!-- SPREAD
+sudo cat /var/snap/k8s/common/args/kube-scheduler | grep -e "--bind-address=127.0.0.1"
+-->
+
 Do the same for the Kubernetes controller manager
 (`/var/snap/k8s/common/args/kube-controller-manager`):
 
@@ -236,12 +312,20 @@ sudo sh -c 'cat >>/var/snap/k8s/common/args/kube-controller-manager <<EOL
 EOL'
 ```
 
+<!-- SPREAD
+sudo cat /var/snap/k8s/common/args/kube-controller-manager | grep -e "--bind-address=127.0.0.1"
+-->
+
 Restart both services.
 
 ```
 sudo systemctl restart snap.k8s.kube-scheduler
 sudo systemctl restart snap.k8s.kube-controller-manager
 ```
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get nodes" "Ready"
+-->
 
 ### Worker nodes
 
@@ -256,13 +340,17 @@ This configuration may affect compatibility of workloads.
 ```
 
 Kubelet will not start if it finds kernel configurations incompatible with its
- defaults.
+defaults.
 
 ```
 sudo sh -c 'cat >>/var/snap/k8s/common/args/kubelet <<EOL
 --protect-kernel-defaults=true
 EOL'
 ```
+
+<!-- SPREAD
+sudo cat /var/snap/k8s/common/args/kubelet | grep -e "--protect-kernel-defaults=true"
+-->
 
 Restart `kubelet`.
 
@@ -275,6 +363,10 @@ Reload the system daemons:
 ```
 sudo systemctl daemon-reload
 ```
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get nodes" "Ready"
+-->
 
 #### Edit kubelet service file permissions
 
@@ -291,11 +383,19 @@ permission needs to be performed every time the k8s snap refreshes.
 chmod 600 /etc/systemd/system/snap.k8s.kubelet.service
 ```
 
+<!-- SPREAD
+stat -c '%a' /etc/systemd/system/snap.k8s.kubelet.service | grep "600"
+-->
+
 Restart `kubelet`.
 
 ```
 sudo systemctl restart snap.k8s.kubelet
 ```
+
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get nodes" "Ready"
+-->
 
 #### Set the maximum time an idle session is permitted prior to disconnect
 
@@ -312,27 +412,23 @@ sudo sh -c 'cat >>/var/snap/k8s/common/args/kubelet <<EOL
 EOL'
 ```
 
+<!-- SPREAD
+sudo cat /var/snap/k8s/common/args/kubelet | grep -e "--streaming-connection-idle-timeout=5m"
+-->
+
 Restart `kubelet`.
 
 ```
 sudo systemctl restart snap.k8s.kubelet
 ```
 
+<!-- SPREAD
+repeat_checks "sudo k8s kubectl get nodes" "Ready"
+-->
+
 <!-- Charm end here -->
 
 ## CIS hardening
 
 To assess compliance to the CIS hardening guidelines, please see the [CIS
-assessment page].
-
-<!-- Links -->
-[DISA STIG assessment page]: /snap/reference/disa-stig-audit.md
-[CIS assessment page]: cis-assessment.md
-[upstream instructions]:https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
-[rate limits]:https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1
-[controlling_access]: https://kubernetes.io/docs/concepts/security/controlling-access/
-[RBAC guide]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-[encryption_at_rest]: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
-[authorization_mode]: https://kubernetes.io/docs/reference/access-authn-authz/authorization/#authorization-modules
-[how to set up a FIPS compliant Kubernetes cluster]:/snap/howto/install/fips.md
-[how to install Canonical Kubernetes with DISA STIG hardening]: /snap/howto/install/disa-stig.md
+assessment page](cis-assessment.md).

--- a/docs/canonicalk8s/snap/howto/security/hardening.md
+++ b/docs/canonicalk8s/snap/howto/security/hardening.md
@@ -223,7 +223,7 @@ Make sure the EventRateLimit admission plugin is loaded in the
 
 <!-- SPREAD 
 sudo sed -i 's/\(--enable-admission-plugins="[^"]*\)"/\1,EventRateLimit"/' /var/snap/k8s/common/args/kube-apiserver
-sudo cat /var/snap/k8s/common/args/kube-apiserver | grep "EventRateLimit"
+sudo cat /var/snap/k8s/common/args/kube-apiserver | grep "enable-admission-plugins" | grep "EventRateLimit"
 -->
 
 Load the admission control config file.
@@ -261,7 +261,7 @@ Make sure the AlwaysPullImages admission plugin is loaded in the
 
 <!-- SPREAD SKIP -->
 
-```sh
+```
 --enable-admission-plugins=...,AlwaysPullImages,...
 ```
 
@@ -269,7 +269,7 @@ Make sure the AlwaysPullImages admission plugin is loaded in the
 
 <!-- SPREAD
 sudo sed -i 's/\(--enable-admission-plugins="[^"]*\)"/\1,AlwaysPullImages"/' /var/snap/k8s/common/args/kube-apiserver
-sudo cat /var/snap/k8s/common/args/kube-apiserver | grep "AlwaysPullImages"
+sudo cat /var/snap/k8s/common/args/kube-apiserver | grep "enable-admission-plugins"| grep "AlwaysPullImages"
 -->
 
 Restart the API server.

--- a/docs/canonicalk8s/snap/howto/security/hardening.md
+++ b/docs/canonicalk8s/snap/howto/security/hardening.md
@@ -98,10 +98,8 @@ sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
 ```
 
 <!-- SPREAD
-sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
-    grep -q "RBAC" && echo "okay" || echo "missing" | grep "okay"
-sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | \
-    grep -q "AlwaysAllow" && echo "Remove AlwaysAllow" || echo "okay" | grep "okay"
+sudo grep authorization-mode /var/snap/k8s/common/args/kube-apiserver | grep -q "RBAC" 
+! sudo grep -qE "authorization-mode.*AlwaysAllow" /var/snap/k8s/common/args/kube-apiserver
 -->
 
 By default, the value is `Node,RBAC`

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -43,6 +43,7 @@ extra [Subject Alternative Name][] (SAN) to the certificate. Check the
 current SANs on your node by running the following command:
 
 <!-- SPREAD SKIP -->
+
 ```
 openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -text | grep -A 1 "Subject Alternative Name"
 ```
@@ -73,12 +74,15 @@ node and restart the necessary services. The new expiration date will be
 displayed in the command output:
 
 <!-- SPREAD SKIP -->
+
 ```
 Certificates have been successfully refreshed, and will expire at 2025-08-27 21:00:00 +0000 UTC.
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- SPREAD SKIP -->
+
 ## Refresh Worker node certificates
 
 1. To refresh the certificates on worker nodes, perform the following steps on
@@ -132,6 +136,7 @@ refresh its certificates and restart the necessary services:
 ```
 Certificates have been successfully refreshed, and will expire at 2034-08-27 21:00:00 +0000 UTC.
 ```
+
 <!-- SPREAD SKIP END -->
 
 <!-- Links -->

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -10,10 +10,10 @@ nodes in your {{product}} cluster.
 
 ```{warning}
 Only Kubernetes component certificates refreshes are supported with the
- `k8s refresh-certs` command. Microcluster and etcd certificates' expiration
- is set to 20 years, so renewal is not typically necessary. They are not automatically
- renewed by the command and currently cannot be refreshed manually.
- Additionally, like upstream Kubernetes, rotating the Certificate Authority (CA) is not supported.
+ `k8s refresh-certs` command. Microcluster and etcd certificates are set to
+ expire after 20 years. They are not automatically renewed by this command and
+ cannot currently be refreshed manually. CA rotation is not currently supported
+ in Canonical Kubernetes.
 ```
 
 ## Prerequisites

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -1,5 +1,7 @@
 # How to refresh Kubernetes certificates
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 To keep your {{product}} cluster secure and functional, it is essential
 to regularly refresh its certificates. Certificates in Kubernetes ensure
 secure communication between the various components of the cluster. Expired
@@ -40,9 +42,12 @@ This command refreshes the certificates for the control plane node, adding an
 extra [Subject Alternative Name][] (SAN) to the certificate. Check the
 current SANs on your node by running the following command:
 
+<!-- SPREAD SKIP -->
 ```
 openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -text | grep -A 1 "Subject Alternative Name"
 ```
+
+<!-- SPREAD SKIP END -->
 
 If your node setup includes additional SANs, be sure to provide the
 specific SANs for each node as needed using the `--extra-sans` flag. While this
@@ -67,10 +72,13 @@ see available options.
 node and restart the necessary services. The new expiration date will be
 displayed in the command output:
 
+<!-- SPREAD SKIP -->
 ```
 Certificates have been successfully refreshed, and will expire at 2025-08-27 21:00:00 +0000 UTC.
 ```
+<!-- SPREAD SKIP END -->
 
+<!-- SPREAD SKIP -->
 ## Refresh Worker node certificates
 
 1. To refresh the certificates on worker nodes, perform the following steps on
@@ -124,6 +132,7 @@ refresh its certificates and restart the necessary services:
 ```
 Certificates have been successfully refreshed, and will expire at 2034-08-27 21:00:00 +0000 UTC.
 ```
+<!-- SPREAD SKIP END -->
 
 <!-- Links -->
 

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -1,7 +1,5 @@
 # How to refresh Kubernetes certificates
 
-<!-- SPREAD SUITE: snap_bootstrapped -->
-
 To keep your {{product}} cluster secure and functional, it is essential
 to regularly refresh its certificates. Certificates in Kubernetes ensure
 secure communication between the various components of the cluster. Expired
@@ -12,10 +10,10 @@ nodes in your {{product}} cluster.
 
 ```{warning}
 Only Kubernetes component certificates refreshes are supported with the
- `k8s refresh-certs` command. Microcluster and etcd certificates are set to
- expire after 20 years. They are not automatically renewed by this command and
- cannot currently be refreshed manually. CA rotation is not currently supported
- in Canonical Kubernetes.
+ `k8s refresh-certs` command. Microcluster and etcd certificates' expiration
+ is set to 20 years, so renewal is not typically necessary. They are not automatically
+ renewed by the command and currently cannot be refreshed manually.
+ Additionally, like upstream Kubernetes, rotating the Certificate Authority (CA) is not supported.
 ```
 
 ## Prerequisites
@@ -42,13 +40,9 @@ This command refreshes the certificates for the control plane node, adding an
 extra [Subject Alternative Name][] (SAN) to the certificate. Check the
 current SANs on your node by running the following command:
 
-<!-- SPREAD SKIP -->
-
 ```
 openssl x509 -in /etc/kubernetes/pki/apiserver.crt -noout -text | grep -A 1 "Subject Alternative Name"
 ```
-
-<!-- SPREAD SKIP END -->
 
 If your node setup includes additional SANs, be sure to provide the
 specific SANs for each node as needed using the `--extra-sans` flag. While this
@@ -73,15 +67,9 @@ see available options.
 node and restart the necessary services. The new expiration date will be
 displayed in the command output:
 
-<!-- SPREAD SKIP -->
-
 ```
 Certificates have been successfully refreshed, and will expire at 2025-08-27 21:00:00 +0000 UTC.
 ```
-
-<!-- SPREAD SKIP END -->
-
-<!-- SPREAD SKIP -->
 
 ## Refresh Worker node certificates
 
@@ -91,12 +79,6 @@ each worker node in your cluster:
 ```
 sudo k8s refresh-certs --expires-in 10y --timeout 10m
 ```
-
-<!-- SPREAD 
-# Ensure cluster comes back healthy
-sudo k8s status --wait-ready --timeout 3m
-sudo k8s kubectl wait --for=condition=Ready node --all --timeout=2m
--->
 
 **`--expires-in`**
 
@@ -142,8 +124,6 @@ refresh its certificates and restart the necessary services:
 ```
 Certificates have been successfully refreshed, and will expire at 2034-08-27 21:00:00 +0000 UTC.
 ```
-
-<!-- SPREAD SKIP END -->
 
 <!-- Links -->
 

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -92,6 +92,12 @@ each worker node in your cluster:
 sudo k8s refresh-certs --expires-in 10y --timeout 10m
 ```
 
+<!-- SPREAD 
+# Ensure cluster comes back healthy
+sudo k8s status --wait-ready --timeout 3m
+sudo k8s kubectl wait --for=condition=Ready node --all --timeout=2m
+-->
+
 **`--expires-in`**
 
 This command refreshes the certificates for the worker node. The `--expires-in`

--- a/docs/canonicalk8s/snap/howto/storage/cloud.md
+++ b/docs/canonicalk8s/snap/howto/storage/cloud.md
@@ -179,7 +179,7 @@ Then, bootstrap the cluster:
 
 ```bash
 sudo k8s bootstrap --file ./bootstrap-config.yaml
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 ```
 
 ## Deploy the cloud controller manager

--- a/docs/canonicalk8s/snap/howto/storage/storage.md
+++ b/docs/canonicalk8s/snap/howto/storage/storage.md
@@ -55,6 +55,8 @@ sudo k8s set local-storage.default=true
 
 <!-- SPREAD
 sudo k8s get local-storage | grep "default: true"
+sudo k8s get local-storage | grep "local-path"
+sudo k8s get local-storage | grep "reclaim-policy"
 -->
 
 The local-storage feature provides the following configuration options:

--- a/docs/canonicalk8s/snap/howto/storage/storage.md
+++ b/docs/canonicalk8s/snap/howto/storage/storage.md
@@ -1,5 +1,7 @@
 # How to use default storage
 
+<!-- SPREAD SUITE: snap_bootstrapped -->
+
 {{product}} offers a local-storage option to quickly set up and run a
 cluster, especially for single-node support. This guide walks you through
 enabling and configuring this feature.
@@ -15,7 +17,7 @@ This guide assumes the following:
 
 - You have root or sudo access to the machine
 - You have a bootstrapped {{product}} cluster (see the
-  [getting-started-guide])
+   [getting-started-guide](/snap/tutorial/getting-started.md))
 
 ## Enable local storage
 
@@ -27,6 +29,10 @@ can enable it using the following command:
 sudo k8s enable local-storage
 ```
 
+<!-- SPREAD
+sudo k8s get local-storage | grep "enabled: true"
+-->
+
 ## Configure local storage
 
 While the storage option comes with sensible defaults, you can customize it to
@@ -36,22 +42,32 @@ meet your requirements. Obtain the current configuration by running:
 sudo k8s get local-storage
 ```
 
+<!-- SPREAD
+sudo k8s get local-storage | grep "enabled: true"
+-->
+
 You can modify the configuration using the `set` command. For example, to
-change the local storage path:
+change the default setting:
 
 ```
-sudo k8s set local-storage.local-path=/path/to/new/folder
+sudo k8s set local-storage.default=true
 ```
+
+<!-- SPREAD
+sudo k8s get local-storage | grep "default: true"
+-->
 
 The local-storage feature provides the following configuration options:
 
 - `local-path`: path where the local files will be created.
 - `reclaim-policy`: set the reclaim policy of the persistent volumes
-  provisioned. It should be one of "Retain", "Recycle", or "Delete".
+   provisioned. It should be one of "Retain", "Recycle", or "Delete".
 - `default`: set the local-storage storage class to be the default. If
-  this flag is not set and the cluster already has a default storage class it
-  is not changed. If this flag is not set and the cluster does not have a
-  default class set then the class from the local-storage becomes the default.
+   this flag is not set and the cluster already has a default storage class it
+   is not changed. If this flag is not set and the cluster does not have a
+   default class set then the class from the local-storage becomes the default.
+
+To alter the `local-path` or `reclaim-policy`, you must disable local-storage first.
 
 ## Disable local storage
 
@@ -64,8 +80,9 @@ disable local-storage, run:
 sudo k8s disable local-storage
 ```
 
+<!-- SPREAD
+sudo k8s get local-storage | grep "enabled: false"
+-->
+
 Disabling storage only removes the CSI driver. The persistent volume claims
 will still be available and your data will remain on disk.
-
-<!-- LINKS -->
-[getting-started-guide]: ../../tutorial/getting-started.md

--- a/docs/canonicalk8s/snap/howto/upgrades.md
+++ b/docs/canonicalk8s/snap/howto/upgrades.md
@@ -6,6 +6,8 @@ myst:
 
 # How to upgrade the snap
 
+<!-- SPREAD SUITE: snap_clean -->
+
 Upgrading the Kubernetes version of a node is a critical operation that
 requires careful planning and execution. {{product}} is shipped as a snap,
 which simplifies the upgrade process.
@@ -31,11 +33,22 @@ Snaps automatically check for updates of their specific track
 These updates ensure that the latest changes in the installed track are applied.
 Patch upgrades can also be triggered manually by following the steps below.
 
+<!-- SPREAD 
+sudo snap install k8s --classic --channel=1.34-classic/stable
+sudo k8s bootstrap
+sudo k8s status --wait-ready
+-->
+
 1. **List available revisions:**
 
 ```
 snap info k8s
 ```
+
+<!-- SPREAD 
+snap info k8s | grep "tracking:     1.34-classic/stable"
+-->
+
 
 2. **Refresh the snap:**
 
@@ -77,6 +90,7 @@ steps before upgrading.
 The {{product}} snap channel can be changed by using the `snap refresh`
 command.
 
+
 ```
 snap refresh --channel=1.35-classic/stable k8s
 ```
@@ -90,6 +104,10 @@ and confirming that the cluster is ready:
 snap info k8s
 sudo k8s status --wait-ready
 ```
+
+<!-- SPREAD 
+snap info k8s | grep "installed:                v1.35"
+-->
 
 ```{note}
 In a multi-node cluster, the upgrade should be performed on all nodes.
@@ -121,6 +139,10 @@ confirming that the cluster is ready:
 snap info k8s
 sudo k8s status --wait-ready
 ```
+
+<!-- SPREAD 
+snap info k8s | grep "installed:                v1.34"
+-->
 
 ```{note}
 In a multi-node cluster, the revert should be performed on all nodes.

--- a/docs/canonicalk8s/snap/howto/upgrades.md
+++ b/docs/canonicalk8s/snap/howto/upgrades.md
@@ -34,7 +34,7 @@ These updates ensure that the latest changes in the installed track are applied.
 Patch upgrades can also be triggered manually by following the steps below.
 
 <!-- SPREAD 
-sudo snap install k8s --classic --channel=1.33-classic/stable
+sudo snap install k8s --classic --channel=1.34-classic/stable
 sudo k8s bootstrap
 sudo k8s status --wait-ready --timeout 3m
 # Ensure Cilium exists
@@ -54,7 +54,7 @@ snap info k8s
 ```
 
 <!-- SPREAD 
-snap info k8s | grep "tracking:     1.33-classic/stable"
+snap info k8s | grep "tracking:     1.34-classic/stable"
 -->
 
 
@@ -100,7 +100,7 @@ command.
 
 
 ```
-snap refresh --channel=1.34-classic/stable k8s
+snap refresh --channel=1.35-classic/stable k8s
 ```
 
 4. **Verify the upgrade:**
@@ -114,7 +114,7 @@ sudo k8s status --wait-ready --timeout 3m
 ```
 
 <!-- SPREAD 
-snap info k8s | grep "installed:                v1.34"
+snap info k8s | grep "installed:                v1.35"
 -->
 
 ```{note}
@@ -151,7 +151,7 @@ sudo k8s status --wait-ready --timeout 3m
 ```
 
 <!-- SPREAD 
-snap info k8s | grep "installed:                v1.33"
+snap info k8s | grep "installed:                v1.34"
 -->
 
 ```{note}

--- a/docs/canonicalk8s/snap/howto/upgrades.md
+++ b/docs/canonicalk8s/snap/howto/upgrades.md
@@ -36,7 +36,7 @@ Patch upgrades can also be triggered manually by following the steps below.
 <!-- SPREAD 
 sudo snap install k8s --classic --channel=1.34-classic/stable
 sudo k8s bootstrap
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 -->
 
 1. **List available revisions:**
@@ -63,7 +63,7 @@ confirming that the cluster is ready:
 
 ```
 snap info k8s
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 ```
 
 ## Minor version upgrade
@@ -102,7 +102,7 @@ and confirming that the cluster is ready:
 
 ```
 snap info k8s
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 ```
 
 <!-- SPREAD 
@@ -137,7 +137,7 @@ confirming that the cluster is ready:
 
 ```
 snap info k8s
-sudo k8s status --wait-ready
+sudo k8s status --wait-ready --timeout 3m
 ```
 
 <!-- SPREAD 

--- a/docs/canonicalk8s/snap/howto/upgrades.md
+++ b/docs/canonicalk8s/snap/howto/upgrades.md
@@ -37,6 +37,14 @@ Patch upgrades can also be triggered manually by following the steps below.
 sudo snap install k8s --classic --channel=1.34-classic/stable
 sudo k8s bootstrap
 sudo k8s status --wait-ready --timeout 3m
+# Ensure Cilium exists
+source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
+repeat_checks "sudo k8s kubectl get daemonset -n kube-system" "cilium"
+repeat_checks "sudo k8s kubectl get deployment -n kube-system" "cilium-operator"
+# Ensure Cilium and all pods in kube-system are ready 
+sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m
+sudo k8s kubectl rollout status deployment/cilium-operator -n kube-system --timeout=10m
+sudo k8s kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=10m
 -->
 
 1. **List available revisions:**
@@ -134,6 +142,8 @@ sudo snap revert k8s
 
 Ensure that the revert was successful by checking the version of the snap and
 confirming that the cluster is ready:
+
+
 
 ```
 snap info k8s

--- a/docs/canonicalk8s/snap/howto/upgrades.md
+++ b/docs/canonicalk8s/snap/howto/upgrades.md
@@ -34,7 +34,7 @@ These updates ensure that the latest changes in the installed track are applied.
 Patch upgrades can also be triggered manually by following the steps below.
 
 <!-- SPREAD 
-sudo snap install k8s --classic --channel=1.34-classic/stable
+sudo snap install k8s --classic --channel=1.33-classic/stable
 sudo k8s bootstrap
 sudo k8s status --wait-ready --timeout 3m
 # Ensure Cilium exists
@@ -54,7 +54,7 @@ snap info k8s
 ```
 
 <!-- SPREAD 
-snap info k8s | grep "tracking:     1.34-classic/stable"
+snap info k8s | grep "tracking:     1.33-classic/stable"
 -->
 
 
@@ -100,7 +100,7 @@ command.
 
 
 ```
-snap refresh --channel=1.35-classic/stable k8s
+snap refresh --channel=1.34-classic/stable k8s
 ```
 
 4. **Verify the upgrade:**
@@ -114,7 +114,7 @@ sudo k8s status --wait-ready --timeout 3m
 ```
 
 <!-- SPREAD 
-snap info k8s | grep "installed:                v1.35"
+snap info k8s | grep "installed:                v1.34"
 -->
 
 ```{note}
@@ -151,7 +151,7 @@ sudo k8s status --wait-ready --timeout 3m
 ```
 
 <!-- SPREAD 
-snap info k8s | grep "installed:                v1.34"
+snap info k8s | grep "installed:                v1.33"
 -->
 
 ```{note}

--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -306,9 +306,11 @@ restoration, simply run :
 
 <!-- SPREAD SKIP -->
 
+
 ```
 sudo snap remove k8s
 ```
+
 
 <!-- SPREAD SKIP END -->
 

--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -74,6 +74,10 @@ to wait for {{product}} to bring up the cluster:
 sudo k8s status --wait-ready
 ```
 
+<!-- SPREAD 
+sudo k8s kubectl wait --for=condition=Ready node --all --timeout=5m
+-->
+
 <!-- SPREAD SKIP -->
 
 ```{important}

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -4,6 +4,47 @@ path: /k8s-snap
 reroot: ..
 
 backends:
+  multipass:
+    type: adhoc
+    allocate: |
+      multipass_image=24.04
+      instance_name="spread-k8s-snap"
+
+      # Launch Multipass VM only if it doesn't already exist
+      if ! multipass info "$instance_name" &>/dev/null; then
+        multipass launch --cpus 4 --disk 10G --memory 8G --name "${instance_name}" "${multipass_image}"
+
+        # Enable PasswordAuthentication for root over SSH.
+        multipass exec "$instance_name" -- \
+          sudo sh -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd"
+        multipass exec "$instance_name" -- \
+          sudo sh -c \
+          "if [ -d /etc/ssh/sshd_config.d/ ]
+          then
+            echo 'PasswordAuthentication yes' > /etc/ssh/sshd_config.d/99-spread.conf
+            echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config.d/99-spread.conf
+          else
+            sed -i /etc/ssh/sshd_config -E -e 's/^#?PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#?PermitRootLogin.*/PermitRootLogin yes/'
+          fi"
+        multipass exec "$instance_name" -- \
+          sudo systemctl restart ssh
+      elif [ "$(multipass info --format csv "$instance_name" | tail -1 | cut -d, -f2)" = "Stopped" ]; then
+        multipass start "$instance_name"
+      fi
+
+      # Get the IP from the instance
+      ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)
+      ADDRESS "$ip"
+    discard: |
+      instance_name=$(multipass list --format csv | awk -F',' -v ip="$SPREAD_SYSTEM_ADDRESS" '$3==ip {print $1}' || true)
+      [ -n "$instance_name" ] && multipass delete --purge "${instance_name}" || true
+
+    systems:
+      - ubuntu-24.04-64:
+          username: root
+          password: ubuntu
+          workers: 1
+
   github-ci:
     type: adhoc
     allocate: |

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -4,47 +4,6 @@ path: /k8s-snap
 reroot: ..
 
 backends:
-  multipass:
-    type: adhoc
-    allocate: |
-      multipass_image=24.04
-      instance_name="spread-k8s-snap"
-
-      # Launch Multipass VM only if it doesn't already exist
-      if ! multipass info "$instance_name" &>/dev/null; then
-        multipass launch --cpus 4 --disk 10G --memory 8G --name "${instance_name}" "${multipass_image}"
-
-        # Enable PasswordAuthentication for root over SSH.
-        multipass exec "$instance_name" -- \
-          sudo sh -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd"
-        multipass exec "$instance_name" -- \
-          sudo sh -c \
-          "if [ -d /etc/ssh/sshd_config.d/ ]
-          then
-            echo 'PasswordAuthentication yes' > /etc/ssh/sshd_config.d/99-spread.conf
-            echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config.d/99-spread.conf
-          else
-            sed -i /etc/ssh/sshd_config -E -e 's/^#?PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#?PermitRootLogin.*/PermitRootLogin yes/'
-          fi"
-        multipass exec "$instance_name" -- \
-          sudo systemctl restart ssh
-      elif [ "$(multipass info --format csv "$instance_name" | tail -1 | cut -d, -f2)" = "Stopped" ]; then
-        multipass start "$instance_name"
-      fi
-
-      # Get the IP from the instance
-      ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)
-      ADDRESS "$ip"
-    discard: |
-      instance_name=$(multipass list --format csv | awk -F',' -v ip="$SPREAD_SYSTEM_ADDRESS" '$3==ip {print $1}' || true)
-      [ -n "$instance_name" ] && multipass delete --purge "${instance_name}" || true
-
-    systems:
-      - ubuntu-24.04-64:
-          username: root
-          password: ubuntu
-          workers: 1
-
   github-ci:
     type: adhoc
     allocate: |
@@ -62,6 +21,42 @@ backends:
       - ubuntu-24.04-64:
           username: ubuntu
           password: ubuntu
+          workers: 1
+
+  multipass:
+    type: adhoc
+    allocate: |
+      multipass_image=24.04
+      instance_name="spread-$(date +%s)-$$"
+
+      # Launch Multipass VM
+      multipass launch --cpus 4 --disk 20G --memory 8G --name "${instance_name}" "${multipass_image}"
+
+      # Enable PasswordAuthentication for root over SSH.
+      multipass exec "$instance_name" -- \
+        sudo sh -c "echo root:root | sudo chpasswd"
+      multipass exec "$instance_name" -- \
+        sudo sh -c \
+        "if [ -d /etc/ssh/sshd_config.d/ ]
+        then
+          echo 'PasswordAuthentication yes' > /etc/ssh/sshd_config.d/10-spread.conf
+          echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config.d/10-spread.conf
+        else
+          sed -i /etc/ssh/sshd_config -E -e 's/^#?PasswordAuthentication.*/PasswordAuthentication yes/' -e 's/^#?PermitRootLogin.*/PermitRootLogin yes/'
+        fi"
+      multipass exec "$instance_name" -- \
+        sudo systemctl restart ssh
+
+      # Get the IP from the instance
+      ip=$(multipass info --format csv "$instance_name" | tail -1 | cut -d\, -f3)
+      ADDRESS "$ip"
+    discard: |
+      instance_name=$(multipass list --format csv | awk -F',' -v ip="$SPREAD_SYSTEM_ADDRESS" '$3==ip {print $1}' || true)
+      [ -n "$instance_name" ] && multipass delete --purge "${instance_name}" || true
+    systems:
+      - ubuntu-24.04-64:
+          username: root
+          password: "root"
           workers: 1
 
 suites:
@@ -93,3 +88,5 @@ suites:
       sudo rm -rf /var/snap/k8s || true
     systems:
       - ubuntu-24.04-64
+
+

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -73,7 +73,11 @@ suites:
       fi
       sudo rm -rf /run/containerd || true
     restore-each: |
-      sudo snap remove k8s --purge || true
+      if snap list k8s &>/dev/null; then
+        sudo pkill -9 -f snap.k8s || true
+        sudo snap remove k8s --purge
+      fi
+      
       sudo rm -rf /var/snap/k8s || true
     systems:
       - ubuntu-24.04-64
@@ -96,8 +100,9 @@ suites:
       sudo k8s kubectl wait --for=condition=Ready node --all --timeout=5m
 
       # Ensure Cilium exists
-      bash "$SPREAD_PATH/docs/tools/repeat_checks.sh" "sudo k8s kubectl get daemonset/cilium -n kube-system"
-      bash "$SPREAD_PATH/docs/tools/repeat_checks.sh" "sudo k8s kubectl get deployment/cilium-operator -n kube-system"
+      source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
+      repeat_checks "sudo k8s kubectl get daemonset/cilium -n kube-system" "cilium"
+      repeat_checks "sudo k8s kubectl get deployment/cilium-operator -n kube-system" "cilium-operator"
 
       # Ensure Cilium and all pods in kube-system are ready 
       sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m
@@ -105,7 +110,11 @@ suites:
       sudo k8s kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=10m
 
     restore-each: |
-      sudo snap remove k8s --purge || true
+      if snap list k8s &>/dev/null; then
+        sudo pkill -9 -f snap.k8s || true
+        sudo snap remove k8s --purge
+      fi
+      
       sudo rm -rf /var/snap/k8s || true
     systems:
       - ubuntu-24.04-64

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -60,7 +60,7 @@ backends:
           workers: 1
 
 suites:
-  tests/spread-generated/snap_clean/:
+  tests/spread_generated/snap_clean/:
     summary: docs tests that run from a clean VM and perform install/bootstrap in-task
     prepare-each: |
       # GitHub runners ship with containerd; stop it and remove the socket so
@@ -74,7 +74,7 @@ suites:
     systems:
       - ubuntu-24.04-64
 
-  tests/spread-generated/snap_bootstrapped/:
+  tests/spread_generated/snap_bootstrapped/:
     summary: docs tests that assume a bootstrapped snap cluster
     prepare-each: |
       sudo systemctl stop containerd || true

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -88,5 +88,3 @@ suites:
       sudo rm -rf /var/snap/k8s || true
     systems:
       - ubuntu-24.04-64
-
-

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -101,8 +101,8 @@ suites:
 
       # Ensure Cilium exists
       source ${SPREAD_PATH}/docs/tools/repeat_checks.sh
-      repeat_checks "sudo k8s kubectl get daemonset/cilium -n kube-system" "cilium"
-      repeat_checks "sudo k8s kubectl get deployment/cilium-operator -n kube-system" "cilium-operator"
+      repeat_checks "sudo k8s kubectl get daemonset -n kube-system" "cilium"
+      repeat_checks "sudo k8s kubectl get deployment -n kube-system" "cilium-operator"
 
       # Ensure Cilium and all pods in kube-system are ready 
       sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -94,6 +94,16 @@ suites:
       
       sudo k8s status --wait-ready --timeout 3m
       sudo k8s kubectl wait --for=condition=Ready node --all --timeout=5m
+
+      # Ensure Cilium exists
+      bash "$SPREAD_PATH/docs/tools/repeat_checks.sh" "sudo k8s kubectl get daemonset/cilium -n kube-system"
+      bash "$SPREAD_PATH/docs/tools/repeat_checks.sh" "sudo k8s kubectl get deployment/cilium-operator -n kube-system"
+
+      # Ensure Cilium and all pods in kube-system are ready 
+      sudo k8s kubectl rollout status daemonset/cilium -n kube-system --timeout=10m
+      sudo k8s kubectl rollout status deployment/cilium-operator -n kube-system --timeout=10m
+      sudo k8s kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=10m
+
     restore-each: |
       sudo snap remove k8s --purge || true
       sudo rm -rf /var/snap/k8s || true

--- a/docs/spread.yaml
+++ b/docs/spread.yaml
@@ -67,6 +67,10 @@ suites:
       # the k8s snap can create /run/containerd without conflict.
       sudo systemctl stop containerd || true
       sudo systemctl disable containerd || true
+      # Clean up lingering mounts from previous aborted tests
+      if mount | grep -q "/run/containerd"; then
+        grep /run/containerd /proc/mounts | awk '{print $2}' | xargs -r sudo umount -l || true
+      fi
       sudo rm -rf /run/containerd || true
     restore-each: |
       sudo snap remove k8s --purge || true
@@ -79,10 +83,17 @@ suites:
     prepare-each: |
       sudo systemctl stop containerd || true
       sudo systemctl disable containerd || true
+      # Clean up lingering mounts from previous aborted tests
+      if mount | grep -q "/run/containerd"; then
+        grep /run/containerd /proc/mounts | awk '{print $2}' | xargs -r sudo umount -l || true
+      fi
       sudo rm -rf /run/containerd || true
+      
       sudo snap install k8s --classic --channel=1.35-classic/stable
       sudo k8s bootstrap --timeout 10m
+      
       sudo k8s status --wait-ready --timeout 3m
+      sudo k8s kubectl wait --for=condition=Ready node --all --timeout=5m
     restore-each: |
       sudo snap remove k8s --purge || true
       sudo rm -rf /var/snap/k8s || true

--- a/docs/tools/repeat_checks.sh
+++ b/docs/tools/repeat_checks.sh
@@ -8,7 +8,7 @@ function repeat_checks {
 
   for i in $(seq 1 "$max_retries"); do
     echo "Attempt ${i}/${max_retries}: ${cmd}"
-    bash -lc "$cmd" > output.txt 2>&1
+    bash -lc "$cmd" > output.txt 2>&1 || true
     cat output.txt
 
     if grep -Fq -- "$expected" output.txt; then


### PR DESCRIPTION
## Description

This PR adds automated testing to more of our snap guides. They have been labelled with SPREAD comments in order for task.yaml files to be created by docs-spread-tests.yaml at PR time. 

## Solution

I realised we should also have the option to run these tests locally so I have added a multipass backend to the spread.yaml 

Pages that were excluded due to a rework being needed: 
- docs/canonicalk8s/snap/howto/networking/alternative-cni.md
- docs/canonicalk8s/snap/howto/backup-restore.md

Issues highlighted through this testing and fixed: 
- Hardening command to create /var/snap/k8s/common/etc/encryption/enc.yaml did not work
- Loadbalancer is listed in k8s status 
- Default state of network is enabled 
- DNS cluster IP must be set when dns is disabled 
- To alter the `local-path` or `reclaim-policy`, you must disable local-storage first.
These fixes will need to be backported separately to the release branches. 

Guides that were deemed not necessary to test:
- docs/canonicalk8s/snap/howto/support.md
- docs/canonicalk8s/snap/howto/contribute.md
- docs/canonicalk8s/snap/howto/security/report-security-issue.md 
- all index files 

During development some links were removed from the LINKS section at the end and automatically placed in the text. This is the direction we want to go in so I left them in. Also some misc formatting fixed. 

There are also HW limitations here. I will need to do another pass at this for multinode cluster setup and dual stack enablement. 

The script to generate the task.yaml create_spread_task_file.py automatically skips sphinx directives such as warning so removing SPREAD SKIP comments from the snap getting-started tutorial.

Altered docs-spread-tests.yaml to split snap_clean and snap_bootstrapped into separate tests. This means that both tests run in parallel to speed up the CI. Also if snap_bootstrapped fails, snap_clean will still execute. 

Added trap commands that will execute on exit. These are page specific clean up tasks that run if the default k8s purge does not clean it up.

## Issue

N/A

## Backport

No. I will backport the text fixes after this PR

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.