### PR TITLE
test: point k8sd to homayoon/release-1.37-prep

### DIFF
--- a/build-scripts/components/k8sd/version
+++ b/build-scripts/components/k8sd/version
@@ -1,1 +1,1 @@
-main
+homayoon/release-1.37-prep


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — Integration test run only

This draft PR points the k8sd component at the `homayoon/release-1.37-prep` branch to trigger the integration test suite against [canonical/k8sd#72](https://github.com/canonical/k8sd/pull/72).

### What is being tested
- canonical/k8sd#72: feat: update chart versions and image tags for Cilium, CoreDNS, LocalPV, Metrics Server

### Change
`build-scripts/components/k8sd/version`: `main` → `homayoon/release-1.37-prep`

### After tests pass
Close this PR and merge canonical/k8sd#72 directly.