### PR TITLE
fix: Use local microcluster client for node removal

### DIFF
--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -20,6 +20,7 @@ import (
 	"github.com/canonical/k8s/pkg/utils/node"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/microcluster/v2/cluster"
+	"github.com/canonical/microcluster/v2/microcluster"
 	"github.com/canonical/microcluster/v2/state"
 )
 
@@ -89,7 +90,7 @@ func (e *Endpoints) postClusterRemove(s state.State, r *http.Request) response.R
 		}
 
 		log.Info("Remove node from microcluster")
-		if err := removeNodeFromMicrocluster(ctx, s, req.Name, req.Force); err != nil {
+		if err := removeNodeFromMicrocluster(ctx, s, req.Name, req.Force, e.provider.MicroCluster()); err != nil {
 			if req.Force {
 				log.Error(err, "Failed to remove node from microcluster, but continuing due to force=true; ignore error for workers")
 			} else {
@@ -246,7 +247,7 @@ func removeNodeFromEtcd(ctx context.Context, snap snap.Snap, s state.State, cfg 
 	return nil
 }
 
-func removeNodeFromMicrocluster(ctx context.Context, s state.State, nodeName string, force bool) error {
+func removeNodeFromMicrocluster(ctx context.Context, s state.State, nodeName string, force bool, m *microcluster.MicroCluster) error {
 	log := log.FromContext(ctx).WithValues("name", nodeName)
 
 	maxRetries := 10
@@ -278,9 +279,9 @@ func removeNodeFromMicrocluster(ctx context.Context, s state.State, nodeName str
 	}
 
 	// Remove control plane via microcluster API.
-	c, err := s.Leader()
+	c, err := m.LocalClient()
 	if err != nil {
-		return fmt.Errorf("failed to create client to cluster leader: %w", err)
+		return fmt.Errorf("failed to create local microcluster client: %w", err)
 	}
 
 	// NOTE(hue): node removal process in CAPI might fail, we figured that the context passed to


### PR DESCRIPTION
## Description

In microcluster's `clusterMemberDelete`[1], when a non-leader receives a request to remove itself, it locks `clusterDisableMu` before forwarding the request to the leader [2]. That lock is only released after the forwarded request returns and the response has been flushed back to the caller. The lock prevents the node from re-execing its daemon (via `unix.Exec` in `resetClusterMember`) until the caller has received a response.

At the moment, `removeNodeFromMicrocluster` is calling `s.Leader()` to obtain a client, which connects directly to the dqlite leader's network endpoint. By going directly to the leader, k8sd bypasses the local microcluster handler mentioned above entirely. Because of this, `clusterDisableMu` is never locked.

When the leader subsequently calls `ResetClusterMember` on the node being removed, the re-exec fires as soon as the leader's PUT request is done, before the leader's DELETE response has been returned to k8sd. The entire k8sd process is replaced by `unix.Exec` while the outbound HTTP connection to the leader is still open, so `k8sd` never receives the response. The original caller (e.g.: CAPI) gets a connection reset instead of a success response.

[1] https://github.com/canonical/microcluster/blob/936197c307c8ebbc82f151f33bd0e1e883abe9be/internal/rest/resources/cluster.go#L414
[2] https://github.com/canonical/microcluster/blob/936197c307c8ebbc82f151f33bd0e1e883abe9be/internal/rest/resources/cluster.go#L454-L462
[3] https://github.com/canonical/k8sd/pull/9

## Solution

By using the local client to connect to microcluster, the issue is resolved.

This issue has been incidentally resolved in k8sd [3], which is why this commit is not a backport.

## Issue

Fixes: https://github.com/canonical/k8s-snap/pull/2591

## Backport

This issue can be seen in release-1.35, release-1.34, release-1.33, release-1.32. It can be backported to all of them.

<!-- Should this PR be backported? If so, to which release? -->

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests - existing integration tests should cover this
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - Cannot add labels.
- [ ] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

