### PR TITLE
ci: extend integration test matrix to ubuntu 26.04

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Integration
     strategy:
       matrix:
-        os: ["ubuntu:22.04", "ubuntu:24.04"]
+        os: ["ubuntu:22.04", "ubuntu:24.04", "ubuntu:26.04"]
         arch: ["amd64", "arm64"]
         # TODO(ben): Automatically fetch all supported releases.
         channel:
@@ -68,7 +68,7 @@ jobs:
     name: Run performance tests for ${{ matrix.os }}-${{ matrix.arch }}
     strategy:
       matrix:
-        os: ["ubuntu:22.04", "ubuntu:24.04"]
+        os: ["ubuntu:22.04", "ubuntu:24.04", "ubuntu:26.04"]
         arch: ["amd64", "arm64"]
       fail-fast: false
     uses: ./.github/workflows/compare-performance.yaml

--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu:22.04", "ubuntu:24.04"]
+        os: ["ubuntu:22.04", "ubuntu:24.04", "ubuntu:26.04"]
         arch: ["amd64"]
         channel:
           [


### PR DESCRIPTION
## Summary

Adds Ubuntu 26.04 (Resolute) to the integration test matrices so the 1.36 release is validated on the new LTS.

## Changes

- `nightly-test.yaml`: add `ubuntu:26.04` to the nightly integration and performance test OS matrices
- `weekly-test.yaml`: add `ubuntu:26.04` to the weekly CNCF conformance OS matrix

The FIPS test matrix (`test-on-fips`) is intentionally unchanged — no 26.04 FIPS runners are available yet.

## Acceptance criteria

- [x] Test matrix extended to cover ubuntu:26.04
- [x] FIPS 26.04 excluded (no runners available)
