### PR TITLE
test: retry curl when downloading registry to avoid flaky network errors

### DIFF
--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -55,7 +55,7 @@ class Registry:
         self.instance: Instance = self.harness.new_instance(name_suffix="-registry")
 
         arch = self.instance.arch
-        self.instance.exec(
+        util.stubbornly(retries=5, delay_s=10).on(self.instance).exec(
             [
                 "curl",
                 "-L",

--- a/tests/integration/tests/test_util/registry.py
+++ b/tests/integration/tests/test_util/registry.py
@@ -59,6 +59,7 @@ class Registry:
             [
                 "curl",
                 "-L",
+                "--fail",
                 f"{self.registry_url}/{self.registry_version}/registry_{self.registry_version[1:]}_linux_{arch}.tar.gz",
                 "-o",
                 f"/tmp/registry_{self.registry_version}_linux_{arch}.tar.gz",


### PR DESCRIPTION
Fixes an intermittent `curl: (35)` SSL connect error in `test_airgapped_with_image_mirror` during test setup.