### PR TITLE
fix: capture real nft ruleset and more diagnostics in k8s inspect

### DIFF
--- a/docs/canonicalk8s/snap/reference/inspection-reports.md
+++ b/docs/canonicalk8s/snap/reference/inspection-reports.md
@@ -62,12 +62,34 @@ Collecting system information
  INFO:  Copy k8s diagnostics to the final report tarball
 Collecting networking information
  INFO:  Copy network diagnostics to the final report tarball
+Collecting Cilium diagnostics
+ INFO:  Copy Cilium drop/trace monitor sample to the final report tarball
 Building the report tarball
  SUCCESS:  Report tarball is at /root/inspection-report-20250109_132806.tar.gz
 ```
 
 Use the report to ensure that all necessary services are running and dive into
 every aspect of the system.
+
+## Network diagnostics
+
+Alongside the usual `ip a`/`ip r`/`ss` output, the report also captures the
+node's netfilter and connection-tracking state:
+
+- ``iptables.log`` / ``iptables-legacy.log`` (and IPv6 equivalents) - rule
+  counters from the `nf_tables` and legacy `iptables` backends respectively,
+  as seen through the `iptables`/`iptables-legacy` commands.
+- ``nft-ruleset.log`` - the output of `nft list ruleset`, which reflects the
+  actual netfilter state regardless of which backend owns it. This is useful
+  when another tool on the host (for example Docker) manages its own
+  nftables or iptables rules, since `iptables-save` alone only shows the
+  backend that the `iptables` alternative currently points to.
+- ``conntrack-table.log`` / ``conntrack-stats.log`` - the current connection
+  tracking table and statistics, useful for NAT troubleshooting.
+- ``nstat.log`` - kernel networking counters, useful for narrowing packet
+  drops down to a specific subsystem.
+- ``cilium-monitor.log`` - a short sample of `cilium monitor --type drop
+  --type trace` output from the Cilium pod running on the node, if any.
 
 ## Command arguments
 

--- a/k8s/scripts/inspect.sh
+++ b/k8s/scripts/inspect.sh
@@ -205,14 +205,53 @@ function collect_network_diagnostics {
   log_info "Copy network diagnostics to the final report tarball"
   ip a &>"$INSPECT_DUMP/ip-a.log" || true
   ip r &>"$INSPECT_DUMP/ip-r.log" || true
-  iptables-save &>"$INSPECT_DUMP/iptables.log" || true
-  iptables-legacy-save &>"$INSPECT_DUMP/iptables-legacy.log" || true
+  iptables-save -c &>"$INSPECT_DUMP/iptables.log" || true
+  iptables-legacy-save -c &>"$INSPECT_DUMP/iptables-legacy.log" || true
   ss -plnt &>"$INSPECT_DUMP/ss-plnt.log" || true
 
-  ip6tables-save &>"$INSPECT_DUMP/iptables6.log" || true
-  ip6tables-legacy-save &>"$INSPECT_DUMP/iptables6-legacy.log" || true
+  ip6tables-save -c &>"$INSPECT_DUMP/iptables6.log" || true
+  ip6tables-legacy-save -c &>"$INSPECT_DUMP/iptables6-legacy.log" || true
   ss -plntu &>"$INSPECT_DUMP/ss-plntu.log" || true
   grep -Ei "^(HTTP_PROXY|HTTPS_PROXY|NO_PROXY)=" /etc/environment > "$INSPECT_DUMP/proxy_in_etc_environment"
+
+  # iptables-save/iptables-legacy-save only ever show the rules for the
+  # backend they were built against, and both `iptables.log` and
+  # `iptables-legacy.log` above can end up byte-identical if the "iptables"
+  # alternative on this host resolves to the legacy backend. `nft list
+  # ruleset` is the only view that reflects the actual netfilter state
+  # regardless of which backend (legacy or nf_tables) owns it, which matters
+  # a lot when diagnosing conflicts with other software (e.g. Docker) that
+  # manages its own nftables/iptables rules.
+  if command -v nft &>/dev/null; then
+    nft list ruleset &>"$INSPECT_DUMP/nft-ruleset.log" || true
+  fi
+
+  if command -v conntrack &>/dev/null; then
+    conntrack -L &>"$INSPECT_DUMP/conntrack-table.log" || true
+    conntrack -S &>"$INSPECT_DUMP/conntrack-stats.log" || true
+  fi
+
+  if command -v nstat &>/dev/null; then
+    nstat -az &>"$INSPECT_DUMP/nstat.log" || true
+  fi
+}
+
+function collect_cilium_diagnostics {
+  local cilium_pod
+  cilium_pod=$(k8s kubectl get pod -n kube-system -l k8s-app=cilium \
+    --field-selector "spec.nodeName=$(hostname)" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+  if [ -z "$cilium_pod" ]; then
+    log_info "No local Cilium pod found, skipping Cilium diagnostics"
+    return
+  fi
+
+  log_info "Copy Cilium drop/trace monitor sample to the final report tarball"
+  # `cilium monitor` streams forever, so this is bounded to a short sample
+  # window rather than the usual command timeout.
+  timeout 10s k8s kubectl exec "$cilium_pod" -n kube-system -c cilium-agent -- \
+    cilium-dbg monitor --type drop --type trace &>"$INSPECT_DUMP/cilium-monitor.log" || true
 }
 
 function check_expected_services {
@@ -331,6 +370,9 @@ collect_k8s_diagnostics
 
 printf -- 'Collecting networking information\n'
 collect_network_diagnostics
+
+printf -- 'Collecting Cilium diagnostics\n'
+collect_cilium_diagnostics
 
 if [ -f "$TIMEOUT_LOG" ]; then
   timeout_count=$(wc -l <"$TIMEOUT_LOG")


### PR DESCRIPTION
## Description

`k8s inspect` lacked enough networking information to diagnose conflicts between Canonical K8s and other software (e.g. Docker, Podman) sharing the same host's netfilter/containerd stack. `iptables-save`/`iptables-legacy-save` only ever reflect the backend they're built against, so `iptables.log` and `iptables-legacy.log` can end up byte-identical -- and neither shows the actual `nf_tables` state -- when the `iptables` alternative resolves to the legacy backend. That gap is exactly what made a Docker/CK8s netfilter conflict hard to diagnose in #2602.

## Solution

- Add `nft-ruleset.log` (`nft list ruleset`), which reflects the true netfilter state regardless of which backend (legacy or nf_tables) owns the rules.
- Add `-c` counters to all `iptables*-save` snapshots (v4/v6, both backends) so per-rule hit counts are visible.
- Add `conntrack-table.log` / `conntrack-stats.log` for NAT troubleshooting.
- Add `nstat.log` (kernel networking counters) to localize packet drops to a subsystem.
- Add `cilium-monitor.log`, a bounded 10s `cilium-dbg monitor --type drop --type trace` sample from the local Cilium pod, when present (skipped gracefully otherwise).
- Document all new report files in `inspection-reports.md`.

### Validation

Built the snap, bootstrapped a real cluster in a clean LXD VM, ran `k8s inspect`, and confirmed every new file carried live data. Notably, in that environment Cilium's rules turned out to live entirely in the legacy iptables backend rather than nf_tables, so `nft-ruleset.log` correctly came back empty while `iptables-legacy.log` carried the real per-rule counters -- a live demonstration of the exact backend-visibility gap this fix addresses.

## Issue

Fixes #2602

## Backport

No.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary
- [ ] Confirm whether the `release-notes` label should be kept or removed