### PR TITLE
test: cap downgrade channel selection at the branch's own track

### DIFF
--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -192,9 +192,7 @@ def test_version_downgrades_with_rollback(
         _, num_channels = channels
         ref = config.GH_BASE_REF or config.GH_REF
         max_release = (
-            ref.removeprefix("release-")
-            if ref and ref.startswith("release-")
-            else None
+            ref.removeprefix("release-") if ref and ref.startswith("release-") else None
         )
         channels = snap.get_most_stable_channels(
             int(num_channels),

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -191,12 +191,8 @@ def test_version_downgrades_with_rollback(
             pytest.fail("'recent' requires the number of releases as second argument")
         _, num_channels = channels
         ref = config.GH_BASE_REF or config.GH_REF
-        # On release branches, cap the downgrade path at the branch's own track so
-        # we bootstrap on this release and downgrade through its history, rather
-        # than bootstrapping on a newer in-flight track (e.g. 1.37 while 1.36/1.37
-        # are released in parallel) and downgrading across the skip.
         max_release = (
-            ref.lstrip("release-")
+            ref.removeprefix("release-")
             if ref and ref.startswith("release-")
             else None
         )

--- a/tests/integration/tests/test_version_upgrades.py
+++ b/tests/integration/tests/test_version_upgrades.py
@@ -191,11 +191,21 @@ def test_version_downgrades_with_rollback(
             pytest.fail("'recent' requires the number of releases as second argument")
         _, num_channels = channels
         ref = config.GH_BASE_REF or config.GH_REF
+        # On release branches, cap the downgrade path at the branch's own track so
+        # we bootstrap on this release and downgrade through its history, rather
+        # than bootstrapping on a newer in-flight track (e.g. 1.37 while 1.36/1.37
+        # are released in parallel) and downgrading across the skip.
+        max_release = (
+            ref.lstrip("release-")
+            if ref and ref.startswith("release-")
+            else None
+        )
         channels = snap.get_most_stable_channels(
             int(num_channels),
             config.FLAVOR,
             cp.arch,
             min_release=config.VERSION_UPGRADE_MIN_RELEASE,
+            max_release=max_release,
             reverse=True,
             # Include `latest/edge/<flavor>` only if this is not a release branch.
             include_latest=ref == util.MAIN_BRANCH,


### PR DESCRIPTION
## Problem

`test_version_downgrades_with_rollback` selects channels via `get_most_stable_channels(reverse=True)` with only a `min_release` floor and **no ceiling**. On release branches the selection floats up to the newest published track, so e.g. on release-1.35 it currently resolves to:

```
1.37-classic/candidate  (bootstrap)
1.36-classic/candidate
1.35-classic/stable
1.34/1.33/1.32-classic/stable
```

It bootstraps on **1.37** and downgrades **1.37 → 1.36 → 1.35**, skipping across the parallel in-flight 1.36/1.37 releases. The 1.37-classic/candidate snap is currently broken (bootstrap node never becomes Ready), which fails the test before any downgrade step runs.

## Fix

Pass the existing (previously unused) `max_release` parameter, set to the branch's own version, so a release branch bootstraps on its own track and downgrades through its history:

- release-1.35 → `1.35 → 1.34 → 1.33 → 1.32`
- release-1.33 → `1.33 → 1.32`
- main → unchanged (uncapped, still tests latest)

Smallest diff: one new `max_release` argument + a 3-line branch-version derivation. Verified by simulating `get_most_stable_channels` against the live store channel-map.

## Follow-up

Once this merges to main, it will be cherry-picked/backported to the release branches (1.32–1.36) so their downgrade CI tests their own track.

Part of the release-branch CI stabilization (see #2806 for the related kube-proxy readiness fix).