### PR TITLE
fix: transfer etcd leadership before removing a member

### DIFF
--- a/src/k8s/pkg/client/etcd/client.go
+++ b/src/k8s/pkg/client/etcd/client.go
@@ -10,6 +10,7 @@ import (
 
 type Client struct {
 	*clientv3.Client
+	pkiDir string
 }
 
 func NewClient(pkiDir string, endpoints []string) (*Client, error) {
@@ -31,8 +32,77 @@ func NewClient(pkiDir string, endpoints []string) (*Client, error) {
 	}
 
 	return &Client{
-		client,
+		Client: client,
+		pkiDir: pkiDir,
 	}, nil
+}
+
+// MoveLeaderIfNeeded transfers etcd leadership away from nodeName if it is currently the etcd leader.
+// MoveLeader must be issued to the leader itself, so this creates a targeted client directly to that
+// node. Returns nil if the node is not found or it is not the current leader.
+func (c *Client) MoveLeaderIfNeeded(ctx context.Context, nodeName string) error {
+	return c.moveLeader(ctx, nodeName, NewClient)
+}
+
+func (c *Client) moveLeader(ctx context.Context, nodeName string, createClient func(string, []string) (*Client, error)) error {
+	memberResp, err := c.MemberList(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list etcd members: %w", err)
+	}
+
+	var targetID uint64
+	var targetClientURLs []string
+	for _, m := range memberResp.Members {
+		if m.Name == nodeName {
+			targetID = m.ID
+			targetClientURLs = m.ClientURLs
+			break
+		}
+	}
+	if targetID == 0 {
+		return nil
+	}
+
+	// Query Status from the target node to check if it is the current leader.
+	var leaderID uint64
+	for _, url := range targetClientURLs {
+		statusResp, err := c.Status(ctx, url)
+		if err == nil {
+			leaderID = statusResp.Leader
+			break
+		}
+	}
+	if leaderID == 0 {
+		return fmt.Errorf("failed to determine etcd leader via status calls to %q", nodeName)
+	}
+	if leaderID != targetID {
+		return nil
+	}
+
+	// Pick a non-learner, non-target voter as the transfer target.
+	var transfereeID uint64
+	for _, m := range memberResp.Members {
+		if m.ID != targetID && !m.IsLearner {
+			transfereeID = m.ID
+			break
+		}
+	}
+	if transfereeID == 0 {
+		return fmt.Errorf("no eligible etcd member to transfer leadership to")
+	}
+
+	// MoveLeader must be called from the leader; dial it directly.
+	leaderClient, err := createClient(c.pkiDir, targetClientURLs)
+	if err != nil {
+		return fmt.Errorf("failed to create etcd client for leader: %w", err)
+	}
+	defer leaderClient.Close()
+
+	if _, err := leaderClient.MoveLeader(ctx, transfereeID); err != nil {
+		return fmt.Errorf("failed to transfer etcd leadership from %q: %w", nodeName, err)
+	}
+
+	return nil
 }
 
 func (c *Client) RemoveNodeByName(ctx context.Context, name string) error {

--- a/src/k8s/pkg/client/etcd/client_test.go
+++ b/src/k8s/pkg/client/etcd/client_test.go
@@ -1,0 +1,168 @@
+package etcd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// mockCluster implements clientv3.Cluster. Embedded interface satisfies
+// methods we don't use; only MemberList is overridden.
+type mockCluster struct {
+	clientv3.Cluster
+	members       []*pb.Member
+	memberListErr error
+}
+
+func (m *mockCluster) MemberList(_ context.Context, _ ...clientv3.OpOption) (*clientv3.MemberListResponse, error) {
+	if m.memberListErr != nil {
+		return nil, m.memberListErr
+	}
+
+	return (*clientv3.MemberListResponse)(&pb.MemberListResponse{Members: m.members}), nil
+}
+
+// mockMaintenance implements clientv3.Maintenance. Only Status and MoveLeader
+// are overridden; unused methods panic via the embedded nil interface.
+type mockMaintenance struct {
+	clientv3.Maintenance
+	leaderID             uint64
+	statusErr            error
+	moveLeaderErr        error
+	moveLeaderCalledWith uint64
+}
+
+func (m *mockMaintenance) Status(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
+	if m.statusErr != nil {
+		return nil, m.statusErr
+	}
+
+	return (*clientv3.StatusResponse)(&pb.StatusResponse{Leader: m.leaderID}), nil
+}
+
+func (m *mockMaintenance) MoveLeader(_ context.Context, transfereeID uint64) (*clientv3.MoveLeaderResponse, error) {
+	m.moveLeaderCalledWith = transfereeID
+	return nil, m.moveLeaderErr
+}
+
+func newTestClient(cluster *mockCluster, maintenance *mockMaintenance) *Client {
+	c := clientv3.NewCtxClient(context.Background())
+	c.Cluster = cluster
+	c.Maintenance = maintenance
+
+	return &Client{Client: c}
+}
+
+func mockFactory(maintenance *mockMaintenance) func(string, []string) (*Client, error) {
+	return func(_ string, _ []string) (*Client, error) {
+		return newTestClient(nil, maintenance), nil
+	}
+}
+
+func TestMoveLeaderIfNeeded(t *testing.T) {
+	nodeA := &pb.Member{ID: 1, Name: "node-a", ClientURLs: []string{"https://10.0.0.1:2379"}}
+	nodeB := &pb.Member{ID: 2, Name: "node-b", ClientURLs: []string{"https://10.0.0.2:2379"}}
+	nodeBLearner := &pb.Member{ID: 2, Name: "node-b", ClientURLs: []string{"https://10.0.0.2:2379"}, IsLearner: true}
+	nodeC := &pb.Member{ID: 3, Name: "node-c", ClientURLs: []string{"https://10.0.0.3:2379"}}
+
+	t.Run("NodeNotInMemberList", func(t *testing.T) {
+		g := NewWithT(t)
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{nodeA, nodeB}},
+			&mockMaintenance{leaderID: nodeA.ID},
+		)
+		g.Expect(client.moveLeader(context.Background(), "ghost-node", nil)).To(Succeed())
+	})
+
+	t.Run("NodeIsNotLeader", func(t *testing.T) {
+		g := NewWithT(t)
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{nodeA, nodeB}},
+			&mockMaintenance{leaderID: nodeB.ID},
+		)
+		g.Expect(client.moveLeader(context.Background(), nodeA.Name, nil)).To(Succeed())
+	})
+
+	t.Run("NodeIsLeaderTransfersToVoter", func(t *testing.T) {
+		g := NewWithT(t)
+		leaderMaint := &mockMaintenance{}
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{nodeA, nodeB, nodeC}},
+			&mockMaintenance{leaderID: nodeA.ID},
+		)
+		g.Expect(client.moveLeader(context.Background(), nodeA.Name, mockFactory(leaderMaint))).To(Succeed())
+		g.Expect(leaderMaint.moveLeaderCalledWith).To(Equal(nodeB.ID))
+	})
+
+	t.Run("SkipsLearnerWhenChoosingTransferee", func(t *testing.T) {
+		g := NewWithT(t)
+		leaderMaint := &mockMaintenance{}
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{nodeA, nodeBLearner, nodeC}},
+			&mockMaintenance{leaderID: nodeA.ID},
+		)
+		g.Expect(client.moveLeader(context.Background(), nodeA.Name, mockFactory(leaderMaint))).To(Succeed())
+		g.Expect(leaderMaint.moveLeaderCalledWith).To(Equal(nodeC.ID))
+	})
+
+	t.Run("MemberListError", func(t *testing.T) {
+		g := NewWithT(t)
+		client := newTestClient(
+			&mockCluster{memberListErr: errors.New("etcd unreachable")},
+			&mockMaintenance{},
+		)
+		err := client.moveLeader(context.Background(), nodeA.Name, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to list etcd members"))
+	})
+
+	t.Run("AllStatusCallsFail", func(t *testing.T) {
+		g := NewWithT(t)
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{nodeA, nodeB}},
+			&mockMaintenance{statusErr: errors.New("timeout")},
+		)
+		err := client.moveLeader(context.Background(), nodeA.Name, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to determine etcd leader"))
+	})
+
+	t.Run("LeaderHasNoClientURLs", func(t *testing.T) {
+		g := NewWithT(t)
+		leaderNoURLs := &pb.Member{ID: 1, Name: "node-a"}
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{leaderNoURLs, nodeB}},
+			&mockMaintenance{leaderID: leaderNoURLs.ID},
+		)
+		err := client.moveLeader(context.Background(), leaderNoURLs.Name, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to determine etcd leader"))
+	})
+
+	t.Run("NoVoterAvailableForTransfer", func(t *testing.T) {
+		g := NewWithT(t)
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{nodeA, nodeBLearner}},
+			&mockMaintenance{leaderID: nodeA.ID},
+		)
+		err := client.moveLeader(context.Background(), nodeA.Name, nil)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("no eligible etcd member"))
+	})
+
+	t.Run("MoveLeaderError", func(t *testing.T) {
+		g := NewWithT(t)
+		leaderMaint := &mockMaintenance{moveLeaderErr: errors.New("not leader")}
+		client := newTestClient(
+			&mockCluster{members: []*pb.Member{nodeA, nodeB}},
+			&mockMaintenance{leaderID: nodeA.ID},
+		)
+		err := client.moveLeader(context.Background(), nodeA.Name, mockFactory(leaderMaint))
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to transfer etcd leadership"))
+	})
+}

--- a/src/k8s/pkg/k8sd/api/cluster_remove.go
+++ b/src/k8s/pkg/k8sd/api/cluster_remove.go
@@ -238,6 +238,12 @@ func removeNodeFromEtcd(ctx context.Context, snap snap.Snap, s state.State, cfg 
 	defer client.Close()
 
 	log := log.FromContext(ctx).WithValues("remove", "etcd", "name", nodeName, "clientURLs", clientURLs)
+	log.Info("Transferring etcd leadership if node is the current leader")
+	if err := client.MoveLeaderIfNeeded(ctx, nodeName); err != nil {
+		// Best-effort: log and continue. Etcd will re-elect, but this minimises the leaderless window.
+		log.Error(err, "Failed to transfer etcd leadership before removal")
+	}
+
 	log.Info("Deleting node from etcd cluster")
 	if err := client.RemoveNodeByName(ctx, nodeName); err != nil {
 		return fmt.Errorf("failed to remove node %s from etcd cluster: %w", nodeName, err)


### PR DESCRIPTION
## Description

During cluster node removal, if we incidentally remove the etcd leader, the etcd cluster may remain leaderless. This typically lasts until it detects the scenario and a new leader election is held. We can avoid this issue by triggering the leader transfer ourselves.

## Solution

When removing a node from the etcd cluster, check if it is the current leader, and transfer leadership to another voter if it's the case.

This avoids the brief leaderless window that occurs when the leader is removed without a prior transfer, since `MoveLeader` triggers an immediate election on the transferee rather than waiting for the election timeout.

## Issue

Fixes: https://github.com/canonical/k8sd/issues/55

## Backport

Backported from: https://github.com/canonical/k8sd/pull/48

Yes, `release-1.34`, `release-1.33, `release-1.32`

<!-- Should this PR be backported? If so, to which release? -->

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests - existing integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - cannot add labels
- [x] Confirm whether the `release-notes` label should be kept or removed - N/A

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

