### PR TITLE
docs: Add metadata descriptions to the remainder of our docs

### DIFF
--- a/docs/canonicalk8s/about.md
+++ b/docs/canonicalk8s/about.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Canonical Kubernetes: a full Kubernetes distribution in a snap with built-in DNS, CNI, ingress, storage, gateway, metrics server and load balancer."
+---
+
 # What is {{product}}?
 
 At its core, {{product}} is a full implementation of upstream

--- a/docs/canonicalk8s/capi/explanation/capi-ck8s.md
+++ b/docs/canonicalk8s/capi/explanation/capi-ck8s.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Cluster API (CAPI) and how Canonical Kubernetes integrates with it for declarative cluster provisioning across infrastructure providers."
+---
+
 # Cluster API and {{product}}
 
 ## Cluster API

--- a/docs/canonicalk8s/capi/explanation/in-place-upgrades.md
+++ b/docs/canonicalk8s/capi/explanation/in-place-upgrades.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of in-place Kubernetes upgrades in Canonical Kubernetes CAPI, covering upgrade controllers and annotations that drive the upgrade process."
+---
+
 # In-place upgrades
 
 Regularly upgrading the Kubernetes version of the machines in a cluster 

--- a/docs/canonicalk8s/capi/explanation/index.md
+++ b/docs/canonicalk8s/capi/explanation/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation index for Canonical Kubernetes with Cluster API, covering fundamentals, networking, security, and upgrade concepts."
+---
+
 # Explanation
 
 For a better understanding of how {{product}} CAPI works and related

--- a/docs/canonicalk8s/capi/explanation/installation-methods.md
+++ b/docs/canonicalk8s/capi/explanation/installation-methods.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Canonical Kubernetes installation methods: the k8s snap, Juju charms, and Cluster API, with guidance on choosing the right approach."
+---
+
 ```{include} ../../snap/explanation/installation-methods.md
 ```

--- a/docs/canonicalk8s/capi/explanation/networking.md
+++ b/docs/canonicalk8s/capi/explanation/networking.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Overview of Canonical Kubernetes networking features including CNI, DNS, load balancing, Ingress, and Gateway API."
+---
+
 ```{include} ../../snap/explanation/networking.md
 ```

--- a/docs/canonicalk8s/capi/explanation/security.md
+++ b/docs/canonicalk8s/capi/explanation/security.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliacance."
+    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliance."
 ---
 
 ```{include} /snap/explanation/security.md

--- a/docs/canonicalk8s/capi/explanation/security.md
+++ b/docs/canonicalk8s/capi/explanation/security.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliacance."
+---
+
 ```{include} /snap/explanation/security.md
 ```

--- a/docs/canonicalk8s/capi/howto/custom-bootstrap-config.md
+++ b/docs/canonicalk8s/capi/howto/custom-bootstrap-config.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to pass a custom bootstrap configuration to Canonical Kubernetes CAPI."
+---
+
 # How to use custom bootstrap configuration
 
 The {{product}} bootstrap configuration gets automatically generated based on

--- a/docs/canonicalk8s/capi/howto/custom-ck8s.md
+++ b/docs/canonicalk8s/capi/howto/custom-ck8s.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install a specific Canonical Kubernetes version on CAPI-managed machines using the channel, revision, or localPath spec fields."
+---
+
 # How to install custom {{product}} on machines
 
 By default, the `version` field in the machine specifications will determine

--- a/docs/canonicalk8s/capi/howto/external-etcd.md
+++ b/docs/canonicalk8s/capi/howto/external-etcd.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to use an external etcd cluster as the datastore for a Canonical Kubernetes CAPI workload cluster."
+---
+
 # How to use external etcd with Cluster API
 
 To replace the built-in datastore with an external etcd to

--- a/docs/canonicalk8s/capi/howto/in-place-upgrades.md
+++ b/docs/canonicalk8s/capi/howto/in-place-upgrades.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to perform an in-place Kubernetes upgrade on a CAPI-managed machine by annotating the Machine resource with the upgrade-to annotation."
+---
+
 # How to perform an in-place upgrade for a machine
 
 This guide walks you through the steps to perform an in-place upgrade for a

--- a/docs/canonicalk8s/capi/howto/index.md
+++ b/docs/canonicalk8s/capi/howto/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for Canonical Kubernetes with Cluster API, covering provisioning, upgrades, certificates, networking, and troubleshooting."
+---
+
 # How-to guides
 
 If you have a specific goal, but are already familiar with Kubernetes, our

--- a/docs/canonicalk8s/capi/howto/intermediate-ca.md
+++ b/docs/canonicalk8s/capi/howto/intermediate-ca.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure an intermediate Certificate Authority (CA) with Canonical Kubernetes CAPI workload clusters."
+---
+
 # How to use intermediate CAs with Vault
 
 By default, the ClusterAPI provider will generate self-signed CA certificates

--- a/docs/canonicalk8s/capi/howto/migrate-management.md
+++ b/docs/canonicalk8s/capi/howto/migrate-management.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to migrate a Canonical Kubernetes CAPI management cluster to a different substrate using clusterctl move without disrupting workloads."
+---
+
 # How to migrate the management cluster
 
 Management cluster migration allows admins to move the management cluster

--- a/docs/canonicalk8s/capi/howto/refresh-certs.md
+++ b/docs/canonicalk8s/capi/howto/refresh-certs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to refresh Kubernetes certificates for control plane and worker nodes in a Canonical Kubernetes Cluster API managed cluster."
+---
+
 # How to refresh workload cluster certificates
 
 This how-to will walk you through the steps to refresh the certificates for

--- a/docs/canonicalk8s/capi/howto/rollout-upgrades.md
+++ b/docs/canonicalk8s/capi/howto/rollout-upgrades.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to perform a rolling Kubernetes upgrade on a CAPI-managed cluster, updating the CK8sControlPlane and MachineDeployment resources."
+---
+
 # How to upgrade the Kubernetes version of a cluster
 
 This guide walks you through the steps to rollout an upgrade for a

--- a/docs/canonicalk8s/capi/howto/troubleshooting.md
+++ b/docs/canonicalk8s/capi/howto/troubleshooting.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to troubleshoot Canonical Kubernetes CAPI clusters, including checking provider logs, cluster status, and common provisioning failures."
+---
+
 # How to troubleshoot {{product}}
 
 Identifying issues in a Kubernetes cluster can be difficult, especially to new

--- a/docs/canonicalk8s/capi/howto/upgrade-providers.md
+++ b/docs/canonicalk8s/capi/howto/upgrade-providers.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to upgrade the providers of a Canonical Kubernetes CAPI management cluster using clusterctl."
+---
+
 # How to upgrade the providers of a management cluster
 
 This guide will walk you through the process of upgrading the

--- a/docs/canonicalk8s/capi/index.md
+++ b/docs/canonicalk8s/capi/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Explore how to deploy and manage Canonical Kubernetes with Cluster API through step-by-step tutorials, practical how-to guides, in-depth explanations, and technical reference."
+    description: "Canonical Kubernetes with Cluster API: declarative cluster provisioning and lifecycle management across cloud and on-premises infrastructure."
 ---
 
 # Installing {{product}} with Cluster API

--- a/docs/canonicalk8s/capi/reference/annotations.md
+++ b/docs/canonicalk8s/capi/reference/annotations.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for Canonical Kubernetes CAPI Machine annotations."
+---
+
 # Annotations
 
 Like annotations for other Kubernetes objects, CAPI annotations are key-value

--- a/docs/canonicalk8s/capi/reference/configs.md
+++ b/docs/canonicalk8s/capi/reference/configs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for Canonical Kubernetes CAPI provider configuration options, covering the bootstrap and the control plane providers."
+---
+
 # Providers configurations
 
 {{product}} bootstrap and control plane providers (CABPCK and CACPCK)

--- a/docs/canonicalk8s/capi/reference/index.md
+++ b/docs/canonicalk8s/capi/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference index for Canonical Kubernetes with Cluster API, including annotations, networking configurations, and provider configuration options."
+---
+
 # Reference
 
 Our Reference section is for when you need to check specific details or

--- a/docs/canonicalk8s/capi/reference/ports-and-services.md
+++ b/docs/canonicalk8s/capi/reference/ports-and-services.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Reference for network services, sockets, ports and protocols used by Canonical Kubernetes nodes."
+---
+
 ```{include} /snap/reference/ports-and-services.md
 ```

--- a/docs/canonicalk8s/capi/tutorial/index.md
+++ b/docs/canonicalk8s/capi/tutorial/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Tutorial for Canonical Kubernetes with Cluster API, starting with setting up a management cluster and provisioning workload clusters."
+---
+
 # Tutorials
 
 This section contains a step-by-step guide to help you start exploring how to

--- a/docs/canonicalk8s/charm/explanation/architecture.md
+++ b/docs/canonicalk8s/charm/explanation/architecture.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Canonical Kubernetes charm architecture, covering the k8s and k8s-worker charms and their relationship to the underlying snap."
+---
+
 # Architecture
 
 ```{include} /snap/explanation/architecture.md

--- a/docs/canonicalk8s/charm/explanation/channels.md
+++ b/docs/canonicalk8s/charm/explanation/channels.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Canonical Kubernetes snap channels, including track and risk level components, update behavior, and how to choose the right channel."
+---
+
 ```{include} ../../snap/explanation/channels.md
 ```

--- a/docs/canonicalk8s/charm/explanation/index.md
+++ b/docs/canonicalk8s/charm/explanation/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation index for Canonical Kubernetes charms, covering fundamentals, architecture, channels, networking, security, and upgrade concepts."
+---
+
 # Explanation
 
 For a better understanding of how {{product}} works and related

--- a/docs/canonicalk8s/charm/explanation/installation-methods.md
+++ b/docs/canonicalk8s/charm/explanation/installation-methods.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Canonical Kubernetes installation methods: the k8s snap, Juju charms, and Cluster API, with guidance on choosing the right approach."
+---
+
 ```{include} /snap/explanation/installation-methods.md
 ```

--- a/docs/canonicalk8s/charm/explanation/networking.md
+++ b/docs/canonicalk8s/charm/explanation/networking.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Overview of Canonical Kubernetes networking features including CNI, DNS, load balancing, Ingress, and Gateway API."
+---
+
 ```{include} ../../snap/explanation/networking.md
 ```

--- a/docs/canonicalk8s/charm/explanation/security.md
+++ b/docs/canonicalk8s/charm/explanation/security.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliacance."
+---
+
 ```{include} /snap/explanation/security.md
 :start-after: <!-- Start -->
 :end-before: <!-- First charm end here -->

--- a/docs/canonicalk8s/charm/explanation/security.md
+++ b/docs/canonicalk8s/charm/explanation/security.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliacance."
+    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliance."
 ---
 
 ```{include} /snap/explanation/security.md

--- a/docs/canonicalk8s/charm/explanation/upgrade.md
+++ b/docs/canonicalk8s/charm/explanation/upgrade.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Kubernetes upgrade strategies in Canonical Kubernetes, covering patch and minor upgrades, sequential upgrades, and upgrade best practices."
+---
+
 ```{include} ../../snap/explanation/upgrade.md
 ```

--- a/docs/canonicalk8s/charm/howto/ceph-csi.md
+++ b/docs/canonicalk8s/charm/howto/ceph-csi.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to integrate Canonical Kubernetes with ceph-csi for Ceph-backed Kubernetes persistent volumes using Juju."
+---
+
 # How to integrate {{product}} with ceph-csi
 
 [Ceph] can be used to hold Kubernetes persistent volumes and is the recommended

--- a/docs/canonicalk8s/charm/howto/configure-cluster.md
+++ b/docs/canonicalk8s/charm/howto/configure-cluster.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure a Canonical Kubernetes cluster using Juju, including DNS, networking, labels, and feature flags via charm configuration options."
+---
+
 # How to configure a {{ product }} cluster using Juju
 
 This guide provides instructions for configuring a {{ product }} cluster using

--- a/docs/canonicalk8s/charm/howto/contribute.md
+++ b/docs/canonicalk8s/charm/howto/contribute.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "How to contribute to Canonical Kubernetes. Learn to how to fix issues, improve existing pages and build the docs locally."
+---
+
 ```{include} /snap/howto/contribute.md
 ```

--- a/docs/canonicalk8s/charm/howto/contribute.md
+++ b/docs/canonicalk8s/charm/howto/contribute.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "How to contribute to Canonical Kubernetes. Learn to how to fix issues, improve existing pages and build the docs locally."
+    description: "How to contribute to Canonical Kubernetes. Learn how to fix issues, improve existing pages and build the docs locally."
 ---
 
 ```{include} /snap/howto/contribute.md

--- a/docs/canonicalk8s/charm/howto/cos-lite.md
+++ b/docs/canonicalk8s/charm/howto/cos-lite.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to integrate Canonical Kubernetes with COS Lite (Canonical Observability Stack) for cluster monitoring using Juju."
+---
+
 # How to integrate with COS Lite
 
 It is often advisable to have a monitoring solution which will run whether the

--- a/docs/canonicalk8s/charm/howto/custom-registry.md
+++ b/docs/canonicalk8s/charm/howto/custom-registry.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure the k8s charm to pull container images from a custom or private container registry."
+---
+
 # How to configure a custom registry
 
 The `k8s` charm can be configured to use a custom container registry for its

--- a/docs/canonicalk8s/charm/howto/etcd.md
+++ b/docs/canonicalk8s/charm/howto/etcd.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to deploy Canonical Kubernetes with an external etcd cluster as the datastore using Juju."
+---
+
 # How to integrate {{product}} with external etcd
 
 Integrating [etcd][] with your {{product}} deployment provides a

--- a/docs/canonicalk8s/charm/howto/hardening.md
+++ b/docs/canonicalk8s/charm/howto/hardening.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to harden a Canonical Kubernetes charm cluster with post-deployment security steps aligned with CIS and DISA STIG benchmarks."
+---
+
 # How to harden your {{product}} cluster
 
 The {{product}} hardening guide provides actionable steps to enhance the

--- a/docs/canonicalk8s/charm/howto/index.md
+++ b/docs/canonicalk8s/charm/howto/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for Canonical Kubernetes charms, covering installation, configuration, integrations, upgrades, and troubleshooting."
+---
+
 # How-to guides
 
 If you have a specific goal, and are already familiar with Kubernetes, our

--- a/docs/canonicalk8s/charm/howto/install/charm.md
+++ b/docs/canonicalk8s/charm/howto/install/charm.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes from the k8s charm."
+---
+
 # How to install {{product}} from a charm
 
 {{product}} is packaged as a [charm], available from Charmhub for all

--- a/docs/canonicalk8s/charm/howto/install/custom-workers.md
+++ b/docs/canonicalk8s/charm/howto/install/custom-workers.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to add k8s-worker applications with custom configurations."
+---
+
 # How to add worker nodes with custom configurations
 
 This guide will walk you through how to deploy multiple `k8s-worker`

--- a/docs/canonicalk8s/charm/howto/install/index.md
+++ b/docs/canonicalk8s/charm/howto/install/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Install Canonical Kubernetes how-to guide index, covering charm, LXD, Terraform and custom configuration and deployment options."
+---
+
 # Install {{product}}
 
 There's more than one way to install {{product}}. You'll find links to

--- a/docs/canonicalk8s/charm/howto/install/install-custom.md
+++ b/docs/canonicalk8s/charm/howto/install/install-custom.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to deploy Canonical Kubernetes using Juju with a custom configuration file specifying datastore, pod CIDR, DNS, and other bootstrap options."
+---
+
 # How to install with custom configuration
 
 This guide will walk you through deploying {{product}} using Juju with custom

--- a/docs/canonicalk8s/charm/howto/install/install-lxd.md
+++ b/docs/canonicalk8s/charm/howto/install/install-lxd.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes in LXD virtual machines using Juju."
+---
+
 # How to install {{product}} using localhost/LXD
 
 The main [install instructions][install] cover most situations for installing

--- a/docs/canonicalk8s/charm/howto/install/install-terraform.md
+++ b/docs/canonicalk8s/charm/howto/install/install-terraform.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes using the Terraform Juju provider and the k8s-bundle Terraform module."
+---
+
 # How to install with Terraform
 
 This guide walks you through the process of installing {{ product }} using

--- a/docs/canonicalk8s/charm/howto/openstack.md
+++ b/docs/canonicalk8s/charm/howto/openstack.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to deploy Canonical Kubernetes on OpenStack using the openstack-integrator charm overlay."
+---
+
 # How to integrate with OpenStack
 
 This guide explains how to integrate {{product}} with the OpenStack cloud

--- a/docs/canonicalk8s/charm/howto/proxy.md
+++ b/docs/canonicalk8s/charm/howto/proxy.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure proxy settings for Canonical Kubernetes charm deployments via Juju model configuration."
+---
+
 # How to configure proxy settings for {{product}}
 
 {{product}} packages a number of utilities (for example curl, helm) which need

--- a/docs/canonicalk8s/charm/howto/report-security-issue.md
+++ b/docs/canonicalk8s/charm/howto/report-security-issue.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to report a security vulnerability in Canonical Kubernetes by filing a private security report on the k8s-operator GitHub repository."
+---
+
 # How to report a security issue in {{product}}
 
 While we do our best to keep up to date with the latest security issues, we

--- a/docs/canonicalk8s/charm/howto/upgrade.md
+++ b/docs/canonicalk8s/charm/howto/upgrade.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: How to upgrade Canonical Kubernetes to new minor and patch versions. Learn to use Juju to update control-plane and worker units to the latest releases.
+    description: How to upgrade Canonical Kubernetes to new minor and patch versions.
 ---
 
 # How to upgrade {{product}} 

--- a/docs/canonicalk8s/charm/howto/validate.md
+++ b/docs/canonicalk8s/charm/howto/validate.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to validate a Canonical Kubernetes charm deployment by running end-to-end (e2e) tests with the kubernetes-e2e charm."
+---
+
 # How to validate {{product}}
 
 End-to-end (e2e) tests for **Kubernetes** provide a mechanism

--- a/docs/canonicalk8s/charm/index.md
+++ b/docs/canonicalk8s/charm/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Explore the official Canonical Kubernetes charm documentation. Includes step-by-step tutorials, practical how-to guides, in-depth explanations, and technical reference."
+    description: "Canonical Kubernetes charm documentation: the k8s Juju operator for deploying, scaling, and managing Kubernetes on Juju clouds."
 ---
 
 # {{product}} charm documentation

--- a/docs/canonicalk8s/charm/reference/actions.md
+++ b/docs/canonicalk8s/charm/reference/actions.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for Canonical Kubernetes charm actions, with links to the k8s and k8s-worker action pages on Charmhub."
+---
+
 # Charm actions reference
 
 The up-to-date list of actions are available on Charmhub:

--- a/docs/canonicalk8s/charm/reference/az.md
+++ b/docs/canonicalk8s/charm/reference/az.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for availability zone support in Canonical Kubernetes charms."
+---
+
 # Availability Zones
 
 An availability zone determines the specific location where Juju

--- a/docs/canonicalk8s/charm/reference/charm-configurations.md
+++ b/docs/canonicalk8s/charm/reference/charm-configurations.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for Canonical Kubernetes k8s and k8s-worker charm configuration options."
+---
+
 # Charm configuration options reference
 
 This reference section provides the sites where you can find the configuration

--- a/docs/canonicalk8s/charm/reference/charms.md
+++ b/docs/canonicalk8s/charm/reference/charms.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for the Canonical Kubernetes k8s and k8s-worker charms available on Charmhub and their source code repository."
+---
+
 # {{product}} charms
 
 {{product}} can be deployed via [Juju][] with the following charms:

--- a/docs/canonicalk8s/charm/reference/index.md
+++ b/docs/canonicalk8s/charm/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference index for Canonical Kubernetes charms, covering charm configuration, actions, availability zones, ports, and release notes."
+---
+
 # Reference
 
 Our Reference section is for when you need to check specific details or

--- a/docs/canonicalk8s/charm/reference/ports-and-services.md
+++ b/docs/canonicalk8s/charm/reference/ports-and-services.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Reference for network services, sockets, ports and protocols used by Canonical Kubernetes nodes."
+---
+
 ```{include} /snap/reference/ports-and-services.md
 ```

--- a/docs/canonicalk8s/charm/reference/proxy.md
+++ b/docs/canonicalk8s/charm/reference/proxy.md
@@ -1,2 +1,8 @@
+---
+myst:
+  html_meta:
+    description: "Reference for proxy environment variables in Canonical Kubernetes, including HTTPS_PROXY, HTTP_PROXY, NO_PROXY, and required CIDR exclusions."
+---
+
 ```{include} ../../snap/reference/proxy.md
 ```

--- a/docs/canonicalk8s/charm/tutorial/index.md
+++ b/docs/canonicalk8s/charm/tutorial/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Tutorials for Canonical Kubernetes charms, covering initial cluster deployment and day-two operations with the k8s Juju operator."
+---
+
 # Tutorials
 
 This section contains a step-by-step guide to help you start exploring how to

--- a/docs/canonicalk8s/community.md
+++ b/docs/canonicalk8s/community.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Get involved with the Canonical Kubernetes community: ask questions, report bugs, and contribute the code or documentation."
+---
+
 # Welcome to the {{product}} community
 
 This rapidly growing community is a diverse bunch of people - developers,

--- a/docs/canonicalk8s/community.md
+++ b/docs/canonicalk8s/community.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Get involved with the Canonical Kubernetes community: ask questions, report bugs, and contribute the code or documentation."
+    description: "Get involved with the Canonical Kubernetes community: ask questions, report bugs, and contribute to the code or documentation."
 ---
 
 # Welcome to the {{product}} community

--- a/docs/canonicalk8s/index.md
+++ b/docs/canonicalk8s/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Official Canonical Kubernetes documentation. Learn to deploy and manage lightweight, secure clusters on Ubuntu. Includes tutorials, how-to guides, explanation and reference docs."
+    description: "Canonical Kubernetes documentation: a full Kubernetes distribution available as a snap, Juju charm, or via Cluster API."
 ---
 # {{product}} documentation
 

--- a/docs/canonicalk8s/releases/charm/1.32.md
+++ b/docs/canonicalk8s/releases/charm/1.32.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes charms 1.32 release notes from December 2024, covering new features, bug fixes, and upgrade notes."
+---
+
 # 1.32
 
 **{{product}} Charms 1.32 - Release notes - 20 December 2024**

--- a/docs/canonicalk8s/releases/charm/1.33.md
+++ b/docs/canonicalk8s/releases/charm/1.33.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes charms 1.33 release notes from October 2025, covering new features, bug fixes, and upgrade notes."
+---
+
 # 1.33
 
 **{{product}} Charms 1.33 - Release notes - 07 October 2025**

--- a/docs/canonicalk8s/releases/charm/1.34.md
+++ b/docs/canonicalk8s/releases/charm/1.34.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes charms 1.34 release notes from December 2025, covering new features, bug fixes, and upgrade notes."
+---
+
 # 1.34
 
 **{{product}} Charms 1.34 - Release notes - 17 December 2025**

--- a/docs/canonicalk8s/releases/charm/1.35.md
+++ b/docs/canonicalk8s/releases/charm/1.35.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes charms 1.35 release notes from January 2026, covering new features, bug fixes, and upgrade notes."
+---
+
 # 1.35
 
 **{{product}} Charms 1.35 - Release notes - 16 January 2026**

--- a/docs/canonicalk8s/releases/charm/index.md
+++ b/docs/canonicalk8s/releases/charm/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes index for Canonical Kubernetes charms, listing changes, new features, and bug fixes for each Juju operator version."
+---
+
 # Release notes
 
 This is an index page for all the available releases of the {{product}}

--- a/docs/canonicalk8s/releases/index.md
+++ b/docs/canonicalk8s/releases/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes index for Canonical Kubernetes snap and charm releases, with new features, bug fixes, and compatibility changes."
+---
+
 # Release notes
 
 This is an index page for all the available releases of {{product}}. Each entry

--- a/docs/canonicalk8s/releases/snap/1.32.md
+++ b/docs/canonicalk8s/releases/snap/1.32.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes snap 1.32 release notes from December 2024, the first LTS release, with new features, bug fixes, and upgrade notes."
+---
+
 # 1.32
 
 **{{product}} 1.32 - Release notes - 12 December 2024**

--- a/docs/canonicalk8s/releases/snap/1.33.md
+++ b/docs/canonicalk8s/releases/snap/1.33.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes snap 1.33 release notes from June 2025, covering new features, bug fixes, and upgrade notes."
+---
+
 # 1.33
 
 **{{product}} 1.33 - Release notes - 30 June 2025**

--- a/docs/canonicalk8s/releases/snap/1.34.md
+++ b/docs/canonicalk8s/releases/snap/1.34.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes snap 1.34 release notes from September 2025, covering new features, bug fixes, and upgrade notes"
+---
+
 # 1.34
 
 **{{product}} 1.34 - Release notes - 08 September 2025**

--- a/docs/canonicalk8s/releases/snap/1.35.md
+++ b/docs/canonicalk8s/releases/snap/1.35.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes snap 1.35 release notes from December 2025, covering new features, bug fixes, and upgrade notes."
+---
+
 # 1.35
 
 **{{product}} 1.35 - Release notes - 18 December 2025**

--- a/docs/canonicalk8s/releases/snap/index.md
+++ b/docs/canonicalk8s/releases/snap/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes index for the Canonical Kubernetes snap, listing changes, new features, and bug fixes for each k8s snap version."
+---
+
 # Release notes
 
 This is an index page for all the available releases of {{product}}. Each entry

--- a/docs/canonicalk8s/releases/snap/upgrading.md
+++ b/docs/canonicalk8s/releases/snap/upgrading.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Upgrade notes for Canonical Kubernetes snap, including version-specific migration steps and compatibility changes between releases."
+---
+
 # Upgrade notes
 
 ## Upgrade 1.34 to 1.35

--- a/docs/canonicalk8s/snap/explanation/channels.md
+++ b/docs/canonicalk8s/snap/explanation/channels.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Canonical Kubernetes snap channels, including track and risk level components, update behavior, and how to choose the right channel."
+---
+
 # Channels
 
 {{product}} uses the concept of `channels` to make sure you always get

--- a/docs/canonicalk8s/snap/explanation/clustering.md
+++ b/docs/canonicalk8s/snap/explanation/clustering.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Kubernetes clustering in Canonical Kubernetes, including k8sd's role in cluster coordination."
+---
+
 # Clustering
 
 Kubernetes clustering allows you to manage a group of hosts as a single entity.

--- a/docs/canonicalk8s/snap/explanation/epa.md
+++ b/docs/canonicalk8s/snap/explanation/epa.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Enhanced Platform Awareness (EPA) in Canonical Kubernetes, covering HugePages, real-time kernel, CPU pinning, NUMA, SR-IOV, and DPDK."
+---
+
 # Enhanced Platform Awareness
 
 Enhanced Platform Awareness (EPA) is a methodology and a set of enhancements

--- a/docs/canonicalk8s/snap/explanation/high-availability.md
+++ b/docs/canonicalk8s/snap/explanation/high-availability.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of high availability in Canonical Kubernetes, with automatic HA for clusters of three or more nodes and Raft-based failover."
+---
+
 # High availability
 
 High availability (HA) is a core feature of {{ product }}, ensuring that

--- a/docs/canonicalk8s/snap/explanation/index.md
+++ b/docs/canonicalk8s/snap/explanation/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation index for the Canonical Kubernetes snap, covering fundamentals, architecture, channels, networking, security, and upgrade concepts."
+---
+
 # Explanation
 
 For a better understanding of how {{product}} works and related

--- a/docs/canonicalk8s/snap/explanation/installation-methods.md
+++ b/docs/canonicalk8s/snap/explanation/installation-methods.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Canonical Kubernetes installation methods: the k8s snap, Juju charms, and Cluster API, with guidance on choosing the right approach."
+---
+
 # Choose an installation method
 
 {{ product }} can be installed in a variety of ways, depending on your needs and

--- a/docs/canonicalk8s/snap/explanation/package-management.md
+++ b/docs/canonicalk8s/snap/explanation/package-management.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of package management in Canonical Kubernetes using Helm, including charts, chart repositories, and Helm installation and upgrade workflows."
+---
+
 # Package management with Helm
 
 There are multiple ways of installing and managing packages in Kubernetes.

--- a/docs/canonicalk8s/snap/explanation/roles.md
+++ b/docs/canonicalk8s/snap/explanation/roles.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Kubernetes node roles in Canonical Kubernetes, including how control plane nodes are configured to allow workload scheduling by default."
+---
+
 # Node roles
 
 This document explains how {{product}} assigns Kubernetes node roles, how this

--- a/docs/canonicalk8s/snap/explanation/security.md
+++ b/docs/canonicalk8s/snap/explanation/security.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliacance."
+    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliance."
 ---
 
 <!-- Start -->

--- a/docs/canonicalk8s/snap/explanation/security.md
+++ b/docs/canonicalk8s/snap/explanation/security.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliacance."
+---
+
 <!-- Start -->
 
 # Security in {{product}}

--- a/docs/canonicalk8s/snap/explanation/upgrade.md
+++ b/docs/canonicalk8s/snap/explanation/upgrade.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Explanation of Kubernetes upgrade strategies in Canonical Kubernetes, covering patch and minor upgrades, sequential upgrades, and upgrade best practices." 
+---
+
 # Upgrading {{product}}
 
 Upgrading your cluster to the latest Kubernetes version is a critical part of

--- a/docs/canonicalk8s/snap/explanation/upgrade.md
+++ b/docs/canonicalk8s/snap/explanation/upgrade.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Explanation of Kubernetes upgrade strategies in Canonical Kubernetes, covering patch and minor upgrades, sequential upgrades, and upgrade best practices." 
+    description: "Explanation of Kubernetes upgrade strategies in Canonical Kubernetes, covering patch and minor upgrades, sequential upgrades, and upgrade best practices."
 ---
 
 # Upgrading {{product}}

--- a/docs/canonicalk8s/snap/howto/backup-restore.md
+++ b/docs/canonicalk8s/snap/howto/backup-restore.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to back up and restore a Canonical Kubernetes cluster."
+---
+
 # How to backup and restore a {{product}} cluster
 
 [Velero][] is a popular open source backup solution for Kubernetes. Its core

--- a/docs/canonicalk8s/snap/howto/epa.md
+++ b/docs/canonicalk8s/snap/howto/epa.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to set up Enhanced Platform Awareness (EPA) features in Canonical Kubernetes, including HugePages, real-time kernel, CPU pinning, and SR-IOV."
+---
+
 # How to set up Enhanced Platform Awareness
 
 This section explains how to set up the Enhanced Platform Awareness (EPA)

--- a/docs/canonicalk8s/snap/howto/external-datastore.md
+++ b/docs/canonicalk8s/snap/howto/external-datastore.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure Canonical Kubernetes to use an external etcd cluster as the cluster datastore during the bootstrap process."
+---
+
 # How to use an external datastore
 
 {{product}} supports using an external datastore such as etcd

--- a/docs/canonicalk8s/snap/howto/image-management.md
+++ b/docs/canonicalk8s/snap/howto/image-management.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to manage container images in Canonical Kubernetes using the containerd CLI, including listing and importing images."
+---
+
 # How to manage images
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/index.md
+++ b/docs/canonicalk8s/snap/howto/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How-to guides for the Canonical Kubernetes snap, covering installation, networking, storage, security, observability, and upgrades."
+---
+
 # How-to guides
 
 If you have a specific goal, but are already familiar with Kubernetes, our

--- a/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-bootstrap-config.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes with a custom bootstrap configuration, using interactive mode or a YAML file to set cluster features."
+---
+
 # How to install with a custom bootstrap configuration
 
 <!-- SPREAD SUITE: snap_clean -->

--- a/docs/canonicalk8s/snap/howto/install/custom-worker.md
+++ b/docs/canonicalk8s/snap/howto/install/custom-worker.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to join a worker node to a Canonical Kubernetes cluster with a custom configuration using a YAML file passed to k8s join-cluster."
+---
+
 # How to join worker nodes with a custom configuration
 
 When creating a {{ product }} cluster you may need to join a worker node with

--- a/docs/canonicalk8s/snap/howto/install/disa-stig.md
+++ b/docs/canonicalk8s/snap/howto/install/disa-stig.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes with DISA STIG hardening, meeting U.S. DoD security guidelines for Kubernetes and the host operating system."
+---
+
 # How to install {{ product }} with DISA STIG hardening
 
 ```{versionadded} release-1.34

--- a/docs/canonicalk8s/snap/howto/install/fips.md
+++ b/docs/canonicalk8s/snap/howto/install/fips.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install a FIPS 140-3 compliant Canonical Kubernetes cluster on Ubuntu for U.S. government and regulated industry compliance requirements."
+---
+
 # How to install a FIPS compliant Kubernetes cluster
 
 ```{versionadded} release-1.34

--- a/docs/canonicalk8s/snap/howto/install/index.md
+++ b/docs/canonicalk8s/snap/howto/install/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Canonical Kubernetes snap installation how-to guide index, covering snap, Multipass, LXD, air-gapped, DISA STIG, FIPS, and custom configuration."
+---
+
 # Install {{product}}
 
 There's more than one way to install {{product}}. You'll find links to

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes in an LXD virtual machine."
+---
+
 # How to install {{product}} in LXD
 
 {{product}} can also be installed inside an LXD virtual machine. This is a

--- a/docs/canonicalk8s/snap/howto/install/multipass.md
+++ b/docs/canonicalk8s/snap/howto/install/multipass.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes with Multipass on Ubuntu, macOS, or Windows, enabling multi-node cluster deployment on any platform."
+---
+
 # How to install {{product}} with Multipass (Ubuntu/macOS/Windows)
 
 [Multipass] provides an easy way to run Ubuntu in a virtual machine, regardless

--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes in air-gapped environments, including snap download, network requirements, and offline image management."
+---
+
 # How to install {{product}} in air-gapped environments
 
 There are situations where it is necessary or desirable to run {{product}}

--- a/docs/canonicalk8s/snap/howto/install/snap.md
+++ b/docs/canonicalk8s/snap/howto/install/snap.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to install Canonical Kubernetes from the k8s snap."
+---
+
 # How to install {{product}} from a snap
 
 <!-- SPREAD SUITE: snap_clean -->

--- a/docs/canonicalk8s/snap/howto/install/uninstall.md
+++ b/docs/canonicalk8s/snap/howto/install/uninstall.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to uninstall Canonical Kubernetes by safely removing the node from the cluster before deleting the k8s snap."
+---
+
 # How to uninstall the {{product}} snap
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/networking/alternative-cni.md
+++ b/docs/canonicalk8s/snap/howto/networking/alternative-cni.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to replace the default CNI in Canonical Kubernetes with an alternative Container Network Interface (CNI) plugin."
+---
+
 # How to use an alternative CNI
 
 While {{product}} ships with a default [Container Network Interface] (CNI) that

--- a/docs/canonicalk8s/snap/howto/networking/default-dns.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-dns.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to enable, disable, and configure the default DNS service in Canonical Kubernetes for cluster-internal service discovery."
+---
+
 # How to use default DNS
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/networking/default-gateway.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-gateway.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "How to enable, diable and configure the Gateway API controller in Canonical Kubernetes for advanced Kubernetes network traffic management."
+    description: "How to enable, disable and configure the Gateway API controller in Canonical Kubernetes for advanced Kubernetes network traffic management."
 ---
 
 # How to use the default Gateway

--- a/docs/canonicalk8s/snap/howto/networking/default-gateway.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-gateway.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to enable, diable and configure the Gateway API controller in Canonical Kubernetes for advanced Kubernetes network traffic management."
+---
+
 # How to use the default Gateway
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/networking/default-ingress.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-ingress.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to enable, disable and configure the default Ingress controller in Canonical Kubernetes to route external traffic to cluster services."
+---
+
 # How to use default Ingress
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "How to enable, disble and configure the Canonical Kubernetes load balancer to expose services with external IPs from a configured IP address pool."
+    description: "How to enable, disable and configure the Canonical Kubernetes load balancer to expose services with external IPs from a configured IP address pool."
 ---
 
 # How to use the default load balancer

--- a/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to enable, disble and configure the Canonical Kubernetes load balancer to expose services with external IPs from a configured IP address pool."
+---
+
 # How to use the default load balancer
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/networking/default-network.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-network.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to enable, disable and configure the default network plugin in Canonical Kubernetes."
+---
+
 # How to use the default Network
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/networking/dualstack.md
+++ b/docs/canonicalk8s/snap/howto/networking/dualstack.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to enable dual-stack networking in Canonical Kubernetes, assigning both IPv4 and IPv6 addresses to pods and services."
+---
+
 # How to enable dual-stack networking
 
 Dual-stack networking allows Kubernetes to support both IPv4 and IPv6 addresses

--- a/docs/canonicalk8s/snap/howto/networking/index.md
+++ b/docs/canonicalk8s/snap/howto/networking/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Networking how-to guide index for Canonical Kubernetes, covering DNS, CNI, Ingress, load balancer, Gateway API, dual-stack, IPv6, UFW, and proxy."
+---
+
 # Networking
 
 Networking is a core part of a working Kubernetes cluster. These topics cover

--- a/docs/canonicalk8s/snap/howto/networking/ipv6.md
+++ b/docs/canonicalk8s/snap/howto/networking/ipv6.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to set up an IPv6-only Kubernetes cluster with Canonical Kubernetes by specifying IPv6 CIDRs during the bootstrap process."
+---
+
 # How to set up an IPv6-only cluster
 
 An IPv6-only Kubernetes cluster operates exclusively using IPv6 addresses,

--- a/docs/canonicalk8s/snap/howto/networking/proxy.md
+++ b/docs/canonicalk8s/snap/howto/networking/proxy.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure proxy settings for the Canonical Kubernetes snap using systemd configuration files."
+---
+
 # How to configure proxy settings for {{product}}
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure UFW (Uncomplicated Firewall) rules for Canonical Kubernetes."
+---
+
 # How to configure Uncomplicated Firewall (UFW)
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/observability.md
+++ b/docs/canonicalk8s/snap/howto/observability.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "How to set up ovbservability on a Canonical Kubernetes cluster by installing Prometheus for metrics collection and alerting."
+    description: "How to set up observability on a Canonical Kubernetes cluster by installing Prometheus for metrics collection and alerting."
 ---
 
 # How to use Prometheus with {{product}}

--- a/docs/canonicalk8s/snap/howto/observability.md
+++ b/docs/canonicalk8s/snap/howto/observability.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to set up ovbservability on a Canonical Kubernetes cluster by installing Prometheus for metrics collection and alerting."
+---
+
 # How to use Prometheus with {{product}}
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/restore-quorum.md
+++ b/docs/canonicalk8s/snap/howto/restore-quorum.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to recover a Canonical Kubernetes highly available cluster after quorum loss, restoring the cluster datastore."
+---
+
 # How to recover a cluster after quorum loss
 
 Highly available {{product}} clusters are designed to tolerate the loss of

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to assess CIS compliance for Canonical Kubernetes using kube-bench."
+---
+
 # How to assess CIS compliance
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/security/hardening.md
+++ b/docs/canonicalk8s/snap/howto/security/hardening.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to harden a Canonical Kubernetes cluster with post-deployment security steps aligned with CIS and DISA STIG benchmarks."
+---
+
 # How to harden your {{product}} cluster
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/security/index.md
+++ b/docs/canonicalk8s/snap/howto/security/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Security how-to guide index for Canonical Kubernetes, covering cluster hardening, CIS assessment, certificates, and security issue reporting."
+---
+
 # Security
 
 Administrators are provided with detailed instructions and compliance guidance

--- a/docs/canonicalk8s/snap/howto/security/intermediate-ca.md
+++ b/docs/canonicalk8s/snap/howto/security/intermediate-ca.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure Canonical Kubernetes to use an intermediate Certificate Authority (CA) via the bootstrap configuration file."
+---
+
 # How to use intermediate CAs with Vault
 
 By default, {{product}} will generate self-signed CA certificates for the

--- a/docs/canonicalk8s/snap/howto/security/refresh-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-certs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to refresh Kubernetes certificates for control plane and worker nodes in a Canonical Kubernetes cluster."
+---
+
 # How to refresh Kubernetes certificates
 
 To keep your {{product}} cluster secure and functional, it is essential

--- a/docs/canonicalk8s/snap/howto/security/refresh-external-certs.md
+++ b/docs/canonicalk8s/snap/howto/security/refresh-external-certs.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to refresh externally managed Kubernetes certificates for control plane and worker nodes in a Canonical Kubernetes cluster."
+---
+
 # How to refresh externally managed Kubernetes certificates
 
 This guide walks you through refreshing external certificates for both control

--- a/docs/canonicalk8s/snap/howto/security/report-security-issue.md
+++ b/docs/canonicalk8s/snap/howto/security/report-security-issue.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to report a security vulnerability in Canonical Kubernetes by filing a private security report on the k8s-snap GitHub repository."
+---
+
 # How to report a security issue in {{product}}
 
 While we do our best to keep up to date with the latest security issues, we

--- a/docs/canonicalk8s/snap/howto/storage/ceph.md
+++ b/docs/canonicalk8s/snap/howto/storage/ceph.md
@@ -1,10 +1,16 @@
+---
+myst:
+  html_meta:
+    description: "How to integrate Canonical Kubernetes with Ceph storage using the ceph-csi driver for RBD-backed persistent volumes."
+---
+
 # How to use Ceph storage with {{product}}
 
 Distributed, redundant storage is a must-have when you want to develop reliable
 applications. [Ceph] is a storage solution which provides exactly that, and is
 built with distributed clusters in mind. In this tutorial, we'll be looking at
 how to integrate {{product}} with a Ceph cluster. Specifically, by the
-end of this tutorial you'll have a Kubernetes pod with a mounted RBD-backed
+end of this how-to guide you'll have a Kubernetes pod with a mounted RBD-backed
 volume. RBD stands for RADOS Block Device and it is the abstraction used by Ceph
 to provide reliable and distributed storage. This how-to guide is adapted from
 [block-devices-and-kubernetes].

--- a/docs/canonicalk8s/snap/howto/storage/cloud.md
+++ b/docs/canonicalk8s/snap/howto/storage/cloud.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to use AWS EBS cloud storage with Canonical Kubernetes on EC2 instances, including IAM policies and cloud controller manager setup."
+---
+
 # How to use cloud storage
 
 {{product}} simplifies the process of integrating and managing cloud storage

--- a/docs/canonicalk8s/snap/howto/storage/index.md
+++ b/docs/canonicalk8s/snap/howto/storage/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Storage how-to guide index for Canonical Kubernetes, covering local storage, Ceph, and cloud storage configuration."
+---
+
 # Storage
 
 Most Kubernetes clusters will need some type of persistent storage for running

--- a/docs/canonicalk8s/snap/howto/storage/storage.md
+++ b/docs/canonicalk8s/snap/howto/storage/storage.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to enable and configure the default local-storage option in Canonical Kubernetes."
+---
+
 # How to use default storage
 
 <!-- SPREAD SUITE: snap_bootstrapped -->

--- a/docs/canonicalk8s/snap/howto/support.md
+++ b/docs/canonicalk8s/snap/howto/support.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to get support for Canonical Kubernetes through community channels, troubleshooting guides, and professional Ubuntu support services."
+---
+
 # How to get support
 
 Support for {{product}} is available in a variety of ways:

--- a/docs/canonicalk8s/snap/index.md
+++ b/docs/canonicalk8s/snap/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Explore the official Canonical Kubernetes snap documentation. Includes step-by-step tutorials, practical how-to guides, in-depth explanations, and technical reference."
+    description: "Canonical Kubernetes snap documentation: a lightweight, secure Kubernetes distribution installable as a snap, with built-in networking, ingress, and storage."
 ---
 
 # {{product}} snap documentation

--- a/docs/canonicalk8s/snap/reference/annotations.md
+++ b/docs/canonicalk8s/snap/reference/annotations.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for Canonical Kubernetes cluster annotations."
+---
+
 # Annotations
 
 This page outlines the annotations that can be configured during cluster

--- a/docs/canonicalk8s/snap/reference/certificates.md
+++ b/docs/canonicalk8s/snap/reference/certificates.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for Canonical Kubernetes certificate authorities, certificates, and configuration directory paths used in TLS-secured cluster communication."
+---
+
 # Cluster certificates and configuration directories
 
 This reference page provides an overview of certificate authorities (CAs),

--- a/docs/canonicalk8s/snap/reference/cis-audit.md
+++ b/docs/canonicalk8s/snap/reference/cis-audit.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for CIS Kubernetes Benchmark hardening in Canonical Kubernetes, with per-control guidance for manual CIS compliance auditing."
+---
+
 #  CIS hardening for {{product}}
 
 CIS Hardening refers to the process of implementing security configurations that

--- a/docs/canonicalk8s/snap/reference/commands.md
+++ b/docs/canonicalk8s/snap/reference/commands.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for Canonical Kubernetes k8s snap CLI commands."
+---
+
 # Commands
 
 These are the commands provided by the k8s snap:

--- a/docs/canonicalk8s/snap/reference/commands.md
+++ b/docs/canonicalk8s/snap/reference/commands.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Reference documentation for Canonical Kubernetes k8s snap CLI commands."
+    description: "Reference documentation for Canonical Kubernetes k8s-snap CLI commands."
 ---
 
 # Commands

--- a/docs/canonicalk8s/snap/reference/config-files/bootstrap-config.md
+++ b/docs/canonicalk8s/snap/reference/config-files/bootstrap-config.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for the Canonical Kubernetes bootstrap configuration file."
+---
+
 # Bootstrap configuration file
 
 A YAML file can be supplied to the `k8s bootstrap` command to configure and

--- a/docs/canonicalk8s/snap/reference/config-files/disa-stig-config.md
+++ b/docs/canonicalk8s/snap/reference/config-files/disa-stig-config.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for Canonical Kubernetes DISA STIG configuration files for bootstrap, control plane join, and worker node join operations."
+---
+
 # DISA STIG example configuration files
 
 During the [installation of a DISA STIG hardened cluster], {{product}} provides

--- a/docs/canonicalk8s/snap/reference/config-files/index.md
+++ b/docs/canonicalk8s/snap/reference/config-files/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference index for Canonical Kubernetes configuration files, including bootstrap, node join, DISA STIG, and external certificate refresh formats."
+---
+
 # Configuration files
 
 {{product}} uses several configuration files to control its behavior and

--- a/docs/canonicalk8s/snap/reference/config-files/node-join-config.md
+++ b/docs/canonicalk8s/snap/reference/config-files/node-join-config.md
@@ -1,4 +1,7 @@
 ---
+myst:
+  html_meta:
+    description: "Reference for the Canonical Kubernetes node join configuration file, covering all options for control plane and worker node joins."
 tocdepth: 2
 ---
 

--- a/docs/canonicalk8s/snap/reference/config-files/refresh-external-certs-config.md
+++ b/docs/canonicalk8s/snap/reference/config-files/refresh-external-certs-config.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for the Canonical Kubernetes refresh external certificates configuration file."
+---
+
 # Refresh certificates configuration file
 
 A YAML file can be supplied to the `k8s refresh-certs --external-certificates`

--- a/docs/canonicalk8s/snap/reference/disa-stig-audit.md
+++ b/docs/canonicalk8s/snap/reference/disa-stig-audit.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for DISA STIG guidelines for Canonical Kubernetes, with per-control guidance for manual DISA STIG compliance auditing."
+---
+
 # DISA STIG for {{product}}
 
 Security Technical Implementation Guides (STIGs) are developed by the Defense

--- a/docs/canonicalk8s/snap/reference/dqlite.md
+++ b/docs/canonicalk8s/snap/reference/dqlite.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for the Dqlite databases in Canonical Kubernetes."
+---
+
 # Dqlite database
 
 {{product}} uses Dqlite for k8sd, which manages Kubernetes cluster management

--- a/docs/canonicalk8s/snap/reference/dqlite.md
+++ b/docs/canonicalk8s/snap/reference/dqlite.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Reference documentation for the Dqlite databases in Canonical Kubernetes."
+    description: "Reference documentation for the Dqlite database in Canonical Kubernetes."
 ---
 
 # Dqlite database

--- a/docs/canonicalk8s/snap/reference/etcd.md
+++ b/docs/canonicalk8s/snap/reference/etcd.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference documentation for the etcd datastore in Canonical Kubernetes."
+---
+
 # Etcd database
 
 {{product}} uses **etcd** as the default Kubernetes datastore.

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference index for the Canonical Kubernetes snap, including architecture, etcd, Dqlite, commands, configuration files, ports, and release notes."
+---
+
 # Reference
 
 Our Reference section is for when you need to check specific details or

--- a/docs/canonicalk8s/snap/reference/index.md
+++ b/docs/canonicalk8s/snap/reference/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Reference index for the Canonical Kubernetes snap, including architecture, etcd, Dqlite, commands, configuration files, ports, and release notes."
+    description: "Reference index for the Canonical Kubernetes snap, including architecture, etcd, Dqlite, CLI commands, configuration files, ports, and release notes."
 ---
 
 # Reference

--- a/docs/canonicalk8s/snap/reference/inspection-reports.md
+++ b/docs/canonicalk8s/snap/reference/inspection-reports.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for Canonical Kubernetes inspection reports, a diagnostic tarball with service logs, SBOM, system and network diagnostics used for troubleshooting."
+---
+
 # Inspection reports
 
 {{product}} ships with a command to compile a complete report on {{product}} and

--- a/docs/canonicalk8s/snap/reference/ports-and-services.md
+++ b/docs/canonicalk8s/snap/reference/ports-and-services.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for network services, sockets, ports and protocols used by Canonical Kubernetes nodes."
+---
+
 # Services and ports
 
 ## Network services

--- a/docs/canonicalk8s/snap/reference/proxy.md
+++ b/docs/canonicalk8s/snap/reference/proxy.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reference for proxy environment variables in Canonical Kubernetes, including HTTPS_PROXY, HTTP_PROXY, NO_PROXY, and required CIDR exclusions."
+---
+
 # Proxy environment variables
 
 {{product}} uses the standard system-wide environment variables to

--- a/docs/canonicalk8s/snap/tutorial/index.md
+++ b/docs/canonicalk8s/snap/tutorial/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Tutorials for the Canonical Kubernetes snap, covering initial cluster setup and everyday cluster operations."
+---
+
 # Tutorials
 
 This section contains a step-by-step guide to help you start exploring how to


### PR DESCRIPTION
## Description

To improve SEO, we need to add metadata descriptions to our docs. We have been carrying this out on a best effort basis so far but now this ensures every page is complete. 

## Solution

All pages have a metadata description in a html block. 

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.

