### PR TITLE
ci: add nightly Go candidate smoke test

### DIFF
--- a/.github/workflows/build-snap.yaml
+++ b/.github/workflows/build-snap.yaml
@@ -13,6 +13,14 @@ on:
       flavor:
         description: k8s-snap flavor (e.g. strict)
         type: string
+      go-snap-risk:
+        description: |
+          Optional Go snap risk level (e.g. candidate) to build with. When set,
+          overrides the risk of the go/<track>/<risk> build-snap in
+          snap/snapcraft.yaml. Leave empty to use the channel pinned in
+          snap/snapcraft.yaml.
+        type: string
+        default: ""
     outputs:
       snap-artifact:
         description: Name of the uploaded snap artifact
@@ -33,6 +41,14 @@ jobs:
           INPUT_FLAVOR: ${{ inputs.flavor }}
         run: |
           ./build-scripts/patches/"$INPUT_FLAVOR"/apply
+      - name: Override Go snap risk
+        if: inputs.go-snap-risk != ''
+        env:
+          GO_SNAP_RISK: ${{ inputs.go-snap-risk }}
+        run: |
+          # Swap only the risk so the Go track stays intact across bumps.
+          sed -i -E "s|(- go/[^/[:space:]]+/)[^[:space:]]+|\1${GO_SNAP_RISK}|" snap/snapcraft.yaml
+          grep -nE '^\s*- go/' snap/snapcraft.yaml
       - name: Setup LXD
         uses: canonical/setup-lxd@a3c85fc6fb7fff43fcfeae87659e41a8f635b7dd # v0.1.3
       - name: Install snapcraft

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -42,6 +42,26 @@ jobs:
       max-parallel: 10
       upload-results: true
 
+  build-snap-go-candidate:
+    name: Build snap (Go candidate)
+    uses: ./.github/workflows/build-snap.yaml
+    with:
+      arch: amd64
+      go-snap-risk: candidate
+
+  test-go-candidate-smoke:
+    name: Go candidate smoke test
+    needs: build-snap-go-candidate
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      arch: amd64
+      os: ubuntu:24.04
+      # Smallest tag set, used as a lightweight smoke test.
+      test-tags: "pull_request"
+      artifact: ${{ needs.build-snap-go-candidate.outputs.snap-artifact }}
+      parallel: true
+      # upload-results stays false so these don't enter the aggregated report.
+
   test-performance:
     name: Run performance tests for ${{ matrix.os }}-${{ matrix.arch }}
     strategy:


### PR DESCRIPTION
## What

Extends the nightly CI to build the k8s-snap against the **candidate** risk of the Go (FIPS) snap and run a lightweight smoke test against the freshly built snap.

## Why

The Go/Go-FIPS snap team is introducing a flow where each Go release first lands in the `candidate` channel and is only promoted to `stable` once consuming projects have re-built and tested against it. This lets a bad Go candidate be caught before it reaches stable.
