### PR TITLE
fix: prevent iSCSI session recovery timeout during node cleanup

### DIFF
--- a/src/k8s/pkg/snap/util/cleanup/cleanup.go
+++ b/src/k8s/pkg/snap/util/cleanup/cleanup.go
@@ -17,6 +17,7 @@ func TryCleanupContainers(ctx context.Context, s snap.Snap) {
 
 	internal.RemoveContainers(ctx)
 	internal.RemoveNetworkNamespaces(ctx, netnsHelper)
+	internal.SyncISCSIDevices(ctx)
 	internal.RemoveVolumeMountsGracefully(ctx, s, mountHelper)
 	internal.LogoutISCSISessions(ctx)
 	internal.RemoveVolumeMountsForce(ctx, s, mountHelper)

--- a/src/k8s/pkg/snap/util/cleanup/cleanup.go
+++ b/src/k8s/pkg/snap/util/cleanup/cleanup.go
@@ -18,6 +18,7 @@ func TryCleanupContainers(ctx context.Context, s snap.Snap) {
 	internal.RemoveContainers(ctx)
 	internal.RemoveNetworkNamespaces(ctx, netnsHelper)
 	internal.RemoveVolumeMountsGracefully(ctx, s, mountHelper)
+	internal.LogoutISCSISessions(ctx)
 	internal.RemoveVolumeMountsForce(ctx, s, mountHelper)
 	internal.RemovePluginSockets(ctx)
 	internal.RemoveLoopDevices(ctx, mountHelper)

--- a/src/k8s/pkg/snap/util/cleanup/internal/iscsi.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/iscsi.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"strings"
 
 	"github.com/canonical/k8s/pkg/log"
+	"golang.org/x/sys/unix"
 )
 
 // iscsiadmNoObjectsFound is the exit code returned by iscsiadm when no iSCSI sessions exist.
@@ -32,5 +34,43 @@ func LogoutISCSISessions(ctx context.Context) {
 			return
 		}
 		log.Error(err, "failed to logout iSCSI sessions", "output", string(out))
+	}
+}
+
+// SyncISCSIDevices flushes all pending I/O to iSCSI-backed block devices.
+// This must be called before unmounting volumes or logging out iSCSI sessions
+// to prevent data corruption caused by in-flight writes being lost.
+func SyncISCSIDevices(ctx context.Context) {
+	log := log.FromContext(ctx)
+
+	// Flush all dirty filesystem pages to their backing block devices.
+	unix.Sync()
+
+	if _, err := exec.LookPath("iscsiadm"); err != nil {
+		return
+	}
+
+	out, err := exec.CommandContext(ctx, "iscsiadm", "-m", "session", "-P", "3").CombinedOutput()
+	if err != nil {
+		return
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Attached scsi disk") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		dev := "/dev/" + fields[3]
+
+		log.Info("Flushing iSCSI block device buffer", "device", dev)
+		flushOut, err := exec.CommandContext(ctx, "blockdev", "--flushbufs", dev).CombinedOutput()
+		if err != nil {
+			log.Error(err, "Failed to flush iSCSI block device buffers", "device", dev, "output", string(flushOut))
+		}
 	}
 }

--- a/src/k8s/pkg/snap/util/cleanup/internal/iscsi.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/iscsi.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+
+	"github.com/canonical/k8s/pkg/log"
+)
+
+// iscsiadmNoObjectsFound is the exit code returned by iscsiadm when no iSCSI sessions exist.
+// Defined as ISCSI_ERR_NO_OBJS_FOUND in open-iscsi.
+// https://github.com/open-iscsi/open-iscsi/blob/2.1.11/include/iscsi_err.h#L50
+const iscsiadmNoObjectsFound = 21
+
+// LogoutISCSISessions logs out all active iSCSI sessions, allowing volume unmounts to proceed
+// without blocking on the kernel's iSCSI session recovery timeout (default: 120s).
+// This is required when iSCSI-backed volumes (e.g. Longhorn) are present and the iSCSI target
+// becomes unreachable after services are stopped.
+func LogoutISCSISessions(ctx context.Context) {
+	log := log.FromContext(ctx)
+
+	if _, err := exec.LookPath("iscsiadm"); err != nil {
+		log.Info("iscsiadm not found, skipping iSCSI session logout")
+		return
+	}
+
+	out, err := exec.CommandContext(ctx, "iscsiadm", "-m", "session", "-u").CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == iscsiadmNoObjectsFound {
+			return
+		}
+		log.Error(err, "failed to logout iSCSI sessions", "output", string(out))
+	}
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/iscsi_test.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/iscsi_test.go
@@ -13,3 +13,9 @@ func TestLogoutISCSISessions_NoIscsiadm(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	internal.LogoutISCSISessions(context.Background())
 }
+
+func TestSyncISCSIDevices_NoIscsiadm(t *testing.T) {
+	// When iscsiadm is not available the function must return without panicking.
+	t.Setenv("PATH", t.TempDir())
+	internal.SyncISCSIDevices(context.Background())
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/iscsi_test.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/iscsi_test.go
@@ -1,0 +1,15 @@
+package internal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canonical/k8s/pkg/snap/util/cleanup/internal"
+)
+
+func TestLogoutISCSISessions_NoIscsiadm(t *testing.T) {
+	// When iscsiadm is not available the function must return without panicking.
+	// We cannot control PATH in a unit test environment, so we just verify it doesn't panic.
+	t.Setenv("PATH", t.TempDir())
+	internal.LogoutISCSISessions(context.Background())
+}

--- a/src/k8s/pkg/snap/util/cleanup/internal/volume_mounts.go
+++ b/src/k8s/pkg/snap/util/cleanup/internal/volume_mounts.go
@@ -67,7 +67,9 @@ func RemoveVolumeMountsForce(ctx context.Context, s snap.Snap, mountHelper mount
 		for _, prefix := range prefixes {
 			if strings.HasPrefix(mountPoint, prefix) {
 				// unmount lingering Pod volumes by force, to prevent potential volume leaks.
-				return mountHelper.Unmount(ctx, mountPoint, unix.MNT_FORCE)
+				// MNT_DETACH prevents blocking on network-backed storage (e.g.: iSCSI)
+				// if the session logout in LogoutISCSISessions did not complete.
+				return mountHelper.Unmount(ctx, mountPoint, unix.MNT_FORCE|unix.MNT_DETACH)
 			}
 		}
 


### PR DESCRIPTION

## Description

In a CAPI CK8S RollingUpgrade with MaxSurge=0 scenario + Longhorn, we have observed that cluster node removal operation may be delayed due to lingering iSCSI sessions:

```
18:03:02 management-cluster-management-cp-1 k8s.k8sd[2633]: I0403 18:03:02.776017    2633 app/hooks_remove.go:127] "Remove hook completed " logger="k8sd" hook="preremove" node="management-cluster-management-cp-1"
...
18:03:01 management-cluster-management-cp-1 iscsid[9431]: connection4:0 cannot make a connection to 100.72.164.146:3260 (-1,22)
18:03:01 management-cluster-management-cp-1 iscsid[9431]: connection1:0 cannot make a connection to 100.72.164.146:3260 (-1,22)
18:03:02 management-cluster-management-cp-1 kernel:  session5: session recovery timed out after 120 secs
18:03:02 management-cluster-management-cp-1 kernel:  session1: session recovery timed out after 120 secs
...

18:03:02 management-cluster-management-cp-1 systemd[1]: var-lib-kubelet-plugins-kubernetes.io-csi-driver.longhorn.io-0d00477da2bfd55d25c83a9d64117e3e654dad991d322ae3332e50dbb76028a9-globalmount.mount: Deactivated successfully.
18:03:02 management-cluster-management-cp-1 systemd[1]: var-lib-kubelet-plugins-kubernetes.io-csi-driver.longhorn.io-7a69a96beccf0f324142c7940b9213667f5938baa5646f4b96c28a0a72551792-globalmount.mount: Deactivated successfully.
...
18:03:02 management-cluster-management-cp-1 k8s.k8sd[2633]: I0403 18:03:02.649390    2633 app/hooks_remove.go:90] "Cleaning up containerd paths" logger="k8sd" hook="preremove" node="management-cluster-management-cp-1"
...
```

## Solution

Log out all active iSCSI sessions before unmounting volumes to avoid a 120-second hang caused by the kernel's iSCSI session recovery timeout. When services are stopped during node removal, iSCSI targets (e.g.: Longhorn) become unreachable, causing `MNT_FORCE` on plugin mounts to block until the kernel declares the session dead.

Also add `MNT_DETACH` to `RemoveVolumeMountsForce` as defense in depth for cases where `iscsiadm` is unavailable or the logout does not complete.

## Issue

Fixes: https://github.com/canonical/k8sd/issues/58

## Backport

"Backported" from: https://github.com/canonical/k8sd/pull/59

Yes, release-1.34, release-1.33.

<!-- Should this PR be backported? If so, to which release? -->

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - cannot add labels
- [ ] Confirm whether the `release-notes` label should be kept or removed - N/A

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

