### PR TITLE
test: increase stubbornly retries for snap preload and teardown waits

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -212,7 +212,7 @@ def preload_snaps(instance: harness.Instance):
         )
 
         LOG.info("Wait for snap changes to finish...")
-        stubbornly(retries=20, delay_s=5).on(instance).until(
+        stubbornly(retries=40, delay_s=5).on(instance).until(
             lambda p: "Doing" not in p.stdout.decode()
         ).exec(["snap", "changes"])
 
@@ -337,7 +337,7 @@ def remove_k8s_snap(instance: harness.Instance):
     )
 
     LOG.info("Waiting for shims to go away...")
-    stubbornly(retries=20, delay_s=5).on(instance).until(
+    stubbornly(retries=40, delay_s=5).on(instance).until(
         lambda p: all(
             x not in p.stdout.decode()
             for x in ["containerd-shim", "cilium", "coredns", "/pause"]
@@ -345,7 +345,7 @@ def remove_k8s_snap(instance: harness.Instance):
     ).exec(["ps", "-fea"])
 
     LOG.info("Waiting for kubelet and containerd mounts to go away...")
-    stubbornly(retries=20, delay_s=5).on(instance).until(
+    stubbornly(retries=40, delay_s=5).on(instance).until(
         lambda p: all(
             x not in p.stdout.decode()
             for x in ["/var/lib/kubelet/pods", "/run/containerd/io.containerd"]


### PR DESCRIPTION
## Description

Increases the retry budget (20 → 40 attempts, still 5s delay) for two separate `stubbornly()` waits in `tests/integration/tests/test_util/util.py` that were timing out under load/flakiness:

1. **`preload_snaps`**: waiting for `snap changes` to report no `Doing` entries during snap preloading.
2. **`remove_k8s_snap`**: waiting for kubelet/containerd mounts (`/var/lib/kubelet/pods`, `/run/containerd/io.containerd`) to disappear after `snap remove`, which was causing teardown failures in tests like `test_clustering_race.py` (timeout after 100s).

Both changes use the same underlying `stubbornly()` helper and address the same class of problem (integration test infra needing more time under load), so they're kept in one PR rather than split.

## Solution

Doubled the retry count (same delay) for both waits, giving up to ~200s instead of ~100s before failing.

## Issue

N/A - CI stability fix, not a reported bug.

## Backport

Yes - `backport release-1.33`, `release-1.34`, `release-1.35`, `release-1.36` labels added. The same unfixed `retries=20` pattern exists identically on those branches.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary
- [x] Confirm whether the `release-notes` label should be kept or removed