### PR TITLE
fix: improve etcd node removal handling

### DIFF
--- a/src/k8s/pkg/client/etcd/client.go
+++ b/src/k8s/pkg/client/etcd/client.go
@@ -2,11 +2,15 @@ package etcd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	pkiutil "github.com/canonical/k8s/pkg/utils/pki"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
+
+// ErrNotFound is returned when an etcd member is not found.
+var ErrNotFound = errors.New("etcd member not found")
 
 type Client struct {
 	*clientv3.Client
@@ -51,7 +55,8 @@ func (c *Client) RemoveNodeByName(ctx context.Context, name string) error {
 	}
 
 	if memberID == 0 {
-		return fmt.Errorf("no etcd member found with name: %s", name)
+		// Member not found.
+		return fmt.Errorf("%w: %s", ErrNotFound, name)
 	}
 
 	if _, err = c.MemberRemove(ctx, memberID); err != nil {

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
 	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
+	etcdclient "github.com/canonical/k8s/pkg/client/etcd"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
@@ -240,7 +242,11 @@ func removeNodeFromEtcd(ctx context.Context, snap snap.Snap, s state.State, cfg 
 	log := log.FromContext(ctx).WithValues("remove", "etcd", "name", nodeName, "clientURLs", clientURLs)
 	log.Info("Deleting node from etcd cluster")
 	if err := client.RemoveNodeByName(ctx, nodeName); err != nil {
-		return fmt.Errorf("failed to remove node %s from etcd cluster: %w", nodeName, err)
+		if errors.Is(err, etcdclient.ErrNotFound) {
+			log.Info("Node not found in the etcd cluster, nothing to remove", "node", nodeName)
+		} else {
+			return fmt.Errorf("failed to remove node %s from etcd cluster: %w", nodeName, err)
+		}
 	}
 
 	return nil

--- a/src/k8s/pkg/k8sd/app/hooks_join.go
+++ b/src/k8s/pkg/k8sd/app/hooks_join.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	upgradesv1alpha "github.com/canonical/k8s-snap-api/api/v1alpha"
+	etcdclient "github.com/canonical/k8s/pkg/client/etcd"
 	"github.com/canonical/k8s/pkg/client/kubernetes"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/pki"
@@ -486,7 +487,8 @@ func registerEtcdMemberReverter(snap snap.Snap, nodeName string, endpoints []str
 				log.Error(err, "failed to create etcd client for member removal using peer endpoints")
 			} else {
 				defer etcdClient.Close()
-				if err := etcdClient.RemoveNodeByName(rmCtx, nodeName); err != nil {
+				err := etcdClient.RemoveNodeByName(rmCtx, nodeName)
+				if err != nil && !errors.Is(err, etcdclient.ErrNotFound) {
 					log.Error(err, "failed to remove node from etcd cluster using peer endpoints")
 				} else {
 					if err := os.RemoveAll(snap.EtcdDir()); err != nil {


### PR DESCRIPTION
## Description

When removing a Kubernetes cluster node, if the node is no longer present in the etcd cluster, we can consider that a success, since that's the desired outcome.

## Solution

`etcd.Client.RemoveNodeByName` now returns `ErrNotFound` error if the member is not found (`memberID == 0`). This error is now being handled properly in `removeNodeFromEtcd` (`cluster_remove.go`), and `registerEtcdMemberReverter`, which is called during cleanup on join failure.

By doing so, we're making the etcd node removal operation idempotent on subsequent calls.

## Issue

Partially-Fixes: https://github.com/canonical/k8s-snap/issues/2605

## Backport

Backported from: https://github.com/canonical/k8sd/pull/48

Can be backported to release-1.34.

<!-- Should this PR be backported? If so, to which release? -->

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - Cannot add label
- [x] Confirm whether the `release-notes` label should be kept or removed - N/A

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

