### PR TITLE
fix: Wait for CRD Established condition before using custom resources

### DIFF
--- a/src/k8s/pkg/client/kubernetes/crds.go
+++ b/src/k8s/pkg/client/kubernetes/crds.go
@@ -62,7 +62,7 @@ func (c *Client) ApplyCRDs(ctx context.Context) error {
 		log.V(1).Info("Applied CRD", "name", crd.Name, "version", crd.APIVersion, "kind", crd.Kind)
 
 		if waitErr := control.WaitUntilReady(ctx, func() (bool, error) {
-			return c.CRDExists(ctx, crd.Name)
+			return c.CRDEstablished(ctx, crd.Name)
 		}); waitErr != nil {
 			return fmt.Errorf("failed to wait for CRD to be ready: %w", waitErr)
 		}
@@ -73,23 +73,28 @@ func (c *Client) ApplyCRDs(ctx context.Context) error {
 	return nil
 }
 
-// CRDExists checks if a given CRD exists in the cluster.
-func (c *Client) CRDExists(ctx context.Context, crdName string) (bool, error) {
+// CRDEstablished checks if a given CRD is established in the cluster,
+// meaning the API server is serving its resources.
+func (c *Client) CRDEstablished(ctx context.Context, crdName string) (bool, error) {
 	apiExtClient, err := apiextensionsclient.NewForConfig(c.RESTConfig())
 	if err != nil {
 		return false, fmt.Errorf("failed to create API extensions client: %w", err)
 	}
 
-	_, err = apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, v1.GetOptions{})
-	if err == nil {
-		return true, nil // CRD exists
+	crd, err := apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, v1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get CRD: %w", err)
 	}
 
-	if apierrors.IsNotFound(err) {
-		return false, nil // CRD does not exist
+	for _, cond := range crd.Status.Conditions {
+		if cond.Type == apiextensionsv1.Established {
+			return cond.Status == apiextensionsv1.ConditionTrue, nil
+		}
 	}
-
-	return false, fmt.Errorf("failed to check CRD existence: %w", err)
+	return false, nil
 }
 
 // convertUnstructuredToCRD converts an unstructured object to a CRD object.

--- a/src/k8s/pkg/client/kubernetes/crds_test.go
+++ b/src/k8s/pkg/client/kubernetes/crds_test.go
@@ -1,0 +1,122 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestCRDEstablished(t *testing.T) {
+	tests := []struct {
+		name           string
+		crdName        string
+		handler        http.HandlerFunc
+		expectedResult bool
+		expectedError  string
+	}{
+		{
+			name:    "CRD is established",
+			crdName: "upgrades.k8sd.io",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				crd := &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "upgrades.k8sd.io"},
+					Status: apiextensionsv1.CustomResourceDefinitionStatus{
+						Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+							{
+								Type:   apiextensionsv1.Established,
+								Status: apiextensionsv1.ConditionTrue,
+							},
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(crd)
+			},
+			expectedResult: true,
+		},
+		{
+			name:    "CRD exists but not established",
+			crdName: "upgrades.k8sd.io",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				crd := &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "upgrades.k8sd.io"},
+					Status: apiextensionsv1.CustomResourceDefinitionStatus{
+						Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+							{
+								Type:   apiextensionsv1.Established,
+								Status: apiextensionsv1.ConditionFalse,
+							},
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(crd)
+			},
+			expectedResult: false,
+		},
+		{
+			name:    "CRD exists but no conditions",
+			crdName: "upgrades.k8sd.io",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				crd := &apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "upgrades.k8sd.io"},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(crd)
+			},
+			expectedResult: false,
+		},
+		{
+			name:    "CRD does not exist",
+			crdName: "upgrades.k8sd.io",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				json.NewEncoder(w).Encode(metav1.Status{
+					Status: metav1.StatusFailure,
+					Reason: metav1.StatusReasonNotFound,
+					Code:   http.StatusNotFound,
+				})
+			},
+			expectedResult: false,
+		},
+		{
+			name:    "API server error",
+			crdName: "upgrades.k8sd.io",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expectedError: "failed to get CRD",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			client := &Client{
+				config: &rest.Config{Host: server.URL},
+			}
+
+			result, err := client.CRDEstablished(context.Background(), tt.crdName)
+
+			if tt.expectedError != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedError))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(result).To(Equal(tt.expectedResult))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`CRDExists` only checks whether the CRD object existed, not whether the API server had finished registering its endpoints. On rolling upgrades with `maxSurge=0`, this race caused `"no matches for k8sd.io/v1alpha"` errors when listing upgrades immediately after CRD application.

## Solution

Rename `CRDExists` to `CRDEstablished` and check the `Established` status condition, which the Kubernetes API server sets once it is serving the CRD's resources.

## Issue

Fixes: https://github.com/canonical/k8sd/issues/60

## Backport

<!-- Should this PR be backported? If so, to which release? -->

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

"Backported" from: https://github.com/canonical/k8sd/pull/61

Can be backported to release-1.34, release-1.33

## Checklist

- [x] PR title formatted as `type: title`
- [x] Covered by unit tests
- [ ] Covered by integration tests - should already by covered by existing tests
- [ ] Documentation updated - N/A
- [x] CLA signed
- [ ] Backport label added if necessary - cannot add labels
- [ ] Confirm whether the `release-notes` label should be kept or removed - N/A

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

