### PR TITLE
fix(test): enable verbose output for CNCF conformance sonobuoy run

### DIFF
--- a/.github/workflows/weekly-test.yaml
+++ b/.github/workflows/weekly-test.yaml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 6" # Runs every saturday at midnight
+  # TODO: remove once ginkgo verbose fix is validated
+  pull_request:
+    paths:
+      - "tests/integration/tests/test_cncf_conformance.py"
 permissions:
   contents: read
   actions: read

--- a/tests/integration/tests/test_cncf_conformance.py
+++ b/tests/integration/tests/test_cncf_conformance.py
@@ -10,6 +10,21 @@ from test_util import harness, tags, util
 
 LOG = logging.getLogger(__name__)
 
+# Injected into the sonobuoy manifest before running so that the e2e plugin
+# produces verbose per-test output (required by CNCF for conformance submissions).
+# sonobuoy's --plugin-env flag is unreliable in this environment, so we generate
+# the manifest, patch it directly, then run from the patched file.
+_INJECT_VERBOSE_SCRIPT = """\
+content = open('sonobuoy_manifest.yaml').read()
+patched = content.replace(
+    '      - name: E2E_EXTRA_ARGS\\n',
+    '      - name: E2E_EXTRA_GINKGO_ARGS\\n        value: --v\\n      - name: E2E_EXTRA_ARGS\\n',
+    1,
+)
+assert '- name: E2E_EXTRA_GINKGO_ARGS' in patched, 'E2E_EXTRA_GINKGO_ARGS injection failed'
+open('sonobuoy_manifest.yaml', 'w').write(patched)
+"""
+
 
 @pytest.mark.node_count(3)
 @pytest.mark.tags(tags.CONFORMANCE)
@@ -17,18 +32,31 @@ def test_cncf_conformance(instances: List[harness.Instance]):
     cluster_node = cluster_setup(instances)
     install_sonobuoy(cluster_node)
 
+    # Generate the conformance manifest so we can patch it directly.
+    # sonobuoy gen auto-detects the k8s version from the running cluster.
     cluster_node.exec(
         [
             "./sonobuoy",
-            "run",
+            "gen",
             "--plugin",
             "e2e",
-            "--plugin-env=e2e.E2E_EXTRA_GINKGO_ARGS=--v",
             "--mode",
             "certified-conformance",
-            "--wait",
+            ">",
+            "sonobuoy_manifest.yaml",
         ],
     )
+
+    # Inject E2E_EXTRA_GINKGO_ARGS=--v for verbose per-test output.
+    cluster_node.exec(
+        ["dd", "of=/tmp/inject_verbose.py"],
+        input=_INJECT_VERBOSE_SCRIPT.encode(),
+    )
+    cluster_node.exec(["python3", "/tmp/inject_verbose.py"])
+
+    # -f is incompatible with --wait, so start the run and wait separately.
+    cluster_node.exec(["./sonobuoy", "run", "-f", "sonobuoy_manifest.yaml"])
+    cluster_node.exec(["./sonobuoy", "wait", "--wait"])
     cluster_node.exec(
         ["./sonobuoy", "retrieve", "-f", "sonobuoy_e2e.tar.gz"],
     )

--- a/tests/integration/tests/test_cncf_conformance.py
+++ b/tests/integration/tests/test_cncf_conformance.py
@@ -23,6 +23,7 @@ def test_cncf_conformance(instances: List[harness.Instance]):
             "run",
             "--plugin",
             "e2e",
+            "--plugin-env=e2e.E2E_EXTRA_ARGS=--ginkgo.v",
             "--mode",
             "certified-conformance",
             "--wait",

--- a/tests/integration/tests/test_cncf_conformance.py
+++ b/tests/integration/tests/test_cncf_conformance.py
@@ -23,7 +23,7 @@ def test_cncf_conformance(instances: List[harness.Instance]):
             "run",
             "--plugin",
             "e2e",
-            "--plugin-env=e2e.E2E_EXTRA_ARGS=--ginkgo.v",
+            "--plugin-env=e2e.E2E_EXTRA_ARGS=--ginkgo.v --progress-report-url=http://localhost:8099/progress",
             "--mode",
             "certified-conformance",
             "--wait",

--- a/tests/integration/tests/test_cncf_conformance.py
+++ b/tests/integration/tests/test_cncf_conformance.py
@@ -23,7 +23,7 @@ def test_cncf_conformance(instances: List[harness.Instance]):
             "run",
             "--plugin",
             "e2e",
-            "--plugin-env=e2e.E2E_EXTRA_ARGS=--ginkgo.v --progress-report-url=http://localhost:8099/progress",
+            "--plugin-env=e2e.E2E_EXTRA_GINKGO_ARGS=--v",
             "--mode",
             "certified-conformance",
             "--wait",


### PR DESCRIPTION
Produce verbose per-test output in `e2e.log` for CNCF conformance submissions.

Without verbose output, the log only contains the compact dot-progress summary (~14 lines). CNCF requires the full per-test output.

**Approach:** generate the sonobuoy manifest explicitly, inject `E2E_EXTRA_GINKGO_ARGS=--v` directly into the manifest YAML, then run sonobuoy from the patched file. The `--plugin-env` flag proved unreliable in the LXD CI environment despite working correctly locally.

**Also included:**
- Pin `canonical/setup-lxd` to `5.21/stable` to avoid LXD core26 failure on GitHub Actions
- Upload sonobuoy artifacts on both success and failure (`if: always()`)
- Temporary `pull_request` trigger for this branch (to be removed before merge)