### PR TITLE
docs: mention MetalLB as the default load balancer implementation

### DIFF
--- a/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
+++ b/docs/canonicalk8s/snap/howto/networking/default-loadbalancer.md
@@ -8,9 +8,9 @@ myst:
 
 <!-- SPREAD SUITE: snap_bootstrapped -->
 
-{{product}} includes a default load balancer. As this is not an
-essential service for all deployments, it is not enabled by default. This guide
-explains how to configure and enable the `load-balancer`.
+{{product}} includes a default load balancer, implemented using [MetalLB].
+As this is not an essential service for all deployments, it is not enabled by
+default. This guide explains how to configure and enable the `load-balancer`.
 
 ## Prerequisites
 
@@ -150,3 +150,4 @@ fi
 <!-- LINKS -->
 [CIDR]: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
 [getting-started-guide]: /snap/tutorial/getting-started
+[MetalLB]: https://metallb.io/


### PR DESCRIPTION
Names the underlying implementation in the intro, matching how default-network.md names Cilium, and links out to metallb.io.

## Description

Mentions about metallb implementation within the docs, such that it gets reflected under https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/default-loadbalancer/

## Solution
Included specification about `MetalLB` with it's reference.

## Issue

<!-- Include a link to the GitHub issue number if applicable. -->

## Backport
#2630

<!-- Label the PR with `backport release-1.XX` to automatically create a backport once this PR is merged -->

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary 
- [ ] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.

<!-- The PR title is expected to contain one of the following prefixes, following the
[Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/):

* feat: A new feature
* fix: A bug fix
* docs: Documentation only changes
* style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* refactor: A code change that neither fixes a bug nor adds a feature
* perf: A code change that improves performance
* test: Adding missing tests or correcting existing tests
* build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* chore: Other changes that don't modify src or test files
* revert: Reverts a previous commit -->

