### PR TITLE
test: replace lifetime-restart check with post-stabilization check in upgrade tests

### DIFF
--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -1450,31 +1450,33 @@ def check_service_restarts(
 def check_no_service_restarts_after_stabilization(
     instance: harness.Instance,
     services: Optional[List[str]] = None,
-    settle_s: int = 15,
-    poll_interval_s: int = 5,
+    retries: int = 3,
+    delay_s: int = config.DEFAULT_WAIT_DELAY_S,
 ):
-    """Fail if a service keeps restarting *after* this point (crash loop),
-    sampling NRestarts over a short settle window. Tolerates the expected
-    one-shot restart(s) a refresh itself causes; call once a step is
-    already confirmed stable."""
+    """Fail if a service's restart count is still climbing after this
+    point (crash loop). Reuses the same Retrying/wait_fixed cadence as
+    wait_until_k8s_ready instead of a fixed sleep: each attempt compares
+    against the previous sample (sliding baseline), so a single one-shot
+    restart from the refresh itself doesn't fail the check - only
+    restarts that keep recurring across consecutive samples do."""
     if services is None:
         services = _get_enabled_services(instance)
 
-    baseline = _get_service_restart_counts(instance, services)
-    samples = max(1, settle_s // poll_interval_s)
-    for _ in range(samples):
-        time.sleep(poll_interval_s)
-        current = _get_service_restart_counts(instance, services)
-        violations = [
-            (service, baseline[service], current[service])
-            for service in services
-            if current[service] > baseline[service]
-        ]
-        assert not violations, (
-            "Services restarted after stabilization (crash-loop suspected): "
-            + ", ".join(f"{s} ({b} -> {n})" for s, b, n in violations)
-        )
-        baseline = current
+    previous = _get_service_restart_counts(instance, services)
+    for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(delay_s)):
+        with attempt:
+            current = _get_service_restart_counts(instance, services)
+            violations = [
+                (service, previous[service], current[service])
+                for service in services
+                if current[service] > previous[service]
+            ]
+            previous = current
+            assert (
+                not violations
+            ), "Services still restarting (crash-loop suspected): " + ", ".join(
+                f"{s} ({b} -> {n})" for s, b, n in violations
+            )
 
 
 def check_service_logs_for_panics(

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -1403,8 +1403,8 @@ def _get_service_restart_counts(
     instance: harness.Instance,
     services: Optional[List[str]] = None,
 ) -> Dict[str, int]:
-    """Read systemd's NRestarts counter for the given services. Lifetime
-    counter, never resets between test steps on its own."""
+    """Read systemd's NRestarts counter per service. Lifetime counter,
+    never resets between steps."""
     if services is None:
         services = _get_enabled_services(instance)
 
@@ -1424,12 +1424,10 @@ def check_service_restarts(
     services: Optional[List[str]] = None,
     max_restarts: int = 0,
 ):
-    """Fail if any service has restarted more than max_restarts times
-    (lifetime NRestarts counter). Correct only for a baseline where zero
-    restarts are expected outright (e.g. a fresh bootstrap in
-    test_smoke.py). Don't call repeatedly across upgrade/downgrade steps -
-    restarts there are expected and accumulate; use
-    check_no_service_restarts_after_stabilization() instead."""
+    """Fail if any service restarted more than max_restarts times. Only
+    correct for a zero-restarts baseline (e.g. fresh bootstrap). For
+    upgrade/downgrade steps use check_no_service_restarts_after_stabilization()
+    instead."""
     if services is None:
         services = _get_enabled_services(instance)
 
@@ -1453,12 +1451,9 @@ def check_no_service_restarts_after_stabilization(
     retries: int = 3,
     delay_s: int = config.DEFAULT_WAIT_DELAY_S,
 ):
-    """Fail if a service's restart count is still climbing after this
-    point (crash loop). Reuses the same Retrying/wait_fixed cadence as
-    wait_until_k8s_ready instead of a fixed sleep: each attempt compares
-    against the previous sample (sliding baseline), so a single one-shot
-    restart from the refresh itself doesn't fail the check - only
-    restarts that keep recurring across consecutive samples do."""
+    """Fail if a service keeps restarting after this point (crash loop).
+    Uses a sliding baseline so one expected refresh-triggered restart
+    doesn't fail the check - only ongoing restarts do."""
     if services is None:
         services = _get_enabled_services(instance)
 

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -13,7 +13,7 @@ import urllib.request
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, List, Mapping, Optional, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
 import pytest
 from tenacity import (
@@ -1399,6 +1399,30 @@ def _get_enabled_services(instance: harness.Instance) -> List[str]:
     return services
 
 
+def _get_service_restart_counts(
+    instance: harness.Instance,
+    services: Optional[List[str]] = None,
+) -> Dict[str, int]:
+    """
+    Read the current systemd NRestarts counter for the given (or all
+    enabled) k8s snap services. This is a lifetime counter that only
+    resets on a full unit stop/reset or host reboot - it never resets
+    between test steps on its own.
+    """
+    if services is None:
+        services = _get_enabled_services(instance)
+
+    counts = {}
+    for service in services:
+        result = instance.exec(
+            ["systemctl", "show", f"snap.k8s.{service}", "-p", "NRestarts"],
+            capture_output=True,
+            text=True,
+        )
+        counts[service] = int(result.stdout.strip().split("=")[1])
+    return counts
+
+
 def check_service_restarts(
     instance: harness.Instance,
     services: Optional[List[str]] = None,
@@ -1408,26 +1432,77 @@ def check_service_restarts(
     Check that k8s snap services have not restarted excessively.
     Uses systemctl show to read the NRestarts counter for each service.
     By default, fails if any service has restarted at all (max_restarts=0).
+
+    NOTE: NRestarts is a lifetime counter. This check is only correct
+    against a baseline where no restarts are expected at all (e.g. a
+    freshly bootstrapped cluster in test_smoke.py). It is NOT correct to
+    call this repeatedly across multiple refresh/upgrade steps within a
+    single test, since restarting kubelet (and other services) during a
+    snap refresh is expected product behavior (e.g. node-ip argument
+    updates, deprecated flag removal, cert refresh) and those restarts
+    accumulate across steps. For upgrade/downgrade tests, use
+    check_no_service_restarts_after_stabilization() instead, which
+    verifies stability *after* a refresh rather than asserting zero
+    restarts ever happened.
     """
     if services is None:
         services = _get_enabled_services(instance)
 
-    violations = []
-    for service in services:
-        result = instance.exec(
-            ["systemctl", "show", f"snap.k8s.{service}", "-p", "NRestarts"],
-            capture_output=True,
-            text=True,
-        )
-        n_restarts = int(result.stdout.strip().split("=")[1])
-        if n_restarts > max_restarts:
-            violations.append((service, n_restarts))
+    counts = _get_service_restart_counts(instance, services)
+    violations = [
+        (service, n_restarts)
+        for service, n_restarts in counts.items()
+        if n_restarts > max_restarts
+    ]
 
     assert (
         not violations
     ), f"Services have restarted more than {max_restarts} time(s): " + ", ".join(
         f"{s} ({n} restarts)" for s, n in violations
     )
+
+
+def check_no_service_restarts_after_stabilization(
+    instance: harness.Instance,
+    services: Optional[List[str]] = None,
+    settle_s: int = 15,
+    poll_interval_s: int = 5,
+):
+    """
+    Verify that no k8s snap service is crash-looping *after* the point
+    this check is called - typically right after a refresh/upgrade step
+    has already been confirmed stable (e.g. via wait_until_k8s_ready and
+    check_snap_services_ready).
+
+    A refresh can legitimately restart services once as part of normal
+    reconciliation (kubelet restarting to apply new node-ip args, drop
+    deprecated flags, or apply refreshed certificates) - that is expected
+    and is NOT what this check guards against. Instead of asserting zero
+    restarts ever happened (which the raw NRestarts lifetime counter
+    can't distinguish from crash-looping), this samples the counter
+    multiple times over a short settle window and fails only if it keeps
+    climbing *after* we believed the node had stabilized, which indicates
+    an actual crash loop rather than the one-shot restart(s) caused by
+    the refresh itself.
+    """
+    if services is None:
+        services = _get_enabled_services(instance)
+
+    baseline = _get_service_restart_counts(instance, services)
+    samples = max(1, settle_s // poll_interval_s)
+    for _ in range(samples):
+        time.sleep(poll_interval_s)
+        current = _get_service_restart_counts(instance, services)
+        violations = [
+            (service, baseline[service], current[service])
+            for service in services
+            if current[service] > baseline[service]
+        ]
+        assert not violations, (
+            "Services restarted after stabilization (crash-loop suspected): "
+            + ", ".join(f"{s} ({b} -> {n})" for s, b, n in violations)
+        )
+        baseline = current
 
 
 def check_service_logs_for_panics(

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -1403,12 +1403,8 @@ def _get_service_restart_counts(
     instance: harness.Instance,
     services: Optional[List[str]] = None,
 ) -> Dict[str, int]:
-    """
-    Read the current systemd NRestarts counter for the given (or all
-    enabled) k8s snap services. This is a lifetime counter that only
-    resets on a full unit stop/reset or host reboot - it never resets
-    between test steps on its own.
-    """
+    """Read systemd's NRestarts counter for the given services. Lifetime
+    counter, never resets between test steps on its own."""
     if services is None:
         services = _get_enabled_services(instance)
 
@@ -1428,23 +1424,12 @@ def check_service_restarts(
     services: Optional[List[str]] = None,
     max_restarts: int = 0,
 ):
-    """
-    Check that k8s snap services have not restarted excessively.
-    Uses systemctl show to read the NRestarts counter for each service.
-    By default, fails if any service has restarted at all (max_restarts=0).
-
-    NOTE: NRestarts is a lifetime counter. This check is only correct
-    against a baseline where no restarts are expected at all (e.g. a
-    freshly bootstrapped cluster in test_smoke.py). It is NOT correct to
-    call this repeatedly across multiple refresh/upgrade steps within a
-    single test, since restarting kubelet (and other services) during a
-    snap refresh is expected product behavior (e.g. node-ip argument
-    updates, deprecated flag removal, cert refresh) and those restarts
-    accumulate across steps. For upgrade/downgrade tests, use
-    check_no_service_restarts_after_stabilization() instead, which
-    verifies stability *after* a refresh rather than asserting zero
-    restarts ever happened.
-    """
+    """Fail if any service has restarted more than max_restarts times
+    (lifetime NRestarts counter). Correct only for a baseline where zero
+    restarts are expected outright (e.g. a fresh bootstrap in
+    test_smoke.py). Don't call repeatedly across upgrade/downgrade steps -
+    restarts there are expected and accumulate; use
+    check_no_service_restarts_after_stabilization() instead."""
     if services is None:
         services = _get_enabled_services(instance)
 
@@ -1468,23 +1453,10 @@ def check_no_service_restarts_after_stabilization(
     settle_s: int = 15,
     poll_interval_s: int = 5,
 ):
-    """
-    Verify that no k8s snap service is crash-looping *after* the point
-    this check is called - typically right after a refresh/upgrade step
-    has already been confirmed stable (e.g. via wait_until_k8s_ready and
-    check_snap_services_ready).
-
-    A refresh can legitimately restart services once as part of normal
-    reconciliation (kubelet restarting to apply new node-ip args, drop
-    deprecated flags, or apply refreshed certificates) - that is expected
-    and is NOT what this check guards against. Instead of asserting zero
-    restarts ever happened (which the raw NRestarts lifetime counter
-    can't distinguish from crash-looping), this samples the counter
-    multiple times over a short settle window and fails only if it keeps
-    climbing *after* we believed the node had stabilized, which indicates
-    an actual crash loop rather than the one-shot restart(s) caused by
-    the refresh itself.
-    """
+    """Fail if a service keeps restarting *after* this point (crash loop),
+    sampling NRestarts over a short settle window. Tolerates the expected
+    one-shot restart(s) a refresh itself causes; call once a step is
+    already confirmed stable."""
     if services is None:
         services = _get_enabled_services(instance)
 

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -134,7 +134,7 @@ def test_version_upgrades(
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance, retries=10, delay_s=10)
-            util.check_service_restarts(instance)
+            util.check_no_service_restarts_after_stabilization(instance)
             util.check_service_logs_for_panics(instance)
             LOG.info(f"Upgraded {instance.id} to channel {channel}")
 
@@ -249,7 +249,7 @@ def test_version_downgrades_with_rollback(
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance, retries=10, delay_s=10)
-            util.check_service_restarts(instance)
+            util.check_no_service_restarts_after_stabilization(instance)
             util.check_service_logs_for_panics(instance)
 
         last_channel = current_channel
@@ -261,7 +261,7 @@ def test_version_downgrades_with_rollback(
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance, retries=10, delay_s=10)
-            util.check_service_restarts(instance)
+            util.check_no_service_restarts_after_stabilization(instance)
             util.check_service_logs_for_panics(instance)
 
         for instance in instances:
@@ -272,7 +272,7 @@ def test_version_downgrades_with_rollback(
             util.wait_until_k8s_ready(cp, instances)
             LOG.info("Verifying snap service health")
             util.check_snap_services_ready(instance, retries=10, delay_s=10)
-            util.check_service_restarts(instance)
+            util.check_no_service_restarts_after_stabilization(instance)
             util.check_service_logs_for_panics(instance)
 
             LOG.info("Rollback segment complete. Proceeding to next downgrade segment.")


### PR DESCRIPTION
## Description

`test_version_upgrades.py::test_version_upgrades` and `test_version_downgrades_with_rollback` intermittently fail with e.g. `AssertionError: Services have restarted more than 0 time(s): kubelet (3 restarts)`.

## Root cause

`check_service_restarts()` reads systemd's `NRestarts` counter, which is a **lifetime counter** that never resets between test steps (only on a full unit stop/reset or host reboot). It was introduced in #2385 for `test_smoke.py`, where "zero restarts ever" against a freshly bootstrapped cluster is a correct invariant — nothing should be crash-looping right after a clean install.

The same commit also added an identical call to `test_version_upgrades.py`'s multi-hop channel loop (4 call sites), which is fundamentally incorrect there: restarting kubelet during a snap refresh is expected, product-side behavior — confirmed in `k8sd`'s post-refresh hooks (`updateNodeIPAddresses`, `removeDeprecatedKubeletFlags`) and `NodeConfigurationController`, all of which call `RestartServices(["kubelet"])` when relevant args or certs change. A single multi-hop upgrade test can legitimately trigger several of these across its loop, and since the counter is never reset, restarts accumulate step over step until `max_restarts=0` eventually trips — regardless of whether any individual restart indicated a real problem.

## Solution

Add `check_no_service_restarts_after_stabilization()`: instead of asserting zero restarts ever happened, it samples the restart counter over a short settle window (default 15s, 5s polls) taken *after* a step has already been confirmed stable (post `wait_until_k8s_ready` + `check_snap_services_ready`), and only fails if the counter keeps climbing during that window — i.e. an actual crash loop, not the expected one-shot restart(s) caused by the refresh itself.

Replaced all 4 `check_service_restarts()` call sites in `test_version_upgrades.py` with the new check. `test_smoke.py`'s use of `check_service_restarts()` is untouched — asserting zero restarts on a fresh bootstrap is correct as-is, so it keeps using the original (now documented) function.

## Issue

N/A - CI stability fix following root-cause investigation into `test_version_upgrades` flakiness.

## Backport

Not yet added - want to confirm this lands cleanly on `main` first before backporting, since the settle-window approach adds ~15-60s of test runtime per upgrade/downgrade step across `release-1.33`-`1.37` and I'd like at least one clean CI run's signal before propagating.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests
- [x] Covered by integration tests (this *is* the integration test infra)
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary
- [x] Confirm whether the `release-notes` label should be kept or removed (removing - test-only change, not user-facing)
