### PR TITLE
docs: Add related links to how-to guides

### DIFF
--- a/docs/canonicalk8s/capi/howto/external-etcd.md
+++ b/docs/canonicalk8s/capi/howto/external-etcd.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to use an external etcd cluster as the datastore for a Canonical Kubernetes CAPI workload cluster."
+relatedlinks: "[etcd&#32;documentation](https://etcd.io/docs/latest/)"
 ---
 
 # How to use external etcd with Cluster API

--- a/docs/canonicalk8s/capi/howto/intermediate-ca.md
+++ b/docs/canonicalk8s/capi/howto/intermediate-ca.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to configure an intermediate Certificate Authority (CA) with Canonical Kubernetes CAPI workload clusters."
+relatedlinks: "[Vault&#32;documentation](https://developer.hashicorp.com/vault/docs)"
 ---
 
 # How to use intermediate CAs with Vault

--- a/docs/canonicalk8s/capi/howto/provision.md
+++ b/docs/canonicalk8s/capi/howto/provision.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: Deploy a Canonical Kubernetes cluster using the Cluster API and execute typical cluster operations in this how-to guide.
+relatedlinks: "[Cluster&#32;API&#32;documentation](https://cluster-api.sigs.k8s.io/)"
 ---
 
 # Provision a {{product}} cluster with CAPI

--- a/docs/canonicalk8s/charm/howto/ceph-csi.md
+++ b/docs/canonicalk8s/charm/howto/ceph-csi.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to integrate Canonical Kubernetes with ceph-csi for Ceph-backed Kubernetes persistent volumes using Juju."
+relatedlinks: "[Ceph&#32;documentation](https://docs.ceph.com/)"
 ---
 
 # How to integrate {{product}} with ceph-csi

--- a/docs/canonicalk8s/charm/howto/cos-lite.md
+++ b/docs/canonicalk8s/charm/howto/cos-lite.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to integrate Canonical Kubernetes with COS Lite (Canonical Observability Stack) for cluster monitoring using Juju."
+relatedlinks: "[COS&#32;Lite&#32;bundle](https://documentation.ubuntu.com/observability/track-3.0/)"
 ---
 
 # How to integrate with COS Lite

--- a/docs/canonicalk8s/charm/howto/etcd.md
+++ b/docs/canonicalk8s/charm/howto/etcd.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to deploy Canonical Kubernetes with an external etcd cluster as the datastore using Juju."
+relatedlinks: "[etcd&#32;documentation](https://etcd.io/docs/latest/)"
 ---
 
 # How to integrate {{product}} with external etcd

--- a/docs/canonicalk8s/charm/howto/install/charm.md
+++ b/docs/canonicalk8s/charm/howto/install/charm.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install Canonical Kubernetes from the k8s charm."
+relatedlinks: "[Juju&#32;documentation](https://canonical.com/juju/docs)"
 ---
 
 # How to install {{product}} from a charm

--- a/docs/canonicalk8s/charm/howto/install/install-lxd.md
+++ b/docs/canonicalk8s/charm/howto/install/install-lxd.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install Canonical Kubernetes in LXD virtual machines using Juju."
+relatedlinks: "[LXD&#32;documentation](https://canonical.com/lxd/docs/default/)"
 ---
 
 # How to install {{product}} using localhost/LXD

--- a/docs/canonicalk8s/charm/howto/install/install-terraform.md
+++ b/docs/canonicalk8s/charm/howto/install/install-terraform.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install Canonical Kubernetes using the Terraform Juju provider and the k8s-bundle Terraform module."
+relatedlinks: "[Terraform&#32;documentation](https://developer.hashicorp.com/terraform/docs)"
 ---
 
 # How to install with Terraform

--- a/docs/canonicalk8s/charm/howto/openstack.md
+++ b/docs/canonicalk8s/charm/howto/openstack.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to deploy Canonical Kubernetes on OpenStack using the openstack-integrator charm overlay."
+relatedlinks: "[OpenStack&#32;documentation](https://docs.openstack.org/)"
 ---
 
 # How to integrate with OpenStack

--- a/docs/canonicalk8s/snap/howto/backup-restore.md
+++ b/docs/canonicalk8s/snap/howto/backup-restore.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to back up and restore a Canonical Kubernetes cluster."
+relatedlinks: "[Velero&#32;documentation](https://velero.io/docs/)"
 ---
 
 # How to backup and restore a {{product}} cluster

--- a/docs/canonicalk8s/snap/howto/epa.md
+++ b/docs/canonicalk8s/snap/howto/epa.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to set up Enhanced Platform Awareness (EPA) features in Canonical Kubernetes, including HugePages, real-time kernel, CPU pinning, and SR-IOV."
+relatedlinks: "[MAAS&#32;documentation](https://maas.io/docs/), [Ubuntu&#32;Pro&#32;documentation](https://ubuntu.com/pro/docs)"
 ---
 
 # How to set up Enhanced Platform Awareness

--- a/docs/canonicalk8s/snap/howto/external-datastore.md
+++ b/docs/canonicalk8s/snap/howto/external-datastore.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to configure Canonical Kubernetes to use an external etcd cluster as the cluster datastore during the bootstrap process."
+relatedlinks: "[etcd&#32;documentation](https://etcd.io/docs/latest/)"
 ---
 
 # How to use an external datastore

--- a/docs/canonicalk8s/snap/howto/install/dev-env.md
+++ b/docs/canonicalk8s/snap/howto/install/dev-env.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: Troubleshoot and resolve common issues that come from running the Canonical Kubernetes snap in a dev environment.
+relatedlinks: "[containerd&#32;documentation](https://containerd.io/docs/)"
 ---
 # Install {{product}} in development environments
 

--- a/docs/canonicalk8s/snap/howto/install/disa-stig.md
+++ b/docs/canonicalk8s/snap/howto/install/disa-stig.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install Canonical Kubernetes with DISA STIG hardening, meeting U.S. DoD security guidelines for Kubernetes and the host operating system."
+relatedlinks: "[DISA&#32;STIG&#32;documentation](https://public.cyber.mil/stigs/), [Ubuntu&#32;Pro&#32;documentation](https://ubuntu.com/pro/docs)"
 ---
 
 # How to install {{ product }} with DISA STIG hardening

--- a/docs/canonicalk8s/snap/howto/install/fips.md
+++ b/docs/canonicalk8s/snap/howto/install/fips.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install a FIPS 140-3 compliant Canonical Kubernetes cluster on Ubuntu for U.S. government and regulated industry compliance requirements."
+relatedlinks: "[FIPS&#32;140-3&#32;standard](https://csrc.nist.gov/publications/detail/fips/140/3/final), [Ubuntu&#32;Pro&#32;documentation](https://ubuntu.com/pro/docs)"
 ---
 
 # How to install a FIPS compliant Kubernetes cluster

--- a/docs/canonicalk8s/snap/howto/install/lxd.md
+++ b/docs/canonicalk8s/snap/howto/install/lxd.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install Canonical Kubernetes in an LXD virtual machine."
+relatedlinks: "[LXD&#32;documentation](https://canonical.com/lxd/docs/default/)"
 ---
 
 # How to install {{product}} in LXD

--- a/docs/canonicalk8s/snap/howto/install/multipass.md
+++ b/docs/canonicalk8s/snap/howto/install/multipass.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install Canonical Kubernetes with Multipass on Ubuntu, macOS, or Windows, enabling multi-node cluster deployment on any platform."
+relatedlinks: "[Multipass&#32;documentation](https://canonical.com/multipass/docs/stable)"
 ---
 
 # How to install {{product}} with Multipass (Ubuntu/macOS/Windows)

--- a/docs/canonicalk8s/snap/howto/install/snap.md
+++ b/docs/canonicalk8s/snap/howto/install/snap.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to install Canonical Kubernetes from the k8s snap."
+relatedlinks: "[Snapcraft&#32;documentation](https://snapcraft.io/docs/)"
 ---
 
 # How to install {{product}} from a snap

--- a/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
+++ b/docs/canonicalk8s/snap/howto/networking/multi-peer-bgp.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "How to configure MetalLB with multiple BGP peers in Canonical Kubernetes."
+---
+
 # How to configure multi-peer BGP
 
 ```{versionadded} release-1.36

--- a/docs/canonicalk8s/snap/howto/networking/ufw.md
+++ b/docs/canonicalk8s/snap/howto/networking/ufw.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to configure UFW (Uncomplicated Firewall) rules for Canonical Kubernetes."
+relatedlinks: "[Ubuntu&#32;UFW&#32;documentation](https://ubuntu.com/server/docs/security-firewall)"
 ---
 
 # How to configure Uncomplicated Firewall (UFW)

--- a/docs/canonicalk8s/snap/howto/observability.md
+++ b/docs/canonicalk8s/snap/howto/observability.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to set up observability on a Canonical Kubernetes cluster by installing Prometheus for metrics collection and alerting."
+relatedlinks: "[Prometheus&#32;documentation](https://prometheus.io/docs/)"
 ---
 
 # How to use Prometheus with {{product}}

--- a/docs/canonicalk8s/snap/howto/security/cis-assessment.md
+++ b/docs/canonicalk8s/snap/howto/security/cis-assessment.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to assess CIS compliance for Canonical Kubernetes using kube-bench."
+relatedlinks: "[kube-bench](https://github.com/aquasecurity/kube-bench), [CIS&#32;Kubernetes&#32;Benchmark](https://www.cisecurity.org/benchmark/kubernetes)"
 ---
 
 # How to assess CIS compliance

--- a/docs/canonicalk8s/snap/howto/security/intermediate-ca.md
+++ b/docs/canonicalk8s/snap/howto/security/intermediate-ca.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to configure Canonical Kubernetes to use an intermediate Certificate Authority (CA) via the bootstrap configuration file."
+relatedlinks: "[Vault&#32;documentation](https://developer.hashicorp.com/vault/docs)"
 ---
 
 # How to use intermediate CAs with Vault

--- a/docs/canonicalk8s/snap/howto/storage/ceph.md
+++ b/docs/canonicalk8s/snap/howto/storage/ceph.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to integrate Canonical Kubernetes with Ceph storage using the ceph-csi driver for RBD-backed persistent volumes."
+relatedlinks: "[Ceph&#32;documentation](https://docs.ceph.com/)"
 ---
 
 # How to use Ceph storage with {{product}}

--- a/docs/canonicalk8s/snap/howto/storage/cloud.md
+++ b/docs/canonicalk8s/snap/howto/storage/cloud.md
@@ -2,6 +2,7 @@
 myst:
   html_meta:
     description: "How to use AWS EBS cloud storage with Canonical Kubernetes on EC2 instances, including IAM policies and cloud controller manager setup."
+relatedlinks: "[AWS&#32;EBS&#32;documentation](https://docs.aws.amazon.com/ebs/)"
 ---
 
 # How to use cloud storage


### PR DESCRIPTION
## Description

This is the final PR where we are adding important related links to our how-to guides. 

## Solution

The links are used sparingly. They primarily point to other Canonical docsets where possible. 

## Issue

N/A

## Backport

N/A

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Documentation updated
- [x] CLA signed
- [x] Backport label added if necessary 
- [x] Confirm whether the `release-notes` label should be kept or removed

If any item on the checklist is not complete, please provide justification why.