### PR TITLE
docs: Add updated patch notices [Backport release-1.32]

### DIFF
--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -65,6 +65,10 @@ Kubernetes 1.32, please see the relevant sections of the
 
 ## Patch notices
 
+Jul 23, 2026
+
+- Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.
+
 Jun 15, 2026
 
 - Version bumps

--- a/docs/canonicalk8s/snap/reference/versions/1.32.md
+++ b/docs/canonicalk8s/snap/reference/versions/1.32.md
@@ -67,7 +67,8 @@ Kubernetes 1.32, please see the relevant sections of the
 
 Jul 23, 2026
 
-- Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.
+- Honor AnnotationDisableSeparateFeatureUpgrades during node joins to 
+prevent unintended upgrades.
 
 Jun 15, 2026
 


### PR DESCRIPTION
# Description

Backport of #2658 to `release-1.33`.

Cherry picked from commit 1c87568e158ceeb44d4b954250168a5d3f186c9a