### PR TITLE
test: fix integration tests for snap upgrades/downgrades and kube-proxy

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -1631,11 +1631,12 @@ def _installed_k8s_version(instance: harness.Instance) -> Optional[tuple]:
     if len(lines) < 2:
         return None
 
-    fields = lines[-1].split()
-    if len(fields) < 2:
-        return None
+    for line in lines[1:]:
+        fields = line.split()
+        if len(fields) >= 2 and fields[0] == "k8s":
+            return major_minor(fields[1])
 
-    return major_minor(fields[1])
+    return None
 
 
 def _is_kube_proxy_expected_active(instance: harness.Instance) -> Optional[bool]:

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -244,7 +244,9 @@ def test_version_downgrades_with_rollback(
             util.snap_refresh(instance, channel)
             util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(instance, retries=10, delay_s=10, skip_services=["kube-proxy"])
+            util.check_snap_services_ready(
+                instance, retries=10, delay_s=10, skip_services=["kube-proxy"]
+            )
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 
@@ -256,7 +258,9 @@ def test_version_downgrades_with_rollback(
             util.snap_refresh(instance, last_channel)
             util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(instance, retries=10, delay_s=10, skip_services=["kube-proxy"])
+            util.check_snap_services_ready(
+                instance, retries=10, delay_s=10, skip_services=["kube-proxy"]
+            )
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 
@@ -267,7 +271,9 @@ def test_version_downgrades_with_rollback(
             util.snap_refresh(instance, current_channel)
             util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(instance, retries=10, delay_s=10, skip_services=["kube-proxy"])
+            util.check_snap_services_ready(
+                instance, retries=10, delay_s=10, skip_services=["kube-proxy"]
+            )
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -226,7 +226,7 @@ def test_version_downgrades_with_rollback(
     util.join_cluster(cp2, join_token_cp2)
     # util.join_cluster(w0, join_token_w0)
 
-    util.wait_until_k8s_ready(cp, instances)
+    util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
 
     for channel in channels[1:]:
         for instance in instances:
@@ -242,9 +242,9 @@ def test_version_downgrades_with_rollback(
                 f"Step 1. Downgrade {instance.id} from {current_channel} → {channel}"
             )
             util.snap_refresh(instance, channel)
-            util.wait_until_k8s_ready(cp, instances)
+            util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(instance, retries=10, delay_s=10)
+            util.check_snap_services_ready(instance, retries=10, delay_s=10, skip_services=["kube-proxy"])
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 
@@ -254,9 +254,9 @@ def test_version_downgrades_with_rollback(
         for instance in instances:
             LOG.debug(f"Step 2. Roll back from {current_channel} → {last_channel}")
             util.snap_refresh(instance, last_channel)
-            util.wait_until_k8s_ready(cp, instances)
+            util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(instance, retries=10, delay_s=10)
+            util.check_snap_services_ready(instance, retries=10, delay_s=10, skip_services=["kube-proxy"])
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 
@@ -265,9 +265,9 @@ def test_version_downgrades_with_rollback(
                 f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
             )
             util.snap_refresh(instance, current_channel)
-            util.wait_until_k8s_ready(cp, instances)
+            util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(instance, retries=10, delay_s=10)
+            util.check_snap_services_ready(instance, retries=10, delay_s=10, skip_services=["kube-proxy"])
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -226,7 +226,7 @@ def test_version_downgrades_with_rollback(
     util.join_cluster(cp2, join_token_cp2)
     # util.join_cluster(w0, join_token_w0)
 
-    util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
+    util.wait_until_k8s_ready(cp, instances)
 
     for channel in channels[1:]:
         for instance in instances:
@@ -242,11 +242,9 @@ def test_version_downgrades_with_rollback(
                 f"Step 1. Downgrade {instance.id} from {current_channel} → {channel}"
             )
             util.snap_refresh(instance, channel)
-            util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
+            util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(
-                instance, retries=10, delay_s=10, skip_services=["kube-proxy"]
-            )
+            util.check_snap_services_ready(instance, retries=10, delay_s=10)
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 
@@ -256,11 +254,9 @@ def test_version_downgrades_with_rollback(
         for instance in instances:
             LOG.debug(f"Step 2. Roll back from {current_channel} → {last_channel}")
             util.snap_refresh(instance, last_channel)
-            util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
+            util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(
-                instance, retries=10, delay_s=10, skip_services=["kube-proxy"]
-            )
+            util.check_snap_services_ready(instance, retries=10, delay_s=10)
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 
@@ -269,11 +265,9 @@ def test_version_downgrades_with_rollback(
                 f"Step 3. Final downgrade to channel from {last_channel} → {current_channel}"
             )
             util.snap_refresh(instance, current_channel)
-            util.wait_until_k8s_ready(cp, instances, skip_services=["kube-proxy"])
+            util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
-            util.check_snap_services_ready(
-                instance, retries=10, delay_s=10, skip_services=["kube-proxy"]
-            )
+            util.check_snap_services_ready(instance, retries=10, delay_s=10)
             util.check_service_restarts(instance)
             util.check_service_logs_for_panics(instance)
 


### PR DESCRIPTION
Fixes a Nightly CI issue where the kube-proxy state check fails during downgrade tests due to Cilium replacement predating configs. Also fixes `_installed_k8s_version` to reliably parse the snap version.