### PR TITLE
fix: retry Snap Store/dl.k8s.io requests with exponential backoff

### DIFF
--- a/tests/integration/tests/test_util/snap.py
+++ b/tests/integration/tests/test_util/snap.py
@@ -1,14 +1,12 @@
 #
 # Copyright 2026 Canonical, Ltd.
 #
-import json
 import logging
 import re
 import urllib.error
-import urllib.request
 from typing import List, Optional
 
-from test_util.util import major_minor
+from test_util.util import fetch_json, major_minor
 
 LOG = logging.getLogger(__name__)
 
@@ -25,17 +23,14 @@ RISK_LEVELS = ["stable", "candidate", "beta", "edge"]
 
 def get_snap_info(snap_name=SNAP_NAME):
     """Get the snap info from the Snap Store API."""
-    req = urllib.request.Request(
-        SNAPSTORE_INFO_API + snap_name, headers=SNAPSTORE_HEADERS
-    )
+    url = SNAPSTORE_INFO_API + snap_name
     try:
-        with urllib.request.urlopen(req) as response:  # nosec
-            return json.loads(response.read().decode())
+        return fetch_json(url, headers=SNAPSTORE_HEADERS)  # nosec
     except urllib.error.HTTPError as e:
-        LOG.exception("HTTPError ({%s}): {%s} {%s}", req.full_url, e.code, e.reason)
+        LOG.exception("HTTPError ({%s}): {%s} {%s}", url, e.code, e.reason)
         raise
     except urllib.error.URLError as e:
-        LOG.exception("URLError ({%s}): {%s}", req.full_url, e.reason)
+        LOG.exception("URLError ({%s}): {%s}", url, e.reason)
         raise
 
 

--- a/tests/integration/tests/test_util/util.py
+++ b/tests/integration/tests/test_util/util.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import subprocess
 import time
+import urllib.error
 import urllib.request
 from datetime import datetime
 from functools import partial
@@ -20,9 +21,11 @@ from tenacity import (
     RetryCallState,
     Retrying,
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     stop_never,
+    wait_exponential,
     wait_fixed,
 )
 from test_util import config, harness
@@ -34,6 +37,40 @@ MAIN_BRANCH = "main"
 # kube-proxy was replaced by the Cilium kube-proxy replacement in 1.36. Snaps older
 # than this always run kube-proxy and ignore `network.kube-proxy-enabled`.
 KUBE_PROXY_REPLACEMENT_MIN_VERSION = (1, 36)
+
+
+def _is_retryable_http_error(exc: BaseException) -> bool:
+    """True for 429, 5xx, or network-level errors."""
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code == 429 or 500 <= exc.code < 600
+    if isinstance(exc, urllib.error.URLError):
+        return True
+    return False
+
+
+def fetch_text(
+    url: str,
+    headers: Optional[dict] = None,
+    retries: int = 6,
+    min_wait_s: float = 1.0,
+    max_wait_s: float = 30.0,
+) -> str:
+    """GET url as text with exponential backoff on transient errors."""
+    req = urllib.request.Request(url, headers=headers or {})
+    for attempt in Retrying(
+        stop=stop_after_attempt(retries),
+        wait=wait_exponential(multiplier=min_wait_s, max=max_wait_s),
+        retry=retry_if_exception(_is_retryable_http_error),
+        reraise=True,
+    ):
+        with attempt:
+            with urllib.request.urlopen(req) as response:  # nosec
+                return response.read().decode()
+
+
+def fetch_json(url: str, headers: Optional[dict] = None, **kwargs) -> dict:
+    """Like fetch_text() but parses the response as JSON."""
+    return json.loads(fetch_text(url, headers=headers, **kwargs))
 
 
 def run(command: list, **kwargs) -> subprocess.CompletedProcess:
@@ -808,9 +845,7 @@ def tracks_least_risk(track: str, arch: str) -> str:
         "User-Agent": "Mozilla/5.0",
     }
 
-    req = urllib.request.Request(INFO_URL, headers=HEADERS)
-    with urllib.request.urlopen(req) as response:
-        snap_info = json.loads(response.read().decode())
+    snap_info = fetch_json(INFO_URL, headers=HEADERS)
 
     risks = [
         channel["channel"]["risk"]
@@ -858,16 +893,9 @@ def _major_minor_from_stable_upstream(maj: Optional[int] = None) -> Optional[tup
     addr = "https://dl.k8s.io/release/stable{dash_maj}.txt".format(
         dash_maj=f"-{maj}" if maj else ""
     )
-    for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(2)):
-        with attempt:
-            LOG.info(
-                "Attempt %d: Fetching upstream version",
-                attempt.retry_state.attempt_number,
-            )
-            with urllib.request.urlopen(addr) as r:
-                stable = r.read().decode().strip()
-                LOG.info("Successfully fetched upstream version: %s", stable)
-                return major_minor(stable)
+    stable = fetch_text(addr).strip()
+    LOG.info("Successfully fetched upstream version: %s", stable)
+    return major_minor(stable)
 
 
 def _find_stable_track(major: int, minor: int, flavor: str) -> Optional[str]:
@@ -892,10 +920,8 @@ def _find_stable_track(major: int, minor: int, flavor: str) -> Optional[str]:
     }
 
     try:
-        req = urllib.request.Request(INFO_URL, headers=HEADERS)
-        with urllib.request.urlopen(req) as response:
-            snap_info = json.loads(response.read().decode())
-    except urllib.error.URLError:
+        snap_info = fetch_json(INFO_URL, headers=HEADERS)
+    except (urllib.error.HTTPError, urllib.error.URLError):
         LOG.warning(
             "Failed to query snap store for %s", config.SNAP_NAME, exc_info=True
         )


### PR DESCRIPTION
## Description

CI intermittently fails outright on transient Snap Store errors, e.g.:
```
HTTPError ({https://api.snapcraft.io/v2/snaps/info/k8s}): {429} {Too Many Requests}
```
Traced from a failed run of #2812: `test_version_upgrades`/`test_version_downgrades_with_rollback` crash on a single rate-limited request with no chance to recover.

## Root cause

Checked all raw network calls in the integration test suite (`tests/integration/tests/test_util/*.py`) - 4 total:
- `snap.get_snap_info()` - no retry at all (the one that failed in CI)
- `util.tracks_least_risk()` - no retry at all
- `util._find_stable_track()` - no retry at all
- `util._major_minor_from_stable_upstream()` - fixed-delay retry only, no backoff

## Fix

Added generic `fetch_text()`/`fetch_json()` helpers in `test_util/util.py`: exponential backoff on 429/5xx/network-level errors, other 4xx (e.g. 404) still fail fast. Switched all 4 call sites to use them instead of duplicating urllib boilerplate.

## Verification

Ran locally: a live call against the real Snap Store API, a synthetic 429-then-success case, and a synthetic 404 case (confirms it doesn't waste retries on non-transient errors).

## Backport

TBD pending review - will add labels once merged, same as recent related PRs.

## Checklist

- [x] PR title formatted as `type: title`
- [ ] Covered by unit tests (verified locally instead, see above)
- [x] Covered by integration tests (fixes flakiness in the existing suite)
- [ ] Documentation updated
- [x] CLA signed
- [ ] Backport label added if necessary
- [x] release-notes label removed (test-only change)
