### PR TITLE
ci: [DO NOT MERGE] test metrics-server control-plane toleration fix

### DIFF
--- a/build-scripts/components/k8sd/version
+++ b/build-scripts/components/k8sd/version
@@ -1,1 +1,1 @@
-main
+fix/metrics-server-control-plane-toleration


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — CLOSED

The k8sd fix has been merged to `main` (PR #73) and backported to `release-1.36` (PR #74). This test-trigger PR is no longer needed.

The new snap build needs to be triggered manually via Launchpad: `https://launchpad.net/~containers/k8s/+snap/k8s-snap-1.36-classic`