### PR TITLE
tests: skip feature-upgrades inplace on pre-1.36 tracks

### DIFF
--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -308,6 +308,12 @@ def test_feature_upgrades_inplace(instances: List[harness.Instance], tmp_path: P
     """
 
     start_branch = util.previous_track(config.SNAP)
+    start_major_minor = util.major_minor(start_branch)
+    if start_major_minor is None or start_major_minor < (1, 36):
+        pytest.skip(
+            "Feature upgrade inplace test requires bootstrap track >= 1.36 "
+            "(dqlite removed in 1.36)."
+        )
     bootstrap_cp = instances[0]
     worker = instances[-1]
 


### PR DESCRIPTION
## Summary
- gate `test_feature_upgrades_inplace` to only run when the bootstrap track resolves to Kubernetes `>=1.36`
- skip the test when `previous_track(config.SNAP)` cannot be parsed or resolves to `<1.36`

## Why
- pre-1.36 tracks still use dqlite-backed control plane behavior
- this test is intended to validate post-1.36 feature-upgrade behavior; running it against pre-1.36 tracks exercises the wrong backend path and produces misleading failures

## Validation
- `tox -e lint -- tests/test_version_upgrades.py`
- `python3 -m py_compile tests/integration/tests/test_version_upgrades.py`

## Notes for reviewers
- this is a narrow test-scoping change only; no product logic changes