### PR TITLE
docs: Add updated patch notices

### DIFF
--- a/docs/canonicalk8s/releases/snap/1.32.md
+++ b/docs/canonicalk8s/releases/snap/1.32.md
@@ -71,6 +71,10 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Jul 23, 2026
+
+- Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.
+
 Jun 15, 2026
 
 - Version bumps

--- a/docs/canonicalk8s/releases/snap/1.33.md
+++ b/docs/canonicalk8s/releases/snap/1.33.md
@@ -87,7 +87,7 @@ may need to implement for a successful upgrade.
 
 ## Patch notices
 
-Jul 23, 2026 
+Jul 23, 2026
 
 - Fix handling of expired resource versions in ConfigMap watches to ensure seamless recovery.
 - Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.

--- a/docs/canonicalk8s/releases/snap/1.33.md
+++ b/docs/canonicalk8s/releases/snap/1.33.md
@@ -87,6 +87,11 @@ may need to implement for a successful upgrade.
 
 ## Patch notices
 
+Jul 23, 2026 
+
+- Fix handling of expired resource versions in ConfigMap watches to ensure seamless recovery.
+- Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.
+
 Jun 15, 2026
 
 - Version bumps

--- a/docs/canonicalk8s/releases/snap/1.34.md
+++ b/docs/canonicalk8s/releases/snap/1.34.md
@@ -65,6 +65,11 @@ upgrade and will continue to use k8s-dqlite.
 
 ## Patch notices
 
+Jul 23, 2026 
+
+- Fix handling of expired resource versions in ConfigMap watches to ensure seamless recovery.
+- Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.
+
 Jun 15, 2026
 
 - Version bump

--- a/docs/canonicalk8s/releases/snap/1.34.md
+++ b/docs/canonicalk8s/releases/snap/1.34.md
@@ -65,7 +65,7 @@ upgrade and will continue to use k8s-dqlite.
 
 ## Patch notices
 
-Jul 23, 2026 
+Jul 23, 2026
 
 - Fix handling of expired resource versions in ConfigMap watches to ensure seamless recovery.
 - Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.

--- a/docs/canonicalk8s/releases/snap/1.35.md
+++ b/docs/canonicalk8s/releases/snap/1.35.md
@@ -82,6 +82,10 @@ prior to upgrading.
 
 ## Patch notices
 
+Jul 23, 2026
+
+- Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.
+
 Jun 15, 2026
 
 - Version bumps


### PR DESCRIPTION
## Description

We do not have an automated way of updating our users as to what is on each version of our product. Therefore we manually update patch notices. This PR contains updates as of 23rd July that have landed on stable. No changes to the charm releases since last update.

## Solution

Updated patch notices 

## Issue

N/A

## Backport

1.35, 1.34, 1.33, 1.32

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.