### PR TITLE
test: increase retries for failure-domain propagation

### DIFF
--- a/tests/integration/tests/test_node_availability_zone.py
+++ b/tests/integration/tests/test_node_availability_zone.py
@@ -76,7 +76,7 @@ def test_node_availability_zone(
         # Apply the AZ labels.
         for instance in instances:
             az = _get_az(instance, same_az, az_suffix)
-            util.stubbornly(retries=5, delay_s=10).on(instance).exec(
+            util.stubbornly(retries=30, delay_s=10).on(instance).exec(
                 [
                     "k8s",
                     "kubectl",
@@ -99,7 +99,7 @@ def test_node_availability_zone(
                 az,
                 failure_domain,
             )
-            util.stubbornly(retries=5, delay_s=10).on(instance).until(
+            util.stubbornly(retries=30, delay_s=10).on(instance).until(
                 lambda p: str(failure_domain) in p.stdout.decode()
             ).exec(
                 [


### PR DESCRIPTION
Fixes intermittent failures in `test_node_availability_zone[etcd-False]` by allowing more time (up to 5 mins instead of 50s) for the failure-domain to propagate in the datastore.