### PR TITLE
feat: (backport-1.32) migrate from `rocks.c.c` to `ghcr.io`

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -144,7 +144,7 @@ jobs:
           TEST_VERSION_UPGRADE_CHANNELS: "recent 6"
           TEST_VERSION_UPGRADE_MIN_RELEASE: "1.32"
           TEST_STRICT_INTERFACE_CHANNELS: "recent 6 strict"
-          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}, {"name": "rocks.canonical.com", "port": 5002, "remote": "https://rocks.canonical.com/cdk"}]'
+          TEST_MIRROR_LIST: '[{"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}, {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io", "username": "", "password": ""}]'
         run: |
           cd tests/integration && sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- tox -e integration -- ${{ inputs.extra-test-args }} ${{ matrix.test }}
       - name: Prepare inspection reports

--- a/docs/canonicalk8s/assets/how-to-dualstack-manifest.yaml
+++ b/docs/canonicalk8s/assets/how-to-dualstack-manifest.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: nginxdualstack
-        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        image: ghcr.io/canonical/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
 ---

--- a/docs/canonicalk8s/assets/how-to-ipv6-only-manifest.yaml
+++ b/docs/canonicalk8s/assets/how-to-ipv6-only-manifest.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: nginx-ipv6
-        image: rocks.canonical.com/cdk/diverdane/nginxipv6:1.0.0
+        image: ghcr.io/canonical/cdk/diverdane/nginxipv6:1.0.0
         ports:
         - containerPort: 80
 ---

--- a/docs/canonicalk8s/conf.py
+++ b/docs/canonicalk8s/conf.py
@@ -189,7 +189,6 @@ if os.environ.get("READTHEDOCS"):
 # A regex list of URLs that are ignored by 'make linkcheck'
 linkcheck_ignore = [
     'http://127.0.0.1:8000',
-    'http://rocks.canonical.com',
     'about',
     'https://ceph.io',
     'https://charmhub.io/k8s',

--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -64,7 +64,7 @@ required. Ensure that the placeholder gateway rule survives a node reboot.
 #### Ensure proxy access
 
 This section is only relevant if access to upstream image registries
-(e.g. docker.io, quay.io, rocks.canonical.com, etc.)
+(e.g. docker.io, quay.io, ghcr.io, etc.)
 is only allowed through an HTTP proxy (e.g. [squid][squid]).
 
 Ensure that all nodes can use the proxy to access the image registry.

--- a/tests/integration/templates/nginx-dualstack.yaml
+++ b/tests/integration/templates/nginx-dualstack.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: nginxdualstack
-        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        image: ghcr.io/canonical/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/templates/nginx-ipv6-only.yaml
+++ b/tests/integration/templates/nginx-ipv6-only.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: nginxipv6
-        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        image: ghcr.io/canonical/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -166,11 +166,6 @@ USE_LOCAL_MIRROR = (os.getenv("TEST_USE_LOCAL_MIRROR") or "1") == "1"
 DEFAULT_MIRROR_LIST = [
     {"name": "ghcr.io", "port": 5000, "remote": "https://ghcr.io"},
     {"name": "docker.io", "port": 5001, "remote": "https://registry-1.docker.io"},
-    {
-        "name": "rocks.canonical.com",
-        "port": 5002,
-        "remote": "https://rocks.canonical.com/cdk",
-    },
 ]
 
 # Local mirror configuration.


### PR DESCRIPTION
## Description

Backport #2682 to `release-1.32`