### PR TITLE
ci: pin snapcraft to 8.x for core20 build

### DIFF
--- a/.github/workflows/build-snap.yaml
+++ b/.github/workflows/build-snap.yaml
@@ -33,7 +33,8 @@ jobs:
           channel: '5.21/stable'
       - name: Install snapcraft
         run: |
-          sudo snap install snapcraft --classic
+          # Pin to 8.x: snapcraft 9 dropped core20 support, which this snap uses.
+          sudo snap install snapcraft --classic --channel=8.x
       - name: Build k8s snap
         id: build
         env:


### PR DESCRIPTION
## Problem

The snap build on `release-1.33` fails because the workflow installs `snapcraft --classic` (now **9.0.0**), and snapcraft 9 dropped support for the `core20` base this branch uses:

```
Recommended resolution: Use Snapcraft 8 from the '8.x' channel of snapcraft where 'core20' was last supported.
```

This blocks CI on every PR targeting `release-1.33` (e.g. backport #2594).

## Fix

Pin the snapcraft install to the `8.x` channel, the last series supporting `core20`.

Only `release-1.33` is affected — `release-1.34`/`1.35`/`main` use `core22`, which snapcraft 9 still supports.