### PR TITLE
fix: update FIPS panic message assertion to match go-fips 1.25 wording

### DIFF
--- a/tests/integration/tests/test_build.py
+++ b/tests/integration/tests/test_build.py
@@ -92,7 +92,7 @@ def test_build(instances: List[harness.Instance]):
         )
         LOG.info(result.stderr)
         assert result.stderr.startswith(
-            "panic: opensslcrypto: FIPS mode requested (environment variable GOFIPS) but not available in OpenSSL"
+            "panic: opensslcrypto: FIPS mode requested (environment variable GOFIPS) but not available"
         ) or result.stderr.startswith(
             "panic: opensslcrypto: can't enable FIPS mode for OpenSSL"
         ), f"{component} should fail with FIPS enabled on non-compliant system"


### PR DESCRIPTION
The go-fips toolchain's `crypto/internal/backend` panic message changed: the suffix changed from "but not available in OpenSSL" to "but not available: <openssl version>" (e.g. `OpenSSL 3.0.2 15 Mar 2022`). `test_build` still correctly asserts k8sd refuses to start in FIPS mode on a non-compliant system, it just needs the updated prefix. Trims the assertion to the stable shared prefix so both old and new wording match, consistent with the fix already on `main` and `release-1.35`.

Note: release-1.34 pins `go/1.24-fips/stable` (not 1.25-fips), so the wording drift here comes from a rebuild within that mutable channel rather than a toolchain version bump. Confirmed via this branch's own CI failure showing the new wording under the 1.24-fips build. The trimmed prefix is a strict subset of both variants, so it's robust to either.

Landed directly on `release-1.34` rather than on `autoupdate/sync/release-1.34` (the cron's PR #2666): that branch gets force-recreated from `release-1.34`'s tip on every daily cron run, which discarded this exact fix twice while it sat there. Once this merges, the next cron cycle picks it up automatically.