### PR TITLE
docs: Update errors in our docs found in spread tests [Backport release-1.32]

### DIFF
--- a/docs/canonicalk8s/_parts/common_hardening.md
+++ b/docs/canonicalk8s/_parts/common_hardening.md
@@ -8,9 +8,8 @@ as described in the upstream Kubernetes documentation on
 Create the `EncryptionConfiguration` file under `/var/snap/k8s/common/etc/encryption/`.
 
 ```
-sudo sh -c '
-mkdir -p /var/snap/k8s/common/etc/encryption/
-cat >/var/snap/k8s/common/etc/encryption/enc.yaml << EOL
+sudo mkdir -p /var/snap/k8s/common/etc/encryption/
+cat << EOL | sudo tee /var/snap/k8s/common/etc/encryption/enc.yaml > /dev/null
 kind: "EncryptionConfiguration"
 apiVersion: apiserver.config.k8s.io/v1
 resources:
@@ -22,7 +21,7 @@ resources:
         secret: ${BASE 64 ENCODED SECRET}
   - identity: {}
 EOL
-chmod 600 /var/snap/k8s/common/etc/encryption/enc.yaml
+sudo chmod 600 /var/snap/k8s/common/etc/encryption/enc.yaml
 ```
 
 Set the `--encryption-provider-config` file as an argument to the kubernetes

--- a/docs/canonicalk8s/snap/howto/networking/default-dns.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-dns.md
@@ -64,7 +64,8 @@ Change the cluster domain name:
 sudo k8s set dns.cluster-domain=<new-domain-name>
 ```
 
-Assign a new cluster IP to the DNS service:
+Assign a new cluster IP to the DNS service (DNS must be disabled in order to 
+do this):
 
 ```
 sudo k8s set dns.service-ip=<new-cluster-ip>

--- a/docs/canonicalk8s/snap/howto/networking/default-ingress.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-ingress.md
@@ -85,7 +85,7 @@ Consult the official
 Use the following command to enable the proxy protocol:
 
 ```
-sudo k8s set ingress.enable-proxy-protocol=<new-enable-proxy-protocol>
+sudo k8s set ingress.enable-proxy-protocol=true
 ```
 
 Adjust the value of `<new-enable-proxy-protocol>` with your proxy protocol

--- a/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
@@ -21,8 +21,7 @@ command:
 sudo k8s status
 ```
 
-The load balancer is not enabled by default, it won't be listed on the status
-output unless it has been subsequently enabled.
+The load balancer is not enabled by default.
 
 To check the current configuration of the `load-balancer`, run the following:
 

--- a/docs/canonicalk8s/snap/howto/networking/default-network.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-network.md
@@ -21,7 +21,7 @@ Find out whether Network is enabled or disabled with the following command:
 sudo k8s status
 ```
 
-The default state for the cluster is `network disabled`.
+The default state for the cluster is `network enabled`.
 
 ## Enable Network
 

--- a/docs/canonicalk8s/snap/howto/storage/storage.md
+++ b/docs/canonicalk8s/snap/howto/storage/storage.md
@@ -37,10 +37,10 @@ sudo k8s get local-storage
 ```
 
 You can modify the configuration using the `set` command. For example, to
-change the local storage path:
+change the default setting:
 
 ```
-sudo k8s set local-storage.local-path=/path/to/new/folder
+sudo k8s set local-storage.default=true
 ```
 
 The local-storage feature provides the following configuration options:
@@ -52,6 +52,9 @@ The local-storage feature provides the following configuration options:
   this flag is not set and the cluster already has a default storage class it
   is not changed. If this flag is not set and the cluster does not have a
   default class set then the class from the local-storage becomes the default.
+
+To alter the `local-path` or `reclaim-policy`, you must disable local-storage 
+first.
 
 ## Disable local storage
 


### PR DESCRIPTION
# Description
Manual backport of #2626 to `release-1.32`.

(cherry picked from commit a5ec8a1d0e64a4a73c1d9ccb161436d532569a34)


