### PR TITLE
fix: remove self-approval step from auto-merge and isolate per-PR errors

### DIFF
--- a/build-scripts/hack/auto-merge-successful-pr.py
+++ b/build-scripts/hack/auto-merge-successful-pr.py
@@ -5,7 +5,6 @@ import subprocess
 import json
 
 LABEL = "automerge"
-APPROVE_MSG = "All status checks passed for PR #{}."
 
 
 def sh(cmd: str) -> str:
@@ -31,10 +30,9 @@ def check_pr_passed(pr_number) -> bool:
     return all(check["bucket"] in ["pass", "skipping"] for check in checks)
 
 
-def approve_and_merge_pr(pr_number) -> None:
-    """Approve and merge the PR."""
-    print(APPROVE_MSG.format(pr_number) + " Proceeding with merge...")
-    sh(f'gh pr review {pr_number} --approve -b "{APPROVE_MSG.format(pr_number)}"')
+def merge_pr(pr_number) -> None:
+    """Merge the PR using admin bypass, no review step required."""
+    print(f"All status checks passed for PR #{pr_number}. Proceeding with merge...")
     sh(f"gh pr merge {pr_number} --admin --squash")
 
 
@@ -44,11 +42,13 @@ def process_pull_requests():
 
     for pr in prs:
         pr_number: int = pr["number"]
-
-        if check_pr_passed(pr_number):
-            approve_and_merge_pr(pr_number)
-        else:
-            print(f"Status checks have not passed for PR #{pr_number}. Skipping merge.")
+        try:
+            if check_pr_passed(pr_number):
+                merge_pr(pr_number)
+            else:
+                print(f"Status checks have not passed for PR #{pr_number}. Skipping merge.")
+        except Exception as e:
+            print(f"Failed to process PR #{pr_number}: {e}")
 
 
 if __name__ == "__main__":

--- a/build-scripts/hack/auto-merge-successful-pr.py
+++ b/build-scripts/hack/auto-merge-successful-pr.py
@@ -3,6 +3,7 @@
 import shlex
 import subprocess
 import json
+import sys
 
 LABEL = "automerge"
 
@@ -25,8 +26,17 @@ def get_pull_requests() -> list:
 
 def check_pr_passed(pr_number) -> bool:
     """Check if all status checks passed for the given PR."""
-    checks_json = sh(f"gh pr checks {pr_number} --json bucket")
-    checks = json.loads(checks_json)
+    # gh pr checks exits non-zero when checks are pending or failed, but still
+    # emits valid JSON to stdout. Avoid raising so pending PRs are quietly
+    # skipped rather than counted as processing errors.
+    _pipe = subprocess.PIPE
+    result = subprocess.run(
+        shlex.split(f"gh pr checks {pr_number} --json bucket"),
+        stdout=_pipe, stderr=_pipe, text=True
+    )
+    if not result.stdout.strip():
+        return False
+    checks = json.loads(result.stdout.strip())
     return all(check["bucket"] in ["pass", "skipping"] for check in checks)
 
 
@@ -39,6 +49,7 @@ def merge_pr(pr_number) -> None:
 def process_pull_requests():
     """Process the PRs and merge if checks have passed."""
     prs = get_pull_requests()
+    failed = []
 
     for pr in prs:
         pr_number: int = pr["number"]
@@ -48,7 +59,12 @@ def process_pull_requests():
             else:
                 print(f"Status checks have not passed for PR #{pr_number}. Skipping merge.")
         except Exception as e:
-            print(f"Failed to process PR #{pr_number}: {e}")
+            print(f"Failed to merge PR #{pr_number}: {e}")
+            failed.append(pr_number)
+
+    if failed:
+        print(f"The following PRs failed to merge: {failed}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The auto-merge workflow has been failing since 2026-07-07 because `BOT_TOKEN` now authenticates as the same account (`bschimke95`) that authors the automerge PRs via `peter-evans/create-pull-request`. GitHub rejects self-approval (`Cannot approve your own pull request`), and because the loop had no per-PR error handling, the first fully-green PR crashed every run before any later PRs were processed.

This removes the self-review step entirely, isolates each PR's processing in its own try/except so one failure cannot abort the batch, and ensures the script exits non-zero when any merge fails so the workflow stays visibly red rather than silently succeeding. It also fixes `check_pr_passed` to not raise on `gh pr checks`' non-zero exit code (which it uses to signal pending or failed checks), so PRs with pending checks are quietly skipped rather than counted as errors.

Notes: The repo has `enforce_admins: true` on branch protection and the automerge ruleset (10124087) has `bypass_actors: []` with `current_user_can_bypass: never` -- this means `gh pr merge --admin --squash` cannot bypass the required-review gate on its own. For the automation to actually merge PRs again, one of the following repo-setting changes is also needed (outside the scope of this code patch): (a) add `bschimke95` (or a dedicated GitHub App) to the ruleset's `bypass_actors` and set `enforce_admins: false` on the protected branches, or (b) restore a separate reviewer identity (a PAT or App token for an account that is not the PR author) in the approve step. PR #2667 is intentionally left unmerged; the automation will pick it up on its next run once the settings allow.