### PR TITLE
test: validate k8sd security dependency bumps via CI

### DIFF
--- a/build-scripts/components/k8sd/version
+++ b/build-scripts/components/k8sd/version
@@ -1,1 +1,1 @@
-main
+fix/bump-security-deps-main


### PR DESCRIPTION
## What

Temporarily points the k8sd build component (`build-scripts/components/k8sd/version`) at the `fix/bump-security-deps-main` branch of canonical/k8sd to run it through k8s-snap CI.

## Why

The k8sd PR bumps security-sensitive Go dependencies and the Go toolchain:
- `go 1.25.7 → 1.26.1`
- `helm 3.19.5 → 3.20.2` (drives coreDNS/cilium/metallb/localpv chart installs)
- `k8s.io/* 0.35.0 → 0.35.1`
- `containerd 1.7.30 → 1.7.32`
- assorted `golang.org/x/*`, prometheus, genproto bumps
- adds `exclude` for go-jose v4.1.3 (CVE-2026-34986)

k8sd's own CI only covers unit tests + lint. This PR exercises the full integration build and e2e path in k8s-snap to confirm the dependency bumps are safe before merging.

## Merge plan

🚫 **Do not merge.** This is a CI validation PR. Once green:
1. Merge the k8sd PR.
2. Revert the version pin back to `main` (or close this PR).