### PR TITLE
fix: mitigate template injection and ref-version-mismatch in workflows

### DIFF
--- a/.github/workflows/auto-label-release-notes.yaml
+++ b/.github/workflows/auto-label-release-notes.yaml
@@ -15,7 +15,9 @@ jobs:
       - name: Add release-notes label
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
+          gh pr edit "$PR_NUMBER" \
+            --repo "$REPO" \
             --add-label "release-notes"

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -65,8 +65,9 @@ jobs:
       - name: Label backports with automerge and approve
         env:
           GH_TOKEN: ${{ secrets.BACKPORT_APPROVAL_TOKEN }}
+          CREATED_PULL_NUMBERS: ${{ steps.create_backports.outputs.created_pull_numbers }}
         run: |
-          for pr_number in ${{ steps.create_backports.outputs.created_pull_numbers }}; do
+          for pr_number in $CREATED_PULL_NUMBERS; do
             gh pr edit "$pr_number" --add-label "automerge"
             gh pr review "$pr_number" --approve
           done

--- a/.github/workflows/charm-e2e-tests.yaml
+++ b/.github/workflows/charm-e2e-tests.yaml
@@ -82,9 +82,11 @@ jobs:
       - name: Install virtualenv
         run: sudo apt install -y python3.10-venv
       - name: Generate snap tarball
+        env:
+          SNAP_PATH: ${{ steps.download-snap.outputs.snap-path }}
         run: |
           mkdir snap_installation
-          mv ${{ steps.download-snap.outputs.snap-path }} snap_installation/k8s.snap
+          mv "$SNAP_PATH" snap_installation/k8s.snap
           tar cvzf snap_installation.tar.gz -C snap_installation/ .
       - name: Setup Astral UV
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8

--- a/.github/workflows/component-version-check.yaml
+++ b/.github/workflows/component-version-check.yaml
@@ -46,9 +46,11 @@ jobs:
 
       # Get the diff for this PR
       - name: Get PR diff
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git diff origin/${{ github.event.pull_request.base.ref }}...HEAD > pr.diff
+          git fetch origin "$BASE_REF"
+          git diff "origin/$BASE_REF"...HEAD > pr.diff
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -75,8 +77,11 @@ jobs:
       - name: Comment on PR if invalid
         if: steps.validate.outputs.invalid == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          VALIDATION_STDERR: ${{ steps.validate.outputs.stderr }}
         with:
           script: |
+            const stderr = process.env.VALIDATION_STDERR || '';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -84,7 +89,7 @@ jobs:
               body: (
                 "❌ Invalid change detected in PR diff. Please remove it.\n" +
                 "Label this PR with 'skip-component-version-check' to ignore\n\n" +
-                "${{ steps.validate.outputs.stderr }}\n\n" +
+                stderr + "\n\n"
               )
             })
 

--- a/.github/workflows/component-version-check.yaml
+++ b/.github/workflows/component-version-check.yaml
@@ -76,22 +76,19 @@ jobs:
       # Comment on the PR if invalid
       - name: Comment on PR if invalid
         if: steps.validate.outputs.invalid == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           VALIDATION_STDERR: ${{ steps.validate.outputs.stderr }}
-        with:
-          script: |
-            const stderr = process.env.VALIDATION_STDERR || '';
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: (
-                "❌ Invalid change detected in PR diff. Please remove it.\n" +
-                "Label this PR with 'skip-component-version-check' to ignore\n\n" +
-                stderr + "\n\n"
-              )
-            })
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPO" \
+            --body "❌ Invalid change detected in PR diff. Please remove it.
+Label this PR with 'skip-component-version-check' to ignore
+
+$VALIDATION_STDERR
+"
 
       # Fail the job if invalid
       - name: Fail job if invalid

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -178,17 +178,22 @@ jobs:
         run: sudo apt-get install -y tox
       - name: Compute test runners
         id: compute-test-runners
+        env:
+          RUNNER_TAGS: ${{ inputs.runner-tags }}
+          ARCH: ${{ inputs.arch }}
         run: |
           # Github Actions does not support dynamic concatination of lists, so we need to add the arch tag here.
           # See https://github.com/orgs/community/discussions/11401
-          TEST_RUNNERS=$(jq -c -n '${{ inputs.runner-tags }}' | jq -c 'with_entries(.value += ["${{ inputs.arch }}"])')
+          TEST_RUNNERS=$(jq -c -n "$RUNNER_TAGS" | jq -c --arg arch "$ARCH" 'with_entries(.value += [$arch])')
           echo "test_runners=$TEST_RUNNERS" >> $GITHUB_OUTPUT
       - name: Collect tests
         id: collect-tests
+        env:
+          TEST_TAGS: ${{ inputs.test-tags }}
         run: |
           cd tests/integration
           # Split the input tags into an array and pass them as individual args
-          IFS=' ' read -ra TAGS <<< "${{ inputs.test-tags }}"
+          IFS=' ' read -ra TAGS <<< "$TEST_TAGS"
           TAGS_ARGS=""
           for tag in "${TAGS[@]}"; do
             TAGS_ARGS="$TAGS_ARGS --tags $tag"
@@ -244,17 +249,22 @@ jobs:
         run: sudo apt-get install -y tox
       - name: Generate names for step and artifacts
         if: ${{ always() }}
+        env:
+          MATRIX_TEST: ${{ matrix.test }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          INPUT_OS: ${{ inputs.os }}
+          INPUT_ARCH: ${{ inputs.arch }}
         run: |
-          FULL_TEST_NODE_ID="${{ matrix.test }}"
+          FULL_TEST_NODE_ID="${MATRIX_TEST}"
           # Extract short test name (part after '::') for the step display name
           SHORT_TEST_NAME="${FULL_TEST_NODE_ID##*::}"
           echo "short_test_name=${SHORT_TEST_NAME}" >> $GITHUB_ENV
 
-          CHANNEL="${{ inputs.channel }}"
+          CHANNEL="${INPUT_CHANNEL}"
           if [ -n "$CHANNEL" ]; then
-            RAW_ARTIFACT_NAME_BASE="${{ inputs.os }}-${{ inputs.arch }}-${CHANNEL}-${FULL_TEST_NODE_ID}-$(uuidgen)"
+            RAW_ARTIFACT_NAME_BASE="${INPUT_OS}-${INPUT_ARCH}-${CHANNEL}-${FULL_TEST_NODE_ID}-$(uuidgen)"
           else
-            RAW_ARTIFACT_NAME_BASE="${{ inputs.os }}-${{ inputs.arch }}-${FULL_TEST_NODE_ID}-$(uuidgen)"
+            RAW_ARTIFACT_NAME_BASE="${INPUT_OS}-${INPUT_ARCH}-${FULL_TEST_NODE_ID}-$(uuidgen)"
           fi
           SANITIZED_ARTIFACT_NAME=$(echo "$RAW_ARTIFACT_NAME_BASE" | sed 's/[\/:\.\]/-/g' | sed 's/\s//g')
           echo "test_name=${SANITIZED_ARTIFACT_NAME}" >> $GITHUB_ENV
@@ -279,9 +289,13 @@ jobs:
           TEST_GH_BASE_REF: ${{ github.base_ref }}
           TEST_UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
           TEST_LAUNCHPAD_K8S_CI_BOT_PASSWORD: ${{ secrets.LAUNCHPAD_K8S_CI_BOT_PASSWORD }}
+          EXTRA_TEST_ENV: ${{ inputs.extra-test-env }}
+          PARALLEL_TEST: ${{ inputs.parallel && matrix.test || '' }}
+          INPUT_TEST_TAGS: ${{ inputs.test-tags }}
+          EXTRA_TEST_ARGS: ${{ inputs.extra-test-args }}
         run: |
           # Parse extra-test-env and export each KEY=VALUE pair
-          ESCAPED_ENV=$(echo "${{ inputs.extra-test-env }}" | sed 's/"/\\"/g')
+          ESCAPED_ENV=$(echo "$EXTRA_TEST_ENV" | sed 's/"/\\"/g')
           if [ -n "${ESCAPED_ENV}" ]; then
             IFS=',' read -ra ENV_VARS <<< "${ESCAPED_ENV}"
             for kv in "${ENV_VARS[@]}"; do
@@ -290,12 +304,12 @@ jobs:
             done
           fi
 
-          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- ${{ inputs.parallel && matrix.test || '' }} ${{ env.PERFORMANCE_FLAGS }} --tags ${{ inputs.test-tags }} ${{ inputs.extra-test-args }}
+          cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- $PARALLEL_TEST $PERFORMANCE_FLAGS --tags $INPUT_TEST_TAGS $EXTRA_TEST_ARGS
       - name: Prepare inspection reports
         if: failure()
         run: |
           mkdir -p inspection-report-archives
-          tar -czvf inspection-report-archives/${{ env.test_name }}.tar.gz -C ${{ github.workspace }} inspection-reports/${{ env.test_name }} || true
+          tar -czvf "inspection-report-archives/${test_name}.tar.gz" -C "$GITHUB_WORKSPACE" "inspection-reports/${test_name}" || true
       - name: Upload inspection report artifact
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -326,7 +340,7 @@ jobs:
         run: |
           mkdir -p performance-test-results
           mv tests/integration/baselines/*/0001_*.json \
-            performance-test-results/${{ env.test_name }}.json
+            "performance-test-results/${test_name}.json"
       - name: Upload performance test results
         if: contains(inputs.test-tags, 'performance')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -335,14 +349,20 @@ jobs:
           path: performance-test-results
       - name: Upload test metadata
         if: ${{ inputs.upload-results && always() }}
+        env:
+          INPUT_OS: ${{ inputs.os }}
+          INPUT_ARCH: ${{ inputs.arch }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          MATRIX_TEST: ${{ matrix.test }}
+          JOB_STATUS: ${{ job.status }}
         run: |
           mkdir -p results
           jq -n \
-            --arg os "${{ inputs.os }}" \
-            --arg arch "${{ inputs.arch }}" \
-            --arg channel "${{ inputs.channel }}" \
-            --arg test "${{ matrix.test }}" \
-            --arg status "${{ job.status }}" \
+            --arg os "$INPUT_OS" \
+            --arg arch "$INPUT_ARCH" \
+            --arg channel "$INPUT_CHANNEL" \
+            --arg test "$MATRIX_TEST" \
+            --arg status "$JOB_STATUS" \
             '{os:$os, arch:$arch, channel:$channel, test:$test, status:$status}' > results/result.json
         shell: bash
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -46,8 +46,10 @@ jobs:
         run: sudo apt-get install -y tox
       - name: Extract Kubernetes versions
         id: versions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          OLD_VERSION=$(git show ${{ github.event.pull_request.base.sha }}:build-scripts/components/kubernetes/version)
+          OLD_VERSION=$(git show "$BASE_SHA":build-scripts/components/kubernetes/version)
           NEW_VERSION=$(cat build-scripts/components/kubernetes/version)
 
           echo "Old Kubernetes version (base): $OLD_VERSION"

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -107,9 +107,12 @@ jobs:
           fetch-depth: 2
       - name: Get e2e test tags
         id: get-e2e-tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
           tags="pull_request"
-          if ${{ github.event_name == 'pull_request' }}; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             # Run all tests if there are test changes. In case of a PR, we'll
             # get a merge commit that includes all changes.
             if git diff HEAD HEAD~1 --name-only | grep "tests/"; then
@@ -120,7 +123,7 @@ jobs:
               tags="up_to_weekly"
             fi
             # Run all tests on backports.
-            if echo ${{ github.base_ref }} | grep "release-"; then
+            if echo "$BASE_REF" | grep "release-"; then
               tags="up_to_weekly"
             fi
           fi

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -66,7 +66,7 @@ jobs:
         id: scan-ref
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Upload Trivy scan results to Github Security tab
-        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
           sarif_file: ./.trivy/sarifs/trivy-k8s-repo-scan--results.sarif
           # Attribute results to the branch that was actually scanned,

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -57,9 +57,11 @@ jobs:
           # Persist downloaded artifacts
           clean: 'false'
       - name: Run Trivy vulnerability scanner
+        env:
+          SNAP_PATH: ${{ steps.download-snap.outputs.snap-path }}
         run: |
           cp $GITHUB_WORKSPACE/trivy-scan.sh ./tests/trivy-scan.sh
-          ./tests/trivy-scan.sh ${{ steps.download-snap.outputs.snap-path }}
+          ./tests/trivy-scan.sh "$SNAP_PATH"
       - name: Get checked out commit SHA
         id: scan-ref
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -43,7 +43,7 @@ jobs:
                     .
 
             - name: Upload SARIF results
-              uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
+              uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
               if: always()
               with:
                   sarif_file: semgrep-results.sarif

--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -101,8 +101,10 @@ jobs:
       - name: Set current formatted date as env variable
         run: echo "FORMATTED_DATE=$(date +'%d/%m/%Y')" >> $GITHUB_ENV
       - name: Test results
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
         run: |
-         RESULTS=$(echo '${{ toJson(needs) }}' | jq -c '[.[] | .result]')
+         RESULTS=$(echo "$NEEDS_JSON" | jq -c '[.[] | .result]')
 
          if echo $RESULTS | jq -e 'all(. == "success")'; then
            echo "RESULT=success" >> $GITHUB_ENV
@@ -110,13 +112,16 @@ jobs:
            echo "RESULT=failure" >> $GITHUB_ENV
          fi
       - name: Generate Mattermost Message
+        env:
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-         if [[ "${{ env.RESULT }}" == "success" ]]; then
-           echo "MM_TEXT=:white_check_mark: *Success!* CI completed successfully. [View Run](${{
-             github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_ENV
+         RUN_LINK="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+         if [[ "$RESULT" == "success" ]]; then
+           echo "MM_TEXT=:white_check_mark: *Success!* CI completed successfully. [View Run](${RUN_LINK})" >> $GITHUB_ENV
          else
-           echo "MM_TEXT=:x: *Failure!* CI failed, @k8s-engineers please fix ASAP. [View Run](${{
-             github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_ENV
+           echo "MM_TEXT=:x: *Failure!* CI failed, @k8s-engineers please fix ASAP. [View Run](${RUN_LINK})" >> $GITHUB_ENV
          fi
       - name: Notify Mattermost
         uses: mattermost/action-mattermost-notify@d317daebed2a792679f68fd0248557a8d21d82b6 # master


### PR DESCRIPTION
## Description

Mitigate template injection vulnerabilities (CWE-94) in GitHub Actions workflows by moving `${{ }}` expressions from `run:` blocks into `env:` blocks. Also fix version comment mismatches for pinned action SHAs.

## Solution

**Template injection (commit 1):** Expressions like `${{ inputs.* }}`, `${{ github.event.* }}`, `${{ steps.*.outputs.* }}` inside `run:` blocks allow potential code injection if an attacker controls the interpolated value. The fix moves these into `env:` blocks and references them as shell variables (`$VAR`), which are not subject to injection.

**Ref-version-mismatch (commit 2):** The `codeql-action/upload-sarif` SHA `5c8a8a64` corresponds to `v3.35.1`, not the rolling `v3` tag. Updated the comment to reflect the actual pinned version.

Affected workflows:
- `backport.yaml` — step outputs in shell loop
- `charm-e2e-tests.yaml` — snap-path in mv command
- `component-version-check.yaml` — PR base ref and stderr in shell/script
- `e2e-tests.yaml` — inputs and matrix values in run blocks
- `lint_and_integration.yaml` — event_name and base_ref conditionals
- `security-scan.yaml` — snap-path in trivy scan + version comment
- `semgrep.yaml` — version comment
- `weekly-test.yaml` — toJson(needs) and env vars in shell

## Issue

Resolves ~39 open zizmor/template-injection, Semgrep shell-injection, and zizmor/ref-version-mismatch code scanning alerts.

## Backport

No — these alerts only fire on main where the workflows are actively scanned.

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests — N/A (workflow YAML, no unit tests applicable)
- [x] Covered by integration tests — CI must pass to validate no workflow regressions
- [x] Documentation updated — N/A
- [x] CLA signed
- [ ] Backport label added if necessary — not needed
- [x] Confirm whether the `release-notes` label should be kept or removed — remove (internal CI change)