### PR TITLE
test: cover the LoadBalancer reply path on multi-homed nodes

### DIFF
--- a/tests/integration/lxd-multi-nic-client-profile.yaml
+++ b/tests/integration/lxd-multi-nic-client-profile.yaml
@@ -1,0 +1,17 @@
+description: "LXD profile for an off-cluster client that reaches the public network through the router"
+devices:
+  eth1:
+    name: eth1
+    network: LXD_MULTI_NIC_CLIENT_NETWORK
+    type: nic
+config:
+  user.network-config: |
+    version: 2
+    ethernets:
+      eth0:
+        dhcp4: true
+      eth1:
+        addresses: [172.16.221.103/24]
+        routes:
+        - to: 10.68.93.0/24
+          via: 172.16.221.1

--- a/tests/integration/lxd-multi-nic-profile.yaml
+++ b/tests/integration/lxd-multi-nic-profile.yaml
@@ -1,0 +1,24 @@
+description: "LXD profile for Canonical Kubernetes nodes with three NICs (management, cluster, public)"
+devices:
+  eth1:
+    name: eth1
+    network: LXD_MULTI_NIC_CLUSTER_NETWORK
+    type: nic
+  eth2:
+    name: eth2
+    network: LXD_MULTI_NIC_PUBLIC_NETWORK
+    type: nic
+config:
+  user.network-config: |
+    version: 2
+    ethernets:
+      eth0:
+        dhcp4: true
+      eth1:
+        dhcp4: true
+        dhcp4-overrides:
+          use-routes: false
+      eth2:
+        dhcp4: true
+        dhcp4-overrides:
+          use-routes: false

--- a/tests/integration/lxd-multi-nic-router-profile.yaml
+++ b/tests/integration/lxd-multi-nic-router-profile.yaml
@@ -1,0 +1,22 @@
+description: "LXD profile for the router between the public and the client network"
+devices:
+  eth1:
+    name: eth1
+    network: LXD_MULTI_NIC_PUBLIC_NETWORK
+    type: nic
+  eth2:
+    name: eth2
+    network: LXD_MULTI_NIC_CLIENT_NETWORK
+    type: nic
+config:
+  user.network-config: |
+    version: 2
+    ethernets:
+      eth0:
+        dhcp4: true
+      eth1:
+        dhcp4: true
+        dhcp4-overrides:
+          use-routes: false
+      eth2:
+        addresses: [172.16.221.1/24]

--- a/tests/integration/templates/loadbalancer-multi-nic-test.yaml
+++ b/tests/integration/templates/loadbalancer-multi-nic-test.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-nginx-multi-nic
+spec:
+  selector:
+    matchLabels:
+      run: my-nginx-multi-nic
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        run: my-nginx-multi-nic
+    spec:
+      # One replica per node, so that the node announcing the LoadBalancer VIP also
+      # hosts a backend and some requests are served locally.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                run: my-nginx-multi-nic
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: my-nginx-multi-nic
+        image: ghcr.io/containerd/nginx:1.27.0
+        # Serve the pod name so that the test can tell which backend answered.
+        command:
+        - /bin/sh
+        - -c
+        - echo "$POD_NAME" > /usr/share/nginx/html/index.html; exec nginx -g "daemon off;"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-nginx-multi-nic
+  labels:
+    run: my-nginx-multi-nic
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    run: my-nginx-multi-nic

--- a/tests/integration/tests/test_multi_nic_loadbalancer.py
+++ b/tests/integration/tests/test_multi_nic_loadbalancer.py
@@ -1,0 +1,215 @@
+#
+# Copyright 2026 Canonical, Ltd.
+#
+import json
+import logging
+from typing import List
+
+import pytest
+from test_util import config, harness, tags, util
+
+LOG = logging.getLogger(__name__)
+
+# Routing table and rule priority for the source based policy routing configured on the
+# nodes. This mirrors what the advanced-routing charm sets up on multi-homed clusters.
+POLICY_TABLE = "100"
+POLICY_RULE_PRIORITY = "101"
+
+
+def _address_of(instance: harness.Instance, device: str) -> str:
+    """Return the IPv4 address configured on device."""
+    process = instance.exec(
+        ["ip", "-4", "-json", "addr", "show", "dev", device], capture_output=True
+    )
+    return json.loads(process.stdout.decode())[0]["addr_info"][0]["local"]
+
+
+def _configure_policy_routing(node: harness.Instance, router_address: str):
+    """Route replies sourced from the public network through the router.
+
+    The default route stays on the management NIC, so a reply that is routed while its
+    source is still the backend pod address cannot reach the client.
+    """
+    public_gateway = str(config.LXD_MULTI_NIC_PUBLIC_NETWORK_GATEWAY)
+    for args in (
+        [
+            "route",
+            "add",
+            config.LXD_MULTI_NIC_PUBLIC_CIDR,
+            "dev",
+            "eth2",
+            "table",
+            POLICY_TABLE,
+        ],
+        [
+            "route",
+            "add",
+            "default",
+            "via",
+            public_gateway,
+            "dev",
+            "eth2",
+            "table",
+            POLICY_TABLE,
+        ],
+        [
+            "route",
+            "add",
+            config.LXD_MULTI_NIC_CLIENT_CIDR,
+            "via",
+            router_address,
+            "dev",
+            "eth2",
+            "table",
+            POLICY_TABLE,
+        ],
+        [
+            "rule",
+            "add",
+            "from",
+            config.LXD_MULTI_NIC_PUBLIC_CIDR,
+            "table",
+            POLICY_TABLE,
+            "priority",
+            POLICY_RULE_PRIORITY,
+        ],
+    ):
+        node.exec(["ip", *args])
+
+
+# The devices annotation must cover the interface holding the default route, otherwise
+# replies served by a pod on the ingress node never get reverse-NATed.
+BOOTSTRAP_CONFIG_TEMPLATE = """
+cluster-config:
+  network:
+    enabled: true
+  dns:
+    enabled: true
+  load-balancer:
+    enabled: true
+    l2-mode: true
+    cidrs:
+    - {lb_pool}
+  annotations:
+    k8sd/v1alpha1/cilium/devices: eth+
+"""
+
+
+@pytest.mark.node_count(3)
+@pytest.mark.network_type("multinic")
+@pytest.mark.disable_k8s_bootstrapping()
+@pytest.mark.tags(tags.NIGHTLY)
+@pytest.mark.skipif(
+    config.SUBSTRATE != "lxd",
+    reason="the multi-nic topology is only provisioned on the LXD substrate",
+)
+def test_loadbalancer_multi_nic_policy_routing(
+    h: harness.Harness, instances: List[harness.Instance]
+):
+    """External LoadBalancer traffic must work when the backend runs on the ingress node.
+
+    The nodes have three NICs: the default route is on the management NIC, the node
+    addresses are on the cluster NIC and the LoadBalancer VIP is announced on the public
+    NIC. Source based policy routing only steers replies whose source is on the public
+    network towards the client.
+
+    Cilium reverse-NATs the reply of a LoadBalancer connection served by a pod on the
+    ingress node in the eBPF program of the egress device, while the kernel selects that
+    device with the pod IP as source. If the default route device is not managed by
+    Cilium, such replies leave the node untranslated and through the wrong NIC.
+    """
+    router = h.new_instance(network_type="multinicrouter", name_suffix="-router")
+    client = h.new_instance(network_type="multinicclient", name_suffix="-client")
+
+    router.exec(["sysctl", "-w", "net.ipv4.ip_forward=1"])
+    router_address = _address_of(router, "eth1")
+    LOG.info("Router reaches the public network on %s", router_address)
+
+    for node in instances:
+        _configure_policy_routing(node, router_address)
+
+    # The client is off-cluster: it only reaches the public network through the router.
+    util.stubbornly(retries=5, delay_s=2).on(client).exec(
+        ["ping", "-c", "1", "-W", "2", _address_of(instances[0], "eth2")]
+    )
+
+    # Put the node addresses on the cluster network instead of the interface that holds
+    # the default route, as on the affected deployments.
+    cluster_addresses = [_address_of(node, "eth1") for node in instances]
+    instances[0].exec(
+        ["k8s", "bootstrap", "--address", cluster_addresses[0], "--file", "-"],
+        input=BOOTSTRAP_CONFIG_TEMPLATE.format(
+            lb_pool=config.LXD_MULTI_NIC_LB_POOL
+        ).encode(),
+    )
+    util.wait_until_k8s_ready(instances[0], instances[:1])
+
+    for node, address in zip(instances[1:], cluster_addresses[1:]):
+        token = util.get_join_token(instances[0], node)
+        node.exec(["k8s", "join-cluster", token, "--address", address])
+    util.wait_until_k8s_ready(instances[0], instances)
+
+    for node, address in zip(instances, cluster_addresses):
+        process = instances[0].exec(
+            ["k8s", "kubectl", "get", "node", node.id, "-o", "json"],
+            capture_output=True,
+        )
+        internal_ips = [
+            entry["address"]
+            for entry in json.loads(process.stdout.decode())["status"]["addresses"]
+            if entry["type"] == "InternalIP"
+        ]
+        assert address in internal_ips, (
+            f"node {node.id} reports {internal_ips} instead of the cluster network "
+            f"address {address}"
+        )
+
+    util.wait_for_network(instances[0])
+    util.wait_for_load_balancer(instances[0])
+
+    manifest = config.MANIFESTS_DIR / "loadbalancer-multi-nic-test.yaml"
+    instances[0].exec(
+        ["k8s", "kubectl", "apply", "-f", "-"], input=manifest.read_bytes()
+    )
+    instances[0].exec(
+        [
+            "k8s",
+            "kubectl",
+            "rollout",
+            "status",
+            "deploy/my-nginx-multi-nic",
+            "--timeout",
+            "5m",
+        ]
+    )
+
+    process = instances[0].exec(
+        ["k8s", "kubectl", "get", "svc", "my-nginx-multi-nic", "-o", "json"],
+        capture_output=True,
+    )
+    vip = json.loads(process.stdout.decode())["status"]["loadBalancer"]["ingress"][0][
+        "ip"
+    ]
+    LOG.info("LoadBalancer VIP is %s", vip)
+
+    served_by = set()
+    failures = []
+    for attempt in range(45):
+        process = client.exec(
+            ["curl", "--silent", "--show-error", "--max-time", "5", f"http://{vip}/"],
+            capture_output=True,
+            check=False,
+        )
+        if process.returncode != 0:
+            failures.append(f"attempt {attempt} failed with exit {process.returncode}")
+            continue
+        served_by.add(process.stdout.decode().strip())
+
+    assert not failures, f"requests to the LoadBalancer VIP {vip} failed: {failures}"
+    # Every node runs a replica, so the node announcing the VIP serves part of the
+    # requests itself. Without responses from all backends the locally served reply path
+    # would not have been exercised at all.
+    assert len(served_by) == 3, (
+        f"only {sorted(served_by)} answered, the reply path of a locally served request "
+        "was not exercised"
+    )

--- a/tests/integration/tests/test_util/config.py
+++ b/tests/integration/tests/test_util/config.py
@@ -135,6 +135,77 @@ LXD_DUAL_NIC_PROFILE = (
     or (DIR / ".." / ".." / "lxd-dual-nic-profile.yaml").read_text()
 )
 
+# The multi-nic networks reproduce a node with a management network that carries the
+# default route, a separate cluster network for the node addresses and a public network
+# that hosts LoadBalancer VIPs, plus a client network that is only reachable through a
+# router. The CIDRs are fixed so that tests can reserve VIPs outside the DHCP ranges.
+
+# LXD_MULTI_NIC_CLUSTER_NETWORK carries the Kubernetes node addresses (eth1).
+LXD_MULTI_NIC_CLUSTER_NETWORK = (
+    os.getenv("TEST_LXD_MULTI_NIC_CLUSTER_NETWORK") or "mnic-cluster0"
+)
+LXD_MULTI_NIC_CLUSTER_CIDR = "10.68.92.0/24"
+
+# LXD_MULTI_NIC_PUBLIC_NETWORK hosts the LoadBalancer VIPs (eth2).
+LXD_MULTI_NIC_PUBLIC_NETWORK = (
+    os.getenv("TEST_LXD_MULTI_NIC_PUBLIC_NETWORK") or "mnic-public0"
+)
+LXD_MULTI_NIC_PUBLIC_CIDR = "10.68.93.0/24"
+
+# LXD_MULTI_NIC_PUBLIC_NETWORK_GATEWAY is the address the LXD bridge owns on
+# LXD_MULTI_NIC_PUBLIC_NETWORK.
+LXD_MULTI_NIC_PUBLIC_NETWORK_GATEWAY = "10.68.93.1"
+
+# LXD_MULTI_NIC_LB_POOL is reserved for LoadBalancer VIPs, outside the DHCP range of
+# LXD_MULTI_NIC_PUBLIC_NETWORK.
+LXD_MULTI_NIC_LB_POOL = "10.68.93.70-10.68.93.80"
+
+# LXD_MULTI_NIC_CLIENT_NETWORK holds the off-cluster client. It has no address on the
+# host, so a reply that leaves a node through the wrong NIC cannot reach the client.
+LXD_MULTI_NIC_CLIENT_NETWORK = (
+    os.getenv("TEST_LXD_MULTI_NIC_CLIENT_NETWORK") or "mnic-client0"
+)
+LXD_MULTI_NIC_CLIENT_CIDR = "172.16.221.0/24"
+
+# LXD_MULTI_NIC_CLIENT_ADDRESS is the address configured by the client profile.
+LXD_MULTI_NIC_CLIENT_ADDRESS = "172.16.221.103"
+
+# LXD_MULTI_NIC_PROFILE_NAME is the profile name for nodes with management, cluster and
+# public NICs.
+LXD_MULTI_NIC_PROFILE_NAME = (
+    os.getenv("TEST_LXD_MULTI_NIC_PROFILE_NAME") or "k8s-integration-multi-nic"
+)
+
+# LXD_MULTI_NIC_PROFILE is the profile for nodes with management, cluster and public NICs.
+LXD_MULTI_NIC_PROFILE = (
+    os.getenv("TEST_LXD_MULTI_NIC_PROFILE")
+    or (DIR / ".." / ".." / "lxd-multi-nic-profile.yaml").read_text()
+)
+
+# LXD_MULTI_NIC_ROUTER_PROFILE_NAME is the profile name for the router instance.
+LXD_MULTI_NIC_ROUTER_PROFILE_NAME = (
+    os.getenv("TEST_LXD_MULTI_NIC_ROUTER_PROFILE_NAME")
+    or "k8s-integration-multi-nic-router"
+)
+
+# LXD_MULTI_NIC_ROUTER_PROFILE is the profile for the router instance.
+LXD_MULTI_NIC_ROUTER_PROFILE = (
+    os.getenv("TEST_LXD_MULTI_NIC_ROUTER_PROFILE")
+    or (DIR / ".." / ".." / "lxd-multi-nic-router-profile.yaml").read_text()
+)
+
+# LXD_MULTI_NIC_CLIENT_PROFILE_NAME is the profile name for the off-cluster client.
+LXD_MULTI_NIC_CLIENT_PROFILE_NAME = (
+    os.getenv("TEST_LXD_MULTI_NIC_CLIENT_PROFILE_NAME")
+    or "k8s-integration-multi-nic-client"
+)
+
+# LXD_MULTI_NIC_CLIENT_PROFILE is the profile for the off-cluster client.
+LXD_MULTI_NIC_CLIENT_PROFILE = (
+    os.getenv("TEST_LXD_MULTI_NIC_CLIENT_PROFILE")
+    or (DIR / ".." / ".." / "lxd-multi-nic-client-profile.yaml").read_text()
+)
+
 # LXD_IMAGE is the image to use for LXD containers.
 LXD_IMAGE = os.getenv("TEST_LXD_IMAGE") or "ubuntu:22.04"
 

--- a/tests/integration/tests/test_util/harness/lxd.py
+++ b/tests/integration/tests/test_util/harness/lxd.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2026 Canonical, Ltd.
 #
+import ipaddress
 import logging
 import os
 import shlex
@@ -13,6 +14,22 @@ from test_util.harness import Harness, HarnessError, Instance
 from test_util.util import run, stubbornly
 
 LOG = logging.getLogger(__name__)
+
+
+def _gateway(cidr: str) -> str:
+    """Return the first address of cidr with the prefix length, e.g. 10.0.0.1/24."""
+    network = ipaddress.ip_network(cidr)
+    return f"{network.network_address + 1}/{network.prefixlen}"
+
+
+def _dhcp_range(cidr: str) -> str:
+    """Return a DHCP range that covers the lower half of cidr.
+
+    Leaving the upper half unused allows tests to reserve addresses, for instance for
+    LoadBalancer VIPs, without colliding with instance addresses.
+    """
+    network = ipaddress.ip_network(cidr)
+    return f"{network.network_address + 20}-{network.network_address + 60}"
 
 
 class LXDHarness(Harness):
@@ -99,6 +116,54 @@ class LXDHarness(Harness):
             ),
         )
 
+        # The multi-nic setup mirrors a node that has a management network with the
+        # default route, a cluster network for the node address and a public network for
+        # LoadBalancer VIPs. Only the client network has no address on the host, so a
+        # reply that leaves a node through the wrong NIC is dropped instead of being
+        # routed by the host.
+        self._configure_network(
+            config.LXD_MULTI_NIC_CLUSTER_NETWORK,
+            f"ipv4.address={_gateway(config.LXD_MULTI_NIC_CLUSTER_CIDR)}",
+            "ipv4.nat=false",
+            f"ipv4.dhcp.ranges={_dhcp_range(config.LXD_MULTI_NIC_CLUSTER_CIDR)}",
+            "ipv6.address=none",
+        )
+        self._configure_network(
+            config.LXD_MULTI_NIC_PUBLIC_NETWORK,
+            f"ipv4.address={_gateway(config.LXD_MULTI_NIC_PUBLIC_CIDR)}",
+            "ipv4.nat=false",
+            f"ipv4.dhcp.ranges={_dhcp_range(config.LXD_MULTI_NIC_PUBLIC_CIDR)}",
+            "ipv6.address=none",
+        )
+        self._configure_network(
+            config.LXD_MULTI_NIC_CLIENT_NETWORK,
+            "ipv4.address=none",
+            "ipv6.address=none",
+        )
+        self.multi_nic_profile = config.LXD_MULTI_NIC_PROFILE_NAME
+        self.multi_nic_router_profile = config.LXD_MULTI_NIC_ROUTER_PROFILE_NAME
+        self.multi_nic_client_profile = config.LXD_MULTI_NIC_CLIENT_PROFILE_NAME
+        for profile_name, profile in (
+            (self.multi_nic_profile, config.LXD_MULTI_NIC_PROFILE),
+            (self.multi_nic_router_profile, config.LXD_MULTI_NIC_ROUTER_PROFILE),
+            (self.multi_nic_client_profile, config.LXD_MULTI_NIC_CLIENT_PROFILE),
+        ):
+            self._configure_profile(
+                profile_name,
+                profile.replace(
+                    "LXD_MULTI_NIC_CLUSTER_NETWORK",
+                    config.LXD_MULTI_NIC_CLUSTER_NETWORK,
+                )
+                .replace(
+                    "LXD_MULTI_NIC_PUBLIC_NETWORK",
+                    config.LXD_MULTI_NIC_PUBLIC_NETWORK,
+                )
+                .replace(
+                    "LXD_MULTI_NIC_CLIENT_NETWORK",
+                    config.LXD_MULTI_NIC_CLIENT_NETWORK,
+                ),
+            )
+
         LOG.debug(
             "Configured LXD substrate (profile %s, image %s)", self.profile, self.image
         )
@@ -122,7 +187,17 @@ class LXDHarness(Harness):
             self.profile,
         ]
 
-        valid_types = ["ipv4", "dualstack", "ipv6", "jumbo", "dualnic", "fan"]
+        valid_types = [
+            "ipv4",
+            "dualstack",
+            "ipv6",
+            "jumbo",
+            "dualnic",
+            "fan",
+            "multinic",
+            "multinicrouter",
+            "multinicclient",
+        ]
         if network_type.lower() not in valid_types:
             raise HarnessError(
                 f"unknown network type {network_type}, need to be one of {', '.join(valid_types)}"
@@ -146,6 +221,15 @@ class LXDHarness(Harness):
 
         if network_type.lower() == "fan":
             launch_lxd_command.extend(["-p", self.fan_profile])
+
+        if network_type.lower() == "multinic":
+            launch_lxd_command.extend(["-p", self.multi_nic_profile])
+
+        if network_type.lower() == "multinicrouter":
+            launch_lxd_command.extend(["-p", self.multi_nic_router_profile])
+
+        if network_type.lower() == "multinicclient":
+            launch_lxd_command.extend(["-p", self.multi_nic_client_profile])
 
         try:
             stubbornly(retries=3, delay_s=1).exec(launch_lxd_command)


### PR DESCRIPTION
## Problem

Cilium reverse-NATs the reply of a LoadBalancer/NodePort connection **served by a pod on the ingress
node** in the eBPF program attached to the *egress* device (`nodeport_rev_dnat_fwd_ipv4()` in
`bpf/lib/nodeport_egress.h`, which also redoes the FIB lookup with the post-rev-DNAT source). The kernel
picks that device while the source is still the backend pod IP, so `ip rule` selectors keyed on the
node's service subnet do not match and the reply is handed to the **default-route** device. If that
device is not in the cilium `devices` filter, no cilium program runs on it: the reply leaves the node
un-reverse-NATed and on the wrong NIC, and the client times out. Only requests whose backend is local to
the VIP-owning node break, which is why it presents as ~1/3 intermittent failures.

Reproduced on 1.32.13/cilium 1.17.12 and 1.37.0/cilium 1.20, i.e. every release since the `devices`
annotation exists. Related: canonical/k8s-snap#2802 (docs), canonical/k8sd#84 (warn when the filter
misses that device), closes canonical/k8s-snap#2803.

## Change

Harness: a `multinic` topology on the LXD substrate.

- Three fixed-CIDR bridges: `mnic-cluster0` (10.68.92.0/24, node addresses), `mnic-public0`
  (10.68.93.0/24, LoadBalancer VIPs) and `mnic-client0` (172.16.221.0/24, **no address on the host**, so
  a reply that leaves a node through the wrong NIC cannot be routed by the host). DHCP is restricted to
  the lower half of each subnet so `10.68.93.70-80` can be reserved for VIPs.
- Three profiles / network types: `multinic` (node: eth0 management + default route, eth1 cluster, eth2
  public), `multinicrouter` (public + client, owns 172.16.221.1), `multinicclient`
  (172.16.221.103, reaches the public network only through the router).

Test `tests/test_multi_nic_loadbalancer.py`:

1. brings up the router and the off-cluster client next to the 3 nodes,
2. programs the customer's policy routing on every node (`table 100` with a route to the client subnet
   via the router, `ip rule from 10.68.93.0/24 table 100`), the default route stays on eth0,
3. bootstraps with node addresses on the **cluster** network (asserting the reported InternalIP), the
   load-balancer feature in L2 mode and `k8sd/v1alpha1/cilium/devices: eth+`,
4. deploys 3 nginx replicas with pod anti-affinity (one per node, each serving its pod name) behind a
   `type: LoadBalancer` service with `externalTrafficPolicy: Cluster`,
5. issues 45 requests from the client and asserts **zero failures** and that **all three** backends
   answered — without the latter the locally served reply path could go untested.

Tagged `nightly`, skipped on non-LXD substrates.
