### PR TITLE
fix: update cri-containerd AppArmor profile for Ubuntu 26.04

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -147,6 +147,16 @@ jobs:
       test-collection-branch: ${{ github.head_ref }}
       parallel: true
 
+  test-cncf-ubuntu-2604:
+    name: CNCF conformance (ubuntu:26.04)
+    needs: [build-snap, python-lint]
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      arch: amd64
+      os: ubuntu:26.04
+      test-tags: conformance_tests
+      artifact: k8s-amd64.snap
+
   security-scan:
     name: Security scan
     needs: build-snap

--- a/k8s/profiles/containerd
+++ b/k8s/profiles/containerd
@@ -40,4 +40,7 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   signal (receive) peer=snap.k8s.k8sd,
   signal (receive) peer=snap.k8s.k8s,
   signal (receive) peer=snap.k8s.hook.remove,
+
+  # Allow signals between container processes (e.g. ISC BIND threads in nslookup).
+  signal (send, receive) peer=cri-containerd.apparmor.d,
 }

--- a/k8s/wrappers/services/containerd
+++ b/k8s/wrappers/services/containerd
@@ -7,8 +7,33 @@ k8s::common::setup_env
 # Ensure XDG_RUNTIME_DIR exists, needed by runc for 'kubectl exec' to work
 [ ! -z "${XDG_RUNTIME_DIR:=}" ] && mkdir -p "${XDG_RUNTIME_DIR}"
 
-# Apply apparmor profile for "cri-containerd.apparmor.d"
-if ! apparmor_parser -r "$SNAP/k8s/profiles/containerd"; then
+# Apply apparmor profile for "cri-containerd.apparmor.d".
+# On AppArmor 5.x (Ubuntu 26.04+), signal mediation was tightened: processes in user
+# namespaces get peer labels suffixed with "//&unconfined", and those are not matched by
+# plain "peer=<profile>" rules. Without the extended rule, BIND 9.18+ threads (e.g.
+# isc-net-0000 in nslookup) cannot signal each other, causing nslookup to exit with
+# SIGSEGV (rc:139) and breaking CNCF conformance tests.
+# Try the extended profile first; if the parser rejects it (older AppArmor), fall back.
+_apparmor_load_profile() {
+  local profile_file="$SNAP/k8s/profiles/containerd"
+  local tmpfile
+
+  # AppArmor 5.x: add rule for "//&unconfined" peer variants used when signalling
+  # across AppArmor policy-namespace boundaries inside containers.
+  tmpfile=$(mktemp)
+  sed 's|^}$|  signal (send, receive) peer="cri-containerd.apparmor.d//**",\n}|' \
+      "$profile_file" > "$tmpfile"
+  if apparmor_parser -r "$tmpfile" 2>/dev/null; then
+    rm -f "$tmpfile"
+    return 0
+  fi
+  rm -f "$tmpfile"
+
+  # Fall back to the base profile (without the 5.x-specific rule).
+  apparmor_parser -r "$profile_file"
+}
+
+if ! _apparmor_load_profile; then
   echo "
 
 WARNING: Failed to configure the 'cri-containerd.apparmor.d' AppArmor profile.


### PR DESCRIPTION
## Problem

Adding `ubuntu:26.04` to the CNCF conformance test matrix (#2739) causes all conformance tests to fail with this pattern:

```
kubectl exec execpodgfntx -- /bin/sh -x -c nslookup nodeport-service...
rc: 139
```

## Root cause

The chain is:

1. **Ubuntu 26.04 ships AppArmor 5.x**, which tightens signal mediation for processes in user namespaces (a.k.a. containers).
2. When `kubectl exec` spawns a shell inside a pod, AppArmor 5.x labels those processes `cri-containerd.apparmor.d//&unconfined` (the `//&unconfined` suffix is new in AppArmor 5.x for user-namespace-isolated processes).
3. **BIND 9.18** (bundled in `agnhost:2.53`, used by CNCF tests) introduces an `isc-net-0000` I/O thread that uses POSIX signals for inter-thread coordination.
4. The `cri-containerd.apparmor.d` profile only had `signal (receive)` rules for snap services — **no send rules and no rules for `//&unconfined` peers**.
5. AppArmor denies `SIGTERM`/`SIGABRT` from `isc-net-0000` → `nslookup` crashes with `SIGSEGV` (exit 139).

Evidence from `dmesg` on the failing CI host:
```
apparmor="DENIED" operation="signal" profile="cri-containerd.apparmor.d"
comm="isc-net-0000" requested_mask="send" denied_mask="send" signal=term
peer="cri-containerd.apparmor.d//&unconfined"
```
(82× SIGABRT denied, 79× SIGTERM denied — one per test retry)

## Fix

Two changes:

### 1. `k8s/profiles/containerd`

Add a self-referential signal rule that allows all container processes to signal each other:

```
signal (send, receive) peer=cri-containerd.apparmor.d,
```

This is compatible with AppArmor 3.x (Ubuntu 22.04) and later.

### 2. `k8s/wrappers/services/containerd`

When loading the profile at containerd startup, first try an extended version with the AppArmor 5.x `//&unconfined` wildcard rule:

```
signal (send, receive) peer="cri-containerd.apparmor.d//**",
```

If `apparmor_parser` rejects the `//` namespace syntax (AppArmor 3.x/4.x), fall back to the base profile. This ensures backward compatibility with Ubuntu 22.04 and 24.04.

## Testing

Profile with both rules parses and loads on Ubuntu 26.04 (AppArmor 5.0.2):
```
apparmor_parser -r /tmp/test-updated-profile.d
# → PROFILE WITH ALL RULES: OK
```

Related: #2739