### PR TITLE
docs: add more references to containerd-base-dir flag

### DIFF
--- a/docs/canonicalk8s/_parts/commands/k8s_bootstrap.md
+++ b/docs/canonicalk8s/_parts/commands/k8s_bootstrap.md
@@ -13,13 +13,14 @@ k8s bootstrap [flags]
 ### Options
 
 ```
-      --address string         microcluster address or CIDR, defaults to the node IP address
-      --file string            path to the YAML file containing your custom cluster bootstrap configuration. Use '-' to read from stdin.
-  -h, --help                   help for bootstrap
-      --interactive            interactively configure the most important cluster options
-      --name string            node name, defaults to hostname
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
+      --address string               microcluster address or CIDR, defaults to the node IP address
+      --file string                  path to the YAML file containing your custom cluster bootstrap configuration. Use '-' to read from stdin.
+  -h, --help                         help for bootstrap
+      --interactive                  interactively configure the most important cluster options
+      --name string                  node name, defaults to hostname
+      --output-format string         set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration             the max time to wait for the command to execute (default 1m30s)
+      --containerd-base-dir string   set a dedicated absolute base directory for containerd
 ```
 
 ### SEE ALSO

--- a/docs/canonicalk8s/_parts/commands/k8s_join-cluster.md
+++ b/docs/canonicalk8s/_parts/commands/k8s_join-cluster.md
@@ -13,12 +13,13 @@ k8s join-cluster <join-token> [flags]
 ### Options
 
 ```
-      --address string         microcluster address or CIDR, defaults to the node IP address
-      --file string            path to the YAML file containing your custom cluster join configuration. Use '-' to read from stdin.
-  -h, --help                   help for join-cluster
-      --name string            node name, defaults to hostname
-      --output-format string   set the output format to one of plain, json or yaml (default "plain")
-      --timeout duration       the max time to wait for the command to execute (default 1m30s)
+      --address string               microcluster address or CIDR, defaults to the node IP address
+      --file string                  path to the YAML file containing your custom cluster join configuration. Use '-' to read from stdin.
+  -h, --help                         help for join-cluster
+      --name string                  node name, defaults to hostname
+      --output-format string         set the output format to one of plain, json or yaml (default "plain")
+      --timeout duration             the max time to wait for the command to execute (default 1m30s)
+      --containerd-base-dir string   set a dedicated absolute base directory for containerd
 ```
 
 ### SEE ALSO

--- a/docs/canonicalk8s/snap/howto/image-management.md
+++ b/docs/canonicalk8s/snap/howto/image-management.md
@@ -33,6 +33,10 @@ at `/snap/k8s/current/bin/ctr`. Although the containerd binary is in the snap
 installation folder, the containerd socket is located at
 `/run/containerd/containerd.sock`.
 
+```{note}
+This socket path may be different if you modified [the base directory containerd was installed in][how-to-containerd].
+```
+
 ## Listing all images
 
 {{product}} imports all images into the `k8s.io` namespace. When you're
@@ -96,3 +100,4 @@ docker.io/library/hello-world:latest
 
 [snap-install-howto]: ./install/snap
 [Source]: https://manpages.debian.org/testing/containerd/ctr.8.en.html
+[how-to-containerd]: /snap/howto/install/dev-env.md/#containerd

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -29,7 +29,7 @@ you choose to do so, please take note of the following considerations.
 containerd-related paths by default (`/run/containerd`, `/var/lib/containerd`,
 `/etc/containerd`). If containerd is already installed at these paths by
 another application (e.g. Docker), the bootstrap will fail. To resolve this,
-provide a base directory for the files to be installed at by setting
+provide a base directory for the files to be installed at by either setting
 `containerd-base-dir` in the bootstrap config YAML:
 
 <!-- SPREAD
@@ -48,6 +48,8 @@ cluster-config:
     enabled: true
 EOF
 ```
+
+or by providing it via the CLI flag `--containerd-base-dir` at node initialization when running `sudo k8s bootstrap` or `sudo k8s join-cluster`.
 
 By doing this, all containerd files will be stored under the parent
 directory specified by `containerd-base-dir`. For example, if

--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -146,10 +146,6 @@ file on each node and set the appropriate `http_proxy`, `https_proxy` and
 `no_proxy` variables as described in the
 [adding proxy configuration section][proxy].
 
-```{note}
-The path to the HTTP proxy config file will change if you [changed the containerd base directory][how-to-containerd].
-```
-
 ````
 
 ````{tab-item} Private registry mirrors
@@ -277,7 +273,9 @@ instructions on all nodes. For each upstream registry that needs mirroring,
 create a `hosts.toml` file. Here's an example that configures
 `http://10.10.10.10:5050` as a mirror for `ghcr.io`:
 
-
+```{note}
+The paths below assume the default containerd base directory (`/etc/containerd`). If you [changed the containerd base directory][how-to-containerd], replace `/etc/containerd` with `<containerd-base-dir>/etc/containerd`.
+```
 
 #### HTTP registry mirror
 

--- a/docs/canonicalk8s/snap/howto/install/offline.md
+++ b/docs/canonicalk8s/snap/howto/install/offline.md
@@ -146,6 +146,10 @@ file on each node and set the appropriate `http_proxy`, `https_proxy` and
 `no_proxy` variables as described in the
 [adding proxy configuration section][proxy].
 
+```{note}
+The path to the HTTP proxy config file will change if you [changed the containerd base directory][how-to-containerd].
+```
+
 ````
 
 ````{tab-item} Private registry mirrors
@@ -352,3 +356,4 @@ to the cluster.
 [regctl]: https://github.com/regclient/regclient/blob/main/docs/regctl.md
 [nodes]: /snap/tutorial/add-remove-nodes.md
 [squid]: https://www.squid-cache.org/
+[how-to-containerd]: /snap/howto/install/dev-env.md/#containerd

--- a/docs/canonicalk8s/snap/howto/troubleshooting.md
+++ b/docs/canonicalk8s/snap/howto/troubleshooting.md
@@ -279,9 +279,9 @@ that uses containerd.
 
 ````{dropdown} Solution
 
-{{product}} is built on the assumption that it is deployed in an isolated environment, as is usually the case for production builds. A typical way of isolating {{product}} is to run it on an LXD VM. See [Install {{product}} in LXD][lxd-install] for instructions.
+We recommend {{product}} is deployed in an isolated environment. A typical way of isolating {{product}} is to run it on an LXD VM. See [Install {{product}} in LXD][lxd-install] for instructions.
 
-If the cluster is being deployed in a developer environment or cannot have the conflicting containerd bin removed, the flag `--containerd-base-dir` can be added to the `bootstrap` and `join-cluster` commands to specify an alternate absolute path for {{product}} to install containerd. See [How to resolve containerd conflicts][how-to-containerd] for further information.
+If the cluster is being deployed in an environment that cannot have the conflicting containerd bin removed, the flag `--containerd-base-dir` can be added to the `bootstrap` and `join-cluster` commands to specify an alternate absolute path for {{product}} to install containerd. See [How to resolve containerd conflicts][how-to-containerd] for further information.
 
 ````
 

--- a/docs/canonicalk8s/snap/howto/troubleshooting.md
+++ b/docs/canonicalk8s/snap/howto/troubleshooting.md
@@ -279,17 +279,9 @@ that uses containerd.
 
 ````{dropdown} Solution
 
-We recommend running {{product}} in an isolated environment, for this purpose,
-you can create a LXD VM for your installation. See
-[Install {{product}} in LXD][lxd-install] for instructions.
+{{product}} is built on the assumption that it is deployed in an isolated environment, as is usually the case for production builds. A typical way of isolating {{product}} is to run it on an LXD VM. See [Install {{product}} in LXD][lxd-install] for instructions.
 
-As an alternative, you may specify a custom containerd path like so:
-
-```bash
-cat <<EOF | sudo k8s bootstrap --file -
-containerd-base-dir: $containerdBaseDir
-EOF
-```
+If the cluster is being deployed in a developer environment or cannot have the conflicting containerd bin removed, the flag `--containerd-base-dir` can be added to the `bootstrap` and `join-cluster` commands to specify an alternate absolute path for {{product}} to install containerd. See [How to resolve containerd conflicts][how-to-containerd] for further information.
 
 ````
 
@@ -550,4 +542,5 @@ troubleshooting a Kubernetes cluster.
 [kubernetes-122955-2020403422]: https://github.com/kubernetes/kubernetes/issues/122955#issuecomment-2020403422
 [@haircommander]: https://github.com/haircommander
 [lxd-install]: /snap/howto/install/lxd.md
+[how-to-containerd]: /snap/howto/install/dev-env.md/#containerd
 [reported here]: https://github.com/cilium/cilium/issues/30889


### PR DESCRIPTION
This PR adds a couple references to the CLI flag added in https://github.com/canonical/k8sd/pull/51 to other areas in the documentation that reference containerd or the join/bootstrap command.