### PR TITLE
test: disable HTTP/2 client on CI registry mirror to avoid GHCR proxy stalls

### DIFF
--- a/tests/integration/templates/registry/registry.service
+++ b/tests/integration/templates/registry/registry.service
@@ -8,12 +8,6 @@
     RestartSec=5s
     LimitNOFILE=40000
     TimeoutStartSec=0
-
-    # Disable the Go HTTP/2 client so that proxy pulls of large upstream blobs
-    # (e.g. ghcr.io/canonical/cilium*) fall back to HTTP/1.1. Large blob transfers
-    # over HTTP/2 have been observed to fail intermittently with
-    # "stream error: ...; PROTOCOL_ERROR; received from peer", forcing a full
-    # multi-minute re-pull and, during bootstrap, stalling node readiness.
     Environment=GODEBUG=http2client=0
 
     ExecStart=/bin/registry serve /etc/distribution/$NAME.yaml

--- a/tests/integration/templates/registry/registry.service
+++ b/tests/integration/templates/registry/registry.service
@@ -9,6 +9,13 @@
     LimitNOFILE=40000
     TimeoutStartSec=0
 
+    # Disable the Go HTTP/2 client so that proxy pulls of large upstream blobs
+    # (e.g. ghcr.io/canonical/cilium*) fall back to HTTP/1.1. Large blob transfers
+    # over HTTP/2 have been observed to fail intermittently with
+    # "stream error: ...; PROTOCOL_ERROR; received from peer", forcing a full
+    # multi-minute re-pull and, during bootstrap, stalling node readiness.
+    Environment=GODEBUG=http2client=0
+
     ExecStart=/bin/registry serve /etc/distribution/$NAME.yaml
 
     [Install]


### PR DESCRIPTION
## What

Disables the Go HTTP/2 client (`GODEBUG=http2client=0`) on the local integration-test registry mirror (`tests/integration/templates/registry/registry.service`), so proxy pulls to the upstream registry (`ghcr.io`) fall back to HTTP/1.1.

## Why

Root-caused in #2816: the CI test harness's pull-through registry mirror (`distribution/distribution` v2.8.3 proxying `ghcr.io`) intermittently fails large blob transfers -- specifically the `cilium`/`cilium-operator-generic` images (~170-340MB) -- with:

```
level=error msg="Error committing to storage: stream error: stream ID 27; PROTOCOL_ERROR; received from peer" ... vars.name="canonical/cilium"
http.response.duration=6m5.463s http.response.status=500
```

Each failed pull burns 5-8.5 minutes before erroring, forcing containerd to restart the pull from scratch. When this happens on the bootstrap node right after `k8s bootstrap`, it can exhaust the node-readiness wait budget entirely, causing `test_version_downgrades_with_rollback` (and `test_version_upgrades`) to fail with a `tenacity.RetryError` before the test even reaches its first upgrade/downgrade step.

This pattern reproduced independently across two different bootstrap channels (`1.37-classic/candidate` and `1.32-classic/stable`), confirming it's a registry-mirror/network reliability issue rather than a channel- or build-specific regression.

Disabling the HTTP/2 client for the registry mirror process is a known, low-risk mitigation for this class of GHCR proxy flakiness (large blob transfers over HTTP/2 being reset mid-stream) -- this only affects the mirror's outbound connections, not any snap/cluster runtime behavior.

## Related

- Fixes/mitigates: #2816
- Distinct from the earlier kube-proxy readiness issue (#2806, already fixed via #2751/#2807-#2810)

## Testing

This is a CI-infrastructure-only change (test harness template); should be validated by re-running the affected integration tests and confirming the registry mirror log no longer shows `PROTOCOL_ERROR`/broken-pipe entries during cilium image pulls.
