### PR TITLE
feat: bump Go to 1.26-fips

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ parts:
   build-deps:
     plugin: nil
     build-snaps:
-      - go/1.25-fips/stable
+      - go/1.26-fips/stable
     build-attributes: [enable-patchelf]
     build-packages:
       - sudo


### PR DESCRIPTION
This PR bumps Go to 1.26-fips. This is required as a part of the k8sd PR to bump microcluster to v3.1.0.