### PR TITLE
docs: Add related links to reference and explanation

### DIFF
--- a/docs/canonicalk8s/capi/explanation/capi-ck8s.md
+++ b/docs/canonicalk8s/capi/explanation/capi-ck8s.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Explanation of Cluster API (CAPI) and how Canonical Kubernetes integrates with it for declarative cluster provisioning across infrastructure providers."
+relatedlinks: "[Cluster&#32;API&#32;documentation](https://cluster-api.sigs.k8s.io/)"
 ---
 
 # Cluster API and {{product}}

--- a/docs/canonicalk8s/capi/explanation/networking.md
+++ b/docs/canonicalk8s/capi/explanation/networking.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Overview of Canonical Kubernetes networking features including CNI, DNS, load balancing, Ingress, and Gateway API."
+relatedlinks: "[Kubernetes&#32;networking](https://kubernetes.io/docs/concepts/services-networking/)"
 ---
 
 ```{include} ../../snap/explanation/networking.md

--- a/docs/canonicalk8s/capi/explanation/security.md
+++ b/docs/canonicalk8s/capi/explanation/security.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliance."
+relatedlinks: "[Kubernetes&#32;security&#32;documentation](https://kubernetes.io/docs/concepts/security/)"
 ---
 
 ```{include} /snap/explanation/security.md

--- a/docs/canonicalk8s/charm/explanation/channels.md
+++ b/docs/canonicalk8s/charm/explanation/channels.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Explanation of Canonical Kubernetes snap channels, including track and risk level components, update behavior, and how to choose the right channel."
+relatedlinks: "[Snap&#32;channels](https://snapcraft.io/docs/channels)"
 ---
 
 ```{include} ../../snap/explanation/channels.md

--- a/docs/canonicalk8s/charm/explanation/networking.md
+++ b/docs/canonicalk8s/charm/explanation/networking.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Overview of Canonical Kubernetes networking features including CNI, DNS, load balancing, Ingress, and Gateway API."
+relatedlinks: "[Kubernetes&#32;networking](https://kubernetes.io/docs/concepts/services-networking/)"
 ---
 
 ```{include} ../../snap/explanation/networking.md

--- a/docs/canonicalk8s/charm/explanation/security.md
+++ b/docs/canonicalk8s/charm/explanation/security.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliance."
+relatedlinks: "[Kubernetes&#32;security&#32;documentation](https://kubernetes.io/docs/concepts/security/)"
 ---
 
 ```{include} /snap/explanation/security.md

--- a/docs/canonicalk8s/snap/explanation/channels.md
+++ b/docs/canonicalk8s/snap/explanation/channels.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Explanation of Canonical Kubernetes snap channels, including track and risk level components, update behavior, and how to choose the right channel."
+relatedlinks: "[Snap&#32;channels](https://snapcraft.io/docs/channels)"
 ---
 
 # Channels

--- a/docs/canonicalk8s/snap/explanation/networking.md
+++ b/docs/canonicalk8s/snap/explanation/networking.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: Overview of Canonical Kubernetes networking features including CNI, DNS, load balancing, Ingress, and Gateway API.
+relatedlinks: "[Kubernetes&#32;networking](https://kubernetes.io/docs/concepts/services-networking/)"
 ---
 
 # Networking

--- a/docs/canonicalk8s/snap/explanation/package-management.md
+++ b/docs/canonicalk8s/snap/explanation/package-management.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Explanation of package management in Canonical Kubernetes using Helm, including charts, chart repositories, and Helm installation and upgrade workflows."
+relatedlinks: "[Helm&#32;documentation](https://helm.sh/docs/)"
 ---
 
 # Package management with Helm

--- a/docs/canonicalk8s/snap/explanation/security.md
+++ b/docs/canonicalk8s/snap/explanation/security.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Explanation of security in Canonical Kubernetes, covering snap confinement, OCI image maintenance, RBAC, TLS certificates, and security compliance."
+relatedlinks: "[Kubernetes&#32;security&#32;documentation](https://kubernetes.io/docs/concepts/security/)"
 ---
 
 <!-- Start -->

--- a/docs/canonicalk8s/snap/reference/config-files/disa-stig-config.md
+++ b/docs/canonicalk8s/snap/reference/config-files/disa-stig-config.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Reference for Canonical Kubernetes DISA STIG configuration files for bootstrap, control plane join, and worker node join operations."
+relatedlinks: "[DISA&#32;STIG&#32;for&#32;Kubernetes](https://stigviewer.com/stigs/kubernetes/)"
 ---
 
 # DISA STIG example configuration files

--- a/docs/canonicalk8s/snap/reference/dqlite.md
+++ b/docs/canonicalk8s/snap/reference/dqlite.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Reference documentation for the Dqlite database in Canonical Kubernetes."
+relatedlinks: "[Dqlite&#32;documentation](https://canonical.com/dqlite/docs)"
 ---
 
 # Dqlite database

--- a/docs/canonicalk8s/snap/reference/etcd.md
+++ b/docs/canonicalk8s/snap/reference/etcd.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "Reference documentation for the etcd datastore in Canonical Kubernetes."
+relatedlinks: "[etcd&#32;documentation](https://etcd.io/docs/latest/)"
 ---
 
 # Etcd database


### PR DESCRIPTION
## Description

This is part of our SEO and GA optimization epic and continues our work to add related links to relevant pages. Builds on the work of https://github.com/canonical/k8s-snap/pull/2643.

## Solution

Adds related links to explanation and reference pages, linking to official external docs for the primary external tool or standard covered by each page.

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.