### PR TITLE
ci: Add automated patch notice generation

### DIFF
--- a/.github/workflows/update-patch-notices.yaml
+++ b/.github/workflows/update-patch-notices.yaml
@@ -9,14 +9,6 @@ permissions:
   contents: read
 
 env:
-  OPENAI_API_KEY: ${{ secrets.PATCH_NOTICES_OPENAI_KEY }}
-  OPENAI_BASE_URL: ${{ secrets.PATCH_NOTICES_OPENAI_BASE_URL }}
-  OPENAI_MODEL: gpt-4o
-  OPENAI_GROUP_MODEL: gpt-4o-mini
-  # Use BOT_TOKEN (not github.token) so the created PR triggers CI checks.
-  # github.token-created PRs are blocked from triggering other workflows
-  # by GitHub's anti-infinite-loop protection.
-  GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
   # -----------------------------------------------------------------------
   # TRACKS — source, short version, and release notes path.
   # To add 1.36 when it ships: append two lines (snap + charm).
@@ -43,20 +35,31 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install patch-notices
-        # Editable install so state.py resolves metadata/ relative to the repo source tree.
+        # Editable install so metadata.py resolves metadata/ relative to the repo source tree.
         run: pip install -e docs/tools/patch-notices/
 
       - name: Set run date
         run: echo "TODAY=$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Run generate for all tracks
+        env:
+          OPENAI_API_KEY: ${{ secrets.PATCH_NOTICES_OPENAI_KEY }}
+          OPENAI_BASE_URL: ${{ secrets.PATCH_NOTICES_OPENAI_BASE_URL }}
+          OPENAI_MODEL: gpt-4o
+          OPENAI_GROUP_MODEL: gpt-4o-mini
+          # Use BOT_TOKEN (not github.token) so the created PR triggers CI checks.
+          # github.token-created PRs are blocked from triggering other workflows
+          # by GitHub's anti-infinite-loop protection.
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           mkdir -p /tmp/summaries
           while IFS= read -r line; do

--- a/.github/workflows/update-patch-notices.yaml
+++ b/.github/workflows/update-patch-notices.yaml
@@ -44,7 +44,6 @@ jobs:
           python-version: "3.12"
 
       - name: Install patch-notices
-        # Editable install so metadata.py resolves metadata/ relative to the repo source tree.
         run: pip install -e docs/tools/patch-notices/
 
       - name: Set run date
@@ -56,9 +55,6 @@ jobs:
           OPENAI_BASE_URL: ${{ secrets.PATCH_NOTICES_OPENAI_BASE_URL }}
           OPENAI_MODEL: gpt-4o
           OPENAI_GROUP_MODEL: gpt-4o-mini
-          # Use BOT_TOKEN (not github.token) so the created PR triggers CI checks.
-          # github.token-created PRs are blocked from triggering other workflows
-          # by GitHub's anti-infinite-loop protection.
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           mkdir -p /tmp/summaries

--- a/.github/workflows/update-patch-notices.yaml
+++ b/.github/workflows/update-patch-notices.yaml
@@ -1,0 +1,93 @@
+name: Update patch notices
+
+on:
+  schedule:
+    - cron: "0 10 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  OPENAI_API_KEY: ${{ secrets.PATCH_NOTICES_OPENAI_KEY }}
+  OPENAI_BASE_URL: ${{ secrets.PATCH_NOTICES_OPENAI_BASE_URL }}
+  OPENAI_MODEL: gpt-4o
+  OPENAI_GROUP_MODEL: gpt-4o-mini
+  # Use BOT_TOKEN (not github.token) so the created PR triggers CI checks.
+  # github.token-created PRs are blocked from triggering other workflows
+  # by GitHub's anti-infinite-loop protection.
+  GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+  # -----------------------------------------------------------------------
+  # TRACKS — source, short version, and release notes path.
+  # To add 1.36 when it ships: append two lines (snap + charm).
+  # To retire a version at EOL: remove its two lines.
+  # -----------------------------------------------------------------------
+  TRACKS: |
+    snap  1.35  docs/canonicalk8s/releases/snap/1.35.md
+    snap  1.34  docs/canonicalk8s/releases/snap/1.34.md
+    snap  1.33  docs/canonicalk8s/releases/snap/1.33.md
+    snap  1.32  docs/canonicalk8s/releases/snap/1.32.md
+    charm 1.35  docs/canonicalk8s/releases/charm/1.35.md
+    charm 1.34  docs/canonicalk8s/releases/charm/1.34.md
+    charm 1.33  docs/canonicalk8s/releases/charm/1.33.md
+    charm 1.32  docs/canonicalk8s/releases/charm/1.32.md
+    # Add 1.36 when it ships:
+    # snap  1.36  docs/canonicalk8s/releases/snap/1.36.md
+    # charm 1.36  docs/canonicalk8s/releases/charm/1.36.md
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install patch-notices
+        # Editable install so state.py resolves metadata/ relative to the repo source tree.
+        run: pip install -e docs/tools/patch-notices/
+
+      - name: Set run date
+        run: echo "TODAY=$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
+
+      - name: Run generate for all tracks
+        run: |
+          mkdir -p /tmp/summaries
+          while IFS= read -r line; do
+            [[ "$line" =~ ^[[:space:]]*# ]] && continue
+            [[ -z "${line// }" ]] && continue
+            read -r source version notes_path <<< "$line"
+            patch-notices generate \
+              --source "$source" \
+              --track "$version" \
+              --release-notes "$notes_path" \
+              --summary-out "/tmp/summaries/${source}-${version}.json"
+          done <<< "$TRACKS"
+
+      - name: Build PR body
+        id: pr_body
+        run: |
+          patch-notices pr-body --summaries-dir /tmp/summaries > /tmp/pr_body.md
+          {
+            echo 'body<<EOF'
+            cat /tmp/pr_body.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          author: "K8s builder bot <k8s-bot@canonical.com>"
+          commit-message: "docs: Update patch notices ${{ env.TODAY }}"
+          title: "docs: Update patch notices ${{ env.TODAY }}"
+          body: ${{ steps.pr_body.outputs.body }}
+          branch: "auto/patch-notices-${{ env.TODAY }}"
+          delete-branch: true
+          base: main

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ k8s_*.txt
 /docs/canonicalk8s/.sphinx/styles/*
 /docs/canonicalk8s/.sphinx/vale.ini
 
+# patch-notices: local working files, not for commit
+docs/tools/patch-notices/metadata/delta-*.json
+docs/tools/patch-notices/patch_notices_review.md
+docs/tools/patch-notices/patch_notices_output.md
+
 *.assert
 .trivy
 squashfs-root

--- a/docs/proposals/003-patch-notices-automation.md
+++ b/docs/proposals/003-patch-notices-automation.md
@@ -1,0 +1,127 @@
+# Proposal information
+
+<!-- Index number -->
+- **Index**: 003
+
+<!-- Status -->
+- **Status**: **DRAFTING**
+
+<!-- Short description for the feature -->
+- **Name**: Automate monthly patch notices
+
+<!-- Owner name and github handle -->
+- **Owner**: Niamh Hennigan @nhennigan
+
+# Proposal Details
+
+## Summary
+
+Add a repository-local `patch-notices` documentation tool and scheduled GitHub
+Actions workflow to prepare monthly Canonical Kubernetes patch notice updates.
+The automation gathers snap and charm release deltas, triages changes with a
+configured OpenAI-compatible endpoint, updates release notes and tracking
+metadata, and opens a pull request for human review.
+
+## Rationale
+
+Monthly patch notices are currently produced with a mostly manual process:
+maintainers identify the latest released revisions for each supported snap and
+charm track, inspect the commits since the last documented update, decide which
+changes are user-facing, update release notes, and carry state forward for the
+next run.
+
+This proposal keeps the human review gate but automates the repetitive data
+collection and first-pass summarisation. The workflow creates a reviewable PR
+instead of publishing directly, so maintainers can verify generated summaries,
+discard false positives, and adjust wording before merge.
+
+## User facing changes
+
+There are no changes to the `k8s` snap, charm, CLI, API, or runtime behaviour.
+The only user-facing output is documentation content in the existing release
+notes pages under `docs/canonicalk8s/releases/`.
+
+## Alternative solutions
+
+- Continue the fully manual process. This avoids AI and CI integration, but it
+  keeps the monthly process slow and easy to run inconsistently across tracks.
+- Keep the tool local-only and do not add a scheduled workflow. This helps with
+  manual runs, but does not ensure that patch notices are prepared regularly.
+
+## Out of scope
+
+- Publishing or merging patch notice updates without human review.
+- Changing the public release notes format beyond adding new dated patch notice
+  entries.
+- Backport automation changes beyond whatever existing repository backport
+  workflows already perform.
+- Supporting projects outside Canonical Kubernetes.
+
+# Implementation Details
+
+## API Changes
+
+None. This proposal does not add or change k8sd APIs.
+
+## CLI Changes
+
+No `k8s` CLI changes are introduced.
+
+The repository-local documentation tool adds a `patch-notices` command for
+maintainers and CI. The relevant subcommands are:
+
+- `fetch`: collect release delta data for a snap or charm track.
+- `review`: run AI triage and write a human-editable workbook.
+- `finalize`: parse an approved workbook and update local metadata.
+- `generate`: combine fetch, triage, release note insertion, and summary output
+  for CI use.
+- `pr-body`: build the generated PR body from per-track summaries.
+
+## Database Changes
+
+None. The tool uses a git-tracked JSON metadata file under
+`docs/tools/patch-notices/metadata/` to remember the last documented SHA and
+date for each track.
+
+## Configuration Changes
+
+The scheduled workflow requires repository secrets for the configured
+OpenAI-compatible endpoint and bot token. Secrets should be scoped to the steps
+that need them, and checkout credentials should not be persisted in the working
+tree.
+
+The workflow track list is configured in `.github/workflows/update-patch-notices.yaml`
+and maps supported snap and charm tracks to their release notes files.
+
+## Documentation Changes
+
+Add documentation for the `patch-notices` tool under `docs/tools/patch-notices/`,
+including setup, manual usage, CI usage, metadata handling, and security notes.
+
+## Testing
+
+The tool should include focused unit tests for:
+
+- release delta fetching and PR number extraction;
+- workbook rendering, parsing, and clean export;
+- release note insertion;
+- PR body generation;
+- sanitising untrusted commit, PR, and AI-generated text before rendering
+  Markdown.
+
+The GitHub Actions workflow should be validated as YAML and reviewed for secret
+scoping, pinned actions, and credential persistence.
+
+## Considerations for backwards compatibility
+
+There are no backwards-incompatible product changes. Existing release notes
+remain valid Markdown, and the metadata file is only used by this tool to decide
+where the next patch notice run starts.
+
+If the automation fails or produces unsuitable output, maintainers can continue
+to update release notes manually and adjust `patch-metadata.json` in the same
+PR.
+
+## Implementation notes and guidelines
+
+No additional implementation guidance is required beyond the sections above.

--- a/docs/tools/patch-notices/README.md
+++ b/docs/tools/patch-notices/README.md
@@ -1,0 +1,206 @@
+# patch-notices
+
+Automates the monthly patch-notices update for Canonical Kubernetes.
+
+For manual use, it pulls the PR delta, runs AI triage, and produces a
+human-editable Markdown workbook. Once approved, `finalize` strips the internal
+tags and writes a clean snippet. For CI use, `generate` combines all three steps
+and writes directly into the release notes file.
+
+## Prerequisites
+
+- Python 3.11+
+- An OpenAI API key (or compatible endpoint)
+- Network access to the Snap Store, Launchpad, Charmhub, and GitHub APIs
+
+## Setup
+
+```bash
+cd docs/tools/patch-notices
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+```
+
+To run the tool tests, install the test extra:
+
+```bash
+pip install -e .[test]
+pytest
+```
+
+Set the required environment variable:
+
+```bash
+# OpenAI directly:
+export OPENAI_API_KEY=sk-...
+
+# Or OpenRouter (supports spend limits):
+export OPENAI_API_KEY=sk-or-...
+export OPENAI_BASE_URL=https://openrouter.ai/api/v1
+export OPENAI_MODEL=openai/gpt-4o
+```
+
+Optionally, set a GitHub token to raise the API rate limit from 60 to 5000
+requests/hour. This is strongly recommended for backfills or long gaps: large
+deltas may require multiple GitHub compare pages plus one diff request per
+commit.
+
+```bash
+export GITHUB_TOKEN=ghp_...  # optional, read-only public_repo scope
+```
+
+The grouping pass (Pass 2 of `review`) uses a separate, lighter model. To override the
+default:
+
+```bash
+export OPENAI_GROUP_MODEL=openai/gpt-4o-mini   # default; change if your endpoint lacks this model
+```
+
+## Manual workflow
+
+Pass `--track` as a short version number, e.g. `1.32`. The tool expands this
+to `1.32-classic/stable` for snap (the default) or `1.32/stable` for charm.
+State is stored under the key `snap:1.32-classic/stable` in `patch-metadata.json`.
+
+### 1. fetch — pull the PR delta
+
+```bash
+patch-notices fetch --track 1.32
+```
+
+Queries the Snap Store for the current stable revision, resolves the build SHA
+via Launchpad, then fetches all PRs between `last_documented_sha`
+(from `metadata/patch-metadata.json`) and that SHA.
+Writes a raw delta to `metadata/delta-<track>.json`.
+
+### 2. review — run AI triage and open the workbook
+
+```bash
+patch-notices review --track 1.32
+```
+
+Reads the delta, processes each PR through the AI (diff > body > title),
+and writes `patch_notices_review.md` in the current directory.
+Prints the path to the written file.
+
+The workbook has three sections:
+- **Included** — benefit-centric summaries tagged `<!-- sha:... -->`
+- **Verification** — original PR titles and numbers for fact-checking
+- **Discarded** — noise items with a one-sentence reason
+
+Edit the workbook freely: delete lines, rewrite summaries, move items between
+sections. The `<!-- sha:... -->` tags are the only thing `finalize` reads.
+
+### 3. finalize — close the loop
+
+```bash
+patch-notices finalize --track 1.32
+```
+
+Parses the workbook for `<!-- sha:... -->` tags, writes
+`patch_notices_output.md` — a clean snippet with all internal tags and
+verification noise removed — then advances `metadata/patch-metadata.json` to the
+head of the fetched delta with today's date.
+
+If all commits were discarded (no included items), the export file is not
+written but the bookmark is still advanced to the latest delta SHA so the
+next run does not re-process the same commits.
+
+If `fetch` found no new commits at all (empty delta), only the
+`last_documented_date` is updated — the SHA is left unchanged.
+
+## State file
+
+`metadata/patch-metadata.json` is git-tracked. Commit it after each monthly
+run so the next person who runs `fetch` starts from the right place.
+
+## Charm patch notices
+
+The same three commands work for Canonical Kubernetes charm releases
+(`canonical/k8s-operator`) by adding `--source charm`.
+
+### How it works
+
+Instead of the Snap Store + Launchpad pipeline, the charm path:
+
+1. Queries **Charmhub** for the current stable revision of the `k8s` charm.
+2. Maps that revision to a **git SHA** via its GitHub tag (`k8s-rev<N>` in
+   `canonical/k8s-operator`).
+3. Fetches all commits between `last_documented_sha` and that SHA.
+
+### Charm track format
+
+Charm tracks use `<version>/stable` internally (no `-classic` suffix). Passing
+`--source charm --track 1.32` expands to `1.32/stable`. State is stored under
+the key `charm:1.32/stable` so snap and charm entries never collide in
+`patch-metadata.json`.
+
+### Initial setup
+
+Before the first run, set the `last_documented_sha` for each charm track in
+`metadata/patch-metadata.json`. Find the right SHA by looking up the
+`k8s-rev<N>` tag on GitHub that corresponds to the charm revision that was
+stable at your last patch notice date:
+
+```
+https://github.com/canonical/k8s-operator/releases/tag/k8s-rev<N>
+```
+
+### Manual workflow commands
+
+```bash
+# 1. Pull the commit delta from canonical/k8s-operator
+patch-notices fetch --source charm --track 1.32
+
+# 2. Run AI triage with the charm-specific prompt; write the workbook
+patch-notices review --source charm --track 1.32
+
+# 3. Update state and export the clean patch notice
+patch-notices finalize --source charm --track 1.32
+```
+
+## Automated workflow (CI)
+
+The `generate` and `pr-body` commands are used by the GitHub Actions workflow
+to process all tracks automatically. See [ARCHITECTURE.md](ARCHITECTURE.md) for the
+full architecture.
+
+### generate — fetch, triage, and insert in one step
+
+```bash
+patch-notices generate \
+  --track 1.32 \
+  --release-notes docs/canonicalk8s/releases/snap/1.32.md \
+  --summary-out summaries/snap-1.32.json
+```
+
+Combines `fetch` + AI triage + direct insertion into the release notes file.
+Advances the state bookmark on success. Writes a summary JSON to `--summary-out`
+(used by `pr-body`) regardless of outcome.
+
+Works for both snap and charm tracks via `--source charm`.
+
+### pr-body — generate the PR body
+
+```bash
+patch-notices pr-body --summaries-dir summaries/ --output pr-body.md
+```
+
+Reads all `*.json` files in `--summaries-dir` (written by `generate`) and
+produces a formatted PR body with a summary table and per-track collapsible
+detail sections. Use `--output -` (default) to print to stdout.
+
+## Security note
+
+Commit titles, bodies, and diffs from the repository are sent to the configured
+LLM endpoint as user content. A malicious commit could attempt to manipulate the
+AI's output (prompt injection). Generated summaries, component entries, discard
+reasons, and commit titles are treated as untrusted plain text before they are
+rendered into release notes, review workbooks, or PR bodies. The human PR review
+step is still required: always review the workbook or PR body before approving.
+
+## See also
+
+[PLAN.md](PLAN.md) — original system specification (snap pipeline only; predates charm support).
+
+[ARCHITECTURE.md](ARCHITECTURE.md) — architecture and PR flow for the automated monthly workflow.

--- a/docs/tools/patch-notices/README.md
+++ b/docs/tools/patch-notices/README.md
@@ -94,7 +94,7 @@ sections. The `<!-- sha:... -->` tags are the only thing `finalize` reads.
 ### 3. finalize — close the loop
 
 ```bash
-patch-notices finalize --track 1.32
+patch-notices finalize
 ```
 
 Parses the workbook for `<!-- sha:... -->` tags, writes
@@ -156,14 +156,21 @@ patch-notices fetch --source charm --track 1.32
 patch-notices review --source charm --track 1.32
 
 # 3. Update state and export the clean patch notice
-patch-notices finalize --source charm --track 1.32
+patch-notices finalize
 ```
 
 ## Automated workflow (CI)
 
 The `generate` and `pr-body` commands are used by the GitHub Actions workflow
-to process all tracks automatically. See [ARCHITECTURE.md](ARCHITECTURE.md) for the
-full architecture.
+to process all tracks automatically. The workflow installs this repo-local
+package, runs `generate` for each configured snap and charm track, updates the
+release notes and `metadata/patch-metadata.json` together, builds a PR body from
+the per-track summaries, and opens a docs PR for review.
+
+The tool intentionally lives in this repository because the tracked metadata,
+release notes paths, supported channels, and PR workflow are specific to
+Canonical Kubernetes. If another project needs the same automation, the package
+boundary here should make extraction straightforward.
 
 ### generate — fetch, triage, and insert in one step
 
@@ -199,8 +206,3 @@ reasons, and commit titles are treated as untrusted plain text before they are
 rendered into release notes, review workbooks, or PR bodies. The human PR review
 step is still required: always review the workbook or PR body before approving.
 
-## See also
-
-[PLAN.md](PLAN.md) — original system specification (snap pipeline only; predates charm support).
-
-[ARCHITECTURE.md](ARCHITECTURE.md) — architecture and PR flow for the automated monthly workflow.

--- a/docs/tools/patch-notices/metadata/patch-metadata.json
+++ b/docs/tools/patch-notices/metadata/patch-metadata.json
@@ -9,8 +9,8 @@
       "last_documented_date": "2026-07-23"
     },
     "snap:1.33-classic/stable": {
-      "last_documented_sha": "99490eff08ecfa9dfbdca19ddd7a38552f575307",
-      "last_documented_date": "2026-08-19"
+      "last_documented_sha": "9d74a1c0ab00c74e3b72ae38742d22d903f4b6a4",
+      "last_documented_date": "2026-07-23"
     },
     "snap:1.32-classic/stable": {
       "last_documented_sha": "7bb5299dbfcd83bc3d5bc47ca60caf9f2f61bc7a",

--- a/docs/tools/patch-notices/metadata/patch-metadata.json
+++ b/docs/tools/patch-notices/metadata/patch-metadata.json
@@ -1,0 +1,36 @@
+{
+  "tracks": {
+    "snap:1.35-classic/stable": {
+      "last_documented_sha": "b876753cabbc9c33a305dc3e51c3b4f86aed7394",
+      "last_documented_date": "2026-07-23"
+    },
+    "snap:1.34-classic/stable": {
+      "last_documented_sha": "64537d9e77bd470709606a6a48e099dfb37fc660",
+      "last_documented_date": "2026-07-23"
+    },
+    "snap:1.33-classic/stable": {
+      "last_documented_sha": "99490eff08ecfa9dfbdca19ddd7a38552f575307",
+      "last_documented_date": "2026-08-19"
+    },
+    "snap:1.32-classic/stable": {
+      "last_documented_sha": "7bb5299dbfcd83bc3d5bc47ca60caf9f2f61bc7a",
+      "last_documented_date": "2026-07-23"
+    },
+    "charm:1.35/stable": {
+      "last_documented_sha": "0a905a808bc3015e0b5231b485e38dd5faf44a64",
+      "last_documented_date": "2026-07-23"
+    },
+    "charm:1.34/stable": {
+      "last_documented_sha": "2c27f24558e978000c4044a9c300e16a9ae29cb6",
+      "last_documented_date": "2026-07-23"
+    },
+    "charm:1.33/stable": {
+      "last_documented_sha": "6b70b9f87123e37ba44b2a50913e3161a85dafdc",
+      "last_documented_date": "2026-07-23"
+    },
+    "charm:1.32/stable": {
+      "last_documented_sha": "9732111d8daf9012312daacb3d1dd816689a4ba3",
+      "last_documented_date": "2026-07-23"
+    }
+  }
+}

--- a/docs/tools/patch-notices/patch_notices/__init__.py
+++ b/docs/tools/patch-notices/patch_notices/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.

--- a/docs/tools/patch-notices/patch_notices/ai.py
+++ b/docs/tools/patch-notices/patch_notices/ai.py
@@ -1,0 +1,308 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+"""AI triage: categorise and summarise each PR in the delta.
+
+Truth hierarchy (per spec): file diffs > PR body > PR title.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import openai
+
+SNAP_SYSTEM_PROMPT = """\
+You are a technical writer producing monthly patch notices for Canonical Kubernetes.
+You will be given a git commit: its title, body, and the file diff for that commit.
+
+## Editorial strategy
+
+- **Focus on impact.** Do not repeat the commit subject. Describe the user-facing
+  benefit, operational impact, or reason the change matters.
+- **Truth hierarchy.** File diffs > PR body > PR title. Ignore misleading titles when
+  the diff tells a different story.
+- **Filter for user action.** Include: bug fixes, features, security-relevant
+  dependency updates, deprecation warnings, operational improvements, and significant
+  upgrade or rollback behaviour changes.
+- **Major docs only.** Include documentation changes only when they introduce a new
+  guide, a new supported workflow, a deprecation notice, or a material change in how
+  an operator uses or manages the product.
+- **Exclude noise.** Discard: copyright changes, linting-only changes, CI-only
+  changes, test-only changes, release preparation, and other low-signal maintenance
+  unless they directly affect shipped behaviour.
+- **Patch notice and release note updates.** Discard commits whose sole purpose
+  is updating, backporting, or amending patch notices, release notes, or changelogs
+  (e.g. "Update release notes patch notices", "docs: backport patch notice update").
+  These are meta-documentation — the changes they describe were already captured by
+  earlier commits in the delta.
+- **Strict revision exclusion.** Discard commits that only update
+  architecture-specific snap revision numbers, e.g.
+  `Update K8s revisions ["amd64-xxxx", "arm64-xxxx"]`.
+
+## Snap-specific rules
+
+- **Include `Update component versions` commits.** These represent real shipped
+  changes and must never be excluded.
+- **Distinguish component bumps from revision bookkeeping:**
+  - *Include*: packaged component updates — Kubernetes, CNI, containerd, runc, Helm,
+    k8s-dqlite, Cilium, CoreDNS, MetalLB, metrics-server, and similar shipped deps.
+  - *Exclude*: commits that only move track-specific amd64/arm64 snap revision numbers.
+- **Version bumps formatting.** When component updates are present, populate the
+  `components` array (see Output format). List each updated component as
+  `"name new-version"`, e.g. `"containerd v1.7.30"`.
+  Only include components where the new version is visible in the diff.
+  If versions are not visible, set `components` to null and use `summary` instead.
+
+## Tone
+
+Professional, concise, and focused on stability, upgrade safety, security, and
+operator experience.
+
+## Output format
+
+Respond with valid JSON only — no markdown fences:
+{
+  "action": "include" | "discard",
+  "category": "Major Feature" | "Deprecation" | "Bug Fix" | "Security" |
+              "Component Bump" | "Performance" | "Documentation" | null,
+  "summary": "<starts with a verb, states the fix/feature AND its consequence for the operator, max 120 chars, or null>",
+  // Prefer: 'Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.'
+  // Over:   'Honor AnnotationDisableSeparateFeatureUpgrades during node joins.'
+  "components": ["<name> <new-version>", ...] | null,
+  // Only for Component Bump when the new version is visible. e.g. ["containerd v1.7.30", "runc v1.3.4"]
+  // null for all other categories and for Component Bumps where versions are not in the diff.
+  "reason": "<one sentence reason if discarded, else null>"
+}
+"""
+
+
+CHARM_SYSTEM_PROMPT = """\
+You are a technical writer producing monthly patch notices for Canonical Kubernetes charms.
+You will be given a git commit from the k8s-operator repository: its title, body, and the
+file diff for that commit.
+
+## Editorial strategy
+
+- **Focus on operator impact.** Describe what changes for a Juju operator managing a
+  Canonical Kubernetes cluster — new options, changed behaviour, fixed bugs, or new
+  capabilities.
+- **Truth hierarchy**: File diffs > PR body > PR title. Ignore misleading titles when
+  the diff tells a different story.
+- **Categories**: Major Features, Deprecations, Bug Fixes, Security,
+  Component Bumps, Performance, Documentation, Internal (discarded).
+
+## Include
+
+- **Config option changes**: new options added to `charmcraft.yaml` config, option
+  defaults changed, options removed or deprecated.
+- **Action changes**: new Juju actions, changed action parameters or output, removed actions.
+- **Relation changes**: new integration endpoints added or removed, changed relation
+  interfaces that affect how the charm integrates with other charms.
+- **OCI/rock image bumps**: when the charm ships a new OCI image or rock version that
+  changes operator-visible behaviour or fixes bugs.
+- **Hook and event handler bug fixes**: fixes in charm hooks (`install`, `upgrade-charm`,
+  `config-changed`, relation hooks, etc.) that change observable cluster behaviour.
+- **Bootstrap and upgrade behaviour changes**: anything that changes how `k8s bootstrap`,
+  cluster join, or charm upgrade works from an operator's perspective.
+- **User-facing documentation changes**: changes to `charmcraft.yaml` descriptions,
+  README, or operator guides that materially change how an operator uses the product.
+
+## Discard
+
+- **Juju ops/libs library bumps**: updating `ops`, `cosl`, or other Juju library
+  dependencies with no visible behaviour change (e.g. `Bump ops to 2.x`).
+- **snap-installation resource revision bumps**: commits that only update which snap
+  revision the charm installs — these are covered by the snap patch notices.
+- **CI-only changes**: GitHub workflow files, tox configs, Makefile targets, and similar
+  that do not affect the shipped charm.
+- **Linting and code style**: `ruff`, `black`, `isort`, `mypy` fixes with no logic change.
+- **Test-only changes**: unit tests, integration tests, spread tests, fixtures — nothing
+  ships to operators.
+- **Release preparation**: version bumps, CHANGELOG updates, release commit messages.
+- **Patch notice and release note updates**: commits that update, backport, or amend the
+  patch notices or release notes themselves — these are meta-documentation, not new
+  operator-facing changes.
+- **Copyright and license header changes**: legal boilerplate with no functional change.
+- **Internal refactors**: code restructuring with no operator-visible behaviour change.
+
+## Tone
+
+Professional, concise, and focused on stability, upgrade safety, security, and
+operator experience. Start summaries with a verb (e.g. "Add", "Fix", "Remove").
+
+## Output format
+
+Respond with valid JSON only — no markdown fences:
+{
+  "action": "include" | "discard",
+  "category": "Major Feature" | "Deprecation" | "Bug Fix" | "Security" |
+              "Component Bump" | "Performance" | "Documentation" | null,
+  "summary": "<starts with a verb, states the fix/feature AND its consequence for the operator, max 120 chars, or null>",
+  // Prefer: 'Honor AnnotationDisableSeparateFeatureUpgrades during node joins to prevent unintended upgrades.'
+  // Over:   'Honor AnnotationDisableSeparateFeatureUpgrades during node joins.'
+  "components": null,
+  // Always null for charm triage (charm releases do not use the Version bumps nested format).
+  "reason": "<one sentence reason if discarded, else null>"
+}
+"""
+
+
+GROUP_PASS_PROMPT = """\
+You are grouping a list of already-triaged commits for a Canonical Kubernetes patch notice.
+
+Each commit has been individually reviewed and approved for inclusion. Your task is to
+identify which commits cover the same feature story, bug fix, or related work so they
+can be rendered as a single combined entry in the release notes.
+
+## Rules
+
+- Assign a short label (e.g. "CoreDNS HA", "BGP relation", "upgrade hook fix") to
+  commits that belong to the same logical story.
+- Use null for standalone commits that do not share a story with any other commit.
+- Be conservative: only group commits when the connection is clear and obvious.
+  When in doubt, leave commits as standalone (null).
+- A group must have at least 2 members — do not create a group for a single commit.
+
+## Output format
+
+Respond with valid JSON only — no markdown fences.
+Return an object where each key is the full commit SHA from the input and the value
+is a group label string (if grouped) or null (if standalone):
+{
+  "<full-sha>": "<short group label>" | null,
+  ...
+}
+"""
+
+# Character cap for the diff included in each triage prompt.
+# When a commit's diff exceeds this limit the diff is omitted entirely and the
+# commit is flagged in the workbook for extra reviewer attention.
+# Override via PATCH_NOTICES_MAX_DIFF_CHARS if your endpoint has a tighter limit.
+_MAX_DIFF_CHARS = int(os.environ.get("PATCH_NOTICES_MAX_DIFF_CHARS", "12000"))
+
+
+def triage(prs: list[dict[str, Any]], source: str = "snap") -> list[dict[str, Any]]:
+    """Run each commit through two LLM passes. Returns an enriched list of records.
+
+    Pass 1 — individual triage: each commit is evaluated in isolation using its own
+    diff (include/discard, category, summary). Commits whose diff exceeds
+    _MAX_DIFF_CHARS have the diff omitted and are flagged with limited_context=True.
+
+    Pass 2 — grouping: a single call assigns group_hints to included commits,
+    identifying related commits to render as one combined workbook entry.
+
+    Supports OpenAI directly or any OpenAI-compatible endpoint.
+    Set OPENAI_BASE_URL to override, e.g.:
+      export OPENAI_BASE_URL=https://models.inference.ai.azure.com
+      export OPENAI_API_KEY=ghp_...
+    """
+    system_prompt = CHARM_SYSTEM_PROMPT if source == "charm" else SNAP_SYSTEM_PROMPT
+    client = openai.OpenAI(
+        api_key=os.environ["OPENAI_API_KEY"],
+        base_url=os.environ.get("OPENAI_BASE_URL") or None,  # empty string → None
+    )
+
+    # Pass 1: triage each commit individually
+    results = []
+    for pr in prs:
+        result = _triage_one(client, pr, system_prompt)
+        results.append({**pr, "triage": result})
+
+    # Pass 2: assign group_hints to included commits (needs ≥2 to form any group)
+    included = [r for r in results if r["triage"]["action"] == "include"]
+    if len(included) >= 2:
+        group_map = _group_pass(client, included)
+        for r in results:
+            if r["triage"]["action"] == "include":
+                r["triage"]["group_hint"] = group_map.get(r["sha"])
+
+    return results
+
+
+def _group_pass(client: openai.OpenAI, included: list[dict[str, Any]]) -> dict[str, str | None]:
+    """Second pass: assign group_hints to included commits via a single LLM call.
+
+    Uses OPENAI_GROUP_MODEL (default: gpt-4o-mini) — grouping from plain-English
+    summaries is simpler than diff triage and does not need a large model.
+
+    Falls back gracefully to an empty map on any error so the workbook is still
+    produced without groups rather than failing the run.
+    """
+    items = [
+        {
+            "sha": r["sha"],
+            "title": r.get("title", ""),
+            "summary": r["triage"].get("summary", ""),
+            "category": r["triage"].get("category", ""),
+        }
+        for r in included
+    ]
+
+    try:
+        response = client.chat.completions.create(
+            model=os.environ.get("OPENAI_GROUP_MODEL", "gpt-4o-mini"),
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": GROUP_PASS_PROMPT},
+                {"role": "user", "content": json.dumps(items, indent=2)},
+            ],
+            temperature=0.1,
+        )
+        return json.loads(response.choices[0].message.content)
+    except Exception as exc:
+        print(f"[warning] Group pass failed ({exc}); group_hints will be null.", flush=True)
+        return {}
+
+
+def _triage_one(client: openai.OpenAI, pr: dict[str, Any], system_prompt: str) -> dict[str, Any]:
+    """Triage a single commit. Returns the parsed JSON response.
+
+    If the commit's diff exceeds _MAX_DIFF_CHARS it is omitted and
+    limited_context is set True so the workbook can flag the entry for
+    extra reviewer attention.
+    """
+    raw_diff = pr.get("diff") or ""
+    if raw_diff and len(raw_diff) > _MAX_DIFF_CHARS:
+        diff_content = "(diff omitted — too large; triaged from PR title and body only)"
+        limited_context = True
+    else:
+        diff_content = raw_diff or "(not available)"
+        limited_context = False
+
+    user_content = (
+        f"Commit {pr.get('sha', '')[:8]}"
+        + (f" (PR #{pr.get('pr_number')})" if pr.get('pr_number') else "")
+        + f": {pr.get('title')}\n\n"
+        f"Author: {pr.get('author')}\n"
+        f"Date: {pr.get('date')}\n\n"
+        f"Body:\n{pr.get('body') or '(none)'}\n\n"
+        f"Diff:\n{diff_content}"
+    )
+    response = client.chat.completions.create(
+        model=os.environ.get("OPENAI_MODEL", "gpt-4o"),
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ],
+        temperature=0.2,
+    )
+    try:
+        result = json.loads(response.choices[0].message.content)
+    except Exception as exc:
+        sha = pr.get("sha", "")[:8]
+        print(f"[warning] JSON parse failed for {sha} ({exc}); flagging for manual review.", flush=True)
+        result = {
+            "action": "include",
+            "category": None,
+            "summary": "(AI response unparseable — review manually)",
+            "components": None,
+            "reason": None,
+        }
+    result["group_hint"] = None  # populated by _group_pass if applicable
+    result["limited_context"] = limited_context
+    result.setdefault("components", None)  # ensure field exists if AI omits it
+    return result

--- a/docs/tools/patch-notices/patch_notices/ai.py
+++ b/docs/tools/patch-notices/patch_notices/ai.py
@@ -183,6 +183,10 @@ is a group label string (if grouped) or null (if standalone):
 # Override via PATCH_NOTICES_MAX_DIFF_CHARS if your endpoint has a tighter limit.
 _MAX_DIFF_CHARS = int(os.environ.get("PATCH_NOTICES_MAX_DIFF_CHARS", "12000"))
 
+# The only actions downstream include/discard filters recognise; anything else
+# must be treated as a manual-review fallback rather than silently dropped.
+_VALID_ACTIONS = {"include", "discard"}
+
 
 def triage(prs: list[dict[str, Any]], source: str = "snap") -> list[dict[str, Any]]:
     """Run each commit through two LLM passes. Returns an enriched list of records.
@@ -196,8 +200,8 @@ def triage(prs: list[dict[str, Any]], source: str = "snap") -> list[dict[str, An
 
     Supports OpenAI directly or any OpenAI-compatible endpoint.
     Set OPENAI_BASE_URL to override, e.g.:
-      export OPENAI_BASE_URL=https://models.inference.ai.azure.com
-      export OPENAI_API_KEY=ghp_...
+      export OPENAI_BASE_URL=https://openrouter.ai/api/v1
+      export OPENAI_API_KEY=sk-or-...
     """
     system_prompt = CHARM_SYSTEM_PROMPT if source == "charm" else SNAP_SYSTEM_PROMPT
     client = openai.OpenAI(
@@ -292,13 +296,15 @@ def _triage_one(client: openai.OpenAI, pr: dict[str, Any], system_prompt: str) -
     )
     try:
         result = json.loads(response.choices[0].message.content)
+        if not isinstance(result, dict) or result.get("action") not in _VALID_ACTIONS:
+            raise ValueError(f"unsupported action {result.get('action')!r}" if isinstance(result, dict) else f"response is not a JSON object: {result!r}")
     except Exception as exc:
         sha = pr.get("sha", "")[:8]
-        print(f"[warning] JSON parse failed for {sha} ({exc}); flagging for manual review.", flush=True)
+        print(f"[warning] Invalid triage response for {sha} ({exc}); flagging for manual review.", flush=True)
         result = {
             "action": "include",
             "category": None,
-            "summary": "(AI response unparseable — review manually)",
+            "summary": "(AI response invalid — review manually)",
             "components": None,
             "reason": None,
         }

--- a/docs/tools/patch-notices/patch_notices/cli.py
+++ b/docs/tools/patch-notices/patch_notices/cli.py
@@ -136,6 +136,10 @@ def cmd_generate(args: argparse.Namespace) -> None:
     delta = _fetch_delta(args.source, channel_key)
 
     if not delta:
+        existing_sha = metadata.load().get("tracks", {}).get(channel_key, {}).get("last_documented_sha")
+        if existing_sha:
+            # Bookmark is unchanged, but refresh the date so up-to-date tracks stay current.
+            metadata.update(channel_key, existing_sha)
         _write_json(args.summary_out, {
             "track": channel_key,
             "status": "up-to-date",

--- a/docs/tools/patch-notices/patch_notices/cli.py
+++ b/docs/tools/patch-notices/patch_notices/cli.py
@@ -1,0 +1,285 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+"""CLI entry point for the patch-notices tool.
+
+Commands
+--------
+fetch      Pull the PR/commit delta since the last documented SHA.
+review     Run AI triage and write the Markdown workbook for manual editing.
+finalize   Parse the edited workbook, update state, and write a clean export.
+generate   Fetch + triage + insert into release notes in one step (CI use).
+pr-body    Collate per-track summary JSONs into a PR body (CI use).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from patch_notices import ai, fetcher, metadata, workbook
+
+console = Console()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _expand_track(version: str, source: str) -> str:
+    """Expand a short version like '1.32' to the full channel string."""
+    if "/" in version:
+        return version  # already a full channel
+    if source == "charm":
+        return f"{version}/stable"
+    return f"{version}-classic/stable"
+
+
+def _make_channel_key(track: str, source: str) -> str:
+    """Return the patch-metadata.json key, e.g. 'snap:1.32-classic/stable'."""
+    return f"charm:{track}" if source == "charm" else f"snap:{track}"
+
+
+def _fetch_delta(source: str, channel_key: str) -> list[dict[str, Any]]:
+    """Fetch the commit delta for a track and return it."""
+    if source == "charm":
+        return fetcher.fetch_charm_delta(channel_key)
+    return fetcher.fetch_snap_delta(channel_key)
+
+
+def _write_json(path: str, data: dict[str, Any]) -> None:
+    """Write *data* as JSON to *path*, creating parent directories as needed."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(data, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+_WORKBOOK_PATH = "patch_notices_review.md"
+_EXPORT_PATH = "patch_notices_output.md"
+
+
+def cmd_fetch(args: argparse.Namespace) -> None:
+    track = _expand_track(args.track, args.source)
+    channel_key = _make_channel_key(track, args.source)
+    console.print(f"[bold]Fetching delta for track:[/bold] {track} [dim](source: {args.source})[/dim]")
+    delta = _fetch_delta(args.source, channel_key)
+    console.print(f"[green]Found {len(delta)} commits.[/green]")
+    console.print(f"[green]Delta written:[/green] {fetcher.delta_path(channel_key)}")
+
+
+def cmd_review(args: argparse.Namespace) -> None:
+    track = _expand_track(args.track, args.source)
+    channel_key = _make_channel_key(track, args.source)
+    console.print(f"[bold]Running AI triage for track:[/bold] {track} [dim](source: {args.source})[/dim]")
+    delta = fetcher.load_delta(channel_key)
+    triage_result = ai.triage(delta, source=args.source)
+    workbook.write(triage_result, output_path=_WORKBOOK_PATH, channel_key=channel_key)
+    console.print(f"[green]Workbook written:[/green] {_WORKBOOK_PATH}")
+
+
+def cmd_finalize(args: argparse.Namespace) -> None:
+    if not Path(_WORKBOOK_PATH).exists():
+        console.print(f"[red]No workbook found at {_WORKBOOK_PATH}. Run `review` first.[/red]")
+        sys.exit(1)
+    channel_key = workbook.read_channel_key(_WORKBOOK_PATH)
+    track = channel_key.split(":", 1)[1].split("/")[0].replace("-classic", "")
+    console.print(f"[bold]Finalizing track:[/bold] {track}")
+
+    try:
+        delta = fetcher.load_delta(channel_key)
+    except FileNotFoundError:
+        console.print("[red]No delta found. Run `fetch` first.[/red]")
+        sys.exit(1)
+
+    included_shas = workbook.parse_included_shas(_WORKBOOK_PATH)
+    if included_shas:
+        workbook.export_clean(_WORKBOOK_PATH, _EXPORT_PATH)
+        console.print(f"[green]Clean export written:[/green] {_EXPORT_PATH}")
+        if not delta:
+            console.print("[red]Workbook contains included items, but the saved delta is empty. Re-run `fetch` and `review`.[/red]")
+            sys.exit(1)
+        latest_sha = delta[-1]["sha"]
+    else:
+        if delta:
+            latest_sha = delta[-1]["sha"]
+            console.print("[yellow]No included items — advancing bookmark to delta head (nothing exported).[/yellow]")
+        else:
+            existing = metadata.load().get("tracks", {}).get(channel_key, {})
+            latest_sha = existing.get("last_documented_sha")
+            if not latest_sha:
+                console.print("[red]No existing state for this track.[/red]")
+                sys.exit(1)
+            console.print("[dim]No new commits — updating date only.[/dim]")
+
+    metadata.update(channel_key, latest_sha)
+    console.print(f"[green]State updated.[/green] Latest SHA: {latest_sha}")
+
+
+def cmd_generate(args: argparse.Namespace) -> None:
+    track = _expand_track(args.track, args.source)
+    channel_key = _make_channel_key(track, args.source)
+    d = date.today()
+    today = f"{d.strftime('%b')} {d.day}, {d.year}"
+    console.print(f"[bold]Generating patch notice:[/bold] {track} [dim](source: {args.source})[/dim]")
+
+    delta = _fetch_delta(args.source, channel_key)
+
+    if not delta:
+        _write_json(args.summary_out, {
+            "track": channel_key,
+            "status": "up-to-date",
+            "date": today,
+            "included": [],
+            "discarded": [],
+            "limited_context": [],
+        })
+        console.print("[dim]Up to date — no new commits.[/dim]")
+        return
+
+    triage_result = ai.triage(delta, source=args.source)
+    included = [r for r in triage_result if r["triage"]["action"] == "include"]
+    discarded = [r for r in triage_result if r["triage"]["action"] == "discard"]
+
+    if not included:
+        summary = workbook.build_track_summary(triage_result, channel_key, today)
+        summary["status"] = "all-discarded"
+        _write_json(args.summary_out, summary)
+        metadata.update(channel_key, delta[-1]["sha"])
+        console.print(
+            f"[yellow]All {len(discarded)} commits discarded — bookmark advanced, "
+            "release notes unchanged.[/yellow]"
+        )
+        return
+
+    # Insert before updating state so a failure here is retryable.
+    workbook.insert_patch_notice(args.release_notes, triage_result, today, args.source)
+    metadata.update(channel_key, delta[-1]["sha"])
+
+    summary = workbook.build_track_summary(triage_result, channel_key, today)
+    _write_json(args.summary_out, summary)
+
+    console.print(
+        f"[green]✓[/green] {track} — "
+        f"[green]{len(included)} included[/green], "
+        f"[dim]{len(discarded)} discarded[/dim]"
+        + (f", [yellow]{len(summary['limited_context'])} ⚠️[/yellow]" if summary["limited_context"] else "")
+    )
+
+
+def cmd_pr_body(args: argparse.Namespace) -> None:
+    summary_dir = Path(args.summaries_dir)
+    if not summary_dir.is_dir():
+        console.print(f"[red]Directory not found:[/red] {args.summaries_dir}")
+        sys.exit(1)
+
+    summaries = [json.loads(f.read_text()) for f in sorted(summary_dir.glob("*.json"))]
+    if not summaries:
+        console.print(f"[red]No summary JSON files found in[/red] {args.summaries_dir}")
+        sys.exit(1)
+
+    body = workbook.build_pr_body(summaries)
+
+    if args.output == "-":
+        print(body)
+    else:
+        Path(args.output).write_text(body)
+        console.print(f"[green]PR body written:[/green] {args.output}")
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    # Shared --track / --source for commands that operate on a track.
+    track_parent = argparse.ArgumentParser(add_help=False)
+    
+    track_parent.add_argument(
+        "--track",
+        required=True,
+        help="Release version, e.g. '1.32'.",
+    )
+    track_parent.add_argument(
+        "--source",
+        default="snap",
+        choices=["snap", "charm"],
+        help="'snap' (default) or 'charm'.",
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="patch-notices",
+        description="Patch-notices updater for Canonical Kubernetes.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser(
+        "fetch",
+        parents=[track_parent],
+        help="Pull the PR delta since the last documented commit.",
+    )
+    p.set_defaults(func=cmd_fetch)
+
+    p = sub.add_parser(
+        "review",
+        parents=[track_parent],
+        help="Run AI triage and write the Markdown workbook.",
+    )
+    p.set_defaults(func=cmd_review)
+
+    p = sub.add_parser(
+        "finalize",
+        help="Close the loop: update state and write the clean export.",
+    )
+    p.set_defaults(func=cmd_finalize)
+
+    p = sub.add_parser(
+        "generate",
+        parents=[track_parent],
+        help="Fetch, triage, and write directly to the release notes file.",
+    )
+    p.add_argument(
+        "--release-notes",
+        required=True,
+        help="Path to the release notes file to update.",
+    )
+    p.add_argument(
+        "--summary-out",
+        required=True,
+        help="Path to write the per-track summary JSON.",
+    )
+    p.set_defaults(func=cmd_generate)
+
+    p = sub.add_parser(
+        "pr-body",
+        help="Generate the PR body markdown from per-track summary JSON files.",
+    )
+    p.add_argument(
+        "--summaries-dir",
+        required=True,
+        help="Directory containing per-track summary JSON files.",
+    )
+    p.add_argument(
+        "--output",
+        default="-",
+        help="Output file path. Use '-' for stdout (default).",
+    )
+    p.set_defaults(func=cmd_pr_body)
+
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    args.func(args)

--- a/docs/tools/patch-notices/patch_notices/fetcher.py
+++ b/docs/tools/patch-notices/patch_notices/fetcher.py
@@ -1,0 +1,359 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+"""Fetch the commit delta between the last documented SHA and the current stable SHA.
+
+Snap pipeline:
+  1. Query Snap Store API  -> current revision number for the track
+  2. Query Launchpad API   -> git SHA for that revision's build
+  3. Query GitHub API      -> list of commits merged between the two SHAs
+
+Charm pipeline:
+  1. Query Charmhub API    -> current revision number for the track
+  2. Query GitHub API      -> git SHA via the k8s-rev<N> tag
+  3. Query GitHub API      -> list of commits merged between the two SHAs
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import Any
+
+import requests
+
+from patch_notices import metadata
+
+SNAP_STORE_API = "https://api.snapcraft.io/v2/snaps/info/k8s"
+LAUNCHPAD_API = "https://api.launchpad.net/devel"
+GITHUB_API = "https://api.github.com"
+GITHUB_REPO = "canonical/k8s-snap"
+CHARMHUB_API = "https://api.charmhub.io/v2/charms/info"
+CHARM_GITHUB_REPO = "canonical/k8s-operator"
+
+# Launchpad snap owner/project path — builds live at ~containers/k8s/+snap/<name>
+LP_SNAP_OWNER = "~containers"
+LP_SNAP_PROJECT = "k8s"
+
+METADATA_DIR = pathlib.Path(__file__).parent.parent / "metadata"
+
+# PR number embedded in squash-merge commit subject, e.g. "fix: something (#2131)"
+_PR_IN_SUBJECT_RE = re.compile(r"\(#(\d+)\)$")
+
+
+# ---------------------------------------------------------------------------
+# Snap pipeline helpers
+# ---------------------------------------------------------------------------
+
+
+def _snap_store_revision(track: str) -> int:
+    """Return the current amd64 revision number published on *track*.
+
+    The track argument should be the full channel name, e.g. '1.32-classic/stable'.
+    The Snap Store channel-map uses '<track>/<risk>' in channel.name, where
+    track contains the version + flavor (e.g. '1.32-classic').
+    """
+    resp = requests.get(
+        SNAP_STORE_API,
+        headers={"Snap-Device-Series": "16"},
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    # Normalise: accept both '1.32-classic/stable' and '1.32-classic' + risk split
+    if "/" in track:
+        track_name, risk = track.split("/", 1)
+    else:
+        raise ValueError(
+            f"track must be in '<version>/<risk>' format, e.g. '1.32-classic/stable'. Got: {track!r}"
+        )
+
+    for entry in data.get("channel-map", []):
+        ch = entry["channel"]
+        if ch["track"] == track_name and ch["risk"] == risk and ch["architecture"] == "amd64":
+            return int(entry["revision"])
+
+    raise ValueError(
+        f"Track '{track}' not found in Snap Store channel-map for 'k8s'. "
+        f"Available stable tracks: {sorted({e['channel']['track'] for e in data.get('channel-map', []) if e['channel']['risk'] == 'stable'})}"
+    )
+
+
+def _launchpad_sha(track: str, revision: int) -> str:
+    """Return the git SHA that produced *revision* for *track* via Launchpad builds.
+
+    Launchpad snap builds live at:
+      /devel/~containers/k8s/+snap/k8s-snap-<track>/builds
+
+    Each build entry has:
+      - store_upload_revision: the snap store revision number (int)
+      - revision_id: the VCS commit SHA used for the build
+    """
+    # Derive the Launchpad snap name from the track, e.g. '1.32-classic/stable' -> 'k8s-snap-1.32-classic'
+    track_name = track.split("/")[0]
+    snap_name = f"k8s-snap-{track_name}"
+    # URL pattern: /devel/~containers/k8s/+snap/<name>/builds
+    builds_url = (
+        f"{LAUNCHPAD_API}/{LP_SNAP_OWNER}/{LP_SNAP_PROJECT}/+snap/{snap_name}/builds"
+    )
+
+    # Paginate through builds (newest first) until we find the matching store revision
+    url: str | None = f"{builds_url}?ws.size=75"
+    while url:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        for build in data.get("entries", []):
+            if build.get("store_upload_revision") == revision:
+                sha = build.get("revision_id")
+                if sha:
+                    return sha
+                raise ValueError(
+                    f"Launchpad build for revision {revision} found but 'revision_id' is empty. "
+                    f"Build keys: {list(build.keys())}"
+                )
+        url = data.get("next_collection_link")
+
+    raise ValueError(
+        f"No Launchpad build found for snap '{snap_name}' with store revision {revision}. "
+        "The build may still be in progress, or the snap name may have changed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# GitHub / shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _github_commit_diff(sha: str, repo: str, headers: dict) -> str:
+    """Return the unified diff for a single commit as a formatted string.
+
+    Makes one API call to GET /repos/{repo}/commits/{sha}. The *headers*
+    dict (auth token, Accept header, API version) is shared with the caller
+    so it does not need to be rebuilt.
+    """
+    resp = requests.get(
+        f"{GITHUB_API}/repos/{repo}/commits/{sha}",
+        headers=headers,
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return "\n\n".join(
+        f"--- {f['filename']} ---\n{f.get('patch', '(binary or no diff)')}"
+        for f in data.get("files", [])
+    )
+
+
+def _github_commits(base_sha: str, head_sha: str, repo: str = GITHUB_REPO) -> list[dict[str, Any]]:
+    """Return one entry per commit between *base_sha* and *head_sha*.
+
+    Uses a GitHub compare request to obtain the commit list, then fetches
+    each commit's individual diff via a dedicated API call so the AI receives
+    focused, accurate context instead of the entire release's aggregate diff.
+    PR numbers are extracted from commit message subjects where GitHub embeds
+    them (e.g. "fix: something (#2131)").
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    headers["Accept"] = "application/vnd.github+json"
+    headers["X-GitHub-Api-Version"] = "2022-11-28"
+
+    resp = requests.get(
+        f"{GITHUB_API}/repos/{repo}/compare/{base_sha}...{head_sha}?per_page=250",
+        headers=headers,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    commits = data.get("commits", [])
+    total_commits = data.get("total_commits")
+    if total_commits is not None and total_commits > len(commits):
+        raise ValueError(
+            f"GitHub compare returned {len(commits)} of {total_commits} commits "
+            f"for {repo} {base_sha}...{head_sha}. Narrow the delta or add pagination."
+        )
+    if not token and len(commits) > 20:
+        print(
+            f"\u26a0 GITHUB_TOKEN not set \u2014 fetching per-commit diffs for {len(commits)} commits "
+            "against the 60 req/hr unauthenticated rate limit. "
+            "Set GITHUB_TOKEN to avoid throttling.",
+            file=sys.stderr,
+        )
+
+    entries: list[dict[str, Any]] = []
+    for commit in commits:
+        msg_lines = commit["commit"]["message"].splitlines()
+        title = msg_lines[0]
+        body = "\n".join(msg_lines[1:]).strip()
+
+        m = _PR_IN_SUBJECT_RE.search(title)
+        pr_number = int(m.group(1)) if m else None
+        pr_url = (
+            f"https://github.com/{repo}/pull/{pr_number}"
+            if pr_number else None
+        )
+
+        diff = _github_commit_diff(commit["sha"], repo, headers)
+
+        entries.append({
+            "sha": commit["sha"],
+            "title": title,
+            "body": body,
+            "html_url": commit.get("html_url", ""),
+            "author": (commit.get("author") or {}).get("login")
+                      or commit["commit"]["author"]["name"],
+            "date": commit["commit"]["author"]["date"][:10],
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "diff": diff,
+        })
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Charm pipeline helpers
+# ---------------------------------------------------------------------------
+
+
+def _charmhub_revision(track: str) -> int:
+    """Return the current amd64 revision number published on *track* for the k8s charm.
+
+    The track argument should be the full channel name, e.g. '1.32/stable'.
+    """
+    resp = requests.get(
+        f"{CHARMHUB_API}/k8s?fields=channel-map",
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    for entry in data.get("channel-map", []):
+        ch = entry["channel"]
+        if (
+            ch.get("name") == track
+            and entry["revision"]["bases"][0].get("architecture") == "amd64"
+        ):
+            return int(entry["revision"]["revision"])
+
+    available = sorted(
+        {e["channel"]["name"] for e in data.get("channel-map", []) if e["channel"].get("risk") == "stable"}
+    )
+    raise ValueError(
+        f"Track '{track}' not found in Charmhub channel-map for 'k8s'. "
+        f"Available stable tracks: {available}"
+    )
+
+
+def _charm_github_sha(revision: int) -> str:
+    """Return the git SHA for *revision* of the k8s charm via its GitHub tag.
+
+    Tags follow the pattern 'k8s-rev{revision}' in canonical/k8s-operator.
+    Tags are lightweight (type 'commit'), so object.sha is the commit SHA directly.
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    headers["Accept"] = "application/vnd.github+json"
+    headers["X-GitHub-Api-Version"] = "2022-11-28"
+
+    tag_name = f"k8s-rev{revision}"
+    resp = requests.get(
+        f"{GITHUB_API}/repos/{CHARM_GITHUB_REPO}/git/refs/tags/{tag_name}",
+        headers=headers,
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    sha = data["object"]["sha"]
+    return sha
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+
+def delta_path(channel_key: str) -> pathlib.Path:
+    """Return the path for a track's saved delta file."""
+    safe = channel_key.replace(":", "-").replace("/", "-")
+    return METADATA_DIR / f"delta-{safe}.json"
+
+
+def _save_delta(channel_key: str, prs: list[dict[str, Any]]) -> None:
+    """Persist delta to metadata/delta-<safe-track>.json."""
+    METADATA_DIR.mkdir(exist_ok=True)
+    path = delta_path(channel_key)
+    path.write_text(json.dumps(prs, indent=2))
+
+
+def load_delta(channel_key: str) -> list[dict[str, Any]]:
+    """Load a previously saved delta from disk."""
+    path = delta_path(channel_key)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"No delta file found for '{channel_key}'. Run `fetch` first."
+        )
+    return json.loads(path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def fetch_charm_delta(channel_key: str) -> list[dict[str, Any]]:
+    """Full charm pipeline: Charmhub -> GitHub tag -> GitHub commits. Returns commit list.
+
+    *channel_key* must be in the form 'charm:<channel>', e.g. 'charm:1.32/stable'.
+    Only '/stable' channels are accepted.
+    """
+    if not channel_key.startswith("charm:"):
+        raise ValueError(
+            f"channel_key must start with 'charm:', got: {channel_key!r}"
+        )
+    channel = channel_key[len("charm:"):]
+    if not channel.endswith("/stable"):
+        raise ValueError(
+            f"Charm patch notices only support '/stable' channels, got: {channel!r}"
+        )
+
+    channel_metadata = metadata.load().get("tracks", {}).get(channel_key, {})
+    base_sha = channel_metadata.get("last_documented_sha")
+    if not base_sha:
+        raise ValueError(
+            f"No last_documented_sha for '{channel_key}' in patch-metadata.json. "
+            "Add an initial entry before running fetch."
+        )
+
+    revision = _charmhub_revision(channel)
+    head_sha = _charm_github_sha(revision)
+    commits = _github_commits(base_sha, head_sha, repo=CHARM_GITHUB_REPO)
+    _save_delta(channel_key, commits)
+    return commits
+
+
+def fetch_snap_delta(channel_key: str) -> list[dict[str, Any]]:
+    """Full pipeline: Snap Store -> Launchpad -> GitHub. Returns PR list."""
+    if not channel_key.startswith("snap:"):
+        raise ValueError(
+            f"channel_key must start with 'snap:', got: {channel_key!r}"
+        )
+    track = channel_key[len("snap:"):]
+    channel_metadata = metadata.load().get("tracks", {}).get(channel_key, {})
+    base_sha = channel_metadata.get("last_documented_sha")
+    if not base_sha:
+        raise ValueError(
+            f"No last_documented_sha for '{channel_key}' in patch-metadata.json. "
+            "Add an initial entry before running fetch."
+        )
+    revision = _snap_store_revision(track)
+    head_sha = _launchpad_sha(track, revision)
+    prs = _github_commits(base_sha, head_sha)
+    _save_delta(channel_key, prs)
+    return prs

--- a/docs/tools/patch-notices/patch_notices/fetcher.py
+++ b/docs/tools/patch-notices/patch_notices/fetcher.py
@@ -149,35 +149,66 @@ def _github_commit_diff(sha: str, repo: str, headers: dict) -> str:
     )
 
 
+# GitHub caps per_page at 250 for an unpaginated compare request, but once a
+# page/per_page parameter is supplied the endpoint's documented cap drops to 100.
+_COMPARE_PAGE_SIZE = 100
+# Safety cap on pages fetched (50k commits) so a misbehaving response can't loop forever.
+_MAX_COMPARE_PAGES = 500
+
+
+def _github_compare_commits(base_sha: str, head_sha: str, repo: str, headers: dict) -> list[dict[str, Any]]:
+    """Return every commit between *base_sha* and *head_sha*, paginating as needed.
+
+    Backfills or long gaps between runs (see README) can produce deltas larger
+    than a single compare page, so pages are fetched until the aggregated
+    commit count reaches total_commits.
+    """
+    commits: list[dict[str, Any]] = []
+    page = 1
+    data: dict[str, Any] = {}
+    while True:
+        resp = requests.get(
+            f"{GITHUB_API}/repos/{repo}/compare/{base_sha}...{head_sha}"
+            f"?per_page={_COMPARE_PAGE_SIZE}&page={page}",
+            headers=headers,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        page_commits = data.get("commits", [])
+        commits.extend(page_commits)
+        total_commits = data.get("total_commits")
+        if not page_commits or (total_commits is not None and len(commits) >= total_commits):
+            break
+        page += 1
+        if page > _MAX_COMPARE_PAGES:
+            break
+
+    total_commits = data.get("total_commits")
+    if total_commits is not None and total_commits > len(commits):
+        raise ValueError(
+            f"GitHub compare returned {len(commits)} of {total_commits} commits "
+            f"for {repo} {base_sha}...{head_sha} after paginating. Narrow the delta."
+        )
+    return commits
+
+
 def _github_commits(base_sha: str, head_sha: str, repo: str = GITHUB_REPO) -> list[dict[str, Any]]:
     """Return one entry per commit between *base_sha* and *head_sha*.
 
-    Uses a GitHub compare request to obtain the commit list, then fetches
-    each commit's individual diff via a dedicated API call so the AI receives
-    focused, accurate context instead of the entire release's aggregate diff.
-    PR numbers are extracted from commit message subjects where GitHub embeds
-    them (e.g. "fix: something (#2131)").
+    Uses paginated GitHub compare requests to obtain the commit list, then
+    fetches each commit's individual diff via a dedicated API call so the AI
+    receives focused, accurate context instead of the entire release's
+    aggregate diff. PR numbers are extracted from commit message subjects
+    where GitHub embeds them (e.g. "fix: something (#2131)").
     """
     token = os.environ.get("GITHUB_TOKEN")
     headers = {"Authorization": f"Bearer {token}"} if token else {}
     headers["Accept"] = "application/vnd.github+json"
     headers["X-GitHub-Api-Version"] = "2022-11-28"
 
-    resp = requests.get(
-        f"{GITHUB_API}/repos/{repo}/compare/{base_sha}...{head_sha}?per_page=250",
-        headers=headers,
-        timeout=30,
-    )
-    resp.raise_for_status()
-    data = resp.json()
+    commits = _github_compare_commits(base_sha, head_sha, repo, headers)
 
-    commits = data.get("commits", [])
-    total_commits = data.get("total_commits")
-    if total_commits is not None and total_commits > len(commits):
-        raise ValueError(
-            f"GitHub compare returned {len(commits)} of {total_commits} commits "
-            f"for {repo} {base_sha}...{head_sha}. Narrow the delta or add pagination."
-        )
     if not token and len(commits) > 20:
         print(
             f"\u26a0 GITHUB_TOKEN not set \u2014 fetching per-commit diffs for {len(commits)} commits "

--- a/docs/tools/patch-notices/patch_notices/metadata.py
+++ b/docs/tools/patch-notices/patch_notices/metadata.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+"""Read and write patch-metadata.json.
+
+The file is git-tracked so that every contributor starts from the correct
+last_documented_sha. Writes are atomic (write to a temp file, then rename)
+to avoid corruption on error.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import tempfile
+from datetime import date
+from typing import Any
+
+METADATA_DIR = pathlib.Path(__file__).parent.parent / "metadata"
+STATE_FILE = METADATA_DIR / "patch-metadata.json"
+
+
+def load() -> dict[str, Any]:
+    """Return the full contents of patch-metadata.json, or an empty dict."""
+    if not STATE_FILE.exists():
+        return {}
+    return json.loads(STATE_FILE.read_text())
+
+
+def update(track: str, latest_sha: str) -> None:
+    """Update *track* with *latest_sha* and today's date. Atomic write."""
+    data = load()
+    data.setdefault("tracks", {})
+    data["tracks"][track] = {
+        "last_documented_sha": latest_sha,
+        "last_documented_date": date.today().isoformat(),
+    }
+    _atomic_write(STATE_FILE, json.dumps(data, indent=2) + "\n")
+
+
+def _atomic_write(path: pathlib.Path, content: str) -> None:
+    """Write *content* to *path* atomically via a sibling temp file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".tmp-patch-metadata-")
+    try:
+        os.write(fd, content.encode())
+        os.close(fd)
+        os.replace(tmp, path)
+    except Exception:
+        os.close(fd)
+        os.unlink(tmp)
+        raise

--- a/docs/tools/patch-notices/patch_notices/sanitize.py
+++ b/docs/tools/patch-notices/patch_notices/sanitize.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+"""Sanitize untrusted text before rendering Markdown."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+MARKDOWN_TEXT_LIMIT = 240
+COMPONENT_TEXT_LIMIT = 120
+LABEL_TEXT_LIMIT = 80
+
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_HTML_TAG_RE = re.compile(r"</?[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
+_MD_SPECIAL_RE = re.compile(r"([\\`*_{}\[\]()#!|<>])")
+_CATEGORY_VALUES = {
+    "Major Feature",
+    "Security",
+    "Deprecation",
+    "Bug Fix",
+    "Performance",
+    "Component Bump",
+    "Documentation",
+}
+
+
+def markdown_text(value: Any, *, limit: int = MARKDOWN_TEXT_LIMIT) -> str:
+    """Return *value* as escaped, single-line Markdown plain text."""
+    text = _single_line(value, limit=limit)
+    return _MD_SPECIAL_RE.sub(r"\\\1", text)
+
+
+def component_text(value: Any) -> str:
+    """Return a component/version entry as escaped plain text."""
+    return markdown_text(value, limit=COMPONENT_TEXT_LIMIT)
+
+
+def label_text(value: Any) -> str:
+    """Return a short label as escaped plain text."""
+    return markdown_text(value, limit=LABEL_TEXT_LIMIT)
+
+
+def category(value: Any) -> str:
+    """Return a known patch-notice category or a manual-review fallback."""
+    text = "" if value is None else str(value).strip()
+    return text if text in _CATEGORY_VALUES else "Review Required"
+
+
+def sha(value: Any) -> str:
+    """Return a validated commit SHA for HTML comments and inline code."""
+    text = _single_line(value, limit=40).lower()
+    if not _SHA_RE.fullmatch(text):
+        raise ValueError(f"Invalid commit SHA: {value!r}")
+    return text
+
+
+def short_sha(value: Any) -> str:
+    """Return the first eight characters of a validated commit SHA."""
+    return sha(value)[:8]
+
+
+def pr_number(value: Any) -> int | None:
+    """Return a validated positive PR number, or None when absent."""
+    if value in (None, ""):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+def github_url(value: Any) -> str:
+    """Return a safe GitHub URL for Markdown link targets, or an empty string."""
+    text = _single_line(value, limit=300)
+    if not text:
+        return ""
+    parsed = urlparse(text)
+    if parsed.scheme != "https" or parsed.netloc != "github.com":
+        return ""
+    if ")" in text or "(" in text:
+        return ""
+    return text.replace(" ", "%20")
+
+
+def _single_line(value: Any, *, limit: int) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    text = _CONTROL_RE.sub(" ", text)
+    text = _HTML_COMMENT_RE.sub(" ", text)
+    text = _HTML_TAG_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    if len(text) > limit:
+        return text[: limit - 1].rstrip() + "..."
+    return text

--- a/docs/tools/patch-notices/patch_notices/workbook.py
+++ b/docs/tools/patch-notices/patch_notices/workbook.py
@@ -29,6 +29,14 @@ from patch_notices import sanitize
 
 SHA_TAG_RE = re.compile(r"<!--\s*sha:([0-9a-f]{7,40})\s*-->")
 
+
+def _safe_short_sha(value: Any) -> str:
+    """Return a short SHA, or 'unknown' if the stored value is malformed."""
+    try:
+        return sanitize.short_sha(value)
+    except ValueError:
+        return "unknown"
+
 CATEGORY_ORDER = [
     "Major Feature",
     "Security",
@@ -98,13 +106,6 @@ def _pr_suffix(value: Any, *, parens: bool = True) -> str:
     if number is None:
         return ""
     return f" (PR #{number})" if parens else f" PR #{number}"
-
-
-def _display_sha(value: Any) -> str:
-    try:
-        return sanitize.short_sha(value)
-    except ValueError:
-        return "unknown"
 
 
 def _clean_entry_lines(triage_results: list[dict[str, Any]]) -> list[str]:
@@ -318,9 +319,10 @@ def insert_patch_notice(
     if "## Patch notices" in text:
         # Insert new entry immediately after the section heading + blank line.
         # Pattern: the heading followed by one or more blank lines.
+        # Callable replacement avoids re interpreting backslashes in entry_block as escapes.
         new_text, n = re.subn(
             r"(## Patch notices\n\n)",
-            f"\\1{entry_block}\n\n",
+            lambda match: match.group(1) + entry_block + "\n\n",
             text,
             count=1,
         )
@@ -372,7 +374,8 @@ def build_track_summary(
     """
     included = [r for r in triage_results if r["triage"]["action"] == "include"]
     discarded = [r for r in triage_results if r["triage"]["action"] == "discard"]
-    limited = [r for r in included if r["triage"].get("limited_context")]
+    # Low-context flag applies regardless of action, so discards need the warning too.
+    limited = [r for r in triage_results if r["triage"].get("limited_context")]
 
     return {
         "track": track,
@@ -494,7 +497,7 @@ def build_pr_body(summaries: list[dict[str, Any]]) -> str:
             lines.append("### ⚠️ Large diff — verify manually before approving")
             lines.append("")
             for item in s["limited_context"]:
-                sha = _display_sha(item.get("sha", ""))
+                sha = _safe_short_sha(item.get("sha", ""))
                 pr = _pr_suffix(item.get("pr_number"))
                 title = sanitize.markdown_text(item.get("title", ""))
                 lines.append(f"- `{sha}`{pr} — {title}")
@@ -505,7 +508,7 @@ def build_pr_body(summaries: list[dict[str, Any]]) -> str:
             lines.append("### Discarded")
             lines.append("")
             for item in s["discarded"]:
-                sha = _display_sha(item.get("sha", ""))
+                sha = _safe_short_sha(item.get("sha", ""))
                 pr = _pr_suffix(item.get("pr_number"), parens=False)
                 reason = sanitize.markdown_text(item.get("reason", ""))
                 title = sanitize.markdown_text(item.get("title", ""))

--- a/docs/tools/patch-notices/patch_notices/workbook.py
+++ b/docs/tools/patch-notices/patch_notices/workbook.py
@@ -1,0 +1,520 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+"""Assemble and parse the Markdown workbook.
+
+Workbook structure
+------------------
+## Included
+<!-- sha:abc1234 -->
+- **Major Feature** Adds XYZ support, reducing manual steps by ...
+
+## Verification
+- #42 — Original PR title
+
+## Discarded
+- #99 — Original title | _Reason: internal refactor, no user impact_
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from patch_notices import sanitize
+
+SHA_TAG_RE = re.compile(r"<!--\s*sha:([0-9a-f]{7,40})\s*-->")
+
+CATEGORY_ORDER = [
+    "Major Feature",
+    "Security",
+    "Deprecation",
+    "Bug Fix",
+    "Performance",
+    "Component Bump",
+    "Documentation",
+]
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _group_included(included: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Return a list of groups. Standalone commits are groups of size 1.
+    Commits sharing a non-null group_hint are collected together, in first-seen order.
+    """
+    groups: list[list[dict[str, Any]]] = []
+    hint_index: dict[str, int] = {}  # group_hint -> index in groups
+    for r in included:
+        hint = r["triage"].get("group_hint") or None
+        if hint is None:
+            groups.append([r])
+        elif hint in hint_index:
+            groups[hint_index[hint]].append(r)
+        else:
+            hint_index[hint] = len(groups)
+            groups.append([r])
+    return groups
+
+
+_CHANNEL_TAG_RE = re.compile(r"<!-- patch-notices:channel:(.+?) -->")
+
+
+def _best_in_group(group: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return the commit from the group with the highest-priority category."""
+    return min(
+        group,
+        key=lambda r: (
+            CATEGORY_ORDER.index(r["triage"].get("category", ""))
+            if r["triage"].get("category") in CATEGORY_ORDER
+            else len(CATEGORY_ORDER)
+        ),
+    )
+
+
+def _sort_by_category(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _key(r: dict[str, Any]) -> int:
+        cat = r["triage"].get("category", "")
+        try:
+            return CATEGORY_ORDER.index(cat)
+        except ValueError:
+            return len(CATEGORY_ORDER)
+
+    return sorted(items, key=_key)
+
+
+def _components(value: Any) -> list[str]:
+    return [component for item in (value or []) if (component := sanitize.component_text(item))]
+
+
+def _pr_suffix(value: Any, *, parens: bool = True) -> str:
+    number = sanitize.pr_number(value)
+    if number is None:
+        return ""
+    return f" (PR #{number})" if parens else f" PR #{number}"
+
+
+def _display_sha(value: Any) -> str:
+    try:
+        return sanitize.short_sha(value)
+    except ValueError:
+        return "unknown"
+
+
+def _clean_entry_lines(triage_results: list[dict[str, Any]]) -> list[str]:
+    """Return clean bullet lines from triage results (no sha tags, no category labels).
+
+    Produces the same output as export_clean but directly from triage results,
+    without needing a workbook file on disk.
+    """
+    included = [r for r in triage_results if r["triage"]["action"] == "include"]
+    groups = _group_included(_sort_by_category(included))
+    lines: list[str] = []
+    for group in groups:
+        if len(group) == 1:
+            r = group[0]
+            category = sanitize.category(r["triage"].get("category", ""))
+            summary = sanitize.markdown_text(r["triage"].get("summary", ""))
+            components = _components(r["triage"].get("components"))
+            if category == "Component Bump" and components:
+                lines.append("- Version bumps")
+                for component in components:
+                    lines.append(f"    - {component}")
+            else:
+                lines.append(f"- {summary}")
+        else:
+            best = _best_in_group(group)
+            category = sanitize.category(best["triage"].get("category", ""))
+            summary = sanitize.markdown_text(best["triage"].get("summary", ""))
+            all_components: list[str] = []
+            for r in group:
+                all_components.extend(_components(r["triage"].get("components")))
+            if category == "Component Bump" and all_components:
+                lines.append("- Version bumps")
+                for component in all_components:
+                    lines.append(f"    - {component}")
+            else:
+                lines.append(f"- {summary}")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Manual workflow
+# ---------------------------------------------------------------------------
+
+
+def write(triage_results: list[dict[str, Any]], output_path: str, channel_key: str = "") -> None:
+    """Render triage results into the three-section workbook."""
+    included = [r for r in triage_results if r["triage"]["action"] == "include"]
+    discarded = [r for r in triage_results if r["triage"]["action"] == "discard"]
+
+    lines: list[str] = []
+    if channel_key:
+        lines.append(f"<!-- patch-notices:channel:{channel_key} -->")
+    lines.append("# Monthly Patch Notice Review\n")
+
+    # -- Included ----------------------------------------------------------
+    lines.append("## Included\n")
+    lines.append(
+        "> Edit summaries freely. Keep the `<!-- sha:... -->` tags — "
+        "`finalize` uses them to update state.\n"
+    )
+    groups = _group_included(_sort_by_category(included))
+    for group in groups:
+        if len(group) == 1:
+            r = group[0]
+            sha = sanitize.sha(r.get("sha", ""))
+            category = sanitize.category(r["triage"].get("category", ""))
+            summary = sanitize.markdown_text(r["triage"].get("summary", ""))
+            components = _components(r["triage"].get("components"))
+            lines.append(f"<!-- sha:{sha} -->")
+            if category == "Component Bump" and components:
+                lines.append(f"- **{category}** Version bumps")
+                for component in components:
+                    lines.append(f"    - {component}")
+            else:
+                lines.append(f"- **{category}** {summary}")
+            if r["triage"].get("limited_context"):
+                lines.append("> \u26a0\ufe0f Large diff \u2014 triaged from PR title and description only. Verify before publishing.")
+        else:
+            # Multi-commit group: one sha tag per commit, one combined bullet
+            best = _best_in_group(group)
+            category = sanitize.category(best["triage"].get("category", ""))
+            hint = sanitize.label_text(best["triage"].get("group_hint", ""))
+            for r in group:
+                lines.append(f"<!-- sha:{sanitize.sha(r.get('sha', ''))} -->")
+            # Merge components from all items in the group for Component Bump groups
+            all_components = []
+            for r in group:
+                all_components.extend(_components(r["triage"].get("components")))
+            if category == "Component Bump" and all_components:
+                lines.append(f"- **{category}** Version bumps")
+                for component in all_components:
+                    lines.append(f"    - {component}")
+            else:
+                summary = sanitize.markdown_text(best["triage"].get("summary", ""))
+                lines.append(f"- **{category}** {summary}")
+            covers = ", ".join(
+                f"`{sanitize.short_sha(r.get('sha', ''))}` {sanitize.markdown_text(r.get('title', ''))}"
+                for r in group
+            )
+            lines.append(f"  _(Group: {hint} — covers: {covers})_")
+            if any(r["triage"].get("limited_context") for r in group):
+                lines.append("> ⚠️ Large diff on one or more commits — partially triaged from PR title and description only. Verify before publishing.")
+    lines.append("")
+
+    # -- Verification ------------------------------------------------------
+    lines.append("## Verification\n")
+    lines.append("> Cross-check summaries against original commit titles.\n")
+    for r in included:
+        sha = sanitize.short_sha(r.get("sha", ""))
+        pr = _pr_suffix(r.get("pr_number"))
+        url = sanitize.github_url(r.get("pr_url") or r.get("html_url", ""))
+        title = sanitize.markdown_text(r.get("title", ""))
+        if url:
+            lines.append(f"- [`{sha}`]({url}){pr} — {title}")
+        else:
+            lines.append(f"- `{sha}`{pr} — {title}")
+    lines.append("")
+
+    # -- Discarded ---------------------------------------------------------
+    lines.append("## Discarded\n")
+    lines.append(
+        "> Items the AI considers noise. Move to Included (with a sha tag) "
+        "if you disagree.\n"
+    )
+    for r in discarded:
+        reason = sanitize.markdown_text(r["triage"].get("reason", ""))
+        sha = sanitize.short_sha(r.get("sha", ""))
+        pr = _pr_suffix(r.get("pr_number"), parens=False)
+        title = sanitize.markdown_text(r.get("title", ""))
+        lc_marker = " *(\u26a0\ufe0f large diff \u2014 verify)*" if r["triage"].get("limited_context") else ""
+        lines.append(f"- `{sha}`{pr} \u2014 {title} | _{reason}_{lc_marker}")
+    lines.append("")
+
+    Path(output_path).write_text("\n".join(lines))
+
+
+def parse_included_shas(workbook_path: str) -> list[str]:
+    """Return all SHAs found in <!-- sha:... --> tags, in document order."""
+    text = Path(workbook_path).read_text()
+    # Only parse SHAs that appear before the Verification section
+    included_section = text.split("## Verification")[0]
+    return SHA_TAG_RE.findall(included_section)
+
+
+def read_channel_key(workbook_path: str) -> str:
+    """Return the channel key embedded by write(), e.g. 'snap:1.32-classic/stable'."""
+    text = Path(workbook_path).read_text()
+    m = _CHANNEL_TAG_RE.search(text)
+    if not m:
+        raise ValueError(
+            f"No channel tag found in {workbook_path}. "
+            "Re-run `review` to regenerate the workbook."
+        )
+    return m.group(1)
+
+
+def export_clean(workbook_path: str, export_path: str) -> None:
+    """Write a clean copy of the Included section, stripped of all tags."""
+    text = Path(workbook_path).read_text()
+    if "## Verification" not in text:
+        raise ValueError(
+            f"'## Verification' section not found in {workbook_path}. "
+            "The workbook may be corrupted — re-run `review` to regenerate it."
+        )
+    included_section = text.split("## Verification")[0]
+    # Remove sha tags
+    clean = SHA_TAG_RE.sub("", included_section)
+    # Remove blockquote editor hints
+    clean = re.sub(r"^> .*\n", "", clean, flags=re.MULTILINE)
+    # Remove group hint lines (indented _(Group: ...)_ lines)
+    clean = re.sub(r"^ {2}_\(Group:.*\)_\n", "", clean, flags=re.MULTILINE)
+    # Strip **Category** labels from bullet lines
+    clean = re.sub(r"^(- )\*\*[^*]+\*\* ", r"\1", clean, flags=re.MULTILINE)
+    # Collapse multiple blank lines
+    clean = re.sub(r"\n{3,}", "\n\n", clean).strip() + "\n"
+    Path(export_path).write_text(clean)
+
+
+# ---------------------------------------------------------------------------
+# CI workflow
+# ---------------------------------------------------------------------------
+
+
+def insert_patch_notice(
+    release_notes_path: str,
+    triage_results: list[dict[str, Any]],
+    date: str,
+    source: str,
+) -> None:
+    """Insert a new dated patch notice entry into the release notes file.
+
+    If ``## Patch notices`` already exists, the new entry is prepended at the
+    top of that section (newest-first order).  If the section is absent it is
+    created at the canonical location:
+
+    - snap: after ``## Upgrade notes``
+    - charm: after ``## Also in this release``
+
+    Writes the file atomically via a sibling temp file.
+    """
+    entry_lines = _clean_entry_lines(triage_results)
+    if not entry_lines:
+        return
+
+    # Build dated entry block (no trailing blank line — caller adds separation)
+    entry_block = date + "\n\n" + "\n".join(entry_lines)
+
+    path = Path(release_notes_path)
+    text = path.read_text()
+
+    if "## Patch notices" in text:
+        # Insert new entry immediately after the section heading + blank line.
+        # Pattern: the heading followed by one or more blank lines.
+        new_text, n = re.subn(
+            r"(## Patch notices\n\n)",
+            f"\\1{entry_block}\n\n",
+            text,
+            count=1,
+        )
+        if n == 0:
+            raise ValueError(
+                f"Found '## Patch notices' in {release_notes_path} but could not "
+                "match expected heading format '## Patch notices\\n\\n'. "
+                "Check for unexpected whitespace."
+            )
+    else:
+        # Section absent — create it after the anchor heading's content block.
+        anchor = "## Upgrade notes" if source == "snap" else "## Also in this release"
+        if anchor not in text:
+            raise ValueError(
+                f"Cannot find anchor heading '{anchor}' in {release_notes_path}. "
+                "Unable to create '## Patch notices' section."
+            )
+        anchor_pos = text.index(anchor)
+        # Walk past the anchor to find the next ## heading
+        after_anchor = text[anchor_pos + len(anchor):]
+        next_heading = re.search(r"\n##\s", after_anchor)
+        new_section = f"\n## Patch notices\n\n{entry_block}\n"
+        if next_heading:
+            insert_pos = anchor_pos + len(anchor) + next_heading.start()
+            new_text = text[:insert_pos] + new_section + text[insert_pos:]
+        else:
+            new_text = text.rstrip() + new_section + "\n"
+
+    # Atomic write: write to temp then rename
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".tmp-patch-notice-")
+    try:
+        os.write(fd, new_text.encode())
+        os.close(fd)
+        os.replace(tmp, path)
+    except Exception:
+        os.close(fd)
+        os.unlink(tmp)
+        raise
+
+
+def build_track_summary(
+    triage_results: list[dict[str, Any]],
+    track: str,
+    date: str,
+) -> dict[str, Any]:
+    """Return a per-track summary dict for the pr-body command.
+
+    *track* is the state key, e.g. ``snap:1.35-classic/stable``.
+    """
+    included = [r for r in triage_results if r["triage"]["action"] == "include"]
+    discarded = [r for r in triage_results if r["triage"]["action"] == "discard"]
+    limited = [r for r in included if r["triage"].get("limited_context")]
+
+    return {
+        "track": track,
+        "status": "updated" if included else "all-discarded",
+        "date": date,
+        "included": [
+            {
+                "category": r["triage"].get("category", ""),
+                "summary": r["triage"].get("summary", ""),
+                "components": r["triage"].get("components"),
+            }
+            for r in included
+        ],
+        "discarded": [
+            {
+                "sha": r.get("sha", "")[:8],
+                "pr_number": r.get("pr_number"),
+                "title": r.get("title", ""),
+                "reason": r["triage"].get("reason", ""),
+            }
+            for r in discarded
+        ],
+        "limited_context": [
+            {
+                "sha": r.get("sha", "")[:8],
+                "pr_number": r.get("pr_number"),
+                "title": r.get("title", ""),
+            }
+            for r in limited
+        ],
+    }
+
+
+def build_pr_body(summaries: list[dict[str, Any]]) -> str:
+    """Generate GitHub PR body markdown from a list of per-track summary dicts."""
+    from datetime import date as _date
+
+    today = _date.today().strftime("%Y-%m-%d")
+
+    def _parse_track(track: str) -> tuple[str, str]:
+        """Return (source, human-readable version) from a state key."""
+        source, rest = track.split(":", 1)
+        version = rest.split("/")[0].replace("-classic", "")
+        return sanitize.markdown_text(source), sanitize.markdown_text(version)
+
+    # Sort: snap before charm, newest version first within each source
+    def _sort_key(s: dict[str, Any]) -> tuple[int, str]:
+        src, ver = _parse_track(s["track"])
+        return (0 if src == "snap" else 1, ver)
+
+    summaries = sorted(summaries, key=_sort_key, reverse=False)
+    # reverse version within source so newest is first
+    snap = sorted([s for s in summaries if s["track"].startswith("snap:")],
+                  key=lambda s: _parse_track(s["track"])[1], reverse=True)
+    charm = sorted([s for s in summaries if s["track"].startswith("charm:")],
+                   key=lambda s: _parse_track(s["track"])[1], reverse=True)
+    summaries = snap + charm
+
+    lines: list[str] = [f"## Patch notices — {today}\n"]
+
+    # Summary table
+    lines.append("| Release | Source | Status | Included | Discarded | ⚠️ |")
+    lines.append("|---|---|---|---|---|---|")
+    for s in summaries:
+        source, version = _parse_track(s["track"])
+        if s["status"] == "updated":
+            status_str = "✅ Updated"
+        elif s["status"] == "up-to-date":
+            status_str = "— Up to date"
+        else:
+            status_str = "— All discarded"
+        n_inc = len(s.get("included", []))
+        n_dis = len(s.get("discarded", []))
+        n_lc = len(s.get("limited_context", []))
+        lines.append(
+            f"| {version} | {source} | {status_str} "
+            f"| {n_inc or ''} | {n_dis or ''} | {n_lc or ''} |"
+        )
+    lines.append("")
+
+    # Collapsible detail blocks — only for tracks with activity
+    for s in summaries:
+        if s["status"] == "up-to-date":
+            continue
+        source, version = _parse_track(s["track"])
+        n_inc = len(s.get("included", []))
+        n_dis = len(s.get("discarded", []))
+        n_lc = len(s.get("limited_context", []))
+        label = f"{source.capitalize()} {version}"
+        parts = []
+        if n_inc:
+            parts.append(f"{n_inc} included")
+        if n_dis:
+            parts.append(f"{n_dis} discarded")
+        if n_lc:
+            parts.append(f"{n_lc} ⚠️")
+        if parts:
+            label += " — " + ", ".join(parts)
+
+        lines.append(f"<details><summary>{label}</summary>")
+        lines.append("")
+
+        if s.get("included"):
+            lines.append("### Included")
+            lines.append("")
+            for item in s["included"]:
+                category = sanitize.category(item.get("category", ""))
+                summary_text = sanitize.markdown_text(item.get("summary", ""))
+                components = _components(item.get("components"))
+                if category == "Component Bump" and components:
+                    lines.append("- Version bumps")
+                    for comp in components:
+                        lines.append(f"    - {comp}")
+                else:
+                    lines.append(f"- {summary_text}")
+            lines.append("")
+
+        if s.get("limited_context"):
+            lines.append("### ⚠️ Large diff — verify manually before approving")
+            lines.append("")
+            for item in s["limited_context"]:
+                sha = _display_sha(item.get("sha", ""))
+                pr = _pr_suffix(item.get("pr_number"))
+                title = sanitize.markdown_text(item.get("title", ""))
+                lines.append(f"- `{sha}`{pr} — {title}")
+                lines.append("  _(triaged from PR title and description only)_")
+            lines.append("")
+
+        if s.get("discarded"):
+            lines.append("### Discarded")
+            lines.append("")
+            for item in s["discarded"]:
+                sha = _display_sha(item.get("sha", ""))
+                pr = _pr_suffix(item.get("pr_number"), parens=False)
+                reason = sanitize.markdown_text(item.get("reason", ""))
+                title = sanitize.markdown_text(item.get("title", ""))
+                lines.append(f"- `{sha}`{pr} — {title}")
+                if reason:
+                    lines.append(f"  _{reason}_")
+            lines.append("")
+
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/docs/tools/patch-notices/pyproject.toml
+++ b/docs/tools/patch-notices/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "patch-notices"
+version = "0.1.0"
+description = "Patch-notices updater for Canonical Kubernetes"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "openai>=1",
+    "requests>=2.31",
+    "rich>=13",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8",
+]
+
+[project.scripts]
+patch-notices = "patch_notices.cli:main"
+
+[tool.setuptools]
+packages = ["patch_notices"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+patch_notices = ["../metadata/patch-metadata.json"]

--- a/docs/tools/patch-notices/tests/test_fetcher.py
+++ b/docs/tools/patch-notices/tests/test_fetcher.py
@@ -39,7 +39,7 @@ def test_github_commits_single_page(monkeypatch: pytest.MonkeyPatch) -> None:
 
     def fake_get(url: str, **_: Any) -> _Response:
         query = parse_qs(urlparse(url).query)
-        assert query == {"per_page": ["250"]}
+        assert query == {"per_page": ["100"], "page": ["1"]}
         return _Response({"total_commits": 2, "commits": commits})
 
     monkeypatch.setattr(fetcher.requests, "get", fake_get)
@@ -49,6 +49,27 @@ def test_github_commits_single_page(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert [entry["sha"] for entry in result] == ["a" * 40, "b" * 40]
     assert all(entry["diff"] == "diff" for entry in result)
+
+
+def test_github_commits_paginates_compare_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    page1 = [_commit(f"{index:040x}") for index in range(100)]
+    page2 = [_commit(f"{index:040x}") for index in range(100, 150)]
+    requested_pages: list[int] = []
+
+    def fake_get(url: str, **_: Any) -> _Response:
+        query = parse_qs(urlparse(url).query)
+        page = int(query["page"][0])
+        requested_pages.append(page)
+        commits = page1 if page == 1 else page2
+        return _Response({"total_commits": 150, "commits": commits})
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")
+
+    result = fetcher._github_commits("base", "head")
+
+    assert requested_pages == [1, 2]
+    assert len(result) == 150
 
 
 def test_github_commits_uses_github_token(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,27 +87,31 @@ def test_github_commits_uses_github_token(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_github_commits_detects_truncated_compare_results(monkeypatch: pytest.MonkeyPatch) -> None:
-    commits = [_commit(f"{index:040x}") for index in range(250)]
+    # GitHub stops returning commits well short of total_commits.
+    full_page = [_commit(f"{index:040x}") for index in range(100)]
     request_count = 0
 
     def fake_get(url: str, **_: Any) -> _Response:
         nonlocal request_count
         request_count += 1
+        commits = full_page if request_count <= 3 else []
         return _Response({"total_commits": 400, "commits": commits})
 
     monkeypatch.setattr(fetcher.requests, "get", fake_get)
     monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")
 
-    with pytest.raises(ValueError, match="GitHub compare returned 250 of 400 commits"):
+    with pytest.raises(ValueError, match="GitHub compare returned 300 of 400 commits"):
         fetcher._github_commits("base", "head")
-    assert request_count == 1
+    assert request_count == 4
 
 
 def test_github_commits_raises_on_incomplete_compare(monkeypatch: pytest.MonkeyPatch) -> None:
     commits = [_commit(f"{index:040x}") for index in range(10)]
 
     def fake_get(url: str, **_: Any) -> _Response:
-        return _Response({"total_commits": 11, "commits": commits})
+        query = parse_qs(urlparse(url).query)
+        page = int(query["page"][0])
+        return _Response({"total_commits": 11, "commits": commits if page == 1 else []})
 
     monkeypatch.setattr(fetcher.requests, "get", fake_get)
     monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")

--- a/docs/tools/patch-notices/tests/test_fetcher.py
+++ b/docs/tools/patch-notices/tests/test_fetcher.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+from typing import Any
+
+import pytest
+
+from patch_notices import fetcher
+
+
+class _Response:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _commit(sha: str, message: str | None = None) -> dict[str, Any]:
+    return {
+        "sha": sha,
+        "html_url": f"https://github.com/canonical/k8s-snap/commit/{sha}",
+        "author": {"login": "octocat"},
+        "commit": {
+            "message": message or f"fix: update {sha[:8]}",
+            "author": {"name": "Octo Cat", "date": "2026-08-19T10:00:00Z"},
+        },
+    }
+
+
+def test_github_commits_single_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    commits = [_commit("a" * 40), _commit("b" * 40)]
+
+    def fake_get(url: str, **_: Any) -> _Response:
+        query = parse_qs(urlparse(url).query)
+        assert query == {"per_page": ["250"]}
+        return _Response({"total_commits": 2, "commits": commits})
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")
+
+    result = fetcher._github_commits("base", "head")
+
+    assert [entry["sha"] for entry in result] == ["a" * 40, "b" * 40]
+    assert all(entry["diff"] == "diff" for entry in result)
+
+
+def test_github_commits_uses_github_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    commit = _commit("a" * 40)
+
+    def fake_get(url: str, **kwargs: Any) -> _Response:
+        assert kwargs["headers"]["Authorization"] == "Bearer github-token"
+        return _Response({"total_commits": 1, "commits": [commit]})
+
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")
+
+    assert fetcher._github_commits("base", "head")[0]["sha"] == "a" * 40
+
+
+def test_github_commits_detects_truncated_compare_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    commits = [_commit(f"{index:040x}") for index in range(250)]
+    request_count = 0
+
+    def fake_get(url: str, **_: Any) -> _Response:
+        nonlocal request_count
+        request_count += 1
+        return _Response({"total_commits": 400, "commits": commits})
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")
+
+    with pytest.raises(ValueError, match="GitHub compare returned 250 of 400 commits"):
+        fetcher._github_commits("base", "head")
+    assert request_count == 1
+
+
+def test_github_commits_raises_on_incomplete_compare(monkeypatch: pytest.MonkeyPatch) -> None:
+    commits = [_commit(f"{index:040x}") for index in range(10)]
+
+    def fake_get(url: str, **_: Any) -> _Response:
+        return _Response({"total_commits": 11, "commits": commits})
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")
+
+    with pytest.raises(ValueError, match="GitHub compare returned 10 of 11 commits"):
+        fetcher._github_commits("base", "head")
+
+
+def test_github_commits_empty_compare_skips_diff_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, **_: Any) -> _Response:
+        return _Response({"status": "identical", "total_commits": 0, "commits": []})
+
+    def fail_diff(*_: Any) -> str:
+        raise AssertionError("diff fetch should not run for an empty compare")
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "_github_commit_diff", fail_diff)
+
+    assert fetcher._github_commits("base", "head") == []
+
+
+def test_github_commits_preserves_pr_number_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    commit = _commit("c" * 40, message="fix: repair the cluster (#1234)\n\nMore details")
+
+    def fake_get(url: str, **_: Any) -> _Response:
+        return _Response({"total_commits": 1, "commits": [commit]})
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher, "_github_commit_diff", lambda *_: "diff")
+
+    result = fetcher._github_commits("base", "head")
+
+    assert result[0]["pr_number"] == 1234
+    assert result[0]["pr_url"] == "https://github.com/canonical/k8s-snap/pull/1234"
+    assert result[0]["body"] == "More details"

--- a/docs/tools/patch-notices/tests/test_sanitize.py
+++ b/docs/tools/patch-notices/tests/test_sanitize.py
@@ -1,0 +1,36 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+from __future__ import annotations
+
+import pytest
+
+from patch_notices import sanitize
+
+
+def test_markdown_text_escapes_markup_and_strips_html() -> None:
+    text = sanitize.markdown_text(
+        "[click](javascript:alert(1)) <script>alert(1)</script> | table\n# heading"
+    )
+
+    assert text == r"\[click\]\(javascript:alert\(1\)\) alert\(1\) \| table \# heading"
+
+
+def test_markdown_text_strips_html_comments() -> None:
+    assert sanitize.markdown_text("safe <!-- hidden --> text") == "safe text"
+
+
+def test_sha_rejects_non_hex_content() -> None:
+    with pytest.raises(ValueError):
+        sanitize.sha("abcdef1 --><script>")
+
+
+def test_github_url_rejects_non_github_targets() -> None:
+    assert sanitize.github_url("javascript:alert(1)") == ""
+    assert sanitize.github_url("https://example.com/canonical/k8s-snap/pull/1") == ""
+    assert sanitize.github_url("https://github.com/canonical/k8s-snap/pull/1")
+
+
+def test_category_uses_manual_review_fallback() -> None:
+    assert sanitize.category("Bug Fix") == "Bug Fix"
+    assert sanitize.category("<script>Bug Fix</script>") == "Review Required"

--- a/docs/tools/patch-notices/tests/test_workbook_sanitize.py
+++ b/docs/tools/patch-notices/tests/test_workbook_sanitize.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Canonical, Ltd.
+# See LICENSE file for licensing details.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from patch_notices import workbook
+
+
+def _triage_result() -> list[dict]:
+    return [
+        {
+            "sha": "abcdef1234567890abcdef1234567890abcdef12",
+            "title": "[bad](javascript:alert(1)) <b>title</b> | table",
+            "pr_number": 12,
+            "pr_url": "https://github.com/canonical/k8s-snap/pull/12",
+            "triage": {
+                "action": "include",
+                "category": "Bug Fix",
+                "summary": "Fix [thing](javascript:alert(1)) <script>x</script> | pipe",
+                "components": None,
+                "reason": None,
+                "limited_context": True,
+                "group_hint": None,
+            },
+        },
+        {
+            "sha": "1234567890abcdef1234567890abcdef12345678",
+            "title": "Discard <img src=x onerror=alert(1)>",
+            "pr_number": 13,
+            "html_url": "https://github.com/canonical/k8s-snap/commit/1234567890abcdef1234567890abcdef12345678",
+            "triage": {
+                "action": "discard",
+                "category": None,
+                "summary": None,
+                "components": None,
+                "reason": "Only updates [CI](javascript:alert(1)) <!-- hidden -->",
+                "limited_context": False,
+                "group_hint": None,
+            },
+        },
+    ]
+
+
+def test_clean_entry_lines_escape_ai_summary() -> None:
+    text = "\n".join(workbook._clean_entry_lines(_triage_result()))
+
+    assert "<script>" not in text
+    assert "[thing](javascript:alert(1))" not in text
+    assert r"\[thing\]\(javascript:alert\(1\)\)" in text
+    assert r"\| pipe" in text
+
+
+def test_write_escapes_workbook_fields(tmp_path: Path) -> None:
+    output = tmp_path / "review.md"
+    workbook.write(_triage_result(), str(output), channel_key="snap:1.35-classic/stable")
+    text = output.read_text()
+
+    assert "<!-- sha:abcdef1234567890abcdef1234567890abcdef12 -->" in text
+    assert "[bad](javascript:alert(1))" not in text
+    assert "<img" not in text
+    assert r"\[bad\]\(javascript:alert\(1\)\)" in text
+    assert r"Only updates \[CI\]\(javascript:alert\(1\)\)" in text
+
+
+def test_insert_patch_notice_escapes_release_note_entry(tmp_path: Path) -> None:
+    notes = tmp_path / "release.md"
+    notes.write_text("# 1.35\n\n## Patch notices\n\nJul 1, 2026\n\n- Existing\n")
+
+    workbook.insert_patch_notice(str(notes), _triage_result(), "Aug 19, 2026", "snap")
+    text = notes.read_text()
+
+    assert "Aug 19, 2026" in text
+    assert "<script>" not in text
+    assert "[thing](javascript:alert(1))" not in text
+    assert r"\[thing\]\(javascript:alert\(1\)\)" in text
+
+
+def test_build_pr_body_escapes_summary_titles_and_reasons() -> None:
+    summary = workbook.build_track_summary(
+        _triage_result(), "snap:1.35-classic/stable", "Aug 19, 2026"
+    )
+    text = workbook.build_pr_body([summary])
+
+    assert "<script>" not in text
+    assert "<img" not in text
+    assert "[bad](javascript:alert(1))" not in text
+    assert "[CI](javascript:alert(1))" not in text
+    assert r"\[bad\]\(javascript:alert\(1\)\)" in text
+    assert r"\[CI\]\(javascript:alert\(1\)\)" in text
+    assert r"\| table" in text
+
+
+def test_build_pr_body_tolerates_malformed_summary_shas() -> None:
+    text = workbook.build_pr_body(
+        [
+            {
+                "track": "snap:1.35-classic/stable",
+                "status": "all-discarded",
+                "date": "Aug 20, 2026",
+                "included": [],
+                "discarded": [
+                    {
+                        "sha": "",
+                        "pr_number": None,
+                        "title": "bad summary",
+                        "reason": "bad sha",
+                    }
+                ],
+                "limited_context": [
+                    {
+                        "sha": "not-a-sha",
+                        "pr_number": 1,
+                        "title": "bad limited context",
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert "`unknown` (PR #1) — bad limited context" in text
+    assert "`unknown` — bad summary" in text


### PR DESCRIPTION
## Description

:warning:  Closed and replaced by #2767. This will allow testing on the repo

We need to keep our users informed about any backports we make to release branches after we make a release. Up to now, we have been manually updating our release notes with patch notices. This is time consuming as each track needs to be checked. Additionally, there can be a lead time between when a change lands on the release branch and when the change lands on stable channels on Charmhub and Snap store which makes it even more important to keep our users informed. 

This PR introduces a way to automate patch notices generation. We do not keep a CHANGELOG and our commit messages are not of high enough quality and consistency to simply pull those in. 

## Solution

The solution can be run manually or on the CI on a monthly basis. The README explains in more detail how to use each function but the workflows are:

**Manual workflow (fetch → review → finalize):**
- fetch: pulls PR delta from Snap Store + Launchpad or Charmhub + GitHub
- review: runs two-pass AI triage, writes a human-editable Markdown workbook
- finalize: reads approved SHAs from the workbook, exports clean snippet, advances the bookmark in patch-metadata.json

**CI workflow (generate + pr-body):**
- generate: combines fetch + triage + direct insertion into release notes
- pr-body: collates per-track summary JSONs into a formatted PR body
- update-patch-notices.yaml: runs on the 1st of each month across all active snap and charm tracks, opens a PR via BOT_TOKEN

## Issue

N/A

## Backport

No

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.
