### PR TITLE
docs: note charm cluster-annotations cannot set nested BGP peers

### DIFF
--- a/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
+++ b/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
@@ -39,9 +39,9 @@ sudo k8s set \
 
 ```{note}
 The `k8s` charm's `cluster-annotations` config option only accepts flat
-`key=value` pairs and cannot express the nested YAML shown below. To set
-multi-peer BGP annotations on a charmed deployment, `juju exec` into a unit
-and use the `k8s` CLI directly, as described in this guide.
+`key=value` pairs and cannot express the nested YAML shown below. On a
+charmed deployment, set multi-peer BGP annotations by running the `k8s` CLI
+on a unit instead: `juju exec --unit <k8s/unit#> -- sudo k8s set annotations=...`.
 ```
 
 Define peers in a YAML file and pass the whole file via the `annotations` key:
@@ -138,7 +138,8 @@ Correct the annotation and the reconciler retries automatically.
   `k8s kubectl get node <node> -o yaml`.
 - No per-peer BFD or multi-hop support.
 - Not settable via the `k8s` charm's `cluster-annotations` config option
-  (nested YAML is unsupported there); use `juju exec` and the `k8s` CLI.
+  (nested YAML is unsupported there); run the `k8s` CLI on a unit instead:
+  `juju exec --unit <k8s/unit#> -- sudo k8s set annotations=...`.
 
 ## Next steps
 

--- a/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
+++ b/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
@@ -37,6 +37,13 @@ sudo k8s set \
 
 ### Set the multi-peer annotation
 
+```{note}
+The `k8s` charm's `cluster-annotations` config option only accepts flat
+`key=value` pairs and cannot express the nested YAML shown below. To set
+multi-peer BGP annotations on a charmed deployment, `juju exec` into a unit
+and use the `k8s` CLI directly, as described in this guide.
+```
+
 Define peers in a YAML file and pass the whole file via the `annotations` key:
 
 ```bash
@@ -130,6 +137,8 @@ Correct the annotation and the reconciler retries automatically.
 - The annotation value is write-only — inspect it directly with
   `k8s kubectl get node <node> -o yaml`.
 - No per-peer BFD or multi-hop support.
+- Not settable via the `k8s` charm's `cluster-annotations` config option
+  (nested YAML is unsupported there); use `juju exec` and the `k8s` CLI.
 
 ## Next steps
 

--- a/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
+++ b/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
@@ -35,6 +35,7 @@ sudo k8s set \
   load-balancer.cidrs=10.0.0.0/24
 ```
 
+(set-the-multi-peer-annotation)=
 ### Set the multi-peer annotation
 
 ```{note}
@@ -137,9 +138,8 @@ Correct the annotation and the reconciler retries automatically.
 - The annotation value is write-only — inspect it directly with
   `k8s kubectl get node <node> -o yaml`.
 - No per-peer BFD or multi-hop support.
-- Not settable via the `k8s` charm's `cluster-annotations` config option
-  (nested YAML is unsupported there); run the `k8s` CLI on a unit instead:
-  `juju exec --unit <k8s/unit#> -- sudo k8s set annotations=...`.
+- Not settable via the `k8s` charm's `cluster-annotations` config option — see
+  the note in [Set the multi-peer annotation](set-the-multi-peer-annotation).
 
 ## Next steps
 


### PR DESCRIPTION
## What

Documents a known limitation of the `k8s` charm: its `cluster-annotations` config option only accepts flat `key=value` pairs, so the nested YAML annotations used for [multi-peer BGP](docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md) can't be set through Juju config. Users on charmed deployments need to `juju exec` into a unit and use the `k8s` CLI directly.

## Why

Follow-up decision from discussion on canonical/k8s-operator#967 — the charm PR to support nested annotations was not merged. Instead we're documenting the gap here, in line with the existing docs' depth.

## Changes

- Added a note in the "Set the multi-peer annotation" section pointing charm users to `juju exec` + the `k8s` CLI.
- Added a bullet to the "Limitations" section.
