### PR TITLE
fix: improve k8s-dqlite node removal handling

### DIFF
--- a/src/k8s/pkg/client/dqlite/client.go
+++ b/src/k8s/pkg/client/dqlite/client.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/canonical/go-dqlite/v2/app"
 	"github.com/canonical/go-dqlite/v2/client"
 )
+
+// ErrNotFound is returned when a dqlite member is not found.
+var ErrNotFound = errors.New("dqlite member not found")
 
 type ClientOpts struct {
 	// ClusterYAML is the path cluster.yaml, containing the list of known dqlite nodes.

--- a/src/k8s/pkg/client/dqlite/remove.go
+++ b/src/k8s/pkg/client/dqlite/remove.go
@@ -46,7 +46,7 @@ func (c *Client) RemoveNodeByAddress(ctx context.Context, address string) error 
 	}
 
 	if !memberExists {
-		return fmt.Errorf("cluster does not have a node with address %v", address)
+		return fmt.Errorf("%w: %s", ErrNotFound, address)
 	}
 
 	if !clusterHasOtherVoters {

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
 	apiv1_annotations "github.com/canonical/k8s-snap-api/api/v1/annotations"
+	dqliteclient "github.com/canonical/k8s/pkg/client/dqlite"
 	databaseutil "github.com/canonical/k8s/pkg/k8sd/database/util"
 	"github.com/canonical/k8s/pkg/k8sd/types"
 	"github.com/canonical/k8s/pkg/log"
@@ -207,6 +209,10 @@ func removeNodeFromK8sDqlite(ctx context.Context, s state.State, snap snap.Snap,
 
 	log.Info("Removing node from k8s-dqlite using address", "address", nodeAddress)
 	if err := client.RemoveNodeByAddress(ctx, nodeAddress); err != nil {
+		if errors.Is(err, dqliteclient.ErrNotFound) {
+			log.Info("Node not found in k8s-dqlite cluster, nothing to remove", "address", nodeAddress)
+			return nil
+		}
 		return fmt.Errorf("failed to remove node from k8s-dqlite cluster: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Description

When removing a Kubernetes cluster node, if the node is no longer present in the k8s-dqlite cluster, we can consider that a success, since that's the desired outcome.

## Solution

`dqlite.Client.RemoveNodeByAddress` now returns `ErrNotFound` error if the member is not found. This error is now being handled properly in `removeNodeFromK8sDqlite` (`cluster_remove.go`).

By doing so, we're making the k8s-dqlite node removal operation idempotent on subsequent calls.

## Issue

Partially-Fixes: https://github.com/canonical/k8s-snap/issues/2605

## Backport

Not applicable to main / [k8sd](https://github.com/canonical/k8sd), `removeNodeFromDatastore` only handles `etcd` and `external`.

Can be backported to release-1.34.

<!-- Should this PR be backported? If so, to which release? -->

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - Cannot add label
- [x] Confirm whether the `release-notes` label should be kept or removed - N/A

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

