### PR TITLE
docs: cilium devices must include the default route device

### DIFF
--- a/docs/canonicalk8s/snap/reference/annotations.md
+++ b/docs/canonicalk8s/snap/reference/annotations.md
@@ -27,6 +27,13 @@ Cilium's VXLAN port you can run the following command:
 sudo k8s set annotations="k8sd/v1alpha1/cilium/tunnel-port=<PORT-NUMBER>"
 ```
 
+In that form commas separate annotations, so a value that itself contains commas
+has to be passed as a YAML document:
+
+```bash
+sudo k8s set annotations="k8sd/v1alpha1/cilium/devices: bond0,bond1.100"
+```
+
 ```{note}
 v1alpha annotations are experimental and subject to change or removal in future {{product}} releases
 ```
@@ -72,6 +79,23 @@ v1alpha annotations are experimental and subject to change or removal in future 
 |-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Values**      | string                                                                                                                                                                 |
 | **Description** | List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports `+` as wildcard in device name, e.g. `eth+,ens+` |
+
+```{warning}
+The list **must** include the device that carries the node's default route, even
+when no service is exposed on it.
+
+Cilium reverse-NATs the reply of a LoadBalancer or NodePort connection in the eBPF
+program attached to the egress device. The Linux stack routes that reply while the
+source address is still the backend Pod IP, so on a node with several networks the
+reply is often sent to the default route device. If Cilium does not manage that
+device, no eBPF program runs on it: the reply leaves the node with the Pod IP as
+source and on the wrong interface, and the client never receives it. This only
+affects connections whose backend Pod happens to run on the node that received
+them, which makes the failure look intermittent.
+
+On a node with `bond0` (default route), `bond1.100` and `bond1.101`, set
+`bond0,bond1.100,bond1.101` (or `bond+`), not just `bond1.100,bond1.101`.
+```
 
 ## `k8sd/v1alpha1/cilium/direct-routing-device`
 


### PR DESCRIPTION
## Problem

Issues were caused by
setting `k8sd/v1alpha1/cilium/devices` to the service-facing interfaces only, leaving out the interface
that carries the node's default route. Roughly 1/3 of external requests to a `LoadBalancer` VIP then time
out, and only those whose backend pod happens to run on the node that received the request.

Mechanism (reproduced and verified in an LXD lab on both 1.32.13/cilium 1.17.12 and 1.37.0/cilium 1.20):
Cilium reverse-NATs the reply of a LoadBalancer/NodePort connection served by a local pod in the eBPF
program attached to the **egress** device. The kernel routes that reply while the source is still the pod
IP, so `ip rule` selectors keyed on the node's service subnet do not match and the reply goes to the
default route device. With no Cilium program on that device, the reply leaves the node un-reverse-NATed
(pod IP as source) and on the wrong interface.

Lab: `devices=eth1,eth2` → 11/30 timeouts; `devices=eth0,eth1,eth2` → 0/30, reply leaves the ingress NIC
with the VIP as source.

## Change

- Warning box under `k8sd/v1alpha1/cilium/devices` explaining that the default route device must be part
  of the list, with an example.
- Note that `k8s set annotations="key=value"` splits on commas, so comma-separated values (such as a
  device list) must be passed as a YAML document. Verified against 1.32-classic/stable:
  `sudo k8s set annotations="k8sd/v1alpha1/cilium/devices: eth0,eth1,eth2"` results in
  `cilium-config devices=eth0,eth1,eth2`.

Related: canonical/k8sd#84 (report the mismatch in the feature status) and canonical/k8sd#85 (accept
`annotations.<key>=<value>`).