### PR TITLE
fix: harden cri-containerd AppArmor profile for kernel 6.17+ stacking

### DIFF
--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -147,18 +147,6 @@ jobs:
       test-collection-branch: ${{ github.head_ref }}
       parallel: true
 
-  test-cncf-ubuntu-2604:
-    name: CNCF conformance (ubuntu:26.04)
-    needs: [build-snap, python-lint]
-    uses: ./.github/workflows/e2e-tests.yaml
-    with:
-      arch: amd64
-      os: ubuntu:26.04
-      test-tags: conformance_tests
-      artifact: k8s-amd64.snap
-      test-collection-repo: ${{github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
-      test-collection-branch: ${{ github.head_ref }}
-
   security-scan:
     name: Security scan
     needs: build-snap

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -147,6 +147,16 @@ jobs:
       test-collection-branch: ${{ github.head_ref }}
       parallel: true
 
+  test-cncf-ubuntu-2604:
+    name: CNCF conformance (ubuntu:26.04)
+    needs: [build-snap, python-lint]
+    uses: ./.github/workflows/e2e-tests.yaml
+    with:
+      arch: amd64
+      os: ubuntu:26.04
+      test-tags: conformance_tests
+      artifact: k8s-amd64.snap
+
   security-scan:
     name: Security scan
     needs: build-snap

--- a/.github/workflows/lint_and_integration.yaml
+++ b/.github/workflows/lint_and_integration.yaml
@@ -156,6 +156,8 @@ jobs:
       os: ubuntu:26.04
       test-tags: conformance_tests
       artifact: k8s-amd64.snap
+      test-collection-repo: ${{github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+      test-collection-branch: ${{ github.head_ref }}
 
   security-scan:
     name: Security scan

--- a/k8s/profiles/containerd
+++ b/k8s/profiles/containerd
@@ -32,12 +32,26 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/** rwklx,
 
 
-  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
-  ptrace (trace,read) peer=cri-containerd.apparmor.d,
+  # Allow ptrace between container processes (e.g. 'docker ps', 'ps' inside a container).
+  # On kernel 6.17+ with AppArmor profile stacking enabled, exec'd processes run under
+  # the stacked peer label "cri-containerd.apparmor.d//&unconfined" rather than the plain
+  # profile name; the //&* glob matches all such stacked variants.
+  # See: https://github.com/containerd/containerd/issues/12886
+  ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d,
+  ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d//&*,
 
   signal (receive) peer=snap.k8s.containerd,
   signal (receive) peer=snap.k8s.kubelet,
   signal (receive) peer=snap.k8s.k8sd,
   signal (receive) peer=snap.k8s.k8s,
   signal (receive) peer=snap.k8s.hook.remove,
+
+  # Allow signals between container processes (e.g. ISC BIND isc-net-0000 threads in
+  # nslookup). On kernel 6.17+ with AppArmor profile stacking, exec'd processes run under
+  # the stacked peer label "cri-containerd.apparmor.d//&unconfined"; without a send rule
+  # AppArmor denies inter-thread signals, causing nslookup to crash with SIGSEGV (rc:139).
+  # The //&* glob matches all stacked variants; it is a no-op on older kernels where
+  # stacking is inactive. See: https://github.com/containerd/containerd/issues/12886
+  signal (send, receive) peer=cri-containerd.apparmor.d,
+  signal (send, receive) peer=cri-containerd.apparmor.d//&*,
 }

--- a/k8s/profiles/containerd
+++ b/k8s/profiles/containerd
@@ -32,12 +32,8 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/** rwklx,
 
 
-  # Allow ptrace between container processes (e.g. 'docker ps', 'ps' inside a container).
-  # Both trace+read (tracer side) and tracedby+readby (tracee side) are required: AppArmor
-  # checks both the tracer's and the tracee's profile, so omitting either half silently
-  # denies the operation. On kernel 6.17+ with AppArmor stacking, exec'd processes get
-  # a stacked peer label (e.g. "cri-containerd.apparmor.d//&unconfined"); //&* covers
-  # all stacked variants. See: https://github.com/containerd/containerd/issues/12886
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  # //&* covers stacked peer labels on kernel 6.17+ (https://github.com/containerd/containerd/issues/12886)
   ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d,
   ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d//&*,
 
@@ -47,12 +43,8 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   signal (receive) peer=snap.k8s.k8s,
   signal (receive) peer=snap.k8s.hook.remove,
 
-  # Allow signals between container processes (e.g. ISC BIND isc-net-0000 threads in
-  # nslookup). No self-referential signal rule existed before; without a send rule,
-  # inter-thread signals are denied and nslookup crashes with SIGSEGV (rc:139).
-  # On kernel 6.17+ with AppArmor stacking, exec'd processes get a stacked peer label
-  # (e.g. "cri-containerd.apparmor.d//&unconfined"); //&* covers all stacked variants.
-  # See: https://github.com/containerd/containerd/issues/12886
+  # Allow signals between container processes.
+  # //&* covers stacked peer labels on kernel 6.17+ (https://github.com/containerd/containerd/issues/12886)
   signal (send,receive) peer=cri-containerd.apparmor.d,
   signal (send,receive) peer=cri-containerd.apparmor.d//&*,
 }

--- a/k8s/profiles/containerd
+++ b/k8s/profiles/containerd
@@ -32,13 +32,10 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/** rwklx,
 
 
-  # Allow ptrace between container processes (e.g. 'docker ps', 'ps' inside a container).
-  # On kernel 6.17+ with AppArmor profile stacking enabled, exec'd processes run under
-  # the stacked peer label "cri-containerd.apparmor.d//&unconfined" rather than the plain
-  # profile name; the //&* glob matches all such stacked variants.
-  # See: https://github.com/containerd/containerd/issues/12886
-  ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d,
-  ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d//&*,
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=cri-containerd.apparmor.d,
+  # kernel 6.17+ with AppArmor stacking: exec'd processes get a stacked peer label
+  ptrace (trace,read) peer=cri-containerd.apparmor.d//&*,
 
   signal (receive) peer=snap.k8s.containerd,
   signal (receive) peer=snap.k8s.kubelet,
@@ -47,11 +44,11 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   signal (receive) peer=snap.k8s.hook.remove,
 
   # Allow signals between container processes (e.g. ISC BIND isc-net-0000 threads in
-  # nslookup). On kernel 6.17+ with AppArmor profile stacking, exec'd processes run under
-  # the stacked peer label "cri-containerd.apparmor.d//&unconfined"; without a send rule
-  # AppArmor denies inter-thread signals, causing nslookup to crash with SIGSEGV (rc:139).
-  # The //&* glob matches all stacked variants; it is a no-op on older kernels where
-  # stacking is inactive. See: https://github.com/containerd/containerd/issues/12886
+  # nslookup). No self-referential signal rule existed before; without a send rule,
+  # inter-thread signals are denied and nslookup crashes with SIGSEGV (rc:139).
+  # On kernel 6.17+ with AppArmor stacking, exec'd processes get a stacked peer label
+  # (e.g. "cri-containerd.apparmor.d//&unconfined"); //&* covers all stacked variants.
+  # See: https://github.com/containerd/containerd/issues/12886
   signal (send, receive) peer=cri-containerd.apparmor.d,
   signal (send, receive) peer=cri-containerd.apparmor.d//&*,
 }

--- a/k8s/profiles/containerd
+++ b/k8s/profiles/containerd
@@ -32,10 +32,14 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   deny /sys/kernel/security/** rwklx,
 
 
-  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
-  ptrace (trace,read) peer=cri-containerd.apparmor.d,
-  # kernel 6.17+ with AppArmor stacking: exec'd processes get a stacked peer label
-  ptrace (trace,read) peer=cri-containerd.apparmor.d//&*,
+  # Allow ptrace between container processes (e.g. 'docker ps', 'ps' inside a container).
+  # Both trace+read (tracer side) and tracedby+readby (tracee side) are required: AppArmor
+  # checks both the tracer's and the tracee's profile, so omitting either half silently
+  # denies the operation. On kernel 6.17+ with AppArmor stacking, exec'd processes get
+  # a stacked peer label (e.g. "cri-containerd.apparmor.d//&unconfined"); //&* covers
+  # all stacked variants. See: https://github.com/containerd/containerd/issues/12886
+  ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d,
+  ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d//&*,
 
   signal (receive) peer=snap.k8s.containerd,
   signal (receive) peer=snap.k8s.kubelet,
@@ -49,6 +53,6 @@ profile cri-containerd.apparmor.d flags=(attach_disconnected,mediate_deleted) {
   # On kernel 6.17+ with AppArmor stacking, exec'd processes get a stacked peer label
   # (e.g. "cri-containerd.apparmor.d//&unconfined"); //&* covers all stacked variants.
   # See: https://github.com/containerd/containerd/issues/12886
-  signal (send, receive) peer=cri-containerd.apparmor.d,
-  signal (send, receive) peer=cri-containerd.apparmor.d//&*,
+  signal (send,receive) peer=cri-containerd.apparmor.d,
+  signal (send,receive) peer=cri-containerd.apparmor.d//&*,
 }


### PR DESCRIPTION
## Problem

On kernel 6.17+ with AppArmor profile stacking enabled, processes created via CRI ExecSync (`kubectl exec`, exec-based liveness/readiness probes) run under a **stacked** peer label `cri-containerd.apparmor.d//&unconfined` instead of the plain `cri-containerd.apparmor.d`. The existing AppArmor profile had no rules that matched this stacked variant.

This causes two classes of denial observed in dmesg:

```
apparmor="DENIED" operation="signal" profile="cri-containerd.apparmor.d"
comm="isc-net-0000" requested_mask="send" denied_mask="send"
peer="cri-containerd.apparmor.d//&unconfined"

apparmor="DENIED" operation="ptrace" profile="cri-containerd.apparmor.d"
peer="cri-containerd.apparmor.d//&unconfined"
```

**Signal denial:** ISC BIND 9.18+ introduces an `isc-net-0000` I/O thread that uses POSIX signals for inter-thread coordination. Without a signal-send rule, AppArmor denies these signals, causing `nslookup` inside containers to crash with SIGSEGV (exit 139). This breaks CNCF conformance ExternalName-service tests on Ubuntu 26.04.

**Ptrace denial:** The existing `ptrace` rule only matched the plain profile name, leaving exec'd processes on stacking kernels unmatched.

Upstream reference: https://github.com/containerd/containerd/issues/12886

## Fix

Two changes to `k8s/profiles/containerd`:

### 1. Signal rules
Add self-referential signal rules covering both the plain profile name and the `//&*` stacked variants:
```
signal (send, receive) peer=cri-containerd.apparmor.d,
signal (send, receive) peer=cri-containerd.apparmor.d//&*,
```

### 2. Ptrace rules
Expand the existing ptrace rule to include `tracedby`/`readby` modes and add the `//&*` stacked variant:
```
ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d,
ptrace (trace,tracedby,read,readby) peer=cri-containerd.apparmor.d//&*,
```

The `//&*` glob is a no-op on older kernels (Ubuntu 22.04/24.04) where AppArmor stacking is inactive — AppArmor 3.x/4.x can parse the syntax but will never match it. No runtime wrapper changes or fallback logic are needed.

### 3. Temporary CNCF test trigger for validation

## Related
- https://github.com/containerd/containerd/issues/12886
- #2739