### PR TITLE
ci(release-1.33): remove pull_request trigger from nightly workflow

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -3,11 +3,6 @@ name: Nightly
 on:
   schedule:
     - cron: "0 0 * * *" # Runs every midnight
-  pull_request:
-    paths:
-      - .github/workflows/e2e-tests.yaml
-      - .github/workflows/nightly-test.yaml
-      - .github/workflows/security-scan.yaml
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The nightly workflow on release branches had a `pull_request` path trigger that fired whenever a PR touched `nightly-test.yaml`, `e2e-tests.yaml`, or `security-scan.yaml`. This caused the full nightly job matrix (hundreds of integration test jobs + Trivy scans) to run on unrelated PRs, wasting CI resources and producing spurious failures.

## Fix

Remove the `pull_request` trigger. The nightly workflow now only runs on its `schedule` (midnight UTC). This matches how `main` already works.