### PR TITLE
docs: Update redirect

### DIFF
--- a/docs/canonicalk8s/redirects.txt
+++ b/docs/canonicalk8s/redirects.txt
@@ -80,3 +80,7 @@
 # Combined charm upgrade pages in 1.36
 "charm/howto/upgrade-minor" "charm/howto/upgrade"
 "charm/howto/upgrade-patch" "charm/howto/upgrade"
+
+# Old files 
+"charm/howto/install-lxd" "charm/howto/install/install-lxd"
+"charm/howto/charm" "charm/howto/install/charm"

--- a/docs/canonicalk8s/redirects.txt
+++ b/docs/canonicalk8s/redirects.txt
@@ -81,6 +81,6 @@
 "charm/howto/upgrade-minor" "charm/howto/upgrade"
 "charm/howto/upgrade-patch" "charm/howto/upgrade"
 
-# Old files 
+# Old files
 "charm/howto/install-lxd" "charm/howto/install/install-lxd"
 "charm/howto/charm" "charm/howto/install/charm"

--- a/docs/canonicalk8s/snap/howto/install/multipass.md
+++ b/docs/canonicalk8s/snap/howto/install/multipass.md
@@ -115,6 +115,6 @@ multipass delete k8s-node --purge
 [Multipass-options]: https://documentation.ubuntu.com/multipass/latest/tutorial/#create-a-customised-instance
 [install instructions]: ./snap
 [Getting started]: ../../tutorial/getting-started
-[Multipass website]: https://multipass.run/docs
+[Multipass website]: https://documentation.ubuntu.com/multipass/stable/
 [latest Windows version]:https://canonical.com/multipass/download/windows
 [latest macOS version]:https://canonical.com/multipass/download/macos


### PR DESCRIPTION
## Description

After looking at the analytics for our k8s docs I can see someone must be linking to our docs as there are requests to these old charm pages. They were moved before GA but adding this redirect should reduce our 404 errors.

## Solution

Update redirects.txt file

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.