### PR TITLE
PoC: integration test for CoreDNS ConfigMap override

### DIFF
--- a/build-scripts/components/k8sd/version
+++ b/build-scripts/components/k8sd/version
@@ -1,1 +1,1 @@
-main
+agents/poc-coredns-configmap-implementation

--- a/docs/canonicalk8s/snap/howto/helm-overrides.md
+++ b/docs/canonicalk8s/snap/howto/helm-overrides.md
@@ -1,0 +1,105 @@
+# How to override feature Helm values
+
+{{product}} manages built-in features (DNS, network, ingress, etc.) by
+deploying and reconciling Helm charts. You can pass extra Helm values to any
+feature by creating a ConfigMap in the `kube-system` namespace. The cluster
+controller picks up changes automatically — no restart is required.
+
+## Prerequisites
+
+- Root or sudo access to the machine.
+- A bootstrapped {{product}} cluster (see the [Getting Started][getting-started-guide] guide).
+
+## Naming convention
+
+Each feature has a dedicated ConfigMap name:
+
+| Feature | ConfigMap name |
+|---------|----------------|
+| DNS (CoreDNS) | `k8sd-coredns-values` |
+
+Additional features will be listed here as support is added.
+
+## ConfigMap format
+
+The ConfigMap must contain a single key `values` whose value is a YAML
+fragment. The values are deep-merged with the feature's defaults — only the
+keys you specify are overridden.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: <configmap-name>
+  namespace: kube-system
+data:
+  values: |
+    key:
+      nestedKey: value
+```
+
+## Example: scale CoreDNS replicas
+
+By default CoreDNS uses an HPA with `minReplicas: 2`. To raise the minimum to
+4 and cap the maximum at 20:
+
+```
+sudo k8s kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8sd-coredns-values
+  namespace: kube-system
+data:
+  values: |
+    hpa:
+      minReplicas: 4
+      maxReplicas: 20
+EOF
+```
+
+The controller reconciles within seconds. Verify the change:
+
+```
+sudo /snap/k8s/current/bin/helm get values ck-dns \
+  --namespace kube-system --output yaml
+```
+
+## Update an override
+
+Apply the same ConfigMap with updated values:
+
+```
+sudo k8s kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8sd-coredns-values
+  namespace: kube-system
+data:
+  values: |
+    hpa:
+      minReplicas: 6
+      maxReplicas: 30
+EOF
+```
+
+## Remove all overrides
+
+Delete the ConfigMap to revert to the feature's defaults:
+
+```
+sudo k8s kubectl delete configmap k8sd-coredns-values -n kube-system
+```
+
+## Notes
+
+- Overrides are merged on top of defaults. Keys you do not specify keep their
+  default values.
+- If the `values` key is missing from the ConfigMap, or if the YAML is
+  invalid, the feature falls back to defaults and surfaces a warning in
+  `sudo k8s status`.
+- Overrides survive feature disable/enable cycles and cluster restarts.
+
+<!-- LINKS -->
+[getting-started-guide]: /snap/tutorial/getting-started

--- a/docs/canonicalk8s/snap/howto/index.md
+++ b/docs/canonicalk8s/snap/howto/index.md
@@ -98,6 +98,13 @@ exposes technologies such as HugePages, CPU pinning, SR-IOV and more.
 Set up Enhanced Platform Awareness <epa>
 ```
 
+## Advanced configuration
+
+```{toctree}
+:titlesonly:
+Override feature Helm values <helm-overrides>
+```
+
 ## Contribute
 
 Contribute to the {{product}} project! 

--- a/docs/canonicalk8s/snap/howto/networking/default-dns.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-dns.md
@@ -73,6 +73,12 @@ sudo k8s set dns.service-ip=<new-cluster-ip>
 Replace `<new-ip>`, `<new-domain-name>`, and `<new-cluster-ip>` with the
 desired values for your DNS configuration.
 
+## Advanced: override Helm values
+
+For fine-grained tuning not exposed by `k8s set` (e.g. HPA replica counts,
+resource limits), you can pass Helm values directly to the CoreDNS chart via
+a ConfigMap. See [Override feature Helm values][helm-overrides] for details.
+
 ## Disable DNS
 
 {{product}} also allows you to disable the built-in DNS,
@@ -97,3 +103,4 @@ sudo k8s help disable
 
 [getting-started-guide]: /snap/tutorial/getting-started
 [networking explanation]: /snap/explanation/networking.md#dns
+[helm-overrides]: /snap/howto/helm-overrides

--- a/tests/integration/tests/test_coredns_configmap_override.py
+++ b/tests/integration/tests/test_coredns_configmap_override.py
@@ -1,0 +1,204 @@
+#
+# Copyright 2025 Canonical, Ltd.
+#
+"""Integration test for the CoreDNS ConfigMap override feature.
+
+This test verifies that the k8sd CoreDNSConfigMapController picks up changes
+to the `k8sd-coredns-values` ConfigMap in kube-system and applies them to
+the CoreDNS Helm release (ck-dns).
+
+Test flow:
+1. Bootstrap a cluster and wait for DNS to be ready.
+2. Apply the override ConfigMap with custom HPA replica counts.
+3. Poll Helm values until the override is reflected.
+4. Update the ConfigMap and verify the new values are applied.
+5. Delete the ConfigMap and verify Helm values revert to defaults.
+"""
+import logging
+from typing import List
+
+import pytest
+import yaml
+from test_util import config, harness, tags, util
+
+LOG = logging.getLogger(__name__)
+
+# The ConfigMap name and namespace that k8sd watches for CoreDNS Helm overrides.
+COREDNS_OVERRIDE_CM_NAME = "k8sd-coredns-values"
+COREDNS_OVERRIDE_CM_NAMESPACE = "kube-system"
+
+# The Helm release name for CoreDNS and the namespace it is deployed to.
+COREDNS_HELM_RELEASE = "ck-dns"
+COREDNS_HELM_NAMESPACE = "kube-system"
+
+
+def _apply_coredns_override_configmap(instance: harness.Instance, values_yaml: str):
+    """Create or replace the CoreDNS override ConfigMap with the given values YAML."""
+    manifest = (
+        f"apiVersion: v1\n"
+        f"kind: ConfigMap\n"
+        f"metadata:\n"
+        f"  name: {COREDNS_OVERRIDE_CM_NAME}\n"
+        f"  namespace: {COREDNS_OVERRIDE_CM_NAMESPACE}\n"
+        f"data:\n"
+        f"  values: |\n"
+    )
+    # Indent the values YAML as a block scalar under the `values` key.
+    for line in values_yaml.splitlines():
+        manifest += f"    {line}\n"
+
+    instance.exec(
+        ["k8s", "kubectl", "apply", "-f", "-"],
+        input=manifest.encode(),
+    )
+
+
+def _delete_coredns_override_configmap(instance: harness.Instance):
+    """Delete the CoreDNS override ConfigMap, ignoring not-found errors."""
+    instance.exec(
+        [
+            "k8s",
+            "kubectl",
+            "delete",
+            "configmap",
+            COREDNS_OVERRIDE_CM_NAME,
+            "-n",
+            COREDNS_OVERRIDE_CM_NAMESPACE,
+            "--ignore-not-found",
+        ],
+    )
+
+
+def _helm_values_cmd() -> List[str]:
+    return [
+        "/snap/k8s/current/bin/helm",
+        "get",
+        "values",
+        COREDNS_HELM_RELEASE,
+        "--namespace",
+        COREDNS_HELM_NAMESPACE,
+        "--output",
+        "yaml",
+    ]
+
+
+def _parse_helm_stdout(p) -> dict:
+    """Parse YAML from a CompletedProcess whose stdout is bytes or str."""
+    raw = p.stdout
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    return yaml.safe_load(raw) or {}
+
+
+def _wait_for_hpa_values(
+    instance: harness.Instance,
+    expected_min: int,
+    expected_max: int,
+    retries: int = 30,
+    delay_s: int = 5,
+):
+    """Poll Helm values until the HPA replica counts match the expected values."""
+
+    def _hpa_matches(p) -> bool:
+        values = _parse_helm_stdout(p)
+        hpa = values.get("hpa", {})
+        actual_min = hpa.get("minReplicas")
+        actual_max = hpa.get("maxReplicas")
+        LOG.info(
+            "Helm HPA values — minReplicas: %s (want %s), maxReplicas: %s (want %s)",
+            actual_min,
+            expected_min,
+            actual_max,
+            expected_max,
+        )
+        return actual_min == expected_min and actual_max == expected_max
+
+    util.stubbornly(retries=retries, delay_s=delay_s).on(instance).until(
+        _hpa_matches
+    ).exec(
+        _helm_values_cmd(),
+        env={"KUBECONFIG": "/etc/kubernetes/admin.conf"},
+    )
+
+
+def _wait_for_default_hpa_values(instance: harness.Instance):
+    """Poll until Helm values no longer contain user-supplied HPA overrides.
+
+    When the ConfigMap is deleted, the controller re-runs ApplyDNS with no
+    overrides, so the Helm release reverts to chart defaults.  The resulting
+    `helm get values` output will either be null/empty or will no longer
+    contain the HPA block we injected.
+    """
+
+    def _defaults_restored(p) -> bool:
+        values = _parse_helm_stdout(p)
+        hpa = values.get("hpa", {})
+        if not hpa:
+            LOG.info("HPA overrides removed from Helm values — defaults restored")
+            return True
+        LOG.info("HPA still in Helm values: %s", hpa)
+        return False
+
+    util.stubbornly(retries=30, delay_s=5).on(instance).until(
+        _defaults_restored
+    ).exec(
+        _helm_values_cmd(),
+        env={"KUBECONFIG": "/etc/kubernetes/admin.conf"},
+    )
+
+
+@pytest.mark.bootstrap_config((config.MANIFESTS_DIR / "bootstrap-all.yaml").read_text())
+@pytest.mark.tags(tags.PULL_REQUEST)
+def test_coredns_configmap_override(instances: List[harness.Instance]):
+    """Verify that the CoreDNSConfigMapController applies and reverts Helm overrides.
+
+    Steps:
+    1. Wait for the cluster and DNS to be ready.
+    2. Apply a ConfigMap with HPA overrides (minReplicas=4, maxReplicas=60).
+    3. Confirm the Helm release reflects the new values.
+    4. Update the ConfigMap (minReplicas=6, maxReplicas=30).
+    5. Confirm the Helm release reflects the updated values.
+    6. Delete the ConfigMap.
+    7. Confirm the HPA overrides are gone from the Helm release.
+    """
+    instance = instances[0]
+
+    # Ensure cleanup even on test failure.
+    try:
+        util.wait_until_k8s_ready(instance, [instance])
+        util.wait_for_dns(instance)
+
+        # --- Step 1: Apply initial ConfigMap override ---
+        LOG.info(
+            "Applying CoreDNS override ConfigMap with minReplicas=4, maxReplicas=60"
+        )
+        _apply_coredns_override_configmap(
+            instance,
+            "hpa:\n  minReplicas: 4\n  maxReplicas: 60\n",
+        )
+
+        LOG.info("Waiting for Helm to reflect minReplicas=4, maxReplicas=60")
+        _wait_for_hpa_values(instance, expected_min=4, expected_max=60)
+
+        # --- Step 2: Update the ConfigMap override ---
+        LOG.info(
+            "Updating CoreDNS override ConfigMap to minReplicas=6, maxReplicas=30"
+        )
+        _apply_coredns_override_configmap(
+            instance,
+            "hpa:\n  minReplicas: 6\n  maxReplicas: 30\n",
+        )
+
+        LOG.info("Waiting for Helm to reflect minReplicas=6, maxReplicas=30")
+        _wait_for_hpa_values(instance, expected_min=6, expected_max=30)
+
+        # --- Step 3: Delete the ConfigMap and verify revert to defaults ---
+        LOG.info("Deleting CoreDNS override ConfigMap")
+        _delete_coredns_override_configmap(instance)
+
+        LOG.info("Waiting for HPA overrides to be removed from Helm values")
+        _wait_for_default_hpa_values(instance)
+
+    finally:
+        # Best-effort cleanup so the override doesn't affect subsequent tests.
+        _delete_coredns_override_configmap(instance)

--- a/tests/integration/tests/test_coredns_configmap_override.py
+++ b/tests/integration/tests/test_coredns_configmap_override.py
@@ -9,10 +9,14 @@ the CoreDNS Helm release (ck-dns).
 
 Test flow:
 1. Bootstrap a cluster and wait for DNS to be ready.
-2. Apply the override ConfigMap with custom HPA replica counts.
-3. Poll Helm values until the override is reflected.
-4. Update the ConfigMap and verify the new values are applied.
-5. Delete the ConfigMap and verify Helm values revert to defaults.
+2. Apply an override ConfigMap with custom HPA replica counts.
+3. Poll Helm values until the HPA override is reflected.
+4. Update the ConfigMap (new HPA counts) and verify the new values are applied.
+5. Update the ConfigMap with resource limits (a value k8sd does not set itself)
+   and verify the limits appear in the Helm release values.
+6. Delete the ConfigMap and verify:
+   a. HPA values revert to the k8sd defaults (minReplicas=2, maxReplicas=100).
+   b. The resource limits are absent from the Helm release values (never set by k8sd).
 """
 
 import logging
@@ -122,23 +126,65 @@ def _wait_for_hpa_values(
     )
 
 
-def _wait_for_default_hpa_values(instance: harness.Instance):
-    """Poll until Helm values no longer contain user-supplied HPA overrides.
+def _wait_for_resource_limits(
+    instance: harness.Instance,
+    expected_cpu: str,
+    expected_memory: str,
+    retries: int = 30,
+    delay_s: int = 5,
+):
+    """Poll Helm values until resource limits match the expected values.
 
-    When the ConfigMap is deleted, the controller re-runs ApplyDNS with no
-    overrides, so the Helm release reverts to chart defaults.  The resulting
-    `helm get values` output will either be null/empty or will no longer
-    contain the HPA block we injected.
+    This exercises an override for a value that k8sd does NOT set itself,
+    ensuring the ConfigMap override can inject arbitrary chart values.
+    """
+
+    def _resources_match(p) -> bool:
+        values = _parse_helm_stdout(p)
+        limits = values.get("resources", {}).get("limits", {})
+        actual_cpu = limits.get("cpu")
+        actual_memory = limits.get("memory")
+        LOG.info(
+            "Helm resource limits — cpu: %s (want %s), memory: %s (want %s)",
+            actual_cpu,
+            expected_cpu,
+            actual_memory,
+            expected_memory,
+        )
+        return actual_cpu == expected_cpu and actual_memory == expected_memory
+
+    util.stubbornly(retries=retries, delay_s=delay_s).on(instance).until(
+        _resources_match
+    ).exec(
+        _helm_values_cmd(),
+        env={"KUBECONFIG": "/etc/kubernetes/admin.conf"},
+    )
+
+
+def _wait_for_defaults_restored(instance: harness.Instance):
+    """Poll until Helm values reflect k8sd defaults after ConfigMap deletion.
+
+    After the ConfigMap is deleted the controller re-runs ApplyDNS with no
+    overrides.  k8sd always passes an explicit `hpa` block so it will revert
+    to the k8sd-defined defaults (minReplicas=2, maxReplicas=100).  The
+    `resources` block was never set by k8sd, so it should be absent entirely.
     """
 
     def _defaults_restored(p) -> bool:
         values = _parse_helm_stdout(p)
         hpa = values.get("hpa", {})
-        if not hpa:
-            LOG.info("HPA overrides removed from Helm values — defaults restored")
-            return True
-        LOG.info("HPA still in Helm values: %s", hpa)
-        return False
+        actual_min = hpa.get("minReplicas")
+        actual_max = hpa.get("maxReplicas")
+        resources_absent = "resources" not in values
+
+        LOG.info(
+            "Checking defaults — hpa.minReplicas: %s (want 2), "
+            "hpa.maxReplicas: %s (want 100), resources absent: %s (want True)",
+            actual_min,
+            actual_max,
+            resources_absent,
+        )
+        return actual_min == 2 and actual_max == 100 and resources_absent
 
     util.stubbornly(retries=30, delay_s=5).on(instance).until(_defaults_restored).exec(
         _helm_values_cmd(),
@@ -157,8 +203,12 @@ def test_coredns_configmap_override(instances: List[harness.Instance]):
     3. Confirm the Helm release reflects the new values.
     4. Update the ConfigMap (minReplicas=6, maxReplicas=30).
     5. Confirm the Helm release reflects the updated values.
-    6. Delete the ConfigMap.
-    7. Confirm the HPA overrides are gone from the Helm release.
+    6. Update the ConfigMap to also set resource limits — a value k8sd never
+       passes itself — to verify arbitrary chart values can be injected.
+    7. Confirm the resource limits appear in the Helm release values.
+    8. Delete the ConfigMap.
+    9. Confirm HPA reverts to k8sd defaults (minReplicas=2, maxReplicas=100)
+       and the resource limits are absent from the Helm release values.
     """
     instance = instances[0]
 
@@ -189,12 +239,33 @@ def test_coredns_configmap_override(instances: List[harness.Instance]):
         LOG.info("Waiting for Helm to reflect minReplicas=6, maxReplicas=30")
         _wait_for_hpa_values(instance, expected_min=6, expected_max=30)
 
-        # --- Step 3: Delete the ConfigMap and verify revert to defaults ---
+        # --- Step 3: Override a value k8sd does not set (resource limits) ---
+        # k8sd never passes `resources` to the CoreDNS chart, so this tests
+        # that the ConfigMap can inject completely new chart values.
+        LOG.info(
+            "Updating ConfigMap to also set resource limits "
+            "(cpu=200m, memory=170Mi) — a value k8sd does not pass itself"
+        )
+        _apply_coredns_override_configmap(
+            instance,
+            "hpa:\n  minReplicas: 6\n  maxReplicas: 30\n"
+            "resources:\n  limits:\n    cpu: 200m\n    memory: 170Mi\n",
+        )
+
+        LOG.info("Waiting for Helm to reflect resource limits cpu=200m, memory=170Mi")
+        _wait_for_resource_limits(
+            instance, expected_cpu="200m", expected_memory="170Mi"
+        )
+
+        # --- Step 4: Delete the ConfigMap and verify revert to defaults ---
         LOG.info("Deleting CoreDNS override ConfigMap")
         _delete_coredns_override_configmap(instance)
 
-        LOG.info("Waiting for HPA overrides to be removed from Helm values")
-        _wait_for_default_hpa_values(instance)
+        LOG.info(
+            "Waiting for HPA to revert to k8sd defaults (min=2, max=100) "
+            "and resource limits to be absent from Helm values"
+        )
+        _wait_for_defaults_restored(instance)
 
     finally:
         # Best-effort cleanup so the override doesn't affect subsequent tests.

--- a/tests/integration/tests/test_coredns_configmap_override.py
+++ b/tests/integration/tests/test_coredns_configmap_override.py
@@ -14,6 +14,7 @@ Test flow:
 4. Update the ConfigMap and verify the new values are applied.
 5. Delete the ConfigMap and verify Helm values revert to defaults.
 """
+
 import logging
 from typing import List
 
@@ -139,9 +140,7 @@ def _wait_for_default_hpa_values(instance: harness.Instance):
         LOG.info("HPA still in Helm values: %s", hpa)
         return False
 
-    util.stubbornly(retries=30, delay_s=5).on(instance).until(
-        _defaults_restored
-    ).exec(
+    util.stubbornly(retries=30, delay_s=5).on(instance).until(_defaults_restored).exec(
         _helm_values_cmd(),
         env={"KUBECONFIG": "/etc/kubernetes/admin.conf"},
     )
@@ -181,9 +180,7 @@ def test_coredns_configmap_override(instances: List[harness.Instance]):
         _wait_for_hpa_values(instance, expected_min=4, expected_max=60)
 
         # --- Step 2: Update the ConfigMap override ---
-        LOG.info(
-            "Updating CoreDNS override ConfigMap to minReplicas=6, maxReplicas=30"
-        )
+        LOG.info("Updating CoreDNS override ConfigMap to minReplicas=6, maxReplicas=30")
         _apply_coredns_override_configmap(
             instance,
             "hpa:\n  minReplicas: 6\n  maxReplicas: 30\n",


### PR DESCRIPTION
## PoC: CoreDNS ConfigMap override — integration test

This PR adds the k8s-snap integration test for the CoreDNS ConfigMap override feature.

The implementation lives in **[canonical/k8sd](https://github.com/canonical/k8sd) branch `agents/poc-coredns-configmap-implementation`** (k8sd was moved out of this repo in #2296). This PR only adds the end-to-end test.

### ConfigMap format

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: k8sd-coredns-values
  namespace: kube-system
data:
  values: |
    hpa:
      minReplicas: 4
      maxReplicas: 60
```

### Test flow (`test_coredns_configmap_override.py`)

1. Bootstrap cluster, wait for DNS ready
2. Apply ConfigMap with `hpa.minReplicas=4, maxReplicas=60` → poll `helm get values ck-dns` until reflected
3. Update ConfigMap to `minReplicas=6, maxReplicas=30` → poll until reflected
4. Delete ConfigMap → poll until HPA block is removed (reverts to chart defaults)
5. Cleanup in `finally` block to avoid side effects

### Live test results (k8s v1.35.0, LXD VM)

| Event | Expected | Result |
|-------|----------|--------|
| ConfigMap CREATE | Helm HPA updated | ✅ `min:4, max:60` |
| ConfigMap UPDATE | Helm HPA updated | ✅ `min:6, max:30` |
| ConfigMap DELETE | Helm reverts to defaults | ✅ `min:2, max:100` |