### PR TITLE
docs: add MetalLB multi-peer BGP annotations to reference

### DIFF
--- a/docs/canonicalk8s/snap/reference/annotations.md
+++ b/docs/canonicalk8s/snap/reference/annotations.md
@@ -127,7 +127,7 @@ v1alpha annotations are experimental and subject to change or removal in future 
 |                 |                                                                                                                              |
 |-----------------|------------------------------------------------------------------------------------------------------------------------------|
 | **Values**      | "true"\|"false"                                                                                                              |
-| **Description** | If set to "true", the BGPAdvertisement is emitted with an empty spec, advertising all IP pools. By default, only the named IPAddressPool is advertised. |
+| **Description** | If set to "true", the BGPAdvertisement is created with an empty spec, which advertises all IP pools. If "false" (default), only the IPAddressPool created by {{product}} is advertised. |
 
 <script>
 const el = document.getElementsByTagName("h2");

--- a/docs/canonicalk8s/snap/reference/annotations.md
+++ b/docs/canonicalk8s/snap/reference/annotations.md
@@ -115,6 +115,20 @@ v1alpha annotations are experimental and subject to change or removal in future 
 | **Values**      | string                                                 |
 | **Description** | Override the default image tag for the metrics-server. |
 
+## `k8sd/v1alpha1/metallb/bgp-peers`
+
+|                 |                                                                                                                                                                                                                                                                          |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | YAML-encoded list of BGP peer configurations                                                                                                                                                                                                                             |
+| **Description** | Configure multi-peer MetalLB BGP mode. Each item may include `peerAddress` (required), `peerASN` (required), `myASN` (optional, falls back to `load-balancer.bgp-local-asn`), `peerPort` (optional, default 179) and `nodeSelector` (optional). When set, this annotation replaces the single-peer typed BGP keys entirely. See [multi-peer BGP]. |
+
+## `k8sd/v1alpha1/metallb/advertise-all-pools`
+
+|                 |                                                                                                                              |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------|
+| **Values**      | "true"\|"false"                                                                                                              |
+| **Description** | If set to "true", the BGPAdvertisement is emitted with an empty spec, advertising all IP pools. By default, only the named IPAddressPool is advertised. |
+
 <script>
 const el = document.getElementsByTagName("h2");
 for(var i=0;i<el.length;i++){
@@ -126,3 +140,4 @@ for(var i=0;i<el.length;i++){
 <!-- Links -->
 
 [bootstrap]: /snap/reference/config-files/bootstrap-config.md
+[multi-peer BGP]: /snap/howto/networking/multi-peer-bgp.md


### PR DESCRIPTION
## Description

The annotations reference page is missing the MetalLB multi-peer BGP annotations introduced in https://github.com/canonical/k8s-snap-api/pull/69.

## Solution

Add `k8sd/v1alpha1/metallb/bgp-peers` and `k8sd/v1alpha1/metallb/advertise-all-pools` to the annotations reference page, following the existing table style, with a cross-link to the [multi-peer BGP how-to](https://documentation.ubuntu.com/canonical-kubernetes/main/snap/howto/networking/multi-peer-bgp/).

## Issue

N/A

## Backport

No — the annotations target an alpha feature in release-1.36.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests — N/A, docs only
- [ ] Covered by integration tests — N/A, docs only
- [x] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary — N/A
- [ ] Confirm whether the `release-notes` label should be kept or removed

Verified with `make lint-md` and `make html` in `docs/canonicalk8s`.