### PR TITLE
docs: Update release notes patch notices

### DIFF
--- a/docs/canonicalk8s/.custom_wordlist.txt
+++ b/docs/canonicalk8s/.custom_wordlist.txt
@@ -214,6 +214,7 @@ gpu
 Graber
 Graber's
 grafana
+gRPC
 haircommander
 Harbor
 hasdoc
@@ -459,6 +460,7 @@ _Read
 README
 readOnlyPort
 ReadtheDocs
+rebalancing
 regctl
 regsync
 remediations
@@ -500,6 +502,7 @@ SecurityContext
 SecurityContexts
 SELinux
 ServiceAccount
+ServiceArgsController
 sha
 sideloading
 Snapcraft
@@ -617,6 +620,7 @@ wordlist
 www
 xdelta
 xfs
+xz
 XXXX
 yaml
 YAMLs

--- a/docs/canonicalk8s/releases/charm/1.33.md
+++ b/docs/canonicalk8s/releases/charm/1.33.md
@@ -33,6 +33,10 @@ relevant sections of the [upstream release notes][upstream-changelog-1.33].
 
 ## Patch notices
 
+Jun 15, 2026
+
+- Tightens the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
+
 Apr 29, 2026
 
 - Update docs with opentelemetry-collector charm as a replacement for 

--- a/docs/canonicalk8s/releases/charm/1.33.md
+++ b/docs/canonicalk8s/releases/charm/1.33.md
@@ -35,7 +35,7 @@ relevant sections of the [upstream release notes][upstream-changelog-1.33].
 
 Jun 15, 2026
 
-- Tightens the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
+- Tighten the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
 
 Apr 29, 2026
 

--- a/docs/canonicalk8s/releases/charm/1.34.md
+++ b/docs/canonicalk8s/releases/charm/1.34.md
@@ -55,6 +55,10 @@ create a cos_substrate [#776]
 
 ## Patch notices
 
+Jun 15, 2026
+
+- Tightens the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
+
 Apr 29, 2026
 
 - Update docs with opentelemetry-collector charm as a replacement for 

--- a/docs/canonicalk8s/releases/charm/1.34.md
+++ b/docs/canonicalk8s/releases/charm/1.34.md
@@ -57,7 +57,7 @@ create a cos_substrate [#776]
 
 Jun 15, 2026
 
-- Tightens the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
+- Tighten the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
 
 Apr 29, 2026
 

--- a/docs/canonicalk8s/releases/charm/1.35.md
+++ b/docs/canonicalk8s/releases/charm/1.35.md
@@ -29,6 +29,10 @@ relevant sections of the [upstream release notes][upstream-changelog-1.35].
 
 ## Patch notices
 
+Jun 15, 2026
+
+- Tightens the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
+
 Apr 29, 2026
 
 - Update docs with opentelemetry-collector charm as a replacement for 

--- a/docs/canonicalk8s/releases/charm/1.35.md
+++ b/docs/canonicalk8s/releases/charm/1.35.md
@@ -31,7 +31,7 @@ relevant sections of the [upstream release notes][upstream-changelog-1.35].
 
 Jun 15, 2026
 
-- Tightens the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
+- Tighten the system:cos ClusterRole to minimal get-only permissions, reducing COS integration RBAC exposure.
 
 Apr 29, 2026
 

--- a/docs/canonicalk8s/releases/snap/1.32.md
+++ b/docs/canonicalk8s/releases/snap/1.32.md
@@ -65,12 +65,12 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
-Jun 15, 2026 
+Jun 15, 2026
 
 - Version bumps
-  - containerd v1.7.31
-  - runc v1.3.5
-  - MetalLB v0.14.9-ck8
+    - containerd v1.7.31
+    - runc v1.3.5
+    - MetalLB v0.14.9-ck8
 - Improve DNS availability by introducing a CoreDNS rebalancing controller and applying best practices to scaling policies, pod distribution rules, and scheduling priorities
 - Verify CoreDNS has a cluster IP assigned before reporting the cluster as ready to improve cluster readiness detection
 - Add ServiceArgsController to detect and remediate service argument drift, automatically restarting affected services.

--- a/docs/canonicalk8s/releases/snap/1.32.md
+++ b/docs/canonicalk8s/releases/snap/1.32.md
@@ -65,6 +65,17 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Jun 15, 2026 
+
+- Version bumps
+  - containerd v1.7.31
+  - runc v1.3.5
+  - MetalLB v0.14.9-ck8
+- Improve DNS availability by introducing a CoreDNS rebalancing controller and applying best practices to scaling policies, pod distribution rules, and scheduling priorities
+- Verify CoreDNS has a cluster IP assigned before reporting the cluster as ready to improve cluster readiness detection
+- Add ServiceArgsController to detect and remediate service argument drift, automatically restarting affected services.
+- Fix k8s-config watch resumption after etcd compaction, preventing missed configuration updates on long-running clusters.
+
 Apr 23, 2026
 
 - Version bumps

--- a/docs/canonicalk8s/releases/snap/1.33.md
+++ b/docs/canonicalk8s/releases/snap/1.33.md
@@ -90,7 +90,7 @@ Jun 15, 2026
   - MetalLB v0.14.9-ck8
 - Improve DNS availability by introducing a CoreDNS rebalancing controller and applying best practices to scaling policies, pod distribution rules, and scheduling priorities
 - Verify CoreDNS has a cluster IP assigned before reporting the cluster as ready to improve cluster readiness detection
-- Adds ServiceArgsController to detect and remediate service argument drift, automatically restarting affected services.
+- Add ServiceArgsController to detect and remediate service argument drift, automatically restarting affected services.
 - Fix k8s-config watch resumption after etcd compaction, preventing missed configuration updates on long-running clusters.
                    
 

--- a/docs/canonicalk8s/releases/snap/1.33.md
+++ b/docs/canonicalk8s/releases/snap/1.33.md
@@ -81,6 +81,19 @@ may need to implement for a successful upgrade.
 
 ## Patch notices
 
+Jun 15, 2026
+
+- Version bumps
+  - Kubernetes v1.33.11
+  - containerd v1.7.31
+  - runc v1.3.5
+  - MetalLB v0.14.9-ck8
+- Improve DNS availability by introducing a CoreDNS rebalancing controller and applying best practices to scaling policies, pod distribution rules, and scheduling priorities
+- Verify CoreDNS has a cluster IP assigned before reporting the cluster as ready to improve cluster readiness detection
+- Adds ServiceArgsController to detect and remediate service argument drift, automatically restarting affected services.
+- Fix k8s-config watch resumption after etcd compaction, preventing missed configuration updates on long-running clusters.
+                   
+
 Apr 23, 2026
 
 - Version bumps

--- a/docs/canonicalk8s/releases/snap/1.33.md
+++ b/docs/canonicalk8s/releases/snap/1.33.md
@@ -84,15 +84,14 @@ may need to implement for a successful upgrade.
 Jun 15, 2026
 
 - Version bumps
-  - Kubernetes v1.33.11
-  - containerd v1.7.31
-  - runc v1.3.5
-  - MetalLB v0.14.9-ck8
+    - Kubernetes v1.33.11
+    - containerd v1.7.31
+    - runc v1.3.5
+    - MetalLB v0.14.9-ck8
 - Improve DNS availability by introducing a CoreDNS rebalancing controller and applying best practices to scaling policies, pod distribution rules, and scheduling priorities
 - Verify CoreDNS has a cluster IP assigned before reporting the cluster as ready to improve cluster readiness detection
 - Add ServiceArgsController to detect and remediate service argument drift, automatically restarting affected services.
-- Fix k8s-config watch resumption after etcd compaction, preventing missed configuration updates on long-running clusters.
-                   
+- Fix k8s-config watch resumption after etcd compaction, preventing missed configuration updates on long-running clusters.               
 
 Apr 23, 2026
 

--- a/docs/canonicalk8s/releases/snap/1.34.md
+++ b/docs/canonicalk8s/releases/snap/1.34.md
@@ -62,7 +62,7 @@ upgrade and will continue to use k8s-dqlite.
 Jun 15, 2026
 
 - Version bump
-    - MetalLB to v0.14.9-ck8
+    - MetalLB v0.14.9-ck8
 - Improve DNS availability by introducing a CoreDNS rebalancing controller and applying best practices to scaling policies, pod distribution rules, and scheduling priorities
 - Verify CoreDNS has a cluster IP assigned before reporting the cluster as ready to improve cluster readiness detection
 - Add ServiceArgsController to automatically detect and remediate service argument drift, improving operational consistency

--- a/docs/canonicalk8s/releases/snap/1.34.md
+++ b/docs/canonicalk8s/releases/snap/1.34.md
@@ -59,6 +59,15 @@ upgrade and will continue to use k8s-dqlite.
 
 ## Patch notices
 
+Jun 15, 2026
+
+- Version bump
+    - MetalLB to v0.14.9-ck8
+- Improve DNS availability by introducing a CoreDNS rebalancing controller and applying best practices to scaling policies, pod distribution rules, and scheduling priorities
+- Verify CoreDNS has a cluster IP assigned before reporting the cluster as ready to improve cluster readiness detection
+- Add ServiceArgsController to automatically detect and remediate service argument drift, improving operational consistency
+- Fix k8s-config watch resumption after etcd compaction, preventing missed configuration updates on long-running clusters
+
 Apr 23, 2026
 
 - Version bumps

--- a/docs/canonicalk8s/releases/snap/1.35.md
+++ b/docs/canonicalk8s/releases/snap/1.35.md
@@ -76,6 +76,17 @@ prior to upgrading.
 
 ## Patch notices
 
+Jun 15, 2026
+
+- Version bumps 
+  - MetalLB v0.15.3-ck2
+  - Helm v4.1.4
+- Add ServiceArgsController to automatically detect and remediate service argument drift, improving operational consistency.
+- Resolve two Go dependency vulnerabilities including a critical gRPC CVE (CVE-2026-33186) and a medium-severity xz CVE (CVE-2025-58058).
+- Prevent etcd quorum loss when joining a second control-plane node by using learner mode with safe retry-based promotion.
+- Improve cluster readiness detection by verifying CoreDNS has a cluster IP assigned before reporting the cluster as ready.
+- Fix k8s-config watch resumption after etcd compaction, preventing missed configuration updates on long-running clusters.
+
 Apr 23, 2026
 
 - Version bumps

--- a/docs/canonicalk8s/releases/snap/1.35.md
+++ b/docs/canonicalk8s/releases/snap/1.35.md
@@ -78,9 +78,9 @@ prior to upgrading.
 
 Jun 15, 2026
 
-- Version bumps 
-  - MetalLB v0.15.3-ck2
-  - Helm v4.1.4
+- Version bumps
+    - MetalLB v0.15.3-ck2
+    - Helm v4.1.4
 - Add ServiceArgsController to automatically detect and remediate service argument drift, improving operational consistency.
 - Resolve two Go dependency vulnerabilities including a critical gRPC CVE (CVE-2026-33186) and a medium-severity xz CVE (CVE-2025-58058).
 - Prevent etcd quorum loss when joining a second control-plane node by using learner mode with safe retry-based promotion.


### PR DESCRIPTION
## Description

We do not have a CHANGELOG so we update our release notes patch notices to keep our users informed what has landed on stable for the charm and the snap.

## Solution

Update the patch notices in the snap and charm

## Issue

N/A

## Backport

Yes, all the way to 1.32 but I will need to manually create them due to conflicts.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.