### PR TITLE
DO NOT MERGE: test k8sd PR #68 e2e

### DIFF
--- a/build-scripts/components/k8sd/version
+++ b/build-scripts/components/k8sd/version
@@ -1,1 +1,1 @@
-main
+KU-6240/release-1.36-k8sd-align


### PR DESCRIPTION
## Purpose

**DO NOT MERGE.** This PR temporarily points the `k8sd` component version at the branch from [canonical/k8sd#68](https://github.com/canonical/k8sd/pull/68) (`KU-6240/release-1.36-k8sd-align`) so that CI runs the k8s-snap e2e/integration test suite against those changes.

Once the e2e results have been reviewed, this PR should be closed without merging (and the branch deleted).