### PR TITLE
fix(ci): pin LXD to 5.21/stable to avoid core26 dependency

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -242,6 +242,7 @@ jobs:
         uses: canonical/setup-lxd@a3c85fc6fb7fff43fcfeae87659e41a8f635b7dd # v0.1.3
         with:
           bridges: "lxdbr0,dualstack-br0,ipv6-br0,jumbo-br0,dual-nic-br0"
+          channel: "5.21/stable"
       - name: Setup Multipass
         if: ${{ inputs.substrate == 'multipass' }}
         uses: ./.github/actions/setup-multipass

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -318,7 +318,7 @@ jobs:
           name: inspection-reports-${{ env.test_name }}
           path: ${{ github.workspace }}/inspection-report-archives/${{ env.test_name }}.tar.gz
       - name: Upload CNCF conformance report artifact
-        if: failure() && contains(inputs.test-tags, 'conformance_tests')
+        if: always() && contains(inputs.test-tags, 'conformance_tests')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sonobuoy-e2e-${{ env.test_name }}

--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 6" # Runs every saturday at midnight
+  # TODO: remove once LXD channel fix is validated
+  pull_request:
+    paths:
+      - ".github/workflows/e2e-tests.yaml"
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -8,10 +8,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 6" # Runs every saturday at midnight
-  # TODO: remove once LXD channel fix is validated
-  pull_request:
-    paths:
-      - ".github/workflows/e2e-tests.yaml"
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
LXD `latest/candidate` (v6.9) now uses `core26` as its base snap, which is not available on GitHub Actions runners. This breaks all LXD-substrate CI jobs including CNCF conformance tests.

Pin to `5.21/stable` (base: `core24`) to restore CI.

Always upload conformance test result artefacts.

TODO remove test trigger