### PR TITLE
docs: Update broken links from moved files in release-1.35

### DIFF
--- a/docs/canonicalk8s/charm/howto/contribute.md
+++ b/docs/canonicalk8s/charm/howto/contribute.md
@@ -114,9 +114,7 @@ write all our documentation in Markdown to make it easier for humans to work
 with. There are a few extra things that come with this - certain features need
 to be specially marked up (e.g. admonitions) to be processed properly. There is
 a guide to using `Myst` (which is a Markdown extension for Sphinx) directives
-and formatting available at
-[Canonical Sphinx Stack documentation](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/)
-.
+and formatting available at [Canonical Sphinx Stack documentation].
 
 ### Local testing
 
@@ -142,3 +140,4 @@ press `F5` in your browser to reload the page without caching)!
 [Diátaxis website]: https://diataxis.fr/
 [_parts]: https://github.com/canonical/k8s-snap/blob/main/docs/canonicalk8s/_parts/doc-cheat-sheet-myst.md
 [community page]: ../reference/community
+[Canonical Sphinx Stack documentation]: https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/

--- a/docs/canonicalk8s/charm/howto/contribute.md
+++ b/docs/canonicalk8s/charm/howto/contribute.md
@@ -114,7 +114,7 @@ write all our documentation in Markdown to make it easier for humans to work
 with. There are a few extra things that come with this - certain features need
 to be specially marked up (e.g. admonitions) to be processed properly. There is
 a guide to using `Myst` (which is a Markdown extension for Sphinx) directives
-and formatting available at 
+and formatting available at
 [Canonical Sphinx Stack documentation](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/)
 .
 

--- a/docs/canonicalk8s/charm/howto/contribute.md
+++ b/docs/canonicalk8s/charm/howto/contribute.md
@@ -114,7 +114,9 @@ write all our documentation in Markdown to make it easier for humans to work
 with. There are a few extra things that come with this - certain features need
 to be specially marked up (e.g. admonitions) to be processed properly. There is
 a guide to using `Myst` (which is a Markdown extension for Sphinx) directives
-and formatting contained in the [_parts][] directory of the docs.
+and formatting available at 
+[Canonical Sphinx Stack documentation](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/)
+.
 
 ### Local testing
 

--- a/docs/canonicalk8s/snap/howto/contribute.md
+++ b/docs/canonicalk8s/snap/howto/contribute.md
@@ -179,7 +179,7 @@ write all our documentation in Markdown to make it easier for humans to work
 with. There are a few extra things that come with this - certain features need
 to be specially marked up (e.g. admonitions) to be processed properly. There is
 a guide to using `Myst` (which is a Markdown extension for Sphinx) directives
-and formatting available at 
+and formatting available at
 [Canonical Sphinx Stack documentation](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/)
 .
 

--- a/docs/canonicalk8s/snap/howto/contribute.md
+++ b/docs/canonicalk8s/snap/howto/contribute.md
@@ -179,9 +179,7 @@ write all our documentation in Markdown to make it easier for humans to work
 with. There are a few extra things that come with this - certain features need
 to be specially marked up (e.g. admonitions) to be processed properly. There is
 a guide to using `Myst` (which is a Markdown extension for Sphinx) directives
-and formatting available at
-[Canonical Sphinx Stack documentation](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/)
-.
+and formatting available at [Canonical Sphinx Stack documentation].
 
 ### Local testing
 
@@ -211,3 +209,4 @@ press `F5` in your browser to reload the page without caching)!
 [Explanation template]: https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/release-1.35/docs/canonicalk8s/_templates/template-explanation
 [Reference template]: https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/release-1.35/docs/canonicalk8s/_templates/template-reference
 [development env guide]: install/dev-env.md
+[Canonical Sphinx Stack documentation]: https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/

--- a/docs/canonicalk8s/snap/howto/contribute.md
+++ b/docs/canonicalk8s/snap/howto/contribute.md
@@ -179,7 +179,9 @@ write all our documentation in Markdown to make it easier for humans to work
 with. There are a few extra things that come with this - certain features need
 to be specially marked up (e.g. admonitions) to be processed properly. There is
 a guide to using `Myst` (which is a Markdown extension for Sphinx) directives
-and formatting contained in the [_parts][] directory of the docs.
+and formatting available at 
+[Canonical Sphinx Stack documentation](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/)
+.
 
 ### Local testing
 
@@ -203,10 +205,9 @@ press `F5` in your browser to reload the page without caching)!
 [Snapcraft documentation]: https://documentation.ubuntu.com/snapcraft/stable/how-to/set-up-snapcraft/
 [code repo]: https://github.com/canonical/k8s-snap
 [Diátaxis website]: https://diataxis.fr/
-[_parts]: https://github.com/canonical/k8s-snap/blob/main/docs/canonicalk8s/_parts/doc-cheat-sheet-myst.md
 [community page]: ../reference/community
-[Tutorial template]: https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/canonicalk8s/_parts/template-tutorial
-[How to template]: https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/canonicalk8s/_parts/template-howto
-[Explanation template]: https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/canonicalk8s/_parts/template-explanation
-[Reference template]: https://raw.githubusercontent.com/canonical/k8s-snap/main/docs/canonicalk8s/_parts/template-reference
+[Tutorial template]: https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/release-1.35/docs/canonicalk8s/_templates/template-tutorial
+[How to template]: https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/release-1.35/docs/canonicalk8s/_templates/template-howto
+[Explanation template]: https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/release-1.35/docs/canonicalk8s/_templates/template-explanation
+[Reference template]: https://raw.githubusercontent.com/canonical/k8s-snap/refs/heads/release-1.35/docs/canonicalk8s/_templates/template-reference
 [development env guide]: install/dev-env.md


### PR DESCRIPTION
## Description

With the upgrade of the sphinx stack to v2, we moved the template files into the _template dir rather than the _parts dir. The latest contribution guide on main was updated so it was missed in the upgrade PR, but was caught in our weekly linkcheck tests. 

## Solution

Updated links

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.
