### PR TITLE
docs: Add related links to our tutorials 

### DIFF
--- a/docs/canonicalk8s/capi/tutorial/getting-started.md
+++ b/docs/canonicalk8s/capi/tutorial/getting-started.md
@@ -2,7 +2,7 @@
 myst:
   html_meta:
     description: Learn how to set up a management cluster to deploy your first Canonical Kubernetes cluster using the Cluster API in this tutorial.
-relatedlinks: "[clusterctl&#32;installation](https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl), [clusterawsadm&#32;documentation](https://cluster-api-aws.sigs.k8s.io/) "
+relatedlinks: "[clusterctl&#32;installation](https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl), [clusterawsadm&#32;documentation](https://cluster-api-aws.sigs.k8s.io/)"
 ---
 
 # Getting started with Cluster API

--- a/docs/canonicalk8s/capi/tutorial/getting-started.md
+++ b/docs/canonicalk8s/capi/tutorial/getting-started.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: Learn how to set up a management cluster to deploy your first Canonical Kubernetes cluster using the Cluster API in this tutorial.
+relatedlinks: "[clusterctl&#32;installation](https://cluster-api.sigs.k8s.io/user/quick-start#install-clusterctl), [clusterawsadm&#32;documentation](https://cluster-api-aws.sigs.k8s.io/) "
 ---
 
 # Getting started with Cluster API

--- a/docs/canonicalk8s/charm/tutorial/basic-operations.md
+++ b/docs/canonicalk8s/charm/tutorial/basic-operations.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to scale a Canonical Kubernetes charm cluster, manage worker nodes, and interact with the cluster using kubectl."
+relatedlinks: "[Juju&#32;documentation](https://canonical.com/juju/docs/juju-cli/), [kubectl&#32;documentation](https://kubernetes.io/docs/reference/kubectl/)"
+---
+
 # Basic {{ product }} charm operations
 
 This tutorial walks you through common management tasks for your {{ product }}

--- a/docs/canonicalk8s/charm/tutorial/getting-started.md
+++ b/docs/canonicalk8s/charm/tutorial/getting-started.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to deploy Canonical Kubernetes using the k8s Juju charm, create a multi-node cluster, and add worker nodes in this tutorial."
+relatedlinks: "[Juju&#32;documentation](https://canonical.com/juju/docs/juju-cli/)"
+---
+
 # Getting started
 
 The {{product}} `k8s` charm takes care of installing and configuring

--- a/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
+++ b/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
@@ -2,7 +2,7 @@
 myst:
   html_meta:
     description: "Learn how to add and remove nodes in a Canonical Kubernetes cluster using two Multipass VMs."
-relatedlinks: "[Multipass&#32;documentation](https://multipass.run/install)"
+relatedlinks: "[Multipass&#32;documentation](https://canonical.com/multipass/docs/stable)"
 ---
 
 # Add and remove nodes

--- a/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
+++ b/docs/canonicalk8s/snap/tutorial/add-remove-nodes.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to add and remove nodes in a Canonical Kubernetes cluster using two Multipass VMs."
+relatedlinks: "[Multipass&#32;documentation](https://multipass.run/install)"
+---
+
 # Add and remove nodes
 
 Typical production clusters are hosted across multiple data centers and cloud

--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -2,7 +2,7 @@
 myst:
   html_meta:
     description: Learn how to deploy your first Canonical Kubernetes cluster using the k8s snap and execute typical cluster operations in this tutorial.
-relatedlinks: "[Snapd&#32;documentation](https://snapcraft.io/docs/), [kubectl&#32;documentation](https://kubernetes.io/docs/reference/kubectl/)"
+relatedlinks: "[Snap&#32;documentation](https://snapcraft.io/docs/), [kubectl&#32;documentation](https://kubernetes.io/docs/reference/kubectl/)"
 ---
 
 # Getting started

--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -2,7 +2,7 @@
 myst:
   html_meta:
     description: Learn how to deploy your first Canonical Kubernetes cluster using the k8s snap and execute typical cluster operations in this tutorial.
-relatedlinks: "[Snapd&#32;documentation](https://snapcraft.io/docs/installing-snapd), [kubectl&#32;documentation](https://kubernetes.io/docs/reference/kubectl/)"
+relatedlinks: "[Snapd&#32;documentation](https://snapcraft.io/docs/), [kubectl&#32;documentation](https://kubernetes.io/docs/reference/kubectl/)"
 ---
 
 # Getting started

--- a/docs/canonicalk8s/snap/tutorial/getting-started.md
+++ b/docs/canonicalk8s/snap/tutorial/getting-started.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: Learn how to deploy your first Canonical Kubernetes cluster using the k8s snap and execute typical cluster operations in this tutorial.
+relatedlinks: "[Snapd&#32;documentation](https://snapcraft.io/docs/installing-snapd), [kubectl&#32;documentation](https://kubernetes.io/docs/reference/kubectl/)"
 ---
 
 # Getting started

--- a/docs/canonicalk8s/snap/tutorial/kubectl.md
+++ b/docs/canonicalk8s/snap/tutorial/kubectl.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    description: "Learn basic Kubernetes cluster operations with kubectl in Canonical Kubernetes, including pod deployment, service management, and cluster inspection."
+relatedlinks: "[kubectl&#32;documentation](https://kubernetes.io/docs/reference/kubectl/)"
+---
+
 # Basic operations with {{product}} using kubectl
 
 Kubernetes provides a command line tool for communicating with a Kubernetes


### PR DESCRIPTION
## Description

These related links allow us to link to official docs of external tools that are a prerequisite or primary subject of the tutorial. These are different to in-body links that aim to serve the users understanding in the moment. These related links on the right hand navigation are for further learning beyond the tutorial.

## Solution

- Limited number of related links added to our tutorials
- `&#32;` is used instead of a space to allow the correct formatting. `clusterctl&#32;installation` -> `clusterctl installation`

<img width="1175" height="590" alt="image" src="https://github.com/user-attachments/assets/68adbcbd-c7c1-480c-b345-4d34d4147be5" />

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.