### PR TITLE
fix: don't skip candidate-only minor versions in upgrade/downgrade channel selection

### DIFF
--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -68,7 +68,6 @@ def get_most_stable_channels(
     include_latest: bool = True,
     min_release: Optional[str] = None,
     max_release: Optional[str] = None,
-    max_risk: str = "candidate",
     reverse: bool = False,
 ) -> List[str]:
     """Get an ascending list of latest channels based on the number of channels
@@ -99,16 +98,6 @@ def get_most_stable_channels(
             risk
         ) < RISK_LEVELS.index(channel_map[version_key][1]):
             channel_map[version_key] = (channel, risk)
-
-    # Only trim the newest contiguous versions below max_risk; never drop
-    # an interior version (e.g. don't skip a candidate-only 1.36 between
-    # 1.37 and stable 1.35).
-    if max_risk:
-        max_risk_index = RISK_LEVELS.index(max_risk)
-        for version_key in sorted(channel_map.keys(), reverse=True):
-            if RISK_LEVELS.index(channel_map[version_key][1]) <= max_risk_index:
-                break
-            del channel_map[version_key]
 
     # Sort channels by major and minor version (ascending order)
     sorted_versions = sorted(

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -68,7 +68,7 @@ def get_most_stable_channels(
     include_latest: bool = True,
     min_release: Optional[str] = None,
     max_release: Optional[str] = None,
-    max_risk: str = "stable",
+    max_risk: str = "candidate",
     reverse: bool = False,
 ) -> List[str]:
     """Get an ascending list of latest channels based on the number of channels
@@ -100,14 +100,22 @@ def get_most_stable_channels(
         ) < RISK_LEVELS.index(channel_map[version_key][1]):
             channel_map[version_key] = (channel, risk)
 
-    # Filter out versions whose most stable channel is riskier than max_risk.
+    # Trim only the newest, not-yet-promoted versions (contiguous from the
+    # top) whose best available risk is worse than max_risk. We deliberately
+    # do NOT drop non-contiguous/interior versions purely by risk: risk only
+    # gets better as a release matures, so it's normal for the 1-2 most
+    # recent minor versions to sit on "candidate" while everything older is
+    # "stable" (e.g. a version currently pending promotion). Dropping such a
+    # version outright - rather than just excluding it from the "newest tip"
+    # - would skip it entirely from the upgrade/downgrade chain, causing
+    # tests to jump two minor versions at once instead of stepping through
+    # every adjacent one (e.g. 1.37 -> 1.35, silently skipping 1.36).
     if max_risk:
         max_risk_index = RISK_LEVELS.index(max_risk)
-        channel_map = {
-            k: v
-            for k, v in channel_map.items()
-            if RISK_LEVELS.index(v[1]) <= max_risk_index
-        }
+        for version_key in sorted(channel_map.keys(), reverse=True):
+            if RISK_LEVELS.index(channel_map[version_key][1]) <= max_risk_index:
+                break
+            del channel_map[version_key]
 
     # Sort channels by major and minor version (ascending order)
     sorted_versions = sorted(

--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -100,16 +100,9 @@ def get_most_stable_channels(
         ) < RISK_LEVELS.index(channel_map[version_key][1]):
             channel_map[version_key] = (channel, risk)
 
-    # Trim only the newest, not-yet-promoted versions (contiguous from the
-    # top) whose best available risk is worse than max_risk. We deliberately
-    # do NOT drop non-contiguous/interior versions purely by risk: risk only
-    # gets better as a release matures, so it's normal for the 1-2 most
-    # recent minor versions to sit on "candidate" while everything older is
-    # "stable" (e.g. a version currently pending promotion). Dropping such a
-    # version outright - rather than just excluding it from the "newest tip"
-    # - would skip it entirely from the upgrade/downgrade chain, causing
-    # tests to jump two minor versions at once instead of stepping through
-    # every adjacent one (e.g. 1.37 -> 1.35, silently skipping 1.36).
+    # Only trim the newest contiguous versions below max_risk; never drop
+    # an interior version (e.g. don't skip a candidate-only 1.36 between
+    # 1.37 and stable 1.35).
     if max_risk:
         max_risk_index = RISK_LEVELS.index(max_risk)
         for version_key in sorted(channel_map.keys(), reverse=True):


### PR DESCRIPTION
## Description

`test_version_downgrades_with_rollback` (and `test_version_upgrades`) can silently skip a minor version in the upgrade/downgrade chain, jumping the etcd (and other component) version further than a real upgrade/downgrade path ever would, which breaks the test.

## Root cause

`get_most_stable_channels()` already picks the best-available channel per minor version in its first pass (e.g. `stable` if published, otherwise `candidate`/`beta`/`edge`), but then had a second pass that **dropped any version whose best channel was riskier than `max_risk`** (default `"stable"`) entirely from the result.

The 1-2 most recent minor versions routinely sit on `candidate` for a while before promotion to `stable` - that's the normal release lifecycle, not an anomaly. Right now (verified live against the Snap Store API), **1.37 and 1.36 both only have a `candidate` channel**; 1.35 and older are `stable`.

`test_version_downgrades_with_rollback` calls `get_most_stable_channels(reverse=True)` to build its downgrade chain. With the old default, both 1.37 and 1.36 were dropped, so `channels[0]` (the bootstrap/"current" version) resolved to **1.35** instead of 1.37, and the first downgrade step went straight **1.35 → 1.34** - the adjacent 1.36 step was skipped entirely.

Note: PR #2815 (open) fixes a *different*, adjacent bug (capping the ceiling so a release branch doesn't float above its own track) - it does **not** fix this; verified locally that even with its `max_release` cap applied, 1.36 still silently disappears.

**No caller anywhere overrides `max_risk`** - it was unused configurability. The property that actually matters here is never skipping an adjacent minor version, not gating on risk tier.

## Fix

Drop the risk-based filtering step entirely. Always use whatever's the best available channel for each version (already computed in the first pass) - no exclusion by risk at all.

## Backport

Yes - this affects every release branch that runs these tests. Will add backport labels once this is reviewed, mirroring #2786/#2789's approach.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests (no existing unit-test scaffolding for `test_util/snap.py`'s pure logic; verified via a local script against the live Snap Store API instead - see above)
- [x] Covered by integration tests (fixes the channel selection used by `test_version_upgrades`/`test_version_downgrades_with_rollback`)
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary
- [x] Confirm whether the `release-notes` label should be kept or removed (removing - test-only change, not user-facing)