### PR TITLE
fix: x509 client certificates based authentication is not working with Canonical K8s snap

### DIFF
--- a/docs/canonicalk8s/snap/reference/certificates.md
+++ b/docs/canonicalk8s/snap/reference/certificates.md
@@ -15,6 +15,11 @@ and locations on the disk.
 | `kubernetes-front-proxy-ca` | CA for front-end proxy     | `/etc/kubernetes/pki/front-proxy-ca.crt` | Signing certificates for the front-proxy    |
 | `client-ca`                 | CA for client certificates | `/etc/kubernetes/pki/client-ca.crt`      | Signing certificates for the client         |
 
+The `client-ca` certificate is generated with the common name
+`kubernetes-ca-client`. CertificateSigningRequests approved through
+`kubectl certificate approve` are signed with this client CA, so the resulting
+client certificates are trusted by the API server's `client-ca.crt` bundle.
+
 ## Certificates
 
 This table provides an overview of the certificates currently in use,

--- a/k8s/wrappers/services/kube-controller-manager
+++ b/k8s/wrappers/services/kube-controller-manager
@@ -3,4 +3,20 @@
 . "$SNAP/k8s/lib.sh"
 
 k8s::util::wait_kube_apiserver
-k8s::common::execute kube-controller-manager
+
+declare -a cluster_signing_args=()
+args_file="${SNAP_COMMON}/args/kube-controller-manager"
+
+if [[ ! -f "${args_file}" ]] ||
+  ! grep -Eq '(^|[[:space:]"'\''])--cluster-signing-cert-file=' "${args_file}" ||
+  grep -Eq '(^|[[:space:]"'\''])--cluster-signing-cert-file=/etc/kubernetes/pki/ca\.crt([[:space:]"'\'']|$)' "${args_file}"; then
+  cluster_signing_args+=("--cluster-signing-cert-file=/etc/kubernetes/pki/client-ca.crt")
+fi
+
+if [[ ! -f "${args_file}" ]] ||
+  ! grep -Eq '(^|[[:space:]"'\''])--cluster-signing-key-file=' "${args_file}" ||
+  grep -Eq '(^|[[:space:]"'\''])--cluster-signing-key-file=/etc/kubernetes/pki/ca\.key([[:space:]"'\'']|$)' "${args_file}"; then
+  cluster_signing_args+=("--cluster-signing-key-file=/etc/kubernetes/pki/client-ca.key")
+fi
+
+k8s::common::execute kube-controller-manager "${cluster_signing_args[@]}"

--- a/tests/integration/tests/test_external_certificates.py
+++ b/tests/integration/tests/test_external_certificates.py
@@ -593,3 +593,138 @@ def test_partial_refresh(instances: List[harness.Instance]):
 
     # Deploy the Pod again to verify the cluster functionality.
     check_nginx_pod_runs(instance)
+
+
+@pytest.mark.node_count(1)
+@pytest.mark.tags(tags.NIGHTLY, tags.PROMOTE_STABLE)
+def test_csr_client_certificate_authentication(instances: List[harness.Instance]):
+    instance = instances[0]
+    csr_name = "test-client-csr"
+    kubeconfig = "/tmp/test-client.conf"
+
+    instance.exec(["k8s", "kubectl", "delete", "csr", csr_name, "--ignore-not-found"])
+    instance.exec(
+        [
+            "rm",
+            "-f",
+            "/tmp/test-client.key",
+            "/tmp/test-client.csr",
+            "/tmp/test-client.crt",
+            kubeconfig,
+        ]
+    )
+    instance.exec(["openssl", "genrsa", "-out", "/tmp/test-client.key", "2048"])
+    instance.exec(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            "/tmp/test-client.key",
+            "-out",
+            "/tmp/test-client.csr",
+            "-subj",
+            "/CN=test-client/O=system:masters",
+        ]
+    )
+
+    csr_b64 = (
+        instance.exec(["base64", "-w0", "/tmp/test-client.csr"], capture_output=True)
+        .stdout.decode()
+        .strip()
+    )
+    csr = {
+        "apiVersion": "certificates.k8s.io/v1",
+        "kind": "CertificateSigningRequest",
+        "metadata": {"name": csr_name},
+        "spec": {
+            "request": csr_b64,
+            "signerName": "kubernetes.io/kube-apiserver-client",
+            "expirationSeconds": 86400,
+            "usages": ["client auth"],
+        },
+    }
+    instance.exec(
+        ["k8s", "kubectl", "apply", "-f", "-"],
+        input=str.encode(yaml.dump(csr)),
+    )
+    instance.exec(["k8s", "kubectl", "certificate", "approve", csr_name])
+
+    cert_proc = (
+        util.stubbornly(retries=30, delay_s=2)
+        .on(instance)
+        .until(lambda p: p.stdout.strip())
+        .exec(
+            [
+                "k8s",
+                "kubectl",
+                "get",
+                "csr",
+                csr_name,
+                "-o",
+                "jsonpath={.status.certificate}",
+            ]
+        )
+    )
+    cert_b64 = cert_proc.stdout.decode().strip()
+    instance.exec(
+        ["bash", "-c", "base64 -d >/tmp/test-client.crt"],
+        input=cert_b64.encode(),
+    )
+
+    instance.exec(
+        [
+            "openssl",
+            "verify",
+            "-CAfile",
+            "/etc/kubernetes/pki/client-ca.crt",
+            "/tmp/test-client.crt",
+        ]
+    )
+    instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "config",
+            "set-cluster",
+            "k8s",
+            "--server=https://127.0.0.1:6443",
+            "--certificate-authority=/etc/kubernetes/pki/ca.crt",
+            f"--kubeconfig={kubeconfig}",
+        ]
+    )
+    instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "config",
+            "set-credentials",
+            "test-client",
+            "--client-certificate=/tmp/test-client.crt",
+            "--client-key=/tmp/test-client.key",
+            f"--kubeconfig={kubeconfig}",
+        ]
+    )
+    instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "config",
+            "set-context",
+            "test-client",
+            "--cluster=k8s",
+            "--user=test-client",
+            f"--kubeconfig={kubeconfig}",
+        ]
+    )
+    instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "config",
+            "use-context",
+            "test-client",
+            f"--kubeconfig={kubeconfig}",
+        ]
+    )
+    instance.exec(["k8s", "kubectl", "--kubeconfig", kubeconfig, "get", "nodes"])


### PR DESCRIPTION
## Description

Fixes x509 client-certificate authentication for certificates issued through the Kubernetes CSR flow in the Canonical K8s snap.

Previously, CSRs approved with kubectl certificate approve could be signed by the wrong CA for API server client authentication. The API server validates client certificates against /etc/kubernetes/pki/client-ca.crt, so CSR-issued client certificates must be signed by the corresponding client CA, not the general Kubernetes CA.

## Solution

1. Updated the kube-controller-manager service wrapper to pass the client CA as the default cluster signing CA:

- --cluster-signing-cert-file=/etc/kubernetes/pki/client-ca.crt
- --cluster-signing-key-file=/etc/kubernetes/pki/client-ca.key

2. Added guard logic so this override is only applied when:

- the controller-manager args file does not exist,
- the args file does not define cluster signing cert/key flags, or
- the args file still points cluster signing to the general Kubernetes CA:
    - /etc/kubernetes/pki/ca.crt
    - /etc/kubernetes/pki/ca.key

3. Preserved user/custom configuration by not overriding cluster signing flags when they are already explicitly configured to another value.

4. Added an integration regression test that:
- creates a private key and CSR for a test client,
- submits a Kubernetes CertificateSigningRequest using signer kubernetes.io/kube-apiserver-client,
- approves the CSR with kubectl certificate approve,
- waits for .status.certificate because CSR signing is asynchronous,
- decodes the issued certificate,
- verifies it chains to /etc/kubernetes/pki/client-ca.crt,
- builds a kubeconfig using the issued client certificate,
- confirms the issued certificate can authenticate to the API server.

5. Updated certificate documentation to clarify that:
- client-ca is the CA used for client certificates,
- its generated certificate common name is kubernetes-ca-client,
- approved Kubernetes CSRs are signed with this client CA so the resulting certificates are trusted by the API server’s client-ca.crt bundle.

Why this approach?
Instead of patching Kubernetes source defaults, this fixes the snap’s runtime configuration directly through the existing service wrapper mechanism. This avoids carrying fragile Kubernetes source patches and keeps the behavior aligned with the snap’s generated controller-manager args.

The wrapper also avoids overwriting explicit custom cluster-signing settings, so users can still configure a different signing CA if needed.

## Issue

Issue https://github.com/canonical/k8s-snap/issues/2448

## Backport

<!-- Should this PR be backported? If so, to which release? -->

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
- [ ] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

